### PR TITLE
Fix #1208 support string arguments with spaces

### DIFF
--- a/modules/distribution/ballerina-home/bin/ballerina
+++ b/modules/distribution/ballerina-home/bin/ballerina
@@ -205,4 +205,4 @@ $JAVACMD \
 	-Djava.io.tmpdir="$BALLERINA_HOME/tmp" \
 	-Djava.security.egd=file:/dev/./urandom \
 	-Dfile.encoding=UTF8 \
-	org.ballerinalang.launcher.Main $*
+	org.ballerinalang.launcher.Main "$@"


### PR DESCRIPTION
Windows already supports string arguments with spaces 
http://unix.stackexchange.com/a/41595