### PR TITLE
Remove name option, add What did it do? section

### DIFF
--- a/samples/getting_started/helloWorldService/README.txt
+++ b/samples/getting_started/helloWorldService/README.txt
@@ -17,4 +17,4 @@ curl -v http://localhost:9090/hello
 
 What did it do?
 ===============
-When you ran the sample, you started the Ballerina server and deployed the helloWorld service. We sent a curl request that specified the Ballerina server host and port followed by the base path ("/hello") for the helloWorld service, thereby invoking that service. The helloWold service received the curl request, created a response message, and sent it back to the client that invoked the service: your terminal. 
+When you ran the sample, you started the Ballerina server and deployed the helloWorld service. You sent a curl request that specified the Ballerina server host and port followed by the base path ("/hello") for the helloWorld service, thereby invoking that service. The helloWold service received the curl request, created a response message, and sent it back to the client that invoked the service: your terminal. 


### PR DESCRIPTION
Since we simplified the sample, passing in the name does nothing, so remove the info on the optional name param. Add a section at the end that walks through what the sample just did.