### PR TITLE
Fix checked-expr test failures

### DIFF
--- a/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_negative.bal
@@ -17,13 +17,13 @@ function testCheckedExprSemanticErrors2() {
     string line = check readLineError();
 }
 
-public struct myerror {
+public type myerror {
     string message;
     error[] cause;
     int code;
 }
 
-public struct customError {
+public type customError {
     string message;
     error[] cause;
     int code;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
@@ -31,7 +31,7 @@ function testSafeAssignmentBasics4 () returns (boolean){
 function testSafeAssignOpInAssignmentStatement1 () returns (boolean) {
     boolean b = false;
     int a = 0;
-    b =? openFileSuccess("/home/sameera/foo.txt");
+    b = check openFileSuccess("/home/sameera/foo.txt");
     return b;
 }
 
@@ -48,7 +48,7 @@ function testSafeAssignOpInAssignmentStatement3 () returns (boolean|error) {
     return fos.status;
 }
 
-struct FileOpenStatus {
+type FileOpenStatus {
     boolean status = false;
 }
 
@@ -71,17 +71,17 @@ function testSafeAssignOpInAssignmentStatement6 () returns boolean {
     return statusFailure;
 }
 
-struct person {
+type person {
     string name;
 }
 
-public struct myerror {
+public type myerror {
     string message;
     error[] cause;
     int code;
 }
 
-public struct customError {
+public type customError {
     string message;
     error[] cause;
     int code;


### PR DESCRIPTION
## Purpose
To fix test failures related to checked-expressions.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes