### PR TITLE
Fix #1884 Support for blocking connectors in non-blocking execution.

### DIFF
--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/exception/BallerinaException.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/exception/BallerinaException.java
@@ -47,7 +47,9 @@ public class BallerinaException extends RuntimeException {
     }
 
     /**
-     * @param bException
+     * Create BallerinaException from bException.
+     *
+     * @param bException Ballerina Exception.
      */
     public BallerinaException(BException bException) {
         this.exception = bException;

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/interpreter/nonblocking/BLangAbstractExecutionVisitor.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/interpreter/nonblocking/BLangAbstractExecutionVisitor.java
@@ -165,6 +165,7 @@ public abstract class BLangAbstractExecutionVisitor extends BLangExecutionVisito
     protected LinkedNode next;
     private ExecutorService executor;
     private ForkJoinInvocationStatus forkJoinInvocationStatus;
+    private boolean completed;
 
     public BLangAbstractExecutionVisitor(RuntimeEnvironment runtimeEnv, Context bContext) {
         this.runtimeEnv = runtimeEnv;
@@ -626,6 +627,7 @@ public abstract class BLangAbstractExecutionVisitor extends BLangExecutionVisito
         if (logger.isDebugEnabled()) {
             logger.debug("Executing EndNode");
         }
+        completed = true;
         next = null;
     }
 
@@ -634,6 +636,7 @@ public abstract class BLangAbstractExecutionVisitor extends BLangExecutionVisito
         if (logger.isDebugEnabled()) {
             logger.debug("Executing ExitNode");
         }
+        completed = true;
         next = null;
         Runtime.getRuntime().exit(0);
     }
@@ -1307,9 +1310,20 @@ public abstract class BLangAbstractExecutionVisitor extends BLangExecutionVisito
         if (logger.isDebugEnabled()) {
             logger.debug("Executing Native Action - " + invokeNativeActionNode.getCallableUnit().getName());
         }
-        BalConnectorCallback connectorCallback = new BalConnectorCallback(bContext, invokeNativeActionNode);
-        invokeNativeActionNode.getCallableUnit().execute(bContext, connectorCallback);
-        next = null;
+        try {
+            if (invokeNativeActionNode.getCallableUnit().isNonBlockingAction()) {
+                BalConnectorCallback connectorCallback = new BalConnectorCallback(bContext, invokeNativeActionNode);
+                invokeNativeActionNode.getCallableUnit().execute(bContext, connectorCallback);
+                // Release current thread.
+                next = null;
+            } else {
+                invokeNativeActionNode.getCallableUnit().execute(bContext);
+                next = invokeNativeActionNode.next;
+            }
+        } catch (RuntimeException e) {
+            BException bException = new BException(e.getMessage());
+            handleBException(bException);
+        }
     }
 
     @Override
@@ -1700,5 +1714,14 @@ public abstract class BLangAbstractExecutionVisitor extends BLangExecutionVisito
 
     private String getNodeLocation(NodeLocation nodeLocation) {
         return nodeLocation != null ? nodeLocation.getFileName() + ":" + nodeLocation.getLineNumber() : "";
+    }
+
+    /**
+     * Indicate whether execution is completed or not.
+     *
+     * @return true, if execution is completed.
+     */
+    public boolean isExecutionCompleted() {
+        return completed;
     }
 }

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/connectors/AbstractNativeAction.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/connectors/AbstractNativeAction.java
@@ -93,14 +93,28 @@ public abstract class AbstractNativeAction implements NativeUnit, Action {
      * @param context           Ballerina context.
      * @param connectorCallback Callback instance to notify completion of the action invocation.
      */
-    public abstract void execute(Context context, BalConnectorCallback connectorCallback);
+    public void execute(Context context, BalConnectorCallback connectorCallback) {
+        throw new BallerinaException("not implemented native action");
+    }
 
     /**
      * Validate Native Action invocation. This method will be invoked when callback.done().
      *
      * @param connectorCallback Connector Callback instance.
      */
-    public abstract void validate(BalConnectorCallback connectorCallback);
+    public void validate(BalConnectorCallback connectorCallback) {
+    }
+
+    /**
+     * Declare implementation of Native action is support non-blocking behaviour.
+     *
+     * Default is false, Override to support non-blocking behaviour.
+     *
+     * @return true, if current is implementation supports non-blocking.
+     */
+    public boolean isNonBlockingAction() {
+        return false;
+    }
 
     // Methods in CallableUnit interface
 

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/connectors/BalConnectorCallback.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/nativeimpl/connectors/BalConnectorCallback.java
@@ -63,10 +63,10 @@ public class BalConnectorCallback extends DefaultBalCallback {
         //context.getControlStack().setValue(4, valueRef);
         context.getControlStack().setReturnValue(0, valueRef);
         responseArrived = true;
-        // If Executor is not null, then this is non-blocking execution.
-        if (actionNode != null) {
+        if (isNonBlockingExecutor()) {
             actionNode.getCallableUnit().validate(this);
         } else {
+            // Release Thread.
             synchronized (context) {
                 context.notifyAll();
             }
@@ -79,5 +79,10 @@ public class BalConnectorCallback extends DefaultBalCallback {
 
     public LinkedNode getCurrentNode() {
         return this.actionNode;
+    }
+
+    public boolean isNonBlockingExecutor() {
+        // If actionNode is not null, then this is non-blocking execution.
+        return actionNode != null;
     }
 }

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/MessageProcessor.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/MessageProcessor.java
@@ -20,7 +20,7 @@ package org.wso2.ballerina.core.runtime;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.ballerina.core.interpreter.nonblocking.ModeResolver;
+import org.wso2.ballerina.core.nativeimpl.connectors.BalConnectorCallback;
 import org.wso2.ballerina.core.runtime.threadpool.RequestWorkerThread;
 import org.wso2.ballerina.core.runtime.threadpool.ResponseWorkerThread;
 import org.wso2.ballerina.core.runtime.threadpool.ThreadPoolFactory;
@@ -47,8 +47,9 @@ public class MessageProcessor implements CarbonMessageProcessor {
             }
             ThreadPoolFactory.getInstance().getExecutor().execute(new RequestWorkerThread(cMsg, carbonCallback));
         } else {
-            // For Response
-            if (ModeResolver.getInstance().isNonblockingEnabled()) {
+            // For Non-Blocking Response path, BalConnectorCallback must be used.
+            if (((BalConnectorCallback) carbonCallback).isNonBlockingExecutor()) {
+                // Start Non-Blocking Execution.
                 ThreadPoolFactory.getInstance().getExecutor().execute(new ResponseWorkerThread(cMsg, carbonCallback));
             } else {
                 ServerConnectorMessageHandler.handleOutbound(cMsg, carbonCallback);

--- a/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/wso2/ballerina/core/runtime/ServerConnectorMessageHandler.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.wso2.ballerina.core.exception.BallerinaException;
 import org.wso2.ballerina.core.interpreter.Context;
 import org.wso2.ballerina.core.interpreter.nonblocking.BLangExecutionVisitor;
-import org.wso2.ballerina.core.interpreter.nonblocking.ModeResolver;
 import org.wso2.ballerina.core.model.Resource;
 import org.wso2.ballerina.core.model.Service;
 import org.wso2.ballerina.core.nativeimpl.connectors.BalConnectorCallback;
@@ -108,7 +107,7 @@ public class ServerConnectorMessageHandler {
         BalConnectorCallback connectorCallback = (BalConnectorCallback) callback;
         try {
             callback.done(cMsg);
-            if (ModeResolver.getInstance().isNonblockingEnabled()) {
+            if (connectorCallback.isNonBlockingExecutor()) {
                 // Continue Non-Blocking
                 BLangExecutionVisitor executor = connectorCallback.getContext().getExecutor();
                 executor.continueExecution(connectorCallback.getCurrentNode().next());

--- a/modules/ballerina-native/src/main/java/org/wso2/ballerina/nativeimpl/connectors/http/AbstractHTTPAction.java
+++ b/modules/ballerina-native/src/main/java/org/wso2/ballerina/nativeimpl/connectors/http/AbstractHTTPAction.java
@@ -130,6 +130,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
 
             clientConnector.send(message, balConnectorCallback);
 
+            // Wait till Response comes.
             while (!balConnectorCallback.isResponseArrived()) {
                 synchronized (context) {
                     if (!balConnectorCallback.isResponseArrived()) {
@@ -165,6 +166,11 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
     @Override
     public void validate(BalConnectorCallback callback) {
         handleTransportException(callback.getValueRef(), callback.getContext());
+    }
+
+    @Override
+    public boolean isNonBlockingAction() {
+        return true;
     }
 
     private void handleTransportException(BValue valueRef) {


### PR DESCRIPTION
Since most of the native actions require blocking execution, Hence this PR will simplify the implementation of blocking native actions. 

Native actions which require non-blocking behavior, have to override following methods. 

- void execute(Context context, BalConnectorCallback connectorCallback)
  - Implement non-blocking execution logic for non-blocking executor. 
- void validate(BalConnectorCallback connectorCallback) 
  - Implement validation logic, that needs to be invoked after receiving the message. 
- boolean isNonBlockingAction()
  - Implement this method to return true, to make native action non-blocking.  
