### PR TITLE
Enforce effective final behaviour for function arguments

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -145,6 +145,7 @@ public enum DiagnosticCode {
     INVALID_VARIABLE_ASSIGNMENT("invalid.variable.assignment"),
     CANNOT_ASSIGN_VALUE_READONLY("cannot.assign.value.to.readonly.field"),
     CANNOT_ASSIGN_VALUE_FINAL("cannot.assign.value.to.final.field"),
+    CANNOT_ASSIGN_VALUE_FUNCTION_ARGUMENT("cannot.assign.value.to.function.argument"),
     CANNOT_ASSIGN_VALUE_ENDPOINT("cannot.assign.value.to.endpoint"),
     UNDERSCORE_NOT_ALLOWED("underscore.not.allowed"),
     OPERATION_DOES_NOT_SUPPORT_INDEXING("operation.does.not.support.indexing"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -290,6 +290,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         } else {
             funcEnv = SymbolEnv.createFunctionEnv(funcNode, funcNode.symbol.scope, env);
         }
+        //set function param flag to final
+        funcNode.symbol.params.forEach(param -> param.flags |= Flags.FUNCTION_FINAL);
 
         funcNode.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachmentPoint =
@@ -683,9 +685,12 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
 
         Name varName = names.fromIdNode(simpleVarRef.variableName);
-        if (!Names.IGNORE.equals(varName) && (simpleVarRef.symbol.flags & Flags.CONST) == Flags.CONST
-                && env.enclInvokable != env.enclPkg.initFunction) {
-            dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_FINAL, varRef);
+        if (!Names.IGNORE.equals(varName) && env.enclInvokable != env.enclPkg.initFunction) {
+            if ((simpleVarRef.symbol.flags & Flags.FINAL) == Flags.FINAL) {
+                dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_FINAL, varRef);
+            } else if ((simpleVarRef.symbol.flags & Flags.FUNCTION_FINAL) == Flags.FUNCTION_FINAL) {
+                dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_FUNCTION_ARGUMENT, varRef);
+            }
         }
     }
 
@@ -1578,7 +1583,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 }
             }
         } else if (retryKind == NodeKind.SIMPLE_VARIABLE_REF) {
-            if (((BLangSimpleVarRef) retryCountExpr).symbol.flags == Flags.CONST) {
+            if (((BLangSimpleVarRef) retryCountExpr).symbol.flags == Flags.FINAL) {
                 if (((BLangSimpleVarRef) retryCountExpr).symbol.type.tag == TypeTags.INT) {
                     error = false;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -27,10 +27,11 @@ import java.util.Set;
 public class Flags {
     public static final int PUBLIC = 1;
     public static final int NATIVE = 2;
-    public static final int CONST = 4;
+    public static final int FINAL = 4;
     public static final int ATTACHED = 8;
     public static final int DEPRECATED = 16;
     public static final int READONLY = 32;
+    public static final int FUNCTION_FINAL = 64;
 
     public static int asMask(Set<Flag> flagSet) {
         int mask = 0;
@@ -43,7 +44,7 @@ public class Flags {
                     mask |= NATIVE;
                     break;
                 case CONST:
-                    mask |= CONST;
+                    mask |= FINAL;
                     break;
                 case ATTACHED:
                     mask |= ATTACHED;

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -224,6 +224,9 @@ error.invalid.variable.assignment=\
 error.cannot.assign.value.to.final.field=\
   cannot assign a value to final ''{0}''
 
+error.cannot.assign.value.to.function.argument=\
+  cannot assign a value to function argument ''{0}''
+
 error.cannot.assign.value.to.readonly.field=\
   cannot assign a value to readonly ''{0}''
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
@@ -49,6 +49,11 @@ public class FinalAccessTest {
         BAssertUtil
                 .validateError(compileResultNegative, 2, "cannot assign a value to final 'bar:globalBarString'", 12, 5);
         BAssertUtil.validateError(compileResultNegative, 3, "cannot assign a value to final 'a'", 24, 5);
+        BAssertUtil.validateError(compileResultNegative, 4, "cannot assign a value to function argument 'a'", 30, 5);
+        BAssertUtil.validateError(compileResultNegative, 5, "cannot assign a value to function argument 'f'", 35, 5);
+        BAssertUtil.validateError(compileResultNegative, 6, "cannot assign a value to function argument 's'", 36, 5);
+        BAssertUtil.validateError(compileResultNegative, 7, "cannot assign a value to function argument 'b'", 37, 5);
+        BAssertUtil.validateError(compileResultNegative, 8, "cannot assign a value to function argument 'j'", 38, 5);
     }
 
     @Test(description = "Test final global variable")
@@ -93,7 +98,7 @@ public class FinalAccessTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testFinalFieldAsParameter");
 
         Assert.assertTrue(returns[0] instanceof BInteger);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 5);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
     }
 
     @Test(description = "Test final paramter")

--- a/tests/ballerina-test/src/test/resources/test-src/types/finaltypes/final-field-test-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/finaltypes/final-field-test-negative.bal
@@ -24,3 +24,17 @@ function bar(@final int a) returns (int) {
     a = 500;
     return a;
 }
+
+function foo(int a) returns (int) {
+    int i = a;
+    a = 500;
+    return a;
+}
+
+function baz(float f, string s, boolean b, json j) returns (float, string, boolean, json) {
+    f = 5.3;
+    s = "Hello";
+    b = true;
+    j = {"a":"b"};
+    return (f, s, b, j);
+}

--- a/tests/ballerina-test/src/test/resources/test-src/types/finaltypes/final-field-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/finaltypes/final-field-test.bal
@@ -30,8 +30,7 @@ public function testFieldAsFinalParameter() returns (int) {
 
 function foo(int a) returns (int) {
     int i = a;
-    a = 5;
-    return a;
+    return i;
 }
 
 function bar(@final int a) returns (int) {


### PR DESCRIPTION
This will add changes needed to enforce final variable behaviour for function arguments. It will throw compile time errors when trying to modify function arguments.

This PR also rename the CONST to FINAL as the constant name