### PR TITLE
Add support for variable references in backtick xml and json

### DIFF
--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/interpreter/BLangExecutor.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/interpreter/BLangExecutor.java
@@ -32,7 +32,7 @@ import org.wso2.ballerina.core.model.VariableDcl;
 import org.wso2.ballerina.core.model.expressions.ActionInvocationExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayInitExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayMapAccessExpr;
-import org.wso2.ballerina.core.model.expressions.BackquoteExpr;
+import org.wso2.ballerina.core.model.expressions.BacktickExpr;
 import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.BinaryExpression;
 import org.wso2.ballerina.core.model.expressions.Expression;
@@ -69,6 +69,7 @@ import org.wso2.ballerina.core.model.values.BXML;
 import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
 import org.wso2.ballerina.core.nativeimpl.connectors.AbstractNativeAction;
 import org.wso2.ballerina.core.nativeimpl.connectors.AbstractNativeConnector;
+
 
 /**
  * {@code BLangExecutor} executes a Ballerina application
@@ -448,13 +449,14 @@ public class BLangExecutor implements NodeExecutor {
     }
 
     @Override
-    public BValue visit(BackquoteExpr backquoteExpr) {
-
-        if (backquoteExpr.getType() == BTypes.JSON_TYPE) {
-            return new BJSON(backquoteExpr.getTemplateStr());
+    public BValue visit(BacktickExpr backtickExpr) {
+        // Evaluate the variable references before creating objects
+        String evaluatedString = evaluteBacktickString(backtickExpr);
+        if (backtickExpr.getType() == BTypes.JSON_TYPE) {
+            return new BJSON(evaluatedString);
 
         } else {
-            return new BXML(backquoteExpr.getTemplateStr());
+            return new BXML(evaluatedString);
         }
     }
 
@@ -570,5 +572,13 @@ public class BLangExecutor implements NodeExecutor {
         }
 
         return valuesCounter;
+    }
+
+    private String evaluteBacktickString(BacktickExpr backtickExpr) {
+        String varString = "";
+        for (Expression expression : backtickExpr.getExpressionList()) {
+            varString = varString + expression.execute(this).stringValue();
+        }
+        return varString;
     }
 }

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/NodeExecutor.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/NodeExecutor.java
@@ -24,7 +24,7 @@ import org.wso2.ballerina.core.interpreter.ServiceVarLocation;
 import org.wso2.ballerina.core.model.expressions.ActionInvocationExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayInitExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayMapAccessExpr;
-import org.wso2.ballerina.core.model.expressions.BackquoteExpr;
+import org.wso2.ballerina.core.model.expressions.BacktickExpr;
 import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.BinaryExpression;
 import org.wso2.ballerina.core.model.expressions.FunctionInvocationExpr;
@@ -84,7 +84,7 @@ public interface NodeExecutor {
 
     BValue visit(MapInitExpr mapInitExpr);
 
-    BValue visit(BackquoteExpr backquoteExpr);
+    BValue visit(BacktickExpr backtickExpr);
 
     BValue visit(VariableRefExpr variableRefExpr);
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/NodeVisitor.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/NodeVisitor.java
@@ -26,7 +26,7 @@ import org.wso2.ballerina.core.model.expressions.AddExpression;
 import org.wso2.ballerina.core.model.expressions.AndExpression;
 import org.wso2.ballerina.core.model.expressions.ArrayInitExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayMapAccessExpr;
-import org.wso2.ballerina.core.model.expressions.BackquoteExpr;
+import org.wso2.ballerina.core.model.expressions.BacktickExpr;
 import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.DivideExpr;
 import org.wso2.ballerina.core.model.expressions.EqualExpression;
@@ -153,7 +153,7 @@ public interface NodeVisitor {
 
     void visit(KeyValueExpression keyValueExpr);
 
-    void visit(BackquoteExpr backquoteExpr);
+    void visit(BacktickExpr backtickExpr);
 
     void visit(VariableRefExpr variableRefExpr);
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/builder/BLangModelBuilder.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/builder/BLangModelBuilder.java
@@ -40,7 +40,7 @@ import org.wso2.ballerina.core.model.expressions.AddExpression;
 import org.wso2.ballerina.core.model.expressions.AndExpression;
 import org.wso2.ballerina.core.model.expressions.ArrayInitExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayMapAccessExpr;
-import org.wso2.ballerina.core.model.expressions.BackquoteExpr;
+import org.wso2.ballerina.core.model.expressions.BacktickExpr;
 import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.BinaryExpression;
 import org.wso2.ballerina.core.model.expressions.DivideExpr;
@@ -465,12 +465,11 @@ public class BLangModelBuilder {
         exprStack.push(expr);
     }
 
-    public void createBackquoteExpr(String stringContent, Position sourceLocation) {
+    public void createBacktickExpr(String stringContent, Position sourceLocation) {
         String templateStr = getValueWithinBackquote(stringContent);
-
-        BackquoteExpr.BackquoteExprBuilder builder = new BackquoteExpr.BackquoteExprBuilder();
+        BacktickExpr.BacktickExprBuilder builder = new BacktickExpr.BacktickExprBuilder();
         builder.setTemplateStr(templateStr);
-        BackquoteExpr expr = builder.build();
+        BacktickExpr expr = builder.build();
         expr.setLocation(sourceLocation);
         exprStack.push(expr);
     }

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/expressions/BacktickExpr.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/expressions/BacktickExpr.java
@@ -21,21 +21,34 @@ import org.wso2.ballerina.core.model.NodeExecutor;
 import org.wso2.ballerina.core.model.NodeVisitor;
 import org.wso2.ballerina.core.model.values.BValue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * {@code BackquoteExpr} represents an xml or a json string wrapped in between backticks/backquotes
+ * {@code BacktickExpr} represents an xml or a json string wrapped in between backticks/backquotes
  *
  * @since 1.0.0
  */
-public class BackquoteExpr extends AbstractExpression {
+public class BacktickExpr extends AbstractExpression {
 
     private String templateStr;
 
-    private BackquoteExpr(String templateStr) {
+    List<Expression> expressionList = new ArrayList<>();
+
+    private BacktickExpr(String templateStr) {
         this.templateStr = templateStr;
     }
 
     public String getTemplateStr() {
         return templateStr;
+    }
+
+    public List<Expression> getExpressionList() {
+        return expressionList;
+    }
+
+    public void addExpression(Expression expression) {
+        expressionList.add(expression);
     }
 
     @Override
@@ -50,18 +63,18 @@ public class BackquoteExpr extends AbstractExpression {
     /**
      *
      */
-    public static class BackquoteExprBuilder {
+    public static class BacktickExprBuilder {
         private String templateStr;
 
-        public BackquoteExprBuilder() {
+        public BacktickExprBuilder() {
         }
 
         public void setTemplateStr(String templateStr) {
             this.templateStr = templateStr;
         }
 
-        public BackquoteExpr build() {
-            return new BackquoteExpr(this.templateStr);
+        public BacktickExpr build() {
+            return new BacktickExpr(this.templateStr);
         }
     }
 }

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/parser/antlr4/BLangAntlr4Listener.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/parser/antlr4/BLangAntlr4Listener.java
@@ -954,7 +954,7 @@ public class BLangAntlr4Listener implements BallerinaListener {
     @Override
     public void exitBacktickString(BallerinaParser.BacktickStringContext ctx) {
         if (ctx.exception == null) {
-            modelBuilder.createBackquoteExpr(ctx.BacktickStringLiteral().getText(), getCurrentLocation(ctx));
+            modelBuilder.createBacktickExpr(ctx.BacktickStringLiteral().getText(), getCurrentLocation(ctx));
         }
     }
 

--- a/modules/ballerina-core/src/test/java/org/wso2/ballerina/lang/expressions/TemplateExpressionTest.java
+++ b/modules/ballerina-core/src/test/java/org/wso2/ballerina/lang/expressions/TemplateExpressionTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ballerina.lang.expressions;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.ballerina.core.interpreter.SymScope;
+import org.wso2.ballerina.core.model.BallerinaFile;
+import org.wso2.ballerina.core.model.SymbolName;
+import org.wso2.ballerina.core.model.values.BInteger;
+import org.wso2.ballerina.core.model.values.BJSON;
+import org.wso2.ballerina.core.model.values.BString;
+import org.wso2.ballerina.core.model.values.BValue;
+import org.wso2.ballerina.core.model.values.BXML;
+import org.wso2.ballerina.core.runtime.internal.BuiltInNativeConstructLoader;
+import org.wso2.ballerina.core.runtime.internal.GlobalScopeHolder;
+import org.wso2.ballerina.core.utils.ParserUtils;
+import org.wso2.ballerina.lang.util.Functions;
+
+/**
+ * Test class to validate the backtick based inline xml and json definitions
+ */
+public class TemplateExpressionTest {
+    private BallerinaFile bFile;
+    @BeforeClass
+    public void setup() {
+        // Add Native functions.
+        SymScope symScope = GlobalScopeHolder.getInstance().getScope();
+        if (symScope.lookup(new SymbolName("ballerina.lang.system:print_string")) == null) {
+            BuiltInNativeConstructLoader.loadConstructs();
+        }
+        bFile = ParserUtils.parseBalFile("lang/expressions/template-expr.bal", symScope);
+    }
+
+    @Test(description = "Test XML backtick expression definition")
+    public void testBacktickXMLExpr() {
+        BValue[] args = { new BString("WSO2")};
+        BValue[] returns = Functions.invoke(bFile, "backtickXMLTest", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BXML.class);
+        String expected = "<name>John</name>";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test JSON backtick expression definition")
+    public void testBacktickJSONExpr() {
+        BValue[] args = { new BString("WSO2")};
+        BValue[] returns = Functions.invoke(bFile, "backtickJSONTest", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        String expected = "{\"name\":\"John\"}";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test JSON backtick expression with string variable reference")
+    public void testBacktickJSONVariableAccessExpr() {
+        BValue[] args = { new BString("WSO2")};
+        BValue[] returns = Functions.invoke(bFile, "backtickStringVariableAccessJSON", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        String expected = "{\"name\":\"WSO2\"}";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test XML backtick expression with variable reference")
+    public void testBacktickXMLVariableAccessExpr() {
+        BValue[] args = { new BString("WSO2")};
+        BValue[] returns = Functions.invoke(bFile, "backtickVariableAccessXML", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BXML.class);
+        String expected = "<name>WSO2</name>";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test JSON backtick expression with integer variable reference")
+    public void testBacktickJSONIntegerVariableAccessExpr() {
+        BValue[] args = { new BInteger(11)};
+        BValue[] returns = Functions.invoke(bFile, "backtickIntegerVariableAccessJSON", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        String expected = "{\"age\":11}";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test JSON backtick expression with embedding full JSON")
+    public void testBacktickJSONFullReplacement() {
+        BValue[] args = { new BInteger(11)};
+        BValue[] returns = Functions.invoke(bFile, "backticJSONEnrichFullJSON", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        String expected =  "{\"name\":\"John\"}";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test JSON backtick expression with multiple variables embedding full JSON")
+    public void testBacktickMultipleVariablesFullJSONReplacement() {
+        BValue[] args = { new BString("Chanaka"), new BString("Fernando")};
+        BValue[] returns = Functions.invoke(bFile, "backticJSONMultipleVariables", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        String expected =  "{\"name\":{\"first_name\":\"Chanaka\",\"last_name\":\"Fernando\"}}";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @Test(description = "Test JSON backtick expression with parts of json added into full JSON")
+    public void testBacktickPartsJSON() {
+        BValue[] args = { new BString("{\"name\":"), new BString("\"chanaka\"}")};
+        BValue[] returns = Functions.invoke(bFile, "backticJSONParts", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        String expected =  "{\"name\":\"chanaka\"}";
+        Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+}

--- a/modules/ballerina-core/src/test/resources/lang/expressions/template-expr.bal
+++ b/modules/ballerina-core/src/test/resources/lang/expressions/template-expr.bal
@@ -1,0 +1,55 @@
+import ballerina.lang.xml;
+import ballerina.lang.json;
+
+function backtickXMLTest (string name)(xml) {
+    xml msg;
+    msg = `<name>John</name>`;
+    return msg;
+}
+
+function backtickJSONTest (string name)(json) {
+    json msg;
+    msg = `{"name":"John"}`;
+    return msg;
+}
+
+function backtickVariableAccessXML(string variable) (xml) {
+    xml backTickMessage;
+    backTickMessage = `<name>${variable}</name>`;
+    return backTickMessage;
+}
+
+
+function backtickStringVariableAccessJSON(string variable) (json) {
+    json backTickMessage;
+    backTickMessage = `{"name":${variable}}`;
+    return backTickMessage;
+}
+
+function backtickIntegerVariableAccessJSON(int variable) (json) {
+    json backTickMessage;
+    backTickMessage = `{"age":${variable}}`;
+    return backTickMessage;
+}
+
+function backticJSONEnrichFullJSON(int variable) (json) {
+    json msg;
+    json backTickMessage;
+    msg = `{"name":"John"}`;
+    backTickMessage = `${msg}`;
+    return backTickMessage;
+}
+
+function backticJSONMultipleVariables(string fname, string lname) (json) {
+    json msg;
+    json backTickMessage;
+    msg = `{"name":{"first_name":${fname}, "last_name":${lname}}}`;
+    backTickMessage = `${msg}`;
+    return backTickMessage;
+}
+
+function backticJSONParts(string firstSection, string secondSection) (json) {
+    json backTickMessage;
+    backTickMessage = `${firstSection}${secondSection}`;
+    return backTickMessage;
+}

--- a/modules/editor/services/workspace-service/src/main/java/org/wso2/ballerina/tooling/service/workspace/rest/datamodel/BLangExpressionModelBuilder.java
+++ b/modules/editor/services/workspace-service/src/main/java/org/wso2/ballerina/tooling/service/workspace/rest/datamodel/BLangExpressionModelBuilder.java
@@ -41,7 +41,7 @@ import org.wso2.ballerina.core.model.expressions.AddExpression;
 import org.wso2.ballerina.core.model.expressions.AndExpression;
 import org.wso2.ballerina.core.model.expressions.ArrayInitExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayMapAccessExpr;
-import org.wso2.ballerina.core.model.expressions.BackquoteExpr;
+import org.wso2.ballerina.core.model.expressions.BacktickExpr;
 import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.DivideExpr;
 import org.wso2.ballerina.core.model.expressions.EqualExpression;
@@ -522,10 +522,10 @@ public class BLangExpressionModelBuilder implements NodeVisitor {
     }
 
     @Override
-    public void visit(BackquoteExpr backquoteExpr) {
+    public void visit(BacktickExpr backtickExpr) {
         StringBuffer buffer = new StringBuffer();
         bufferStack.push(buffer);
-        buffer.append("'"+backquoteExpr.getTemplateStr()+"'").append(";");
+        buffer.append("'"+ backtickExpr.getTemplateStr()+"'").append(";");
     }
 
     @Override

--- a/modules/editor/services/workspace-service/src/main/java/org/wso2/ballerina/tooling/service/workspace/rest/datamodel/BLangJSONModelBuilder.java
+++ b/modules/editor/services/workspace-service/src/main/java/org/wso2/ballerina/tooling/service/workspace/rest/datamodel/BLangJSONModelBuilder.java
@@ -45,7 +45,7 @@ import org.wso2.ballerina.core.model.expressions.AddExpression;
 import org.wso2.ballerina.core.model.expressions.AndExpression;
 import org.wso2.ballerina.core.model.expressions.ArrayInitExpr;
 import org.wso2.ballerina.core.model.expressions.ArrayMapAccessExpr;
-import org.wso2.ballerina.core.model.expressions.BackquoteExpr;
+import org.wso2.ballerina.core.model.expressions.BacktickExpr;
 import org.wso2.ballerina.core.model.expressions.BasicLiteral;
 import org.wso2.ballerina.core.model.expressions.DivideExpr;
 import org.wso2.ballerina.core.model.expressions.EqualExpression;
@@ -821,12 +821,12 @@ public class BLangJSONModelBuilder implements NodeVisitor {
     }
 
     @Override
-    public void visit(BackquoteExpr backquoteExpr) {
+    public void visit(BacktickExpr backtickExpr) {
         JsonObject backquoteExprObj = new JsonObject();
         backquoteExprObj.addProperty(BLangJSONModelConstants.EXPRESSION_TYPE,
                 BLangJSONModelConstants.BACK_QUOTE_EXPRESSION);
         backquoteExprObj.addProperty(BLangJSONModelConstants.BACK_QUOTE_ENCLOSED_STRING,
-                backquoteExpr.getTemplateStr());
+                backtickExpr.getTemplateStr());
         tempJsonArrayRef.peek().add(backquoteExprObj);
     }
 


### PR DESCRIPTION
This will add the support for accessing variables within backtick (backquote) based xml and json message declarations. Here are few examples.
```
function backtickVariableAccessXML(string variable) (xml) {
    xml backTickMessage;
    backTickMessage = `<name>${variable}</name>`;
    return backTickMessage;
}


function backtickVariableAccessJSON(string variable) (json) {
    json backTickMessage;
    backTickMessage = `{"name":${variable}}`;
    return backTickMessage;
}
```