### PR TITLE
Improve LS Code Suggestion Performance

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCache.java
@@ -34,7 +34,7 @@ public class PackageCache {
     private static final CompilerContext.Key<PackageCache> PACKAGE_CACHE_KEY =
             new CompilerContext.Key<>();
 
-    private Map<String, BLangPackage> packageMap;
+    protected Map<String, BLangPackage> packageMap;
 
     public static PackageCache getInstance(CompilerContext context) {
         PackageCache packageCache = context.get(PACKAGE_CACHE_KEY);
@@ -44,7 +44,11 @@ public class PackageCache {
         return packageCache;
     }
 
-    private PackageCache(CompilerContext context) {
+    public static void setInstance(PackageCache packageCache, CompilerContext context) {
+        context.put(PACKAGE_CACHE_KEY, packageCache);
+    }
+
+    protected PackageCache(CompilerContext context) {
         context.put(PACKAGE_CACHE_KEY, this);
         this.packageMap = new HashMap<>();
     }
@@ -58,7 +62,9 @@ public class PackageCache {
     }
 
     public void put(PackageID packageID, BLangPackage bLangPackage) {
-        bLangPackage.packageID = packageID;
+        if (bLangPackage != null) {
+            bLangPackage.packageID = packageID;
+        }
         packageMap.put(packageID.bvmAlias(), bLangPackage);
     }
 }

--- a/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/ParserUtils.java
+++ b/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/ParserUtils.java
@@ -890,8 +890,14 @@ public class ParserUtils {
         sourceDocument.setSourceRoot(sourceRoot);
 
         PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, documentManager);
-        CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(packageRepository, sourceDocument,
-                true, documentManager, CompilerPhase.DEFINE);
+        if ("".equals(pkgName)) {
+            Path filePath = path.getFileName();
+            if (filePath != null) {
+                pkgName = filePath.toString();
+            }
+        }
+        CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(pkgName, packageRepository,
+                                         sourceDocument, true, documentManager, CompilerPhase.DEFINE);
 
         List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics = new ArrayList<>();
         CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
@@ -900,14 +906,7 @@ public class ParserUtils {
         BLangPackage bLangPackage = null;
         try {
             Compiler compiler = Compiler.getInstance(context);
-            if ("".equals(pkgName)) {
-                Path filePath = path.getFileName();
-                if (filePath != null) {
-                    bLangPackage = compiler.compile(filePath.toString());
-                }
-            } else {
-                bLangPackage = compiler.compile(pkgName);
-            }
+            bLangPackage = compiler.compile(pkgName);
         } catch (Exception e) {
             // Ignore.
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -46,11 +46,10 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
 
     public BallerinaLanguageServer() {
         LSGlobalContext lsGlobalContext = new LSGlobalContext();
-        LSPackageCache packageCache = new LSPackageCache();
-        LSAnnotationCache annotationCache = new LSAnnotationCache(packageCache);
+        LSPackageCache lsPackageCache = LSPackageCache.getInstance();
+        LSAnnotationCache annotationCache = new LSAnnotationCache(lsPackageCache);
         
         lsGlobalContext.put(LSGlobalContextKeys.LANGUAGE_SERVER_KEY, this);
-        lsGlobalContext.put(LSGlobalContextKeys.PKG_CACHE_KEY, packageCache);
         lsGlobalContext.put(LSGlobalContextKeys.ANNOTATION_CACHE_KEY, annotationCache);
         lsGlobalContext.put(LSGlobalContextKeys.DOCUMENT_MANAGER_KEY, WorkspaceDocumentManagerImpl.getInstance());
         

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -99,14 +99,12 @@ class BallerinaTextDocumentService implements TextDocumentService {
     private final BallerinaLanguageServer ballerinaLanguageServer;
     private final WorkspaceDocumentManager documentManager;
     private Map<String, List<Diagnostic>> lastDiagnosticMap;
-    private LSPackageCache lSPackageCache;
 
     private final Debouncer diagPushDebouncer;
 
     BallerinaTextDocumentService(LSGlobalContext lsGlobalContext) {
         this.ballerinaLanguageServer = lsGlobalContext.get(LSGlobalContextKeys.LANGUAGE_SERVER_KEY);
         this.documentManager = lsGlobalContext.get(LSGlobalContextKeys.DOCUMENT_MANAGER_KEY);
-        this.lSPackageCache = lsGlobalContext.get(LSGlobalContextKeys.PKG_CACHE_KEY);
         this.lastDiagnosticMap = new HashMap<>();
         this.diagPushDebouncer = new Debouncer(DIAG_PUSH_DEBOUNCE_DELAY);
     }
@@ -119,7 +117,6 @@ class BallerinaTextDocumentService implements TextDocumentService {
             LSServiceOperationContext completionContext = new LSServiceOperationContext();
             completionContext.put(DocumentServiceKeys.POSITION_KEY, position);
             completionContext.put(DocumentServiceKeys.FILE_URI_KEY, position.getTextDocument().getUri());
-            completionContext.put(DocumentServiceKeys.LS_PACKAGE_CACHE_KEY, lSPackageCache);
             try {
                 BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(completionContext,
                         documentManager, false, CompletionCustomErrorStrategy.class, false).get(0);
@@ -162,8 +159,8 @@ class BallerinaTextDocumentService implements TextDocumentService {
                                 LSCustomErrorStrategy.class, false).get(0);
                 hoverContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                         currentBLangPackage.symbol.getName().getValue());
-                lSPackageCache.addPackage(currentBLangPackage);
-                hover = HoverUtil.getHoverContent(hoverContext, currentBLangPackage, lSPackageCache);
+                LSPackageCache.getInstance().addPackage(currentBLangPackage.packageID, currentBLangPackage);
+                hover = HoverUtil.getHoverContent(hoverContext, currentBLangPackage, LSPackageCache.getInstance());
             } catch (Exception | AssertionError e) {
                 hover = new Hover();
                 List<Either<String, MarkedString>> contents = new ArrayList<>();
@@ -191,7 +188,6 @@ class BallerinaTextDocumentService implements TextDocumentService {
                         bLangPackage.symbol.getName().getValue());
                 SignatureTreeVisitor signatureTreeVisitor = new SignatureTreeVisitor(signatureContext);
                 bLangPackage.accept(signatureTreeVisitor);
-                signatureContext.put(DocumentServiceKeys.LS_PACKAGE_CACHE_KEY, lSPackageCache);
                 signatureHelp = SignatureHelpUtil.getFunctionSignatureHelp(signatureContext);
             } catch (Exception e) {
                 signatureHelp = new SignatureHelp();
@@ -212,13 +208,13 @@ class BallerinaTextDocumentService implements TextDocumentService {
                             LSCustomErrorStrategy.class, false).get(0);
             definitionContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                     currentBLangPackage.symbol.getName().getValue());
-            lSPackageCache.addPackage(currentBLangPackage);
+            LSPackageCache.getInstance().addPackage(currentBLangPackage.packageID, currentBLangPackage);
             List<Location> contents;
             try {
                 PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(definitionContext);
                 currentBLangPackage.accept(positionTreeVisitor);
 
-                contents = DefinitionUtil.getDefinitionPosition(definitionContext, lSPackageCache);
+                contents = DefinitionUtil.getDefinitionPosition(definitionContext, LSPackageCache.getInstance());
             } catch (Exception e) {
                 contents = new ArrayList<>();
             }
@@ -253,7 +249,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 for (BLangPackage bLangPackage : bLangPackages) {
                     referenceContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                             bLangPackage.symbol.getName().getValue());
-                    lSPackageCache.addPackage(bLangPackage);
+                    LSPackageCache.getInstance().addPackage(bLangPackage.packageID, bLangPackage);
                     referenceContext.put(NodeContextKeys.REFERENCE_NODES_KEY, contents);
                     contents = ReferenceUtil.getReferences(referenceContext, bLangPackage);
                 }
@@ -307,9 +303,10 @@ class BallerinaTextDocumentService implements TextDocumentService {
                         params.getTextDocument().getUri(), params.getRange().getStart().getLine()));
                 commands.add(CommandUtil.getAllDocGenerationCommand(params.getTextDocument().getUri()));
             } else if (!params.getContext().getDiagnostics().isEmpty()) {
+                LSPackageCache lsPackageCache = LSPackageCache.getInstance();
                 params.getContext().getDiagnostics().forEach(diagnostic -> {
                     commands.addAll(CommandUtil
-                            .getCommandsByDiagnostic(diagnostic, params, lSPackageCache));
+                            .getCommandsByDiagnostic(diagnostic, params, lsPackageCache));
                 });
             }
             return commands;
@@ -397,7 +394,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 for (BLangPackage bLangPackage : bLangPackages) {
                     renameContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                             bLangPackage.symbol.getName().getValue());
-                    lSPackageCache.addPackage(bLangPackage);
+                    LSPackageCache.getInstance().addPackage(bLangPackage.packageID, bLangPackage);
 
                     contents = ReferenceUtil.getReferences(renameContext, bLangPackage);
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -452,22 +452,21 @@ class BallerinaTextDocumentService implements TextDocumentService {
         sourceDocument.setSourceRoot(sourceRoot);
 
         PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, documentManager);
-        CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(packageRepository, sourceDocument,
-                false, documentManager);
+        if ("".equals(pkgName)) {
+            Path filePath = path.getFileName();
+            if (filePath != null) {
+                pkgName = filePath.toString();
+            }
+        }
+        CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(pkgName, packageRepository,
+                                                             sourceDocument, false, documentManager);
 
         List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics = new ArrayList<>();
         CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
         context.put(DiagnosticListener.class, diagnosticListener);
 
         Compiler compiler = Compiler.getInstance(context);
-        if ("".equals(pkgName)) {
-            Path filePath = path.getFileName();
-            if (filePath != null) {
-                compiler.compile(filePath.toString());
-            }
-        } else {
-            compiler.compile(pkgName);
-        }
+        compiler.compile(pkgName);
 
         publishDiagnostics(balDiagnostics, path);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -35,12 +35,10 @@ import java.util.concurrent.CompletableFuture;
 class BallerinaWorkspaceService implements WorkspaceService {
     private BallerinaLanguageServer ballerinaLanguageServer;
     private WorkspaceDocumentManagerImpl workspaceDocumentManager;
-    private LSPackageCache lSPackageCache;
-    
+
     BallerinaWorkspaceService(LSGlobalContext lsGlobalContext) {
         this.ballerinaLanguageServer = lsGlobalContext.get(LSGlobalContextKeys.LANGUAGE_SERVER_KEY);
         this.workspaceDocumentManager = lsGlobalContext.get(LSGlobalContextKeys.DOCUMENT_MANAGER_KEY);
-        this.lSPackageCache = lsGlobalContext.get(LSGlobalContextKeys.PKG_CACHE_KEY);
     }
 
     @Override
@@ -62,7 +60,6 @@ class BallerinaWorkspaceService implements WorkspaceService {
         LSServiceOperationContext executeCommandContext = new LSServiceOperationContext();
         executeCommandContext.put(ExecuteCommandKeys.COMMAND_ARGUMENTS_KEY, params.getArguments());
         executeCommandContext.put(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY, this.workspaceDocumentManager);
-        executeCommandContext.put(ExecuteCommandKeys.LS_PACKAGE_CACHE_KEY, this.lSPackageCache);
         executeCommandContext.put(ExecuteCommandKeys.LANGUAGE_SERVER_KEY, this.ballerinaLanguageServer);
         
         return CompletableFuture.supplyAsync(() -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
@@ -53,8 +53,6 @@ public class DocumentServiceKeys {
             = new LSContext.Key<>();
     public static final LSContext.Key<List<SymbolInformation>> SYMBOL_LIST_KEY
             = new LSContext.Key<>();
-    public static final LSContext.Key<LSPackageCache> LS_PACKAGE_CACHE_KEY
-            = new LSContext.Key<>();
     public static final LSContext.Key<String> CURRENT_PACKAGE_NAME_KEY
             = new LSContext.Key<>();
     public static final LSContext.Key<LSServiceOperationContext> OPERATION_META_CONTEXT_KEY

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSGlobalContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSGlobalContextKeys.java
@@ -23,8 +23,6 @@ import org.ballerinalang.langserver.workspace.WorkspaceDocumentManagerImpl;
  * @since 0.970.0
  */
 public class LSGlobalContextKeys {
-    public static final LSContext.Key<LSPackageCache> PKG_CACHE_KEY
-            = new LSContext.Key<>();
     public static final LSContext.Key<LSAnnotationCache> ANNOTATION_CACHE_KEY
             = new LSContext.Key<>();
     public static final LSContext.Key<WorkspaceDocumentManagerImpl> DOCUMENT_MANAGER_KEY

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
@@ -92,7 +92,6 @@ public class LSPackageCache {
     }
 
     static class ExtendedPackageCache extends PackageCache {
-
         private ExtendedPackageCache(CompilerContext context) {
             super(context);
             this.packageMap = new ConcurrentHashMap<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
@@ -83,7 +83,7 @@ public class LSPackageCache {
                     new org.wso2.ballerinalang.compiler.util.Name(staticPkgName),
                     new org.wso2.ballerinalang.compiler.util.Name("0.0.0"));
             
-            this.packageCache.put(packageID, LSPackageLoader.getPackageById(tempCompilerContext, packageID));
+            LSPackageLoader.getPackageById(tempCompilerContext, packageID);
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -60,8 +60,6 @@ import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
 public class TextDocumentServiceUtil {
 
     private static final String PACKAGE_REGEX = "package\\s+([a-zA_Z_][\\.\\w]*);";
-    private static volatile PackageCache globalPackageCache = null;
-    private static final Object LOCK = new Object();
 
     /**
      * Get the source root for the given package.
@@ -220,15 +218,9 @@ public class TextDocumentServiceUtil {
             context.put(SourceDirectory.class,
                     new LangServerFSProgramDirectory(sourceRoot.getSourceRootPath(), documentManager));
         }
-        if (globalPackageCache == null) {
-            synchronized (LOCK) {
-                if (globalPackageCache == null) {
-                    globalPackageCache = PackageCache.getInstance(context);
-                }
-            }
-        }
-        globalPackageCache.put(new PackageID(packageName), null);
-        PackageCache.setInstance(globalPackageCache, context);
+        LSPackageCache globalPackageCache = LSPackageCache.getInstance();
+        globalPackageCache.removePackage(new PackageID(packageName));
+        PackageCache.setInstance(globalPackageCache.getPackageCache(), context);
         return context;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -26,11 +26,13 @@ import org.ballerinalang.langserver.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.langserver.workspace.repository.LangServerFSProgramDirectory;
 import org.ballerinalang.langserver.workspace.repository.LangServerFSProjectDirectory;
 import org.ballerinalang.langserver.workspace.repository.WorkspacePackageRepository;
+import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.repository.PackageRepository;
 import org.ballerinalang.toml.model.Manifest;
 import org.ballerinalang.toml.parser.ManifestProcessor;
 import org.ballerinalang.util.diagnostic.DiagnosticListener;
 import org.wso2.ballerinalang.compiler.Compiler;
+import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.SourceDirectory;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -58,6 +60,8 @@ import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
 public class TextDocumentServiceUtil {
 
     private static final String PACKAGE_REGEX = "package\\s+([a-zA_Z_][\\.\\w]*);";
+    private static volatile PackageCache globalPackageCache = null;
+    private static final Object LOCK = new Object();
 
     /**
      * Get the source root for the given package.
@@ -171,31 +175,33 @@ public class TextDocumentServiceUtil {
     /**
      * Prepare the compiler context.
      *
+     * @param packageName        Package Name
      * @param packageRepository  Package Repository
      * @param sourceRoot         LSDocument for Source Root
      * @param preserveWhitespace Preserve Whitespace
      * @return {@link CompilerContext}     Compiler context
      */
-    public static CompilerContext prepareCompilerContext(PackageRepository packageRepository, LSDocument sourceRoot,
-                                                         boolean preserveWhitespace,
+    public static CompilerContext prepareCompilerContext(String packageName, PackageRepository packageRepository,
+                                                         LSDocument sourceRoot, boolean preserveWhitespace,
                                                          WorkspaceDocumentManager documentManager) {
-        return prepareCompilerContext(packageRepository, sourceRoot, preserveWhitespace, documentManager,
+        return prepareCompilerContext(packageName, packageRepository, sourceRoot, preserveWhitespace, documentManager,
                 CompilerPhase.CODE_ANALYZE);
     }
 
     /**
      * Prepare the compiler context.
      *
+     * @param packageName        Package Name
      * @param packageRepository  Package Repository
      * @param sourceRoot         LSDocument for Source Root
      * @param preserveWhitespace Preserve Whitespace
      * @return {@link CompilerContext}     Compiler context
      */
-    public static CompilerContext prepareCompilerContext(PackageRepository packageRepository, LSDocument sourceRoot,
-                                                         boolean preserveWhitespace,
+    public static CompilerContext prepareCompilerContext(String packageName, PackageRepository packageRepository,
+                                                         LSDocument sourceRoot, boolean preserveWhitespace,
                                                          WorkspaceDocumentManager documentManager,
                                                          CompilerPhase compilerPhase) {
-        org.wso2.ballerinalang.compiler.util.CompilerContext context = new CompilerContext();
+        CompilerContext context = new CompilerContext();
         context.put(PackageRepository.class, packageRepository);
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, sourceRoot.getSourceRoot());
@@ -214,6 +220,15 @@ public class TextDocumentServiceUtil {
             context.put(SourceDirectory.class,
                     new LangServerFSProgramDirectory(sourceRoot.getSourceRootPath(), documentManager));
         }
+        if (globalPackageCache == null) {
+            synchronized (LOCK) {
+                if (globalPackageCache == null) {
+                    globalPackageCache = PackageCache.getInstance(context);
+                }
+            }
+        }
+        globalPackageCache.put(new PackageID(packageName), null);
+        PackageCache.setInstance(globalPackageCache, context);
         return context;
     }
 
@@ -256,21 +271,18 @@ public class TextDocumentServiceUtil {
                     for (File file : files) {
                         if ((file.isDirectory() && !file.getName().startsWith(".")) ||
                                 (!file.isDirectory() && file.getName().endsWith(".bal"))) {
-                            Compiler compiler = getCompiler(context, fileName, packageRepository, sourceDocument,
-                                    preserveWhitespace, customErrorStrategy, docManager);
+                            Compiler compiler = getCompiler(context, fileName, file.getName(), packageRepository,
+                                                sourceDocument, preserveWhitespace, customErrorStrategy, docManager);
                             packages.add(compiler.compile(file.getName()));
                         }
                     }
                 }
             }
         } else {
-            Compiler compiler = getCompiler(context, fileName, packageRepository, sourceDocument, preserveWhitespace,
-                    customErrorStrategy, docManager);
-            if ("".equals(pkgName)) {
-                packages.add(compiler.compile(fileName));
-            } else {
-                packages.add(compiler.compile(pkgName));
-            }
+            pkgName = ("".equals(pkgName)) ? fileName : pkgName;
+            Compiler compiler = getCompiler(context, fileName, pkgName, packageRepository, sourceDocument,
+                                            preserveWhitespace, customErrorStrategy, docManager);
+            packages.add(compiler.compile(pkgName));
         }
         return packages;
     }
@@ -280,18 +292,19 @@ public class TextDocumentServiceUtil {
      *
      * @param context             Language server context
      * @param fileName            File name which is currently open
+     * @param packageName         Package Name
      * @param packageRepository   package repository
      * @param sourceRoot          LSDocument for root path of the source
      * @param preserveWhitespace  enable/disable preserve white space in compiler
      * @param customErrorStrategy custom error strategy class
      * @return {@link Compiler} ballerina compiler
      */
-    private static Compiler getCompiler(LSContext context, String fileName,
+    private static Compiler getCompiler(LSContext context, String fileName, String packageName,
                                         PackageRepository packageRepository, LSDocument sourceRoot,
                                         boolean preserveWhitespace, Class customErrorStrategy,
                                         WorkspaceDocumentManager documentManager) {
         CompilerContext compilerContext =
-                TextDocumentServiceUtil.prepareCompilerContext(packageRepository, sourceRoot,
+                TextDocumentServiceUtil.prepareCompilerContext(packageName, packageRepository, sourceRoot,
                         preserveWhitespace, documentManager);
         context.put(DocumentServiceKeys.FILE_NAME_KEY, fileName);
         context.put(DocumentServiceKeys.COMPILER_CONTEXT_KEY, compilerContext);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/ExecuteCommandKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/ExecuteCommandKeys.java
@@ -17,7 +17,6 @@ package org.ballerinalang.langserver.command;
 
 import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.LSContext;
-import org.ballerinalang.langserver.LSPackageCache;
 import org.ballerinalang.langserver.workspace.WorkspaceDocumentManagerImpl;
 
 import java.util.List;
@@ -28,8 +27,6 @@ import java.util.List;
  */
 public class ExecuteCommandKeys {
     public static final LSContext.Key<WorkspaceDocumentManagerImpl> DOCUMENT_MANAGER_KEY
-            = new LSContext.Key<>();
-    public static final LSContext.Key<LSPackageCache> LS_PACKAGE_CACHE_KEY
             = new LSContext.Key<>();
     public static final LSContext.Key<List<Object>> COMMAND_ARGUMENTS_KEY
             = new LSContext.Key<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageNameContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageNameContextResolver.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.LSPackageCache;
 import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
@@ -38,9 +37,8 @@ public class PackageNameContextResolver extends AbstractItemResolver {
     @Override
     public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
-        LSPackageCache lsPackageCache = completionContext.get(DocumentServiceKeys.LS_PACKAGE_CACHE_KEY);
 
-        lsPackageCache.getPackageMap().entrySet().forEach(pkgEntry -> {
+        LSPackageCache.getInstance().getPackageMap().entrySet().forEach(pkgEntry -> {
             PackageID packageID = pkgEntry.getValue().packageID;
             String label = packageID.getOrgName().getValue() + "/" + packageID.getName().getValue();
             String insertText = label + ";";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.signature;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.LSPackageCache;
 import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
@@ -166,8 +167,7 @@ public class SignatureHelpUtil {
         List<ParameterInfoModel> paramModels = new ArrayList<>();
         String functionName = signatureContext.get(SignatureKeys.CALLABLE_ITEM_NAME);
         CompilerContext compilerContext = signatureContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
-        BLangPackage bLangPackage = signatureContext.get(DocumentServiceKeys.LS_PACKAGE_CACHE_KEY).
-                findPackage(compilerContext, bInvokableSymbol.pkgID);
+        BLangPackage bLangPackage = LSPackageCache.getInstance().findPackage(compilerContext, bInvokableSymbol.pkgID);
 
         BLangFunction blangFunction = bLangPackage.getFunctions().stream()
                 .filter(bLangFunction -> bLangFunction.getName().getValue().equals(functionName))

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -51,7 +51,7 @@ public abstract class CompletionTest {
 
     private static final String ROOT_DIR = Paths.get("").toAbsolutePath().toString() + File.separator;
 
-    private static final String SAMPLES_COPY_DIR = ROOT_DIR + "samples" + File.separator + "completion";
+    protected static final String SAMPLES_COPY_DIR = ROOT_DIR + "samples" + File.separator + "completion";
 
     @BeforeMethod
     public void loadTestCases() throws IOException {
@@ -63,22 +63,31 @@ public abstract class CompletionTest {
     @Test(dataProvider = "completion-data-provider", enabled = false)
     public void test(String config, String configPath) {
         String configJsonPath = SAMPLES_COPY_DIR + File.separator + configPath + File.separator + config;
-        JsonObject jsonObject = FileUtils.fileContentAsObject(configJsonPath);
-        JsonArray expectedItems = jsonObject.get("items").getAsJsonArray();
-        JsonObject positionObj = jsonObject.get("position").getAsJsonObject();
-        String balPath = SAMPLES_COPY_DIR + File.separator + jsonObject.get("source").getAsString();
+        JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
+
+        List<CompletionItem> responseItemList = getResponseItemList(configJsonObject);
+        List<CompletionItem> expectedList = getExpectedList(configJsonObject);
+        Assert.assertEquals(true, CompletionTestUtil.isSubList(expectedList, responseItemList));
+    }
+
+    protected List<CompletionItem> getResponseItemList(JsonObject configJsonObject) {
+        JsonObject positionObj = configJsonObject.get("position").getAsJsonObject();
+
+        String balPath = SAMPLES_COPY_DIR + File.separator + configJsonObject.get("source").getAsString();
         Position position = new Position();
         String content = FileUtils.fileContent(balPath);
-
         position.setLine(positionObj.get("line").getAsInt());
         position.setCharacter(positionObj.get("character").getAsInt());
         TextDocumentPositionParams positionParams =
                 CompletionTestUtil.getPositionParams(position, balPath);
         WorkspaceDocumentManagerImpl documentManager = CompletionTestUtil.prepareDocumentManager(balPath, content);
-        List<CompletionItem> responseItemList = CompletionTestUtil.getCompletions(documentManager, positionParams);
-        List<CompletionItem> expectedList = CompletionTestUtil.getExpectedItemList(expectedItems);
+        return CompletionTestUtil.getCompletions(documentManager, positionParams);
+    }
 
-        Assert.assertEquals(true, CompletionTestUtil.isSubList(expectedList, responseItemList));
+    protected List<CompletionItem> getExpectedList(JsonObject configJsonObject) {
+        JsonArray expectedItems = configJsonObject.get("items").getAsJsonArray();
+
+        return CompletionTestUtil.getExpectedItemList(expectedItems);
     }
 
     @DataProvider(name = "completion-data-provider")

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -72,7 +72,6 @@ public abstract class CompletionTest {
 
     protected List<CompletionItem> getResponseItemList(JsonObject configJsonObject) {
         JsonObject positionObj = configJsonObject.get("position").getAsJsonObject();
-
         String balPath = SAMPLES_COPY_DIR + File.separator + configJsonObject.get("source").getAsString();
         Position position = new Position();
         String content = FileUtils.fileContent(balPath);
@@ -86,7 +85,6 @@ public abstract class CompletionTest {
 
     protected List<CompletionItem> getExpectedList(JsonObject configJsonObject) {
         JsonArray expectedItems = configJsonObject.get("items").getAsJsonArray();
-
         return CompletionTestUtil.getExpectedItemList(expectedItems);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -64,7 +64,6 @@ public abstract class CompletionTest {
     public void test(String config, String configPath) {
         String configJsonPath = SAMPLES_COPY_DIR + File.separator + configPath + File.separator + config;
         JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
-
         List<CompletionItem> responseItemList = getResponseItemList(configJsonObject);
         List<CompletionItem> expectedList = getExpectedList(configJsonObject);
         Assert.assertEquals(true, CompletionTestUtil.isSubList(expectedList, responseItemList));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/packageimport/PackageImportDelayTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/packageimport/PackageImportDelayTest.java
@@ -1,0 +1,63 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.langserver.completion.packageimport;
+
+import com.google.gson.JsonObject;
+import org.ballerinalang.langserver.completion.CompletionTest;
+import org.ballerinalang.langserver.completion.util.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the endurance of the heavy package imports(eg. http) for the completion.
+ *
+ * Checks the time consumed is equal or below MAX_DELAY_THRESHOLD.
+ */
+public class PackageImportDelayTest extends CompletionTest {
+    private static final long MAX_DELAY_THRESHOLD = 1L;
+
+    @DataProvider(name = "completion-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"packageImport.json", "packageimport"}
+        };
+    }
+
+    @Test(dataProvider = "completion-data-provider")
+    @Override
+    public void test(String config, String configPath) {
+        String configJsonPath = SAMPLES_COPY_DIR + File.separator + configPath + File.separator + config;
+        JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
+
+        // Allow warmup and caching
+        getResponseItemList(configJsonObject);
+
+        //Measure stats
+        long startTime = System.nanoTime();
+        getResponseItemList(configJsonObject);
+        long endTime = System.nanoTime();
+        long totalTime = TimeUnit.NANOSECONDS.toSeconds(endTime - startTime);
+
+        Assert.assertTrue(totalTime <= MAX_DELAY_THRESHOLD);
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport.json
@@ -1,0 +1,23 @@
+{
+  "position": {
+    "line": 3,
+    "character": 10
+  },
+  "source": "packageimport/source/packageImport.bal",
+  "items": [
+      {
+        "label":"endpoint",
+        "detail":"Snippet",
+        "sortText":"190",
+        "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
+        "insertTextFormat":"Snippet"
+      },
+      {
+        "label":"worker",
+        "detail":"Snippet",
+        "sortText":"190",
+        "insertText":"worker ${1:name} {\n\t${2}\n}",
+        "insertTextFormat":"Snippet"
+      }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/source/packageImport.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/source/packageImport.bal
@@ -1,0 +1,4 @@
+import ballerina/http;
+public function main (string[] args) {
+    http:
+}


### PR DESCRIPTION
## Purpose
> Currently Language Server(LS) code suggestions are handled by compiling the latest code every time. There's a substantial delay when waiting for the suggestion with a code that has imports such as `http`. For exmaple;
> ```
> import ballerina/http;
> public function main (string[] args) {
>   http:
> }
> ```
> Since Compiler spends more time on loading external packages(eg. http), we can reduce this by introducing a caching layer. However; Compiler already has a PackageLoader Cache **bounded** to a Compiler Context. Since LS always creates a new CompilerContext the PackageCache is **thrown away**. Thus; there's a need to introduce a **Global Cache** for the PackageLoader.

## Goals
> Code suggestions should not be more than 1 second. Added a test case to monitor the code suggestions delay as well.

## Approach
> Introduced a Global Cache Layer for the Compiler Context. However; monitoring the growth of the caching layer with a cahing library such Guava cache is yet to be done.
> ### Before Global Cache: 
> ![with-delay](https://user-images.githubusercontent.com/1448489/38300283-071c2c42-381a-11e8-90dc-fdac2c255696.gif)
>
> ### After Global Cache:
> ![without-delay](https://user-images.githubusercontent.com/1448489/38300316-1d54f426-381a-11e8-8b18-22f54ca02dab.gif)

## User stories
> N/A

## Release note
> Improve LS Code Suggestion Performance

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.2
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"
 
## Learning
> Had to learn on the internals of the LS and how it handles the code suggestions.