### PR TITLE
Fix message drawing issue

### DIFF
--- a/modules/editor/web/js/ballerina/views/message-manager.js
+++ b/modules/editor/web/js/ballerina/views/message-manager.js
@@ -15,7 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-define(['log', 'lodash','d3','./point', 'backbone','event_channel'], function (log, _, d3,Point, Backbone, EventChannel) {
+define(['log', 'lodash','d3','./point', 'backbone','event_channel', 'ballerina/ast/ballerina-ast-factory'],
+    function (log, _, d3,Point, Backbone, EventChannel, BallerinaASTFactory) {
 
     var MessageManager = function(args) {
         log.debug("Initialising Message Manager");
@@ -108,7 +109,7 @@ define(['log', 'lodash','d3','./point', 'backbone','event_channel'], function (l
     };
 
     MessageManager.prototype.isAtValidDropTarget = function(){
-        return true;
+        return BallerinaASTFactory.isConnectorDeclaration(this.getActivatedDropTarget());
     };
 
     MessageManager.prototype.reset = function(){


### PR DESCRIPTION
This PR fixes the following issue,
When stop drawing a message from a connector action and if we stop drawing on an invalid drop target, an error was thrown. With this fix we validate whether the drop target is a connector declaration. Otherwise we won't draw the message