### PR TITLE
Upgrade netty version to 4.1.7 to suppot HTTP/2 transport

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -140,6 +140,14 @@
             <artifactId>netty-codec-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-pool.wso2</groupId>
             <artifactId>commons-pool</artifactId>
         </dependency>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -122,6 +122,8 @@
                 <include>io.netty:netty-handler</include>
                 <include>io.netty:netty-codec</include>
                 <include>io.netty:netty-codec-http</include>
+                <include>io.netty:netty-codec-http2</include>
+                <include>io.netty:netty-resolver</include>
                 <include>commons-pool.wso2:commons-pool</include>
                 <include>org.wso2.orbit.org.yaml:snakeyaml</include>
                 <include>commons-logging:commons-logging</include>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,16 @@
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-pool.wso2</groupId>
                 <artifactId>commons-pool</artifactId>
                 <version>${commons.pool.version}</version>
@@ -455,7 +465,7 @@
         <mockito.version>1.9.0</mockito.version>
 
         <!-- netty version -->
-        <netty.version>4.0.30.Final</netty.version>
+        <netty.version>4.1.7.Final</netty.version>
 
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
         <org.snakeyaml.version>1.16.0.wso2v1</org.snakeyaml.version>


### PR DESCRIPTION
HTTP/2
HTTP/2 is introduced to address some drawbacks of HTTP/1 versions with features of Binary information exchange, compressed headers,multiplexing, Server Push .

This pull request will upgrade netty version to 4.1.7 to support HTTP/2 transport
