### PR TITLE
Refactor built-in function registering mechanism

### DIFF
--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/DoubleArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/DoubleArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -39,11 +38,11 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.DOUBLE)},
         isPublic = true
 )
-@Component(
+/*@Component(
         name = "func.lang.array_doubleArrayCopyOf",
         immediate = true,
         service = AbstractNativeFunction.class
-)
+)*/
 public class DoubleArrayCopyOf extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/DoubleArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/DoubleArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.DOUBLE)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_doubleArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class DoubleArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/DoubleArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/DoubleArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_doubleArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class DoubleArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/FloatArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/FloatArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.FLOAT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_floatArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class FloatArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/FloatArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/FloatArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.FLOAT)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_floatArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class FloatArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/FloatArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/FloatArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_floatArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class FloatArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/IntArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/IntArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_intArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class IntArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/IntArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/IntArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_intArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class IntArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/IntArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/IntArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_intArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class IntArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/JsonArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/JsonArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.JSON)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_jsonArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class JsonArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/JsonArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/JsonArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.JSON)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_jsonArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class JsonArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/JsonArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/JsonArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_jsonArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class JsonArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/LongArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/LongArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.LONG)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_longArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LongArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/LongArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/LongArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.LONG)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_longArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LongArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/LongArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/LongArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_longArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LongArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/MessageArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/MessageArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.MESSAGE)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.MESSAGE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_messageArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class MessageArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/MessageArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/MessageArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.MESSAGE)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_messageArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class MessageArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/MessageArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/MessageArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.MESSAGE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_messageArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class MessageArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/StringArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/StringArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_stringArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class StringArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/StringArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/StringArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_stringArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class StringArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/StringArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/StringArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_stringArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class StringArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/XmlArrayCopyOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/XmlArrayCopyOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.XML)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_xmlArrayCopyOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class XmlArrayCopyOf extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/XmlArrayLength.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/XmlArrayLength.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BArray;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "arr", type = TypeEnum.ARRAY, elementType = TypeEnum.XML)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_xmlArrayLength",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class XmlArrayLength extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/XmlArrayRangeCopy.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/array/XmlArrayRangeCopy.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.array;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -42,11 +41,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "to", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.array_xmlArrayRangeCopy",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class XmlArrayRangeCopy extends AbstractNativeFunction {
     @Override

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AbstractJSONFunction.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AbstractJSONFunction.java
@@ -25,7 +25,6 @@ import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
-
 import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 
 import java.util.EnumSet;

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddBooleanToArray.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddBooleanToArray.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addBooleanToArray",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddBooleanToArray extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddBooleanToObject.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddBooleanToObject.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -48,11 +45,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addBooleanToObject",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddBooleanToObject extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddDoubleToArray.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddDoubleToArray.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BDouble;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addDoubleToArray",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddDoubleToArray extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddDoubleToObject.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddDoubleToObject.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BDouble;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -48,11 +45,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addDoubleToObject",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddDoubleToObject extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddFloatToArray.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddFloatToArray.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BFloat;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addFloatToArray",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddFloatToArray extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddFloatToObject.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddFloatToObject.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
 import org.wso2.ballerina.core.model.values.BValueType;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -48,11 +45,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addFloatToObject",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddFloatToObject extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddIntToArray.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddIntToArray.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addIntToArray",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddIntToArray extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddIntToObject.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddIntToObject.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -48,11 +45,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addIntToObject",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddIntToObject extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddJSONToArray.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddJSONToArray.java
@@ -24,13 +24,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addJsonToArray",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddJSONToArray extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddJSONToObject.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddJSONToObject.java
@@ -24,13 +24,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -49,11 +46,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addJSONToObject",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddJSONToObject extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddStringToArray.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddStringToArray.java
@@ -23,13 +23,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -45,11 +42,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addStringToArray",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddStringToArray extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddStringToObject.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/AddStringToObject.java
@@ -23,13 +23,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -47,11 +44,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_addStringToObject",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddStringToObject extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetBoolean.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetBoolean.java
@@ -25,15 +25,12 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -49,11 +46,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_getBoolean",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetBoolean extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetDouble.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetDouble.java
@@ -25,14 +25,12 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BDouble;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -48,11 +46,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_getDouble",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetDouble extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetFloat.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetFloat.java
@@ -25,15 +25,12 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BFloat;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -49,11 +46,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_getFloat",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetFloat extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetInt.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetInt.java
@@ -25,15 +25,12 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -49,11 +46,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_getInt",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetInt extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetJSON.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetJSON.java
@@ -24,14 +24,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -47,11 +44,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_getJson",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetJSON extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/GetString.java
@@ -25,14 +25,12 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BString;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -48,11 +46,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_getString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetString extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/Remove.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/Remove.java
@@ -23,13 +23,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -43,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "json", type = TypeEnum.JSON),
                 @Argument(name = "jsonPath", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_remove",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Remove extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/Rename.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/Rename.java
@@ -23,13 +23,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -45,11 +42,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "oldKey", type = TypeEnum.STRING),
                 @Argument(name = "newKey", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_rename",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Rename extends AbstractJSONFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetBoolean.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetBoolean.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
 import org.wso2.ballerina.core.model.values.BValueType;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_setBoolean",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetBoolean extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetDouble.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetDouble.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BDouble;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_setDouble",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetDouble extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetFloat.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetFloat.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BFloat;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_setFloat",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetFloat extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetInt.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetInt.java
@@ -23,14 +23,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_setInt",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetInt extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetJSON.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetJSON.java
@@ -24,13 +24,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -46,11 +43,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_setJson",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetJSON extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/SetString.java
@@ -23,13 +23,10 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.WriteContext;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
@@ -45,11 +42,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
                 @Argument(name = "jsonPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_setString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetString extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/ToString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/json/ToString.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.json;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -26,7 +25,6 @@ import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
 import org.wso2.ballerina.core.model.values.BString;
 import org.wso2.ballerina.core.model.values.BValue;
-import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
 import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
 import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
@@ -41,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "json", type = TypeEnum.JSON)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.json_toString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class ToString extends AbstractJSONFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/AddHeader.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/AddHeader.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.message_addHeader",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddHeader extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/Clone.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/Clone.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -40,12 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE)},
         returnType = {@ReturnType(type = TypeEnum.MESSAGE)},
         isPublic = true
-)
-
-@Component(
-        name = "func.lang.message_clone",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Clone  extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetHeader.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetHeader.java
@@ -1,7 +1,6 @@
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BMessage;
@@ -22,12 +21,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "headerName", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-
-@Component(
-        name = "func.lang.message_getHeader",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetHeader extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetHeaders.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetHeaders.java
@@ -19,7 +19,6 @@
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -38,12 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "headerName", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.STRING)},
         isPublic = true
-)
-
-@Component(
-        name = "func.lang.message_getHeaders",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetHeaders extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetJsonPayload.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetJsonPayload.java
@@ -20,7 +20,6 @@ package org.wso2.ballerina.core.nativeimpl.lang.message;
 
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE)},
         returnType = {@ReturnType(type = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.echo_getJsonPayload",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetJsonPayload extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetStringPayload.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetStringPayload.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.exception.BallerinaException;
@@ -43,11 +42,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.message_getStringPayload",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetStringPayload extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetXMLPayload.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/GetXMLPayload.java
@@ -16,7 +16,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BMessage;
@@ -37,11 +36,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE)},
         returnType = {@ReturnType(type = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.echo_getXmlPayload",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetXMLPayload extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/RemoveHeader.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/RemoveHeader.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -39,11 +38,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE),
                 @Argument(name = "key", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.message_removeHeader",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class RemoveHeader extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetHeader.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetHeader.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @Argument(name = "key", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.message_setHeader",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetHeader extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetJsonPayload.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetJsonPayload.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.Constants;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE),
                 @Argument(name = "payload", type = TypeEnum.JSON)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.echo_setJsonPayload",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetJsonPayload extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetStringPayload.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetStringPayload.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.Constants;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE),
                 @Argument(name = "payload", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.message_setStringPayload",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetStringPayload extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetXMLPayload.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/message/SetXMLPayload.java
@@ -16,7 +16,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.message;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -38,11 +37,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.Constants;
         args = {@Argument(name = "message", type = TypeEnum.MESSAGE),
                 @Argument(name = "payload", type = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.echo_setXmlPayload",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetXMLPayload extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/BooleanValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/BooleanValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "boolean", type = TypeEnum.BOOLEAN)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_booleanValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class BooleanValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Contains.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Contains.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_contains",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Contains extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/DoubleValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/DoubleValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BDouble;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "double", type = TypeEnum.DOUBLE)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_doubleValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class DoubleValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/EqualsIgnoreCase.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/EqualsIgnoreCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_equalsIgnoreCase",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class EqualsIgnoreCase extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/FloatValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/FloatValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BFloat;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "float", type = TypeEnum.FLOAT)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_floatValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class FloatValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/HasPrefix.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/HasPrefix.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_hasPrefix",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class HasPrefix extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/HasSuffix.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/HasSuffix.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BBoolean;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_hasSuffix",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class HasSuffix extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/IndexOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/IndexOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_indexOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class IndexOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/IntValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/IntValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "int", type = TypeEnum.INT)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_intValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class IntValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/JsonValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/JsonValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BJSON;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "json", type = TypeEnum.JSON)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_jsonValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class JsonValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/LastIndexOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/LastIndexOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_LastIndexOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LastIndexOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Length.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Length.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BInteger;
@@ -39,11 +38,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_length",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Length extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/LongValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/LongValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BLong;
@@ -40,11 +39,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "long", type = TypeEnum.LONG)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_longValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LongValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Replace.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Replace.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_replace",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Replace extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ReplaceAll.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ReplaceAll.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_replaceAll",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class ReplaceAll extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ReplaceFirst.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ReplaceFirst.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
                 @Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_replaceFirst",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class ReplaceFirst extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/StringValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/StringValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -39,11 +38,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_stringValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class StringValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ToLowerCase.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ToLowerCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -41,11 +40,6 @@ import java.util.Locale;
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_toLowerCase",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class ToLowerCase extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ToUpperCase.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/ToUpperCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -41,11 +40,6 @@ import java.util.Locale;
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_toUpperCase",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class ToUpperCase extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Trim.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Trim.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -39,11 +38,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_trim",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Trim extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Unescape.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/Unescape.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -39,11 +38,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_unescape",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Unescape extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/XmlValueOf.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/string/XmlValueOf.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.string;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "xml", type = TypeEnum.XML)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.string_xmlValueOf",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class XmlValueOf extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/CurrentTimeMillis.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/CurrentTimeMillis.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BLong;
@@ -37,11 +36,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         functionName = "currentTimeMillis",
         returnType = {@ReturnType(type = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_currentTimeMillis",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class CurrentTimeMillis extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/EpochTime.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/EpochTime.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BLong;
@@ -37,11 +36,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         functionName = "epochTime",
         returnType = {@ReturnType(type = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_epochTime",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class EpochTime extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogBoolean.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogBoolean.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -51,11 +50,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @BallerinaConstant(identifier = "LOG_LEVEL_ERROR", type = TypeEnum.INT, value = "5",
                         argumentRefs = {"logLevel"})
         }
-)
-@Component(
-        name = "func.lang.system_logBoolean",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LogBoolean extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogDouble.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogDouble.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -51,11 +50,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @BallerinaConstant(identifier = "LOG_LEVEL_ERROR", type = TypeEnum.INT, value = "5",
                         argumentRefs = {"logLevel"})
         }
-)
-@Component(
-        name = "func.lang.system_logDouble",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LogDouble extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogFloat.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogFloat.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -51,11 +50,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @BallerinaConstant(identifier = "LOG_LEVEL_ERROR", type = TypeEnum.INT, value = "5",
                         argumentRefs = {"logLevel"})
         }
-)
-@Component(
-        name = "func.lang.system_logFloat",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LogFloat extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogInt.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogInt.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -50,11 +49,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @BallerinaConstant(identifier = "LOG_LEVEL_ERROR", type = TypeEnum.INT, value = "5",
                         argumentRefs = {"logLevel"})
         }
-)
-@Component(
-        name = "func.lang.system_logInt",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LogInt extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogLong.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogLong.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -51,11 +50,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @BallerinaConstant(identifier = "LOG_LEVEL_ERROR", type = TypeEnum.INT, value = "5",
                         argumentRefs = {"logLevel"})
         }
-)
-@Component(
-        name = "func.lang.system_logLong",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LogLong extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/LogString.java
@@ -17,7 +17,6 @@
 */
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -50,11 +49,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
                 @BallerinaConstant(identifier = "LOG_LEVEL_ERROR", type = TypeEnum.INT, value = "5",
                         argumentRefs = {"logLevel"})
         }
-)
-@Component(
-        name = "func.lang.system_logString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class LogString extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/NanoTime.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/NanoTime.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BLong;
@@ -37,11 +36,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.ReturnType;
         functionName = "nanoTime",
         returnType = {@ReturnType(type = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_nanoTime",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class NanoTime extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintBoolean.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintBoolean.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -33,11 +32,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         functionName = "print",
         args = {@Argument(name = "boolean", type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printBoolean",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintBoolean extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintDouble.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintDouble.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -34,11 +33,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         functionName = "print",
         args = {@Argument(name = "double", type = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printDouble",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintDouble extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintFloat.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintFloat.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -34,11 +33,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         functionName = "print",
         args = {@Argument(name = "float", type = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printFloat",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintFloat extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintInt.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintInt.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -34,11 +33,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         functionName = "print",
         args = {@Argument(name = "int", type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printInt",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintInt extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintLong.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintLong.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -34,11 +33,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         functionName = "print",
         args = {@Argument(name = "long", type = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printLong",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintLong extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintString.java
@@ -17,7 +17,6 @@
 */
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -34,11 +33,6 @@ import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
         functionName = "print",
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintString extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnBoolean.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnBoolean.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -37,11 +36,6 @@ import java.io.PrintStream;
         functionName = "println",
         args = {@Argument(name = "boolean", type = TypeEnum.BOOLEAN)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printlnBoolean",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintlnBoolean extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnDouble.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnDouble.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -38,11 +37,6 @@ import java.io.PrintStream;
         functionName = "println",
         args = {@Argument(name = "double", type = TypeEnum.DOUBLE)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printlnDouble",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintlnDouble extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnFloat.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnFloat.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -38,11 +37,6 @@ import java.io.PrintStream;
         functionName = "println",
         args = {@Argument(name = "float", type = TypeEnum.FLOAT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printlnFloat",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintlnFloat extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnInt.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnInt.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -38,11 +37,6 @@ import java.io.PrintStream;
         functionName = "println",
         args = {@Argument(name = "int", type = TypeEnum.INT)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printlnInt",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintlnInt extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnLong.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnLong.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -38,11 +37,6 @@ import java.io.PrintStream;
         functionName = "println",
         args = {@Argument(name = "long", type = TypeEnum.LONG)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printlnLong",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintlnLong extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/system/PrintlnString.java
@@ -17,7 +17,6 @@
 */
 package org.wso2.ballerina.core.nativeimpl.lang.system;
 
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -37,11 +36,6 @@ import java.io.PrintStream;
         functionName = "println",
         args = {@Argument(name = "string", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.system_printlnString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class PrintlnString extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/AddAttribute.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/AddAttribute.java
@@ -25,7 +25,6 @@ import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.jaxen.JaxenException;
 import org.jaxen.XPathSyntaxException;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -53,11 +52,6 @@ import java.util.List;
                 @Argument(name = "name", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_addAttribute",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddAttribute extends AbstractNativeFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/AddElement.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/AddElement.java
@@ -26,7 +26,6 @@ import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.jaxen.JaxenException;
 import org.jaxen.XPathSyntaxException;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -52,11 +51,6 @@ import java.util.List;
                 @Argument(name = "xPath", type = TypeEnum.STRING),
                 @Argument(name = "value", type = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_addElement",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class AddElement extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/GetString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/GetString.java
@@ -27,8 +27,6 @@ import net.sf.saxon.s9api.XPathSelector;
 import net.sf.saxon.s9api.XdmNode;
 import net.sf.saxon.s9api.XdmValue;
 import net.sf.saxon.value.EmptySequence;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BString;
@@ -51,11 +49,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
 //                @Argument(name = "nameSpaces", type = TypeEnum.MAP)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_getString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetString extends AbstractNativeFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/GetXML.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/GetXML.java
@@ -30,8 +30,6 @@ import net.sf.saxon.tree.tiny.TinyAttributeImpl;
 import net.sf.saxon.tree.tiny.TinyElementImpl;
 import net.sf.saxon.tree.tiny.TinyTextImpl;
 import net.sf.saxon.value.EmptySequence;
-
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
@@ -54,11 +52,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
 //                @Argument(name = "nameSpaces", type = TypeEnum.MAP)},
         returnType = {@ReturnType(type = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_getXml",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetXML extends AbstractNativeFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/Remove.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/Remove.java
@@ -22,7 +22,6 @@ import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.jaxen.JaxenException;
 import org.jaxen.XPathSyntaxException;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -45,11 +44,6 @@ import java.util.List;
                 @Argument(name = "xPath", type = TypeEnum.STRING)},
 //                @Argument(name = "nameSpaces", type = TypeEnum.MAP)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_remove",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Remove extends AbstractNativeFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/SetString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/SetString.java
@@ -25,7 +25,6 @@ import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.jaxen.JaxenException;
 import org.jaxen.XPathSyntaxException;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -52,11 +51,6 @@ import java.util.List;
 //                @Argument(name = "nameSpaces", type = TypeEnum.MAP),
                 @Argument(name = "value", type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_setString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetString extends AbstractNativeFunction {
     

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/SetXML.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/SetXML.java
@@ -24,7 +24,6 @@ import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.jaxen.JaxenException;
 import org.jaxen.XPathSyntaxException;
-import org.osgi.service.component.annotations.Component;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.model.types.TypeEnum;
 import org.wso2.ballerina.core.model.values.BValue;
@@ -51,11 +50,6 @@ import java.util.List;
 //                @Argument(name = "nameSpaces", type = TypeEnum.MAP),
                 @Argument(name = "value", type = TypeEnum.XML)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_setXml",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class SetXML extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/ToString.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/lang/xml/ToString.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.lang.xml;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -41,11 +40,6 @@ import org.wso2.ballerina.core.nativeimpl.lang.utils.ErrorHandler;
         args = {@Argument(name = "xml", type = TypeEnum.XML)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.lang.xml_toString",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class ToString extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/net/uri/Encode.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/net/uri/Encode.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.net.uri;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -44,11 +43,6 @@ import java.net.URLEncoder;
         args = {@Argument(name = "url", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.net.uri_encode",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class Encode extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/net/uri/GetQueryParam.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/net/uri/GetQueryParam.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerina.core.nativeimpl.net.uri;
 
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.interpreter.Context;
@@ -49,11 +48,6 @@ import java.util.Map;
                 @Argument(name = "key", type = TypeEnum.STRING)},
         returnType = {@ReturnType(type = TypeEnum.STRING)},
         isPublic = true
-)
-@Component(
-        name = "func.net.uri_getQueryParam",
-        immediate = true,
-        service = AbstractNativeFunction.class
 )
 public class GetQueryParam extends AbstractNativeFunction {
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/internal/BallerinaServiceComponent.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/internal/BallerinaServiceComponent.java
@@ -56,6 +56,9 @@ public class BallerinaServiceComponent {
     @Activate
     protected void start(BundleContext bundleContext) {
 
+        // Load built-in native constructs
+        BuiltInNativeConstructLoader.loadConstructs();
+
         //Creating the processor and registering the service
         bundleContext.registerService(CarbonMessageProcessor.class, new MessageProcessor(), null);
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/internal/BuiltInNativeConstructLoader.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/internal/BuiltInNativeConstructLoader.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerina.core.runtime.internal;
+
+
+import org.wso2.ballerina.core.exception.BallerinaException;
+import org.wso2.ballerina.core.interpreter.SymScope;
+import org.wso2.ballerina.core.model.Symbol;
+import org.wso2.ballerina.core.model.SymbolName;
+import org.wso2.ballerina.core.model.util.LangModelUtils;
+import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
+import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
+import org.wso2.ballerina.core.nativeimpl.lang.array.DoubleArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.DoubleArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.DoubleArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.FloatArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.FloatArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.FloatArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.IntArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.IntArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.IntArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.JsonArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.JsonArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.JsonArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.LongArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.LongArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.LongArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.MessageArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.MessageArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.MessageArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.StringArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.StringArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.StringArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.array.XmlArrayCopyOf;
+import org.wso2.ballerina.core.nativeimpl.lang.array.XmlArrayLength;
+import org.wso2.ballerina.core.nativeimpl.lang.array.XmlArrayRangeCopy;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddBooleanToArray;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddBooleanToObject;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddDoubleToArray;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddDoubleToObject;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddFloatToArray;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddFloatToObject;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddIntToArray;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddIntToObject;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddJSONToArray;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddJSONToObject;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddStringToArray;
+import org.wso2.ballerina.core.nativeimpl.lang.json.AddStringToObject;
+import org.wso2.ballerina.core.nativeimpl.lang.json.GetBoolean;
+import org.wso2.ballerina.core.nativeimpl.lang.json.GetDouble;
+import org.wso2.ballerina.core.nativeimpl.lang.json.GetFloat;
+import org.wso2.ballerina.core.nativeimpl.lang.json.GetInt;
+import org.wso2.ballerina.core.nativeimpl.lang.json.GetJSON;
+import org.wso2.ballerina.core.nativeimpl.lang.json.GetString;
+import org.wso2.ballerina.core.nativeimpl.lang.json.Remove;
+import org.wso2.ballerina.core.nativeimpl.lang.json.Rename;
+import org.wso2.ballerina.core.nativeimpl.lang.json.SetBoolean;
+import org.wso2.ballerina.core.nativeimpl.lang.json.SetDouble;
+import org.wso2.ballerina.core.nativeimpl.lang.json.SetFloat;
+import org.wso2.ballerina.core.nativeimpl.lang.json.SetInt;
+import org.wso2.ballerina.core.nativeimpl.lang.json.SetJSON;
+import org.wso2.ballerina.core.nativeimpl.lang.json.SetString;
+import org.wso2.ballerina.core.nativeimpl.lang.json.ToString;
+import org.wso2.ballerina.core.nativeimpl.lang.message.AddHeader;
+import org.wso2.ballerina.core.nativeimpl.lang.message.Clone;
+import org.wso2.ballerina.core.nativeimpl.lang.message.GetHeader;
+import org.wso2.ballerina.core.nativeimpl.lang.message.GetHeaders;
+import org.wso2.ballerina.core.nativeimpl.lang.message.GetJsonPayload;
+import org.wso2.ballerina.core.nativeimpl.lang.message.GetStringPayload;
+import org.wso2.ballerina.core.nativeimpl.lang.message.GetXMLPayload;
+import org.wso2.ballerina.core.nativeimpl.lang.message.RemoveHeader;
+import org.wso2.ballerina.core.nativeimpl.lang.message.SetHeader;
+import org.wso2.ballerina.core.nativeimpl.lang.message.SetJsonPayload;
+import org.wso2.ballerina.core.nativeimpl.lang.message.SetStringPayload;
+import org.wso2.ballerina.core.nativeimpl.lang.message.SetXMLPayload;
+import org.wso2.ballerina.core.nativeimpl.lang.string.BooleanValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.Contains;
+import org.wso2.ballerina.core.nativeimpl.lang.string.DoubleValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.EqualsIgnoreCase;
+import org.wso2.ballerina.core.nativeimpl.lang.string.FloatValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.HasPrefix;
+import org.wso2.ballerina.core.nativeimpl.lang.string.HasSuffix;
+import org.wso2.ballerina.core.nativeimpl.lang.string.IndexOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.IntValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.JsonValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.LastIndexOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.Length;
+import org.wso2.ballerina.core.nativeimpl.lang.string.LongValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.Replace;
+import org.wso2.ballerina.core.nativeimpl.lang.string.ReplaceAll;
+import org.wso2.ballerina.core.nativeimpl.lang.string.ReplaceFirst;
+import org.wso2.ballerina.core.nativeimpl.lang.string.StringValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.string.ToLowerCase;
+import org.wso2.ballerina.core.nativeimpl.lang.string.ToUpperCase;
+import org.wso2.ballerina.core.nativeimpl.lang.string.Trim;
+import org.wso2.ballerina.core.nativeimpl.lang.string.Unescape;
+import org.wso2.ballerina.core.nativeimpl.lang.string.XmlValueOf;
+import org.wso2.ballerina.core.nativeimpl.lang.system.CurrentTimeMillis;
+import org.wso2.ballerina.core.nativeimpl.lang.system.EpochTime;
+import org.wso2.ballerina.core.nativeimpl.lang.system.LogBoolean;
+import org.wso2.ballerina.core.nativeimpl.lang.system.LogDouble;
+import org.wso2.ballerina.core.nativeimpl.lang.system.LogFloat;
+import org.wso2.ballerina.core.nativeimpl.lang.system.LogInt;
+import org.wso2.ballerina.core.nativeimpl.lang.system.LogLong;
+import org.wso2.ballerina.core.nativeimpl.lang.system.LogString;
+import org.wso2.ballerina.core.nativeimpl.lang.system.NanoTime;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintBoolean;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintDouble;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintFloat;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintInt;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintlnBoolean;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintlnDouble;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintlnFloat;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintlnInt;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintlnLong;
+import org.wso2.ballerina.core.nativeimpl.lang.system.PrintlnString;
+import org.wso2.ballerina.core.nativeimpl.lang.xml.AddAttribute;
+import org.wso2.ballerina.core.nativeimpl.lang.xml.AddElement;
+import org.wso2.ballerina.core.nativeimpl.lang.xml.GetXML;
+import org.wso2.ballerina.core.nativeimpl.lang.xml.SetXML;
+import org.wso2.ballerina.core.nativeimpl.net.uri.Encode;
+import org.wso2.ballerina.core.nativeimpl.net.uri.GetQueryParam;
+
+
+/**
+ * {@code BuiltInNativeConstructLoader} is responsible for loading built-in native constructs in the ballerina core
+ * itself.
+ * <p>
+ * All the external native constructs are plugged into the core through osgi services.
+ * Making built-in constructs also plugged through osgi increases the boot-up time.
+ * That's the main reason for doing this in this fashion.
+ */
+public class BuiltInNativeConstructLoader {
+
+
+    static void loadConstructs() {
+        loadNativeFunctions();
+    }
+
+    /**
+     * Load native functions to the runtime
+     */
+    private static void loadNativeFunctions() {
+        SymScope scope = GlobalScopeHolder.getInstance().getScope();
+
+        //lang.array
+        registerFunction(scope, new DoubleArrayCopyOf());
+        registerFunction(scope, new DoubleArrayLength());
+        registerFunction(scope, new DoubleArrayRangeCopy());
+        registerFunction(scope, new FloatArrayCopyOf());
+        registerFunction(scope, new FloatArrayLength());
+        registerFunction(scope, new FloatArrayRangeCopy());
+        registerFunction(scope, new IntArrayCopyOf());
+        registerFunction(scope, new IntArrayLength());
+        registerFunction(scope, new IntArrayRangeCopy());
+        registerFunction(scope, new JsonArrayCopyOf());
+        registerFunction(scope, new JsonArrayLength());
+        registerFunction(scope, new JsonArrayRangeCopy());
+        registerFunction(scope, new LongArrayCopyOf());
+        registerFunction(scope, new LongArrayLength());
+        registerFunction(scope, new LongArrayRangeCopy());
+        registerFunction(scope, new MessageArrayCopyOf());
+        registerFunction(scope, new MessageArrayLength());
+        registerFunction(scope, new MessageArrayRangeCopy());
+        registerFunction(scope, new StringArrayCopyOf());
+        registerFunction(scope, new StringArrayLength());
+        registerFunction(scope, new StringArrayRangeCopy());
+        registerFunction(scope, new XmlArrayCopyOf());
+        registerFunction(scope, new XmlArrayLength());
+        registerFunction(scope, new XmlArrayRangeCopy());
+
+        //lang.json
+        registerFunction(scope, new AddBooleanToArray());
+        registerFunction(scope, new AddBooleanToObject());
+        registerFunction(scope, new AddDoubleToArray());
+        registerFunction(scope, new AddDoubleToObject());
+        registerFunction(scope, new AddFloatToArray());
+        registerFunction(scope, new AddFloatToObject());
+        registerFunction(scope, new AddIntToArray());
+        registerFunction(scope, new AddIntToObject());
+        registerFunction(scope, new AddJSONToArray());
+        registerFunction(scope, new AddJSONToObject());
+        registerFunction(scope, new AddStringToArray());
+        registerFunction(scope, new AddStringToObject());
+        registerFunction(scope, new GetBoolean());
+        registerFunction(scope, new GetDouble());
+        registerFunction(scope, new GetFloat());
+        registerFunction(scope, new GetInt());
+        registerFunction(scope, new GetJSON());
+        registerFunction(scope, new GetString());
+        registerFunction(scope, new Remove());
+        registerFunction(scope, new Rename());
+        registerFunction(scope, new SetBoolean());
+        registerFunction(scope, new SetDouble());
+        registerFunction(scope, new SetFloat());
+        registerFunction(scope, new SetInt());
+        registerFunction(scope, new SetJSON());
+        registerFunction(scope, new SetString());
+        registerFunction(scope, new ToString());
+
+        //lang.message
+        registerFunction(scope, new AddHeader());
+        registerFunction(scope, new Clone());
+        registerFunction(scope, new GetHeader());
+        registerFunction(scope, new GetHeaders());
+        registerFunction(scope, new GetJsonPayload());
+        registerFunction(scope, new GetStringPayload());
+        registerFunction(scope, new GetXMLPayload());
+        registerFunction(scope, new RemoveHeader());
+        registerFunction(scope, new SetHeader());
+        registerFunction(scope, new SetJsonPayload());
+        registerFunction(scope, new SetStringPayload());
+        registerFunction(scope, new SetXMLPayload());
+
+        // lang.string
+        registerFunction(scope, new BooleanValueOf());
+        registerFunction(scope, new Contains());
+        registerFunction(scope, new DoubleValueOf());
+        registerFunction(scope, new EqualsIgnoreCase());
+        registerFunction(scope, new FloatValueOf());
+        registerFunction(scope, new HasPrefix());
+        registerFunction(scope, new HasSuffix());
+        registerFunction(scope, new IndexOf());
+        registerFunction(scope, new IntValueOf());
+        registerFunction(scope, new JsonValueOf());
+        registerFunction(scope, new LastIndexOf());
+        registerFunction(scope, new Length());
+        registerFunction(scope, new LongValueOf());
+        registerFunction(scope, new Replace());
+        registerFunction(scope, new ReplaceAll());
+        registerFunction(scope, new ReplaceFirst());
+        registerFunction(scope, new StringValueOf());
+        registerFunction(scope, new ToLowerCase());
+        registerFunction(scope, new ToUpperCase());
+        registerFunction(scope, new Trim());
+        registerFunction(scope, new Unescape());
+        registerFunction(scope, new XmlValueOf());
+
+        // lang.system
+        registerFunction(scope, new CurrentTimeMillis());
+        registerFunction(scope, new EpochTime());
+        registerFunction(scope, new LogBoolean());
+        registerFunction(scope, new LogDouble());
+        registerFunction(scope, new LogFloat());
+        registerFunction(scope, new LogInt());
+        registerFunction(scope, new LogLong());
+        registerFunction(scope, new LogString());
+        registerFunction(scope, new NanoTime());
+        registerFunction(scope, new PrintBoolean());
+        registerFunction(scope, new PrintDouble());
+        registerFunction(scope, new PrintFloat());
+        registerFunction(scope, new PrintInt());
+        registerFunction(scope, new PrintlnBoolean());
+        registerFunction(scope, new PrintlnDouble());
+        registerFunction(scope, new PrintlnFloat());
+        registerFunction(scope, new PrintlnInt());
+        registerFunction(scope, new PrintlnLong());
+        registerFunction(scope, new PrintlnString());
+        registerFunction(scope, new PrintlnLong());
+        registerFunction(scope, new PrintlnString());
+
+        // lang.xml
+        registerFunction(scope, new AddAttribute());
+        registerFunction(scope, new AddElement());
+        registerFunction(scope, new org.wso2.ballerina.core.nativeimpl.lang.xml.GetString());
+        registerFunction(scope, new GetXML());
+        registerFunction(scope, new org.wso2.ballerina.core.nativeimpl.lang.xml.Remove());
+        registerFunction(scope, new org.wso2.ballerina.core.nativeimpl.lang.xml.SetString());
+        registerFunction(scope, new SetXML());
+        registerFunction(scope, new org.wso2.ballerina.core.nativeimpl.lang.xml.ToString());
+
+        // net.uri
+        registerFunction(scope, new Encode());
+        registerFunction(scope, new GetQueryParam());
+
+    }
+
+    /**
+     * Add Native Function instance to given SymScope.
+     *
+     * @param symScope SymScope instance.
+     * @param function Function instance.
+     */
+    private static void registerFunction(SymScope symScope, AbstractNativeFunction function) {
+
+        BallerinaFunction functionNameAnnotation = function.getClass().getAnnotation(BallerinaFunction.class);
+        if (functionNameAnnotation == null) {
+            throw new BallerinaException("BallerinaFunction annotation not found");
+        }
+
+        SymbolName symbolName =
+                LangModelUtils.getSymNameWithParams(function.getPackageName() + ":" +
+                                                    functionNameAnnotation.functionName(), function.getParameters());
+        Symbol symbol = new Symbol(function,
+                                   LangModelUtils.getTypesOfParams(function.getParameters()),
+                                   function.getReturnTypes());
+        symScope.insert(symbolName, symbol);
+    }
+
+}

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/registry/PackageRegistry.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/registry/PackageRegistry.java
@@ -73,7 +73,7 @@ public class PackageRegistry {
         String funcName = function.getName();
         SymbolName symbolName = LangModelUtils.getSymNameWithParams(funcName, function.getParameters());
         Symbol symbol = new Symbol(function, LangModelUtils.getTypesOfParams(function.getParameters()),
-                function.getReturnTypes());
+                                   function.getReturnTypes());
 
         GlobalScopeHolder.getInstance().insert(symbolName, symbol);
 


### PR DESCRIPTION
BuiltInNativeConstructLoader is responsible for loading built-in native constructs in the ballerina core itself (no osgi services involved).
All the external native constructs are plugged into the core through osgi services.
Making built-in constructs also plugged through osgi increases the boot-up time.
That's the main reason for doing this in this fashion.