### PR TITLE
Fix dynamic connector name update issue

### DIFF
--- a/modules/editor/web/js/ballerina/visitors/source-gen/action-invocation-expression-visitor.js
+++ b/modules/editor/web/js/ballerina/visitors/source-gen/action-invocation-expression-visitor.js
@@ -31,8 +31,10 @@ define(['require','lodash', 'log', 'event_channel', './abstract-statement-source
 
         ActionInvocationStatementVisitor.prototype.beginVisitActionInvocationStatement = function(action){
             var self = action;
+            var connectorVariable = !_.isNil(self.getConnector()) ?
+                self.getConnector().getConnectorVariable() : "untitledEndpoint";
             this.appendSource(self.getActionPackageName() + ':' + self.getActionConnectorName() + '.' + self.getActionName() +
-                '(' + self.getConnectorVariableReference() + ',' + self.getPath() + ',' + self.getMessageVariableReference() + ')');
+                '(' + connectorVariable + ',' + self.getPath() + ',' + self.getMessageVariableReference() + ')');
             log.debug('Begin Visit action invocation expression');
         };
 


### PR DESCRIPTION
This PR fixes the following:

Add a connector, then an action invocation and connect the action invocation to the connector. Now update the connector name and if you go to the source, changes will not be effected in the action invocation expression