### PR TITLE
In import add button click event use the current model instead of a cached one

### DIFF
--- a/modules/editor/web/js/ballerina/views/ballerina-file-editor.js
+++ b/modules/editor/web/js/ballerina/views/ballerina-file-editor.js
@@ -456,8 +456,7 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
          * @private
          */
         BallerinaFileEditor.prototype._createPackagePropertyPane = function (canvasContainer) {
-            var currentASTRoot = this._model;
-
+            var self = this;
             var topRightControlsContainer = $(canvasContainer).siblings(".top-right-controls-container");
             var propertyPane = topRightControlsContainer.children(".top-right-controls-container-editor-pane");
 
@@ -492,6 +491,7 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
                 $(addImportButton).click(function () {
                     // TODO : Validate new import package name.
                     if (importPackageTextBox.val() != "") {
+                        var currentASTRoot = self.getModel();
                         log.debug("Adding new import");
 
                         // Creating new import.
@@ -520,7 +520,7 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
                 var importsWrapper = propertyPane.find(".imports-wrapper");
 
                 // Adding current imports to view.
-                addImportsToView(currentASTRoot, importsWrapper);
+                addImportsToView(self.getModel(), importsWrapper);
 
                 // When clicked outside of the property pane.
                 $(window).click(function () {


### PR DESCRIPTION
After redrawing `this._model` is set to a new instance. Need to use that new instance for source gen.

Fixes #1047