### PR TITLE
Add guava cache for the LSPackageCache

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.langserver;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.model.elements.PackageID;
 import org.slf4j.Logger;
@@ -26,7 +28,6 @@ import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Package context to keep the builtin and the current package.
@@ -123,9 +124,13 @@ public class LSPackageCache {
     }
 
     static class ExtendedPackageCache extends PackageCache {
+
+        private static final long MAX_CACHE_COUNT = 100L;
+
         private ExtendedPackageCache(CompilerContext context) {
             super(context);
-            this.packageMap = new ConcurrentHashMap<>();
+            Cache<String, BLangPackage> cache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_COUNT).build();
+            this.packageMap = cache.asMap();
         }
 
         public Map<String, BLangPackage> getMap() {

--- a/language-server/pom.xml
+++ b/language-server/pom.xml
@@ -27,6 +27,11 @@
                 <version>${lsp4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${google.guava.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${apache.commons.io.version}</version>
@@ -38,6 +43,7 @@
         <maven.findbugsplugin.version>3.0.3</maven.findbugsplugin.version>
         <lsp4j.version>0.3.0</lsp4j.version>
         <apache.commons.io.version>2.6</apache.commons.io.version>
+        <google.guava.version>21.0</google.guava.version>
     </properties>
     <modules>
         <module>modules/langserver-core</module>


### PR DESCRIPTION
## Purpose
> Add guava cache for the LSPackageCache.

## Goals
> Manage caching of the global package cache LSPackageCache

## Approach
> Add Guava Cache instead of the ConcurrentMap of the LSPackageCache.

## User stories
> N/A

## Release note
> Add guava cache for the LSPackageCache

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/ballerina-platform/ballerina-lang/pull/6496

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.2
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"
 
## Learning
> Had to learn on guava cache and eviction mechanisms.