### PR TITLE
Remove carbon kernel dependency in ballerina distribution

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -156,10 +156,6 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -129,7 +129,6 @@
                 <include>commons-logging:commons-logging</include>
                 <include>org.wso2.staxon:staxon-core</include>
                 <include>org.apache.commons:commons-lang3</include>
-                <include>org.wso2.carbon:org.wso2.carbon.core:jar</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
         <carbon.transport.version>4.2.0-SNAPSHOT</carbon.transport.version>
         <carbon.transport.package.import.version.range>[4.0.0, 5.0.0)</carbon.transport.package.import.version.range>
 
-        <carbon.messaging.version>2.2.0-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>2.2.0</carbon.messaging.version>
         <carbon.messaging.package.import.version.range>[2.0.0, 3.0.0)</carbon.messaging.package.import.version.range>
 
         <carbon.deployment.version>5.0.0</carbon.deployment.version>


### PR DESCRIPTION
Carbon kernel dependency is no longer needed in ballerina distribution.
Also update carbon messaging version to released 2.2.0