### PR TITLE
Suppress Warnings for unused in model classes

### DIFF
--- a/src/main/java/org/wso2/ballerina/model/Action.java
+++ b/src/main/java/org/wso2/ballerina/model/Action.java
@@ -37,6 +37,7 @@ import java.util.List;
  *  }
  *
  */
+@SuppressWarnings("unused")
 public class Action {
 
     private List<Annotation> annotations;

--- a/src/main/java/org/wso2/ballerina/model/Annotation.java
+++ b/src/main/java/org/wso2/ballerina/model/Annotation.java
@@ -24,6 +24,7 @@ package org.wso2.ballerina.model;
  * Annotation can be associated with various Ballerina concepts like Service, Resource, Functions, etc.
  * @see <a href="https://github.com/wso2/ballerina/blob/master/docs/SyntaxSummary.md">Ballerina Syntax Summary</a>
  */
+@SuppressWarnings("unused")
 public class Annotation {
 
     private String name, value;

--- a/src/main/java/org/wso2/ballerina/model/Argument.java
+++ b/src/main/java/org/wso2/ballerina/model/Argument.java
@@ -24,6 +24,7 @@ import java.util.List;
 /**
  * This class represent an Argument which can be a part of Function, Resource and Action definition
  */
+@SuppressWarnings("unused")
 public class Argument {
 
     private String name, value;

--- a/src/main/java/org/wso2/ballerina/model/Connection.java
+++ b/src/main/java/org/wso2/ballerina/model/Connection.java
@@ -21,5 +21,6 @@ package org.wso2.ballerina.model;
 /**
  * A connection represents the instantiation of a connector with a particular configuration.
  */
+@SuppressWarnings("unused")
 public class Connection {
 }

--- a/src/main/java/org/wso2/ballerina/model/Connector.java
+++ b/src/main/java/org/wso2/ballerina/model/Connector.java
@@ -34,6 +34,7 @@ import java.util.List;
  *      ActionDefinition;+
  * }
  */
+@SuppressWarnings("unused")
 public class Connector {
 
     private List<Annotation> annotations;

--- a/src/main/java/org/wso2/ballerina/model/Function.java
+++ b/src/main/java/org/wso2/ballerina/model/Function.java
@@ -37,6 +37,7 @@ import java.util.List;
  *      Statement;+
  *  }
  */
+@SuppressWarnings("unused")
 public class Function {
 
     private List<Annotation> annotations;

--- a/src/main/java/org/wso2/ballerina/model/Node.java
+++ b/src/main/java/org/wso2/ballerina/model/Node.java
@@ -21,6 +21,7 @@ package org.wso2.ballerina.model;
 /**
  * Unit of execution :TODO: Need to refactor this
  */
+@SuppressWarnings("unused")
 public class Node {
     public void run() {
 

--- a/src/main/java/org/wso2/ballerina/model/Resource.java
+++ b/src/main/java/org/wso2/ballerina/model/Resource.java
@@ -40,6 +40,7 @@ import java.util.List;
  *  }*
  *
  */
+@SuppressWarnings("unused")
 public class Resource {
 
     private List<Annotation> annotations;

--- a/src/main/java/org/wso2/ballerina/model/Service.java
+++ b/src/main/java/org/wso2/ballerina/model/Service.java
@@ -35,6 +35,7 @@ import java.util.List;
  *      ResourceDefinition;+
  *  }
  */
+@SuppressWarnings("unused")
 public class Service {
 
     private List<Annotation> annotations;

--- a/src/main/java/org/wso2/ballerina/model/Variable.java
+++ b/src/main/java/org/wso2/ballerina/model/Variable.java
@@ -22,5 +22,6 @@ package org.wso2.ballerina.model;
  * Ballerina has variables of various types. The type system includes built-in primitives,
  * a collection of built-in structured types and array and record type constructors.
  */
+@SuppressWarnings("unused")
 public class Variable {
 }

--- a/src/main/java/org/wso2/ballerina/model/Worker.java
+++ b/src/main/java/org/wso2/ballerina/model/Worker.java
@@ -36,6 +36,7 @@ import java.util.List;
  *      [reply MessageName;]
  *  }
  */
+@SuppressWarnings("unused")
 public class Worker {
 
     private List<Connection> connections;


### PR DESCRIPTION
These classes may not be used within the project, so to identify other warnings easily suppressing unused type for now. Later we may enable again. 