### PR TITLE
 Correct unit test error line numbers

### DIFF
--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -87,14 +87,14 @@ public class TaintedStatusPropagationTest {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/record-negative.bal");
         Assert.assertTrue(result.getDiagnostics().length == 8);
-        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 8, 20);
-        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 12, 20);
-        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 16, 20);
-        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'secureIn'", 20, 20);
-        BAssertUtil.validateError(result, 4, "tainted value passed to sensitive parameter 'secureIn'", 25, 20);
-        BAssertUtil.validateError(result, 5, "tainted value passed to sensitive parameter 'secureIn'", 30, 20);
-        BAssertUtil.validateError(result, 6, "tainted value passed to sensitive parameter 'secureIn'", 36, 20);
-        BAssertUtil.validateError(result, 7, "tainted value passed to sensitive parameter 'secureIn'", 42, 20);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 9, 20);
+        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 13, 20);
+        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 17, 20);
+        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'secureIn'", 21, 20);
+        BAssertUtil.validateError(result, 4, "tainted value passed to sensitive parameter 'secureIn'", 26, 20);
+        BAssertUtil.validateError(result, 5, "tainted value passed to sensitive parameter 'secureIn'", 31, 20);
+        BAssertUtil.validateError(result, 6, "tainted value passed to sensitive parameter 'secureIn'", 37, 20);
+        BAssertUtil.validateError(result, 7, "tainted value passed to sensitive parameter 'secureIn'", 43, 20);
     }
 
     @Test

--- a/tests/ballerina-test/src/test/resources/testng.xml
+++ b/tests/ballerina-test/src/test/resources/testng.xml
@@ -29,17 +29,71 @@ under the License.
     <!-- Ballerina language Test Cases. -->
     <test name="ballerina-lang-test-suite" preserve-order="true" parallel="false">
         <packages>
-
+            <package name="org.ballerinalang.test.vm.*"/>
+            <package name="org.ballerinalang.test.annotations.*"/>
+            <package name="org.ballerinalang.test.expressions.*">
+                <exclude name="org.ballerinalang.test.expressions.identifierliteral.*"/>
+            </package>
+            <package name="org.ballerinalang.test.documentation.*"/>
+            <package name="org.ballerinalang.test.statements.*">
+                <exclude name="org.ballerinalang.test.statements.transform.*"/>
+            </package>
+            <package name="org.ballerinalang.test.types.*">
+                <exclude name="org.ballerinalang.test.types.service.*"/>
+                <exclude name="org.ballerinalang.test.types.null.*"/>
+                
+                <!-- TODO: remove once constraint tests are fixed -->
+                <exclude name="org.ballerinalang.test.types.map.*"/>
+            </package>
+            <package name="org.ballerinalang.test.functions.*"/>
+            <package name="org.ballerinalang.test.worker.*"/>
+            <package name="org.ballerinalang.test.nativeimpl.*"/>
+            <package name="org.ballerinalang.test.connectors.sql.*"/>
+            <!-- <package name="org.ballerinalang.test.net.*"/> -->
+            <!-- <package name="org.ballerinalang.test.connectors.*"/> -->
+            <!--<package name="org.ballerinalang.test.debugger.*"/>-->
+            <package name="org.ballerinalang.test.structs.*"/>
+            <package name="org.ballerinalang.test.endpoint.*"/>
+            <package name="org.ballerinalang.test.closures.*"/>
+            <!--<package name="org.ballerinalang.test.services.nativeimpl.*"/>-->
+            <!--<package name="org.ballerinalang.test.services.session"/>-->
+            <!--<package name="org.ballerinalang.test.services.basics"/>-->
+            <!--<package name="org.ballerinalang.test.services.cors"/>-->
+            <!--<package name="org.ballerinalang.test.services.configuration"/>-->
+            <package name="org.ballerinalang.test.services.dispatching"/>
+            <package name="org.ballerinalang.test.natives.*"/>
+            <package name="org.ballerinalang.test.parser.*"/>
+            <package name="org.ballerinalang.test.launch.*"/>
+            <package name="org.ballerinalang.test.lock.*"/>
+            <package name="org.ballerinalang.test.task.*"/>
+            <!-- <package name="org.ballerinalang.test.caching.*"/> -->
+            <package name="org.ballerinalang.test.mime.*"/>
+            <package name="org.ballerinalang.test.security.*"/>
+            <package name="org.ballerinalang.test.jwt.*"/>
             <package name="org.ballerinalang.test.taintchecking.*"/>
-
+            <package name="org.ballerinalang.test.config.*"/>
+            <package name="org.ballerinalang.test.streaming.*"/>
+            <package name="org.ballerinalang.test.object.*"/>
+            <package name="org.ballerinalang.test.record.*"/>
+            <package name="org.ballerinalang.test.net.grpc"/>
+            <package name="org.ballerinalang.test.metrics.*"/>
+            <package name="org.ballerinalang.test.runtime.*"/>
+            <package name="org.ballerinalang.test.net.http.*">
+                <exclude name="org.ballerinalang.test.net.http.resiliency.*"/>
+                <exclude name="org.ballerinalang.test.net.http.HttpCachingClientTest"/>
+            </package>
         </packages>
 
 		<!-- TODO: remove once constraint tests are fixed -->
-
+		<classes>
+			<class name="org.ballerinalang.test.types.map.BMapValueTest" />
+			<class name="org.ballerinalang.test.types.map.MapAccessExprTest" />
+			<class name="org.ballerinalang.test.types.map.MapInitializerExprTest" />
+		</classes>
     </test>
     <test name="ballerina-security-test-suite" preserve-order="true" parallel="false">
         <packages>
-
+            <package name="org.ballerinalang.test.auth.*"/>
         </packages>
     </test>
 </suite>

--- a/tests/ballerina-test/src/test/resources/testng.xml
+++ b/tests/ballerina-test/src/test/resources/testng.xml
@@ -29,71 +29,17 @@ under the License.
     <!-- Ballerina language Test Cases. -->
     <test name="ballerina-lang-test-suite" preserve-order="true" parallel="false">
         <packages>
-            <package name="org.ballerinalang.test.vm.*"/>
-            <package name="org.ballerinalang.test.annotations.*"/>
-            <package name="org.ballerinalang.test.expressions.*">
-                <exclude name="org.ballerinalang.test.expressions.identifierliteral.*"/>
-            </package>
-            <package name="org.ballerinalang.test.documentation.*"/>
-            <package name="org.ballerinalang.test.statements.*">
-                <exclude name="org.ballerinalang.test.statements.transform.*"/>
-            </package>
-            <package name="org.ballerinalang.test.types.*">
-                <exclude name="org.ballerinalang.test.types.service.*"/>
-                <exclude name="org.ballerinalang.test.types.null.*"/>
-                
-                <!-- TODO: remove once constraint tests are fixed -->
-                <exclude name="org.ballerinalang.test.types.map.*"/>
-            </package>
-            <package name="org.ballerinalang.test.functions.*"/>
-            <package name="org.ballerinalang.test.worker.*"/>
-            <package name="org.ballerinalang.test.nativeimpl.*"/>
-            <package name="org.ballerinalang.test.connectors.sql.*"/>
-            <!-- <package name="org.ballerinalang.test.net.*"/> -->
-            <!-- <package name="org.ballerinalang.test.connectors.*"/> -->
-            <!--<package name="org.ballerinalang.test.debugger.*"/>-->
-            <package name="org.ballerinalang.test.structs.*"/>
-            <package name="org.ballerinalang.test.endpoint.*"/>
-            <package name="org.ballerinalang.test.closures.*"/>
-            <!--<package name="org.ballerinalang.test.services.nativeimpl.*"/>-->
-            <!--<package name="org.ballerinalang.test.services.session"/>-->
-            <!--<package name="org.ballerinalang.test.services.basics"/>-->
-            <!--<package name="org.ballerinalang.test.services.cors"/>-->
-            <!--<package name="org.ballerinalang.test.services.configuration"/>-->
-            <package name="org.ballerinalang.test.services.dispatching"/>
-            <package name="org.ballerinalang.test.natives.*"/>
-            <package name="org.ballerinalang.test.parser.*"/>
-            <package name="org.ballerinalang.test.launch.*"/>
-            <package name="org.ballerinalang.test.lock.*"/>
-            <package name="org.ballerinalang.test.task.*"/>
-            <!-- <package name="org.ballerinalang.test.caching.*"/> -->
-            <package name="org.ballerinalang.test.mime.*"/>
-            <package name="org.ballerinalang.test.security.*"/>
-            <package name="org.ballerinalang.test.jwt.*"/>
+
             <package name="org.ballerinalang.test.taintchecking.*"/>
-            <package name="org.ballerinalang.test.config.*"/>
-            <package name="org.ballerinalang.test.streaming.*"/>
-            <package name="org.ballerinalang.test.object.*"/>
-            <package name="org.ballerinalang.test.record.*"/>
-            <package name="org.ballerinalang.test.net.grpc"/>
-            <package name="org.ballerinalang.test.metrics.*"/>
-            <package name="org.ballerinalang.test.runtime.*"/>
-            <package name="org.ballerinalang.test.net.http.*">
-                <exclude name="org.ballerinalang.test.net.http.resiliency.*"/>
-                <exclude name="org.ballerinalang.test.net.http.HttpCachingClientTest"/>
-            </package>
+
         </packages>
 
 		<!-- TODO: remove once constraint tests are fixed -->
-		<classes>
-			<class name="org.ballerinalang.test.types.map.BMapValueTest" />
-			<class name="org.ballerinalang.test.types.map.MapAccessExprTest" />
-			<class name="org.ballerinalang.test.types.map.MapInitializerExprTest" />
-		</classes>
+
     </test>
     <test name="ballerina-security-test-suite" preserve-order="true" parallel="false">
         <packages>
-            <package name="org.ballerinalang.test.auth.*"/>
+
         </packages>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> Correct unit test error line numbers, changed due aligning the test source with the new syntax changes.