### PR TITLE
Use 'showWelcomePage' method from 'workspace' instead of 'displayInitialTab' to display initial welcome

### DIFF
--- a/modules/editor/web/js/main.js
+++ b/modules/editor/web/js/main.js
@@ -107,7 +107,7 @@ define(['require', 'log', 'jquery', 'lodash', 'backbone', 'app/menu-bar/menu-bar
         },
 
         displayInitialView: function () {
-            this.workspaceManager.displayInitialTab();
+            this.workspaceManager.showWelcomePage(this.workspaceManager);
         },
 
         hideWorkspaceArea: function(){


### PR DESCRIPTION
Use 'showWelcomePage' method from 'workspace' instead of 'displayInitialTab' to display initial welcome.

showWelcomePage checks if a welcome page is already rendered so it avoids rendering it twice in edge cases like in #981. Fixes #981.