### PR TITLE
Change BalDeployer to work with listener based language parsing

### DIFF
--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/parser/visitor/StatementVisitor.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/parser/visitor/StatementVisitor.java
@@ -20,6 +20,7 @@ package org.wso2.ballerina.core.parser.visitor;
 import org.wso2.ballerina.core.interpreter.SymbolTable;
 import org.wso2.ballerina.core.model.Identifier;
 import org.wso2.ballerina.core.model.Worker;
+import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.Expression;
 import org.wso2.ballerina.core.model.expressions.VariableRefExpr;
 import org.wso2.ballerina.core.model.statements.AssignStmt;
@@ -32,6 +33,8 @@ import org.wso2.ballerina.core.model.statements.Statement;
 import org.wso2.ballerina.core.model.statements.ThrowStmt;
 import org.wso2.ballerina.core.model.statements.TryCatchStmt;
 import org.wso2.ballerina.core.model.statements.WhileStmt;
+import org.wso2.ballerina.core.model.values.BValueRef;
+import org.wso2.ballerina.core.model.values.StringValue;
 import org.wso2.ballerina.core.parser.BallerinaBaseVisitor;
 import org.wso2.ballerina.core.parser.BallerinaParser;
 
@@ -348,7 +351,11 @@ public class StatementVisitor extends BallerinaBaseVisitor {
      */
     @Override
     public Object visitReturnStatement(BallerinaParser.ReturnStatementContext ctx) {
-        return new ReturnStmt(this.visitExpressionX(ctx.expressionList().expression(0)));
+        if (ctx.expressionList() != null && ctx.expressionList().expression() != null) {
+            return new ReturnStmt(this.visitExpressionX(ctx.expressionList().expression(0)));
+        } else {
+            return new ReturnStmt(null);
+        }
     }
 
     /**
@@ -361,7 +368,15 @@ public class StatementVisitor extends BallerinaBaseVisitor {
      */
     @Override
     public Object visitReplyStatement(BallerinaParser.ReplyStatementContext ctx) {
-        return new ReplyStmt(this.visitExpressionX(ctx.expression()));
+        if (ctx.expression() != null) {
+            Expression expression = this.visitExpressionX(ctx.expression());
+            return new ReplyStmt(expression);
+        } else if (ctx.Identifier() != null) {
+            Expression expression = new BasicLiteral(new BValueRef(new StringValue(ctx.Identifier().getText())));
+            return new ReplyStmt(expression);
+        } else {
+            return new ReplyStmt(null);
+        }
     }
 
     /**
@@ -447,8 +462,11 @@ public class StatementVisitor extends BallerinaBaseVisitor {
     }
 
     private Expression visitExpressionX(BallerinaParser.ExpressionContext ctx) {
-        ExpressionVisitor expressionVisitor = new ExpressionVisitor(statementSymbolTable);
-        return (Expression) ctx.accept(expressionVisitor);
+        if (ctx != null) {
+            ExpressionVisitor expressionVisitor = new ExpressionVisitor(statementSymbolTable);
+            return (Expression) ctx.accept(expressionVisitor);
+        }
+        return null;
     }
 
     /**

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/deployer/BalDeployer.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/deployer/BalDeployer.java
@@ -28,9 +28,9 @@ import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.model.Application;
 import org.wso2.ballerina.core.model.BallerinaFile;
 import org.wso2.ballerina.core.model.Package;
+import org.wso2.ballerina.core.parser.BallerinaBaseListenerImpl;
 import org.wso2.ballerina.core.parser.BallerinaLexer;
 import org.wso2.ballerina.core.parser.BallerinaParser;
-import org.wso2.ballerina.core.parser.visitor.CompilationUnitVisitor;
 import org.wso2.ballerina.core.runtime.registry.ApplicationRegistry;
 import org.wso2.carbon.deployment.engine.Artifact;
 import org.wso2.carbon.deployment.engine.ArtifactType;
@@ -111,8 +111,16 @@ public class BalDeployer implements Deployer {
                 CommonTokenStream ballerinaToken = new CommonTokenStream(ballerinaLexer);
 
                 BallerinaParser ballerinaParser = new BallerinaParser(ballerinaToken);
-                CompilationUnitVisitor ballerinaBaseVisitor = new CompilationUnitVisitor();
-                BallerinaFile balFile = (BallerinaFile) ballerinaBaseVisitor.visit(ballerinaParser.compilationUnit());
+
+//                // Visitor based approach
+//                CompilationUnitVisitor ballerinaBaseVisitor = new CompilationUnitVisitor();
+//                BallerinaFile balFile = (BallerinaFile) ballerinaBaseVisitor.visit(ballerinaParser.compilationUnit());
+
+                // Listener based approach
+                BallerinaBaseListenerImpl ballerinaBaseListener = new BallerinaBaseListenerImpl();
+                ballerinaParser.addParseListener(ballerinaBaseListener);
+                ballerinaParser.compilationUnit();
+                BallerinaFile balFile = ballerinaBaseListener.balFile;
 
                 Application defaultApp = ApplicationRegistry.getInstance().getDefaultApplication();
                 Package aPackage = defaultApp.getPackage(balFile.getPackageName());


### PR DESCRIPTION
Since most of the recent changes have carried out on listener based implementation, changed the deployer to work with the same model for the moment. 