### PR TITLE
Fix #915 Ballerina message:getStringPayload hangs on no message

### DIFF
--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/values/BMessage.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/model/values/BMessage.java
@@ -44,6 +44,8 @@ public final class BMessage implements BRefType<CarbonMessage> {
      */
     public BMessage() {
         this(new DefaultCarbonMessage());
+        this.builtPayload = new BString("");
+        setAlreadyRead(true);
     }
 
     /**

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/connectors/http/client/AbstractHTTPAction.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/connectors/http/client/AbstractHTTPAction.java
@@ -102,8 +102,8 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
                             .set(Constants.HTTP_CONTENT_LENGTH, String.valueOf(message.getFullMessageLength()));
 
                 } else {
-                    String errMsg = "Message is already built but cannot find the MessageDataSource";
-                    throw new BallerinaException("FATAL: Internal error.! " + errMsg, context);
+                    message.setEndOfMsgAdded(true);
+                    logger.debug("Sending an empty message");
                 }
             }
             ServiceContextHolder.getInstance().getSender().send(message, balConnectorCallback);

--- a/modules/ballerina-core/src/test/java/org/wso2/ballerina/core/nativeimpl/functions/MessageTest.java
+++ b/modules/ballerina-core/src/test/java/org/wso2/ballerina/core/nativeimpl/functions/MessageTest.java
@@ -140,6 +140,14 @@ public class MessageTest {
     }
 
     @Test
+    public void testEmptyString() {
+        BValue[] returns = Functions.invoke(bFile, "testEmptyString");
+        Assert.assertEquals(returns.length, 1);
+        String returnString = returns[0].stringValue();
+        Assert.assertEquals(returnString, "");
+    }
+
+    @Test
     public void testClone() {
         /*final String payload1 = "Hello World...!!! I am the Original Copy.";
         final String payload2 = "Hello World...!!! I am the Cloned Copy.";

--- a/modules/ballerina-core/src/test/resources/samples/nativeimpl/messageTest.bal
+++ b/modules/ballerina-core/src/test/resources/samples/nativeimpl/messageTest.bal
@@ -26,6 +26,14 @@ function testGetStringPayload(message msg) (message){
     return msg;
 }
 
+function testEmptyString() (string){
+    message msg;
+    string strPayload;
+
+    strPayload = ballerina.lang.message:getStringPayload(msg);
+    return strPayload;
+}
+
 function testClone(message msg, string payload2) (int) {
     message clone;
     string v1;


### PR DESCRIPTION
Fixed by adding an empty string payload to the BMessage when initiating only with in the Ballerina. i.e this fix will not change the behavior of initiating a BMessage for an incoming message from transport. 
Also if a new string, json or xml payload is added within ballerina the empty string will get overwritten.