### PR TITLE
Fix XMLLiteralTest failure

### DIFF
--- a/tests/ballerina-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
@@ -12,7 +12,7 @@ function xmlUndeclaredElementPrefix() returns (xml) {
 }
 
 function xmlTemplateWithNonXML() {
-    map m = {};
+    map m ;
     xml x = xml `<root xmlns="http://default/namespace">{{m}}</root>`;
 }
 
@@ -53,7 +53,7 @@ function foo() {
 }
 
 function getAttributesFromNonXml() {
-    map m = {};
+    map m ;
     string s = m@["foo"];
 }
 


### PR DESCRIPTION
## Purpose
> Fix XMLLiteralTest failure due to improper map initialization

## Approach
> Fix map initialization in xml-literals-negative.bal file.
