### PR TITLE
Remove built message handling in http client connector

### DIFF
--- a/modules/ballerina-native/src/main/java/org/wso2/ballerina/nativeimpl/connectors/http/AbstractHTTPAction.java
+++ b/modules/ballerina-native/src/main/java/org/wso2/ballerina/nativeimpl/connectors/http/AbstractHTTPAction.java
@@ -31,7 +31,6 @@ import org.wso2.ballerina.core.nativeimpl.connectors.BallerinaConnectorManager;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.DefaultCarbonMessage;
 import org.wso2.carbon.messaging.Headers;
-import org.wso2.carbon.messaging.MessageDataSource;
 import org.wso2.carbon.messaging.exceptions.ClientConnectorException;
 
 import java.net.MalformedURLException;
@@ -118,21 +117,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
 
         try {
             BalConnectorCallback balConnectorCallback = new BalConnectorCallback(context);
-            // Handle the message built scenario
-            if (message.isAlreadyRead()) {
-                MessageDataSource messageDataSource = message.getMessageDataSource();
-                if (messageDataSource != null) {
-                    messageDataSource.serializeData();
-                    message.setEndOfMsgAdded(true);
-                    message.getHeaders().remove(Constants.HTTP_CONTENT_LENGTH);
-                    message.getHeaders()
-                            .set(Constants.HTTP_CONTENT_LENGTH, String.valueOf(message.getFullMessageLength()));
 
-                } else {
-                    message.setEndOfMsgAdded(true);
-                    logger.debug("Sending an empty message");
-                }
-            }
             org.wso2.carbon.messaging.ClientConnector clientConnector = BallerinaConnectorManager.getInstance().
                     getClientConnector(Constants.PROTOCOL_HTTP);
 


### PR DESCRIPTION
This requires following commit in carbon-transports.

https://github.com/wso2/carbon-transports/commit/d0ffdefd70299a94099a24e89a9118bf347a1883 
Merge has to be done with a future carbon transports release.