### PR TITLE
Change proxy to proxyConfig and BBEs

### DIFF
--- a/docs/ballerina-by-example/examples/https-server-client-connectors/https-server-client-connectors.bal
+++ b/docs/ballerina-by-example/examples/https-server-client-connectors/https-server-client-connectors.bal
@@ -25,7 +25,7 @@ service<http:Service> helloWorld bind helloWorldEP {
     }
 
     sayHello (endpoint conn, http:Request req) {
-        http:Response res = {};
+        http:Response res = new;
         res.setStringPayload("Successful");
         _ = conn -> respond(res);
     }
@@ -45,7 +45,7 @@ endpoint http:ClientEndpoint clientEP {
 @Description {value:"Ballerina client connector can be used to connect to the created https server. You have to run the service before running this main function. As this is a 1-way ssl connection, client needs to provide trustStoreFile and trustStorePassword."}
 function main (string[] args) {
     //Creates an outbound request.
-    http:Request req = {};
+    http:Request req = new;
     var resp = clientEP -> get("/hello/", req);
     match resp {
         http:HttpConnectorError err => io:println(err.message);

--- a/docs/ballerina-by-example/examples/https-server-client-connectors/https-server-client-connectors.sh
+++ b/docs/ballerina-by-example/examples/https-server-client-connectors/https-server-client-connectors.sh
@@ -1,9 +1,4 @@
-#Run the service
-$ ballerina run https-server-client-connectors.bal -s
-ballerina: initiating service(s) in 'https-server-client-connectors.bal'
-ballerina: started HTTPS/WSS server connector http-9095
-
-#Run the main function containing ballerina client
 $ ballerina run https-server-client-connectors.bal
-Response code: 200
-Response: Successful
+ballerina: started HTTPS/WSS server connector 0.0.0.0:9095
+Successful
+ballerina: stopped HTTPS/WSS server connector 0.0.0.0:9095

--- a/docs/ballerina-by-example/examples/https-server-connector/https-server-connector.bal
+++ b/docs/ballerina-by-example/examples/https-server-connector/https-server-connector.bal
@@ -22,7 +22,7 @@ service<http:Service> helloWorld bind helloWorldEP {
     }
 
     sayHello (endpoint conn, http:Request req) {
-        http:Response res = {};
+        http:Response res = new;
         res.setStringPayload("Successful");
         _ = conn -> respond(res);
     }

--- a/docs/ballerina-by-example/examples/https-server-connector/https-server-connector.client.sh
+++ b/docs/ballerina-by-example/examples/https-server-connector/https-server-connector.client.sh
@@ -1,3 +1,3 @@
 #For the demonstration purpose curl -k command will be used to invoke the service.
 $ curl -k https://localhost:9095/hello
-Response: Successful
+Successful

--- a/docs/ballerina-by-example/examples/https-server-connector/https-server-connector.server.sh
+++ b/docs/ballerina-by-example/examples/https-server-connector/https-server-connector.server.sh
@@ -1,4 +1,4 @@
 #Run the service
 $ ballerina run https-server-connector.bal
 ballerina: initiating service(s) in 'https-server-connector.bal'
-ballerina: started HTTPS/WSS server connector http-9095
+ballerina: started HTTPS/WSS server connector 0.0.0.0:9095

--- a/docs/ballerina-by-example/examples/mutual-ssl/mutual-ssl.bal
+++ b/docs/ballerina-by-example/examples/mutual-ssl/mutual-ssl.bal
@@ -15,9 +15,9 @@ endpoint http:ServiceEndpoint helloWorldEP {
         },
         protocols: {
             protocolName: "TLS",
-            versions: "TLSv1.2,TLSv1.1"
+            versions: ["TLSv1.2","TLSv1.1"]
         },
-        ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        ciphers:["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
         sslVerifyClient:"require"
     }
 };
@@ -34,7 +34,7 @@ service<http:Service> helloWorld bind helloWorldEP {
     }
 
     sayHello (endpoint conn, http:Request req) {
-        http:Response res = {};
+        http:Response res = new;
         //Set response payload.
         res.setStringPayload("Successful");
         //Send response to client.
@@ -44,7 +44,7 @@ service<http:Service> helloWorld bind helloWorldEP {
 
 endpoint http:ClientEndpoint clientEP {
     targets: [{
-        uri: "https://localhost:9095",
+        url: "https://localhost:9095",
         secureSocket: {
             keyStore: {
                 filePath: "${ballerina.home}/bre/security/ballerinaKeystore.p12",
@@ -57,14 +57,14 @@ endpoint http:ClientEndpoint clientEP {
             protocols: {
                 protocolName: "TLS"
             },
-            ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+            ciphers:["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
         }
     }]
 };
 @Description {value:"Ballerina client connector can be used to connect to the created https server. You have to run the service before running this main function. As this is a mutual ssl connection, client also needs to provide keyStoreFile, keyStorePassword, trustStoreFile and trustStorePassword."}
 function main (string[] args) {
     //Creates a request.
-    http:Request req = {};
+    http:Request req = new;
     var resp = clientEP -> get("/hello/", req);
     match resp {
         http:HttpConnectorError err => io:println(err.message);

--- a/docs/ballerina-by-example/examples/mutual-ssl/mutual-ssl.sh
+++ b/docs/ballerina-by-example/examples/mutual-ssl/mutual-ssl.sh
@@ -1,9 +1,5 @@
 #Run the service
-$ ballerina run mutual-ssl.bal -s
-ballerina: initiating service(s) in 'mutual-ssl.bal'
-ballerina: started HTTPS/WSS server connector http-9095
-
-#Run the main function containing ballerina client
 $ ballerina run mutual-ssl.bal
-Response code: 200
-Response: Successful
+ballerina: started HTTPS/WSS server connector 0.0.0.0:9095
+Successful
+ballerina: stopped HTTPS/WSS server connector 0.0.0.0:9095

--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -92,7 +92,7 @@ public type ClientEndpointConfiguration {
     string forwarded = "disable",
     FollowRedirects? followRedirects,
     Retry? retry,
-    Proxy? proxy,
+    Proxy? proxyConfig,
     ConnectionThrottling? connectionThrottling,
     TargetService[] targets,
     string|FailoverConfig lbMode = ROUND_ROBIN,

--- a/stdlib/ballerina-http/src/main/ballerina/http/simple_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/simple_client_endpoint.bal
@@ -75,7 +75,7 @@ documentation {
     F{{chunking}} - The chunking behaviour of the request
     F{{followRedirects}} - Redirect related options
     F{{retry}} - Retry related options
-    F{{proxy}} - Proxy related options
+    F{{proxyConfig}} - Proxy related options
     F{{connectionThrottling}} - The configurations for controlling the number of connections allowed concurrently
     F{{cacheConfig}} - The configurations for controlling the caching behaviour
 }
@@ -90,7 +90,7 @@ public type SimpleClientEndpointConfiguration {
     Chunking chunking = "AUTO",
     FollowRedirects? followRedirects,
     Retry? retry,
-    Proxy? proxy,
+    Proxy? proxyConfig,
     ConnectionThrottling? connectionThrottling,
     CacheConfig cacheConfig = {},
 };
@@ -119,7 +119,7 @@ public function SimpleClientEndpoint::init(SimpleClientEndpointConfiguration sim
     self.httpEP.config.chunking = simpleConfig.chunking;
     self.httpEP.config.followRedirects = simpleConfig.followRedirects;
     self.httpEP.config.retry = simpleConfig.retry;
-    self.httpEP.config.proxy = simpleConfig.proxy;
+    self.httpEP.config.proxyConfig = simpleConfig.proxyConfig;
     self.httpEP.config.connectionThrottling = simpleConfig.connectionThrottling;
 
     if (simpleConfig.cacheConfig.enabled) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -329,11 +329,11 @@ public class HttpConstants {
     public static final String FOLLOW_REDIRECT_MAXCOUNT = "maxCount";
 
     //Proxy Indexed
-    public static final String PROXY_STRUCT_REFERENCE = "proxy";
+    public static final String PROXY_STRUCT_REFERENCE = "proxyConfig";
     public static final String PROXY_HOST = "host";
     public static final String PROXY_PORT = "port";
     public static final String PROXY_USERNAME = "userName";
-    public static final String PROXY_PASSWORD = "pasword";
+    public static final String PROXY_PASSWORD = "password";
 
     public static final String HTTP_SERVICE_TYPE = "Service";
     // Filter related


### PR DESCRIPTION
## Purpose
Changed the record type proxy to proxyConfig and migrate BBE s to latest syntax

## Samples
```
import ballerina/http;
import ballerina/io;
import ballerina/mime;

endpoint http:ClientEndpoint clientEP {
    targets: [{
        url: "https://localhost:9095"
    }],
    proxyConfig : {
       host:"localhost",
       port:3128,
       userName:"username",
       password:"password"	
    }
};

function main (string[] args) {
    http:Request req = new;
    var resp = clientEP -> get("/echo/", req);
    match resp {
        http:HttpConnectorError err => io:println(err.message);
        http:Response response => {
             match (response.getStringPayload()) {
                http:PayloadError payloadError => io:println(payloadError.message);
                string res => io:println(res);
             }
        }
    }
}
```

