### PR TITLE
Disable balx generation in ballerina-cli-utils module on build time

### DIFF
--- a/cli/ballerina-cli-utils/pom.xml
+++ b/cli/ballerina-cli-utils/pom.xml
@@ -85,7 +85,7 @@
                 </executions>
             </plugin>
             <!-- Generate balx -->
-            <plugin>
+            <!--<plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>
@@ -130,7 +130,7 @@
                 <configuration>
                     <mainClass>org.ballerinalang.cli.utils.GenerateBalx</mainClass>
                 </configuration>
-            </plugin>
+            </plugin>-->
             <!-- Copy resources -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Purpose
> This PR will disable the balx generation in ballerina-cli-utils module on build time. This will be enabled after updating the bal files with the new synatx