### PR TITLE
Add ArrayType initial version

### DIFF
--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/types/ArrayType.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/types/ArrayType.java
@@ -18,10 +18,70 @@
 package org.wso2.ballerina.core.model.types;
 
 /**
- *  {@code ArrayType} represents an array
- *
- *  @since 1.0.0
+ * {@code ArrayType} represents an array
+ * @param <T> type of the array
+ * @since 1.0.0
  */
-public class ArrayType extends AbstractType {
+public class ArrayType<T> extends AbstractType {
+
+    private T[] thisArray;
+    private int size;
+
+    /**
+     * Constructor for array inline initialization
+     * @param args variable number of initial values
+     */
+    @SuppressWarnings("unchecked")
+    public ArrayType(T... args) {
+        thisArray = (T[]) new Object[args.length];
+        for (int i = 0; i < args.length; i++) {
+            thisArray[i] = args[i];
+
+        }
+    }
+
+    /**
+     * Constructor for creating an array with size
+     * @param size number of elements to be stored in this array
+     */
+    @SuppressWarnings("unchecked")
+    public ArrayType(int size) {
+        thisArray = (T[]) new Object[size];
+        this.size = size;
+    }
+
+    /**
+     * Constructor for creating an empty array
+     *
+     */
+    public ArrayType() {
+
+    }
+
+    /**
+     * Insert a value into a given position
+     * @param index position
+     * @param value value
+     */
+    public void insert(int index, T value) {
+        thisArray[index] = value;
+    }
+
+    /**
+     * Retrieve a value from a given index
+     * @param index position
+     * @return return value
+     */
+    public T get(int index) {
+        return thisArray[index];
+    }
+
+    /**
+     * Retrieve the size of the array
+     * @return returns the size
+     */
+    public int size() {
+        return size;
+    }
 
 }

--- a/modules/ballerina-core/src/test/java/org/wso2/ballerina/core/model/ArrayTypeTest.java
+++ b/modules/ballerina-core/src/test/java/org/wso2/ballerina/core/model/ArrayTypeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ballerina.core.model;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.ballerina.core.model.types.ArrayType;
+import org.wso2.ballerina.core.model.types.IntType;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+public class ArrayTypeTest {
+    @BeforeTest
+    public void setup() {
+    }
+
+    @Test
+    public void testStandardJavaArray() {
+        // Standard Array
+        IntType[] integers = new IntType[4];
+        IntType int0 = new IntType();
+        IntType int1 = new IntType();
+        IntType int2 = new IntType();
+        IntType int3 = new IntType();
+        integers[0] = int0;
+        integers[1] = int1;
+        integers[2] = int2;
+        integers[3] = int3;
+        assertEquals(integers[2], int2);
+    }
+
+    @Test
+    public void testArrayTypeInsertGet() {
+        // ArrayType
+        ArrayType<IntType> integers = new ArrayType<>(4);
+        IntType int0 = new IntType();
+        IntType int1 = new IntType();
+        IntType int2 = new IntType();
+        IntType int3 = new IntType();
+        integers.insert(0, int0);
+        integers.insert(1, int1);
+        integers.insert(2, int2);
+        integers.insert(3, int3);
+        assertEquals(integers.get(2), int2);
+    }
+
+    @Test
+    public void testArrayTypeInitializeWithValue() {
+        // ArrayType
+        IntType int0 = new IntType();
+        IntType int1 = new IntType();
+        IntType int2 = new IntType();
+        IntType int3 = new IntType();
+        ArrayType<IntType> integers = new ArrayType<>(int0, int1, int2, int3);
+        assertEquals(integers.get(2), int2);
+    }
+}


### PR DESCRIPTION
This version supports below operations on the ArrayType.

**Initialize with values**
- standard java array syntax
`IntType[] integers = {int0, int1, int2, int3};
`
- ballerina support (at object creation)
`ArrayType<IntType> integers = new ArrayType<>(int0, int1, int2, int3);
`

**Initialize with size**
- standard java array syntax
`IntType[] integers = new IntType[4];
`
- ballerina support (at object creation)
`ArrayType<IntType> integers = new ArrayType<>(4);
`

**Assign values to index**
- standard java array syntax
`integers[2] = new IntType();
`
- ballerina support (at object creation)
`integers.insert(2, new IntType());
`

**Retrieve values from index**
- standard java array syntax
`IntType x = integers[2];
`
- ballerina support (at object creation)
`IntType x = integers.get(2);`