### PR TITLE
Fix the warning message which comes when running the bal file using the run command

### DIFF
--- a/modules/distribution/carbon-home/bin/ballerina.sh
+++ b/modules/distribution/carbon-home/bin/ballerina.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ---------------------------------------------------------------------------
 #  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #


### PR DESCRIPTION
When executing the run command like below, it throws a warning. 
`./ballerina.sh run test.bal
`
***warning***
`ballerina.sh: 264: ballerina.sh: [[: not found`

This is because we are running a script written for bash under sh, which lacks many of the extended syntax features – [[ is a bash builtin command and is not available in sh.

Due to this reason, I have changed the shell of this script from "sh" to "bash" with this commit.