### PR TITLE
Update function returning rules with workers

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CallableWorkerResponseContext.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CallableWorkerResponseContext.java
@@ -97,7 +97,7 @@ public class CallableWorkerResponseContext extends BaseWorkerResponseContext {
                 this.propagateErrorToTarget();
             }
         } else {
-            if (!this.isFulfilled()) {
+            if (!this.isFulfilled() && this.isWorkersDone()) {
                 this.setAsFulfilled();
                 this.setCurrentSignal(signal);
                 this.printStoredErrors();
@@ -122,6 +122,8 @@ public class CallableWorkerResponseContext extends BaseWorkerResponseContext {
     }
     
     protected boolean isWorkersDone() {
+        /* return count is not mentioned here, because, when a return happens, it will be immediately fulfilled,
+         * and there is no need to call this function to find out if all workers are done */
         return ((this.workerErrors == null ? 0 : this.workerErrors.size()) + this.haltCount) >= this.workerCount;
     }
     


### PR DESCRIPTION
Earlier, in non-void functions, if any of the workers are done execution with either a return or by executing a "done" or else, by falling off the end, the function would return. In the current updated rules, a non-void function would return only if someone return or, if all others are finished with their workers. 