### PR TITLE
Add kernel dependency to ballerina distribution

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -160,6 +160,10 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.staxon</groupId>
             <artifactId>staxon-core</artifactId>
         </dependency>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -129,6 +129,7 @@
                 <include>commons-logging:commons-logging</include>
                 <include>org.wso2.staxon:staxon-core</include>
                 <include>org.apache.commons:commons-lang3</include>
+                <include>org.wso2.carbon:org.wso2.carbon.core:jar</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
Adding back the kernel dependency as there are some other references from native connectors to carbon-transport that still use some Util classes coming from kernel which is causing CNF.

HTTPClientInitializer uses kernel Util class which needs to be there in classpath.