### PR TITLE
Fixing jar copying problem in integration test

### DIFF
--- a/modules/tests/test-integration/pom.xml
+++ b/modules/tests/test-integration/pom.xml
@@ -97,24 +97,6 @@
                                     <version>${activemq.broker.vesion}</version>
                                     <outputDirectory>${basedir}/target/</outputDirectory>
                                 </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <!-- Copying the activemq-all jar to the target directory, to copy it to the server distribution -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
                                 <artifactItem>
                                     <groupId>commons-net</groupId>
                                     <artifactId>commons-net</artifactId>


### PR DESCRIPTION
Due to the duplication of same plugin, the relevant activemq jar will not be copied to target directory of test-integration, which is needed for jms samples. This PR solves this issue.