### PR TITLE
Fix diagnostics and code completion for the unsaved files

### DIFF
--- a/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/BallerinaParserService.java
+++ b/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/BallerinaParserService.java
@@ -422,7 +422,7 @@ public class BallerinaParserService implements ComposerService {
         BallerinaFile bFile;
         String programDir = "";
         if (UNTITLED_BAL.equals(fileName)) {
-            bFile = LSParserUtils.compile(content, CompilerPhase.CODE_ANALYZE, true);
+            bFile = LSParserUtils.compile(content, CompilerPhase.CODE_ANALYZE);
         } else {
             java.nio.file.Path filePath = Paths.get(bFileRequest.getFilePath(), bFileRequest.getFileName());
             bFile = LSParserUtils.compile(content, filePath, CompilerPhase.CODE_ANALYZE);

--- a/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/BLangFragmentParser.java
+++ b/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/BLangFragmentParser.java
@@ -22,6 +22,7 @@ import org.ballerinalang.composer.service.ballerina.parser.service.BLangFragment
 import org.ballerinalang.composer.service.ballerina.parser.service.BLangJSONModelConstants;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.BLangSourceFragment;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.LSParserUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
@@ -122,7 +123,7 @@ public class BLangFragmentParser {
     }
 
     protected static JsonElement getJsonModel(String source) throws IOException {
-        BLangCompilationUnit compilationUnit = ParserUtils.compileFragment(source);
+        BLangCompilationUnit compilationUnit = LSParserUtils.compileFragment(source);
         return CommonUtil.generateJSON(compilationUnit, new HashMap<>());
     }
 

--- a/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/ParserUtils.java
+++ b/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/ParserUtils.java
@@ -17,7 +17,6 @@ package org.ballerinalang.composer.service.ballerina.parser.service.util;
 
 import com.google.common.io.Files;
 import org.ballerinalang.compiler.CompilerPhase;
-import org.ballerinalang.composer.service.ballerina.parser.service.model.BallerinaFile;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.BuiltInType;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.SymbolInformation;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.lang.Action;
@@ -38,6 +37,7 @@ import org.ballerinalang.langserver.CollectDiagnosticListener;
 import org.ballerinalang.langserver.LSPackageLoader;
 import org.ballerinalang.langserver.TextDocumentServiceUtil;
 import org.ballerinalang.langserver.common.LSDocument;
+import org.ballerinalang.langserver.common.modal.BallerinaFile;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.workspace.WorkspaceDocumentManagerImpl;
 import org.ballerinalang.langserver.workspace.repository.WorkspacePackageRepository;
@@ -841,6 +841,7 @@ public class ParserUtils {
      * @param content
      * @return
      */
+    @Deprecated
     public static BLangCompilationUnit compileFragment(String content) {
         Path unsaved = Paths.get(untitledProject.toString(), UNTITLED_BAL);
         synchronized (ParserUtils.class) {
@@ -864,6 +865,7 @@ public class ParserUtils {
      * @param path    file path
      * @return
      */
+    @Deprecated
     public static BallerinaFile compile(String content, Path path) {
         return compile(content, path, CompilerPhase.CODE_ANALYZE);
     }
@@ -876,6 +878,7 @@ public class ParserUtils {
      * @param compilerPhase {CompilerPhase} set phase for the compiler.
      * @return
      */
+    @Deprecated
     public static BallerinaFile compile(String content, Path path, CompilerPhase compilerPhase) {
         if (documentManager.isFileOpen(path)) {
             documentManager.updateFile(path, content);

--- a/language-server/modules/langserver-core/spotbugs-exclude.xml
+++ b/language-server/modules/langserver-core/spotbugs-exclude.xml
@@ -19,4 +19,13 @@
     <Match>
         <Package name="org.ballerinalang.langserver.workspace.repository" />
     </Match>
+    <Match>
+        <Package name="org.ballerinalang.langserver.common.utils" />
+        <OR>
+            <Bug pattern="DE_MIGHT_IGNORE"/>
+        </OR>
+        <OR>
+            <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+        </OR>
+    </Match>
 </FindBugsFilter>

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -95,7 +95,8 @@ import java.util.regex.Pattern;
 class BallerinaTextDocumentService implements TextDocumentService {
     // indicates the frequency to send diagnostics to server upon document did change
     private static final int DIAG_PUSH_DEBOUNCE_DELAY = 500;
-    private static final Pattern tempUntitledFilePattern = Pattern.compile("\\/temp\\/(.*)\\/untitled.bal");
+    private static final Pattern untitledFilePattern =
+            Pattern.compile("^(?:file:\\/\\/)?\\/temp\\/(.*)\\/untitled.bal");
 
     private final BallerinaLanguageServer ballerinaLanguageServer;
     private final WorkspaceDocumentManager documentManager;
@@ -519,7 +520,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
     }
 
     private String getTempFileIdOrNull(String filePath) {
-        Matcher pkgMatcher = tempUntitledFilePattern.matcher(filePath);
+        Matcher pkgMatcher = untitledFilePattern.matcher(filePath);
 
         if (!pkgMatcher.find()) {
             return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -16,12 +16,15 @@
 package org.ballerinalang.langserver;
 
 import com.google.gson.JsonObject;
+import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.langserver.command.CommandUtil;
 import org.ballerinalang.langserver.common.LSCustomErrorStrategy;
 import org.ballerinalang.langserver.common.LSDocument;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
+import org.ballerinalang.langserver.common.modal.BallerinaFile;
 import org.ballerinalang.langserver.common.position.PositionTreeVisitor;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.LSParserUtils;
 import org.ballerinalang.langserver.completions.CompletionCustomErrorStrategy;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.TreeVisitor;
@@ -37,9 +40,6 @@ import org.ballerinalang.langserver.signature.SignatureTreeVisitor;
 import org.ballerinalang.langserver.symbols.SymbolFindingVisitor;
 import org.ballerinalang.langserver.util.Debouncer;
 import org.ballerinalang.langserver.workspace.WorkspaceDocumentManager;
-import org.ballerinalang.langserver.workspace.repository.WorkspacePackageRepository;
-import org.ballerinalang.repository.PackageRepository;
-import org.ballerinalang.util.diagnostic.DiagnosticListener;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensParams;
@@ -72,11 +72,9 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
-import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -88,6 +86,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Text document service implementation for ballerina.
@@ -95,6 +95,7 @@ import java.util.concurrent.CompletableFuture;
 class BallerinaTextDocumentService implements TextDocumentService {
     // indicates the frequency to send diagnostics to server upon document did change
     private static final int DIAG_PUSH_DEBOUNCE_DELAY = 500;
+    private static final Pattern tempUntitledFilePattern = Pattern.compile("\\/temp\\/(.*)\\/untitled.bal");
 
     private final BallerinaLanguageServer ballerinaLanguageServer;
     private final WorkspaceDocumentManager documentManager;
@@ -426,29 +427,19 @@ class BallerinaTextDocumentService implements TextDocumentService {
     }
 
     private void compileAndSendDiagnostics(String content, LSDocument document, Path path) {
-        String sourceRoot = TextDocumentServiceUtil.getSourceRoot(path);
-        String pkgName = TextDocumentServiceUtil.getPackageNameForGivenFile(sourceRoot, path.toString());
-        LSDocument sourceDocument = new LSDocument();
-        sourceDocument.setUri(document.getURIString());
-        sourceDocument.setSourceRoot(sourceRoot);
-
-        PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, documentManager);
-        if ("".equals(pkgName)) {
-            Path filePath = path.getFileName();
-            if (filePath != null) {
-                pkgName = filePath.toString();
-            }
+        BallerinaFile balFile;
+        String tempFileId = getTempFileIdOrNull(path.toString());
+        if (tempFileId == null) {
+            balFile = LSParserUtils.compile(content, path, CompilerPhase.CODE_ANALYZE, false);
+        } else {
+            balFile = LSParserUtils.compile(content, tempFileId, CompilerPhase.CODE_ANALYZE, false);
         }
-        CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(pkgName, packageRepository,
-                                                             sourceDocument, false, documentManager);
-
-        List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics = new ArrayList<>();
-        CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
-        context.put(DiagnosticListener.class, diagnosticListener);
-
-        Compiler compiler = Compiler.getInstance(context);
-        compiler.compile(pkgName);
-
+        List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics;
+        if (balFile.getDiagnostics() != null) {
+            balDiagnostics = balFile.getDiagnostics();
+        } else {
+            balDiagnostics = new ArrayList<>();
+        }
         publishDiagnostics(balDiagnostics, path);
     }
 
@@ -525,5 +516,15 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
     @Override
     public void didSave(DidSaveTextDocumentParams params) {
+    }
+
+    private String getTempFileIdOrNull(String filePath) {
+        Matcher pkgMatcher = tempUntitledFilePattern.matcher(filePath);
+
+        if (!pkgMatcher.find()) {
+            return null;
+        }
+
+        return pkgMatcher.group(1);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -86,8 +86,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Text document service implementation for ballerina.
@@ -95,9 +93,6 @@ import java.util.regex.Pattern;
 class BallerinaTextDocumentService implements TextDocumentService {
     // indicates the frequency to send diagnostics to server upon document did change
     private static final int DIAG_PUSH_DEBOUNCE_DELAY = 500;
-    private static final Pattern untitledFilePattern =
-            Pattern.compile("^(?:file:\\/\\/)?\\/temp\\/(.*)\\/untitled.bal");
-
     private final BallerinaLanguageServer ballerinaLanguageServer;
     private final WorkspaceDocumentManager documentManager;
     private Map<String, List<Diagnostic>> lastDiagnosticMap;
@@ -429,7 +424,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
     private void compileAndSendDiagnostics(String content, LSDocument document, Path path) {
         BallerinaFile balFile;
-        String tempFileId = getTempFileIdOrNull(path.toString());
+        String tempFileId = LSParserUtils.getUnsavedFileIdOrNull(path.toString());
         if (tempFileId == null) {
             balFile = LSParserUtils.compile(content, path, CompilerPhase.CODE_ANALYZE, false);
         } else {
@@ -517,10 +512,5 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
     @Override
     public void didSave(DidSaveTextDocumentParams params) {
-    }
-
-    private String getTempFileIdOrNull(String filePath) {
-        Matcher pkgMatcher = untitledFilePattern.matcher(filePath);
-        return (pkgMatcher.find()) ? pkgMatcher.group(1) : null;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -521,11 +521,6 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
     private String getTempFileIdOrNull(String filePath) {
         Matcher pkgMatcher = untitledFilePattern.matcher(filePath);
-
-        if (!pkgMatcher.find()) {
-            return null;
-        }
-
-        return pkgMatcher.group(1);
+        return (pkgMatcher.find()) ? pkgMatcher.group(1): null;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -521,6 +521,6 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
     private String getTempFileIdOrNull(String filePath) {
         Matcher pkgMatcher = untitledFilePattern.matcher(filePath);
-        return (pkgMatcher.find()) ? pkgMatcher.group(1): null;
+        return (pkgMatcher.find()) ? pkgMatcher.group(1) : null;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageCache.java
@@ -95,9 +95,6 @@ public class LSPackageCache {
             //TODO check whether getPackageDeclaration() is needed
             this.packageCache.put(new PackageID(Names.DOT.value), bLangPackage);
         } else {
-            if (bLangPackage != null) {
-                bLangPackage.packageID = packageID;
-            }
             this.packageCache.put(packageID, bLangPackage);
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -22,6 +22,7 @@ import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.langserver.common.CustomErrorStrategyFactory;
 import org.ballerinalang.langserver.common.LSDocument;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.LSParserUtils;
 import org.ballerinalang.langserver.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.langserver.workspace.repository.LangServerFSProgramDirectory;
 import org.ballerinalang.langserver.workspace.repository.LangServerFSProjectDirectory;
@@ -237,6 +238,12 @@ public class TextDocumentServiceUtil {
                                                      boolean preserveWhitespace, Class customErrorStrategy,
                                                      boolean compileFullProject) {
         String uri = context.get(DocumentServiceKeys.FILE_URI_KEY);
+        String unsavedFileId = LSParserUtils.getUnsavedFileIdOrNull(uri);
+        if (unsavedFileId != null) {
+            // if it is an unsaved file; overrides the file path
+            uri = LSParserUtils.createAndGetTempFile(unsavedFileId).toUri().toString();
+            context.put(DocumentServiceKeys.FILE_URI_KEY, uri);
+        }
         LSDocument document = new LSDocument(uri);
         Path filePath = CommonUtil.getPath(document);
         Path fileNamePath = filePath.getFileName();
@@ -244,7 +251,6 @@ public class TextDocumentServiceUtil {
         if (fileNamePath != null) {
             fileName = fileNamePath.toString();
         }
-
 
         String sourceRoot = TextDocumentServiceUtil.getSourceRoot(filePath);
         String pkgName = TextDocumentServiceUtil.getPackageNameForGivenFile(sourceRoot, filePath.toString());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/modal/BallerinaFile.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/modal/BallerinaFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/modal/BallerinaFile.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/modal/BallerinaFile.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.ballerinalang.composer.service.ballerina.parser.service.model;
+package org.ballerinalang.langserver.common.modal;
 
 import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -25,14 +25,15 @@ import java.util.List;
 /**
  * Class which contains Ballerina model and Diagnostic information.
  */
-@Deprecated
 public class BallerinaFile {
 
-    private BLangPackage bLangPackage;
-    private List<Diagnostic> diagnostics;
+    private BLangPackage bLangPackage = null;
+    private List<Diagnostic> diagnostics = null;
 
     public List<Diagnostic> getDiagnostics() {
-        diagnostics.sort(Comparator.comparingInt(a -> a.getPosition().getStartLine()));
+        if (diagnostics != null) {
+            diagnostics.sort(Comparator.comparingInt(a -> a.getPosition().getStartLine()));
+        }
         return diagnostics;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.common.utils;
+
+import com.google.common.io.Files;
+import org.ballerinalang.compiler.CompilerPhase;
+import org.ballerinalang.langserver.CollectDiagnosticListener;
+import org.ballerinalang.langserver.TextDocumentServiceUtil;
+import org.ballerinalang.langserver.common.LSDocument;
+import org.ballerinalang.langserver.common.modal.BallerinaFile;
+import org.ballerinalang.langserver.workspace.WorkspaceDocumentManagerImpl;
+import org.ballerinalang.langserver.workspace.repository.WorkspacePackageRepository;
+import org.ballerinalang.repository.PackageRepository;
+import org.ballerinalang.util.diagnostic.Diagnostic;
+import org.ballerinalang.util.diagnostic.DiagnosticListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.ballerinalang.compiler.Compiler;
+import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parser Utils.
+ */
+public class LSParserUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(LSParserUtils.class);
+
+    private static final WorkspaceDocumentManagerImpl documentManager =
+            WorkspaceDocumentManagerImpl.getInstance();
+
+    private static Path untitledProject;
+
+    public static final String UNTITLED_BAL = "untitled.bal";
+
+    static {
+        // Here we will create a tmp directory as the untitled project repo.
+        File untitledDir = Files.createTempDir();
+        untitledProject = untitledDir.toPath();
+        // Now lets create a empty untitled.bal to fool compiler.
+        File untitledBal = new File(Paths.get(untitledProject.toString(),
+                                              UNTITLED_BAL).toString());
+        try {
+            untitledBal.createNewFile();
+        } catch (IOException e) {
+            logger.error("Unable to create untitled project directory, " +
+                                 "unsaved files might not work properly.");
+        }
+    }
+
+    /**
+     * Return a compilation unit for a given text.
+     *
+     * @param content content of the fragment
+     * @return BLangCompilationUnit
+     */
+    public static BLangCompilationUnit compileFragment(String content) {
+        BallerinaFile model = compile(content, CompilerPhase.DEFINE, true);
+        if (model.getBLangPackage() != null) {
+            return model.getBLangPackage().getCompilationUnits().stream().
+                    filter(compUnit -> UNTITLED_BAL.equals(compUnit.getName())).findFirst().get();
+        }
+        return null;
+    }
+
+    /**
+     * Compile an unsaved Ballerina file.
+     *
+     * @param content file content
+     * @return BallerinaFile
+     */
+    public static BallerinaFile compile(String content, CompilerPhase compilerPhase, boolean preserveWhiteSpace) {
+        return compile(content, UNTITLED_BAL, compilerPhase, preserveWhiteSpace);
+    }
+
+    /**
+     * Compile a temp Ballerina file.
+     *
+     * @param content       content of the file
+     * @param tempFileId    a unique id for the temp file
+     * @param compilerPhase compiler phase
+     * @param preserveWhiteSpace preserve white-space
+     * @return BallerinaFile
+     */
+    public static BallerinaFile compile(String content,String tempFileId, CompilerPhase compilerPhase,
+                                        boolean preserveWhiteSpace) {
+        createTempFileIfNotExists(untitledProject, tempFileId);
+        Path unsaved = Paths.get(untitledProject.toString(), tempFileId);
+        synchronized (LSParserUtils.class) {
+            // Since we use the same file name for all the fragment passes we need to make sure following -
+            // does not run parallelly.
+            documentManager.openFile(unsaved, content);
+            BallerinaFile model = compile(content, unsaved, compilerPhase, preserveWhiteSpace);
+            documentManager.closeFile(unsaved);
+            return model;
+        }
+    }
+
+    private static void createTempFileIfNotExists(Path untitledProject, String tempFileId) {
+        if (UNTITLED_BAL.equals(tempFileId)) {
+            return;
+        }
+        File untitledBal = new File(Paths.get(untitledProject.toString(), tempFileId + ".bal").toString());
+        try {
+            untitledBal.createNewFile();
+        } catch (IOException e) {
+            logger.error("Unable to create untitled project directory, unsaved files might not work properly.");
+        }
+    }
+
+    /**
+     * Compile a Ballerina file.
+     *
+     * @param content       file content
+     * @param path          file path
+     * @param phase {CompilerPhase} set phase for the compiler.
+     * @return BallerinaFile
+     */
+    public static BallerinaFile compile(String content, Path path, CompilerPhase phase) {
+        return compile(content, path, phase, true);
+    }
+
+    /**
+     * Compile a Ballerina file.
+     *
+     * @param content       file content
+     * @param path          file path
+     * @param phase {CompilerPhase} set phase for the compiler.
+     * @return BallerinaFile
+     */
+    public static BallerinaFile compile(String content, Path path, CompilerPhase phase, boolean preserveWhiteSpace) {
+        if (documentManager.isFileOpen(path)) {
+            documentManager.updateFile(path, content);
+        } else {
+            documentManager.openFile(path, content);
+        }
+
+        String sourceRoot = TextDocumentServiceUtil.getSourceRoot(path);
+        String pkgName = TextDocumentServiceUtil.getPackageNameForGivenFile(sourceRoot, path.toString());
+        LSDocument sourceDocument = new LSDocument();
+        sourceDocument.setUri(path.toUri().toString());
+        sourceDocument.setSourceRoot(sourceRoot);
+
+        PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, documentManager);
+        if ("".equals(pkgName)) {
+            Path filePath = path.getFileName();
+            if (filePath != null) {
+                pkgName = filePath.toString();
+            }
+        }
+        CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(pkgName, packageRepository,
+                                            sourceDocument, preserveWhiteSpace, documentManager, CompilerPhase.DEFINE);
+
+        List<Diagnostic> balDiagnostics = new ArrayList<>();
+        CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
+        context.put(DiagnosticListener.class, diagnosticListener);
+
+        BLangPackage bLangPackage = null;
+        try {
+            Compiler compiler = Compiler.getInstance(context);
+            bLangPackage = compiler.compile(pkgName);
+        } catch (Exception e) {
+            // Ignore.
+        }
+        BallerinaFile bfile = new BallerinaFile();
+        bfile.setBLangPackage(bLangPackage);
+        bfile.setDiagnostics(balDiagnostics);
+        return bfile;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
@@ -39,6 +39,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Parser Utils.
@@ -53,6 +55,9 @@ public class LSParserUtils {
     private static Path untitledProjectPath;
 
     public static final String UNTITLED_BAL = "untitled.bal";
+
+    private static final Pattern untitledFilePattern =
+            Pattern.compile("^(?:file:\\/\\/)?\\/temp\\/(.*)\\/untitled.bal");
 
     static {
         // Here we will create a tmp directory as the untitled project repo.
@@ -75,7 +80,7 @@ public class LSParserUtils {
      * @return BLangCompilationUnit
      */
     public static BLangCompilationUnit compileFragment(String content) {
-        BallerinaFile model = compile(content, CompilerPhase.DEFINE, true);
+        BallerinaFile model = compile(content, CompilerPhase.DEFINE);
         if (model.getBLangPackage() != null) {
             return model.getBLangPackage().getCompilationUnits().stream().
                     filter(compUnit -> UNTITLED_BAL.equals(compUnit.getName())).findFirst().get();
@@ -87,10 +92,23 @@ public class LSParserUtils {
      * Compile an unsaved Ballerina file.
      *
      * @param content file content
+     * @param phase {CompilerPhase} CompilerPhase
      * @return BallerinaFile
      */
-    public static BallerinaFile compile(String content, CompilerPhase compilerPhase, boolean preserveWhiteSpace) {
-        return compile(content, UNTITLED_BAL, compilerPhase, preserveWhiteSpace);
+    public static BallerinaFile compile(String content, CompilerPhase phase) {
+        return compile(content, UNTITLED_BAL, phase);
+    }
+
+    /**
+     * Compile an unsaved Ballerina file.
+     *
+     * @param content file content
+     * @param tempFileId temp file id
+     * @param phase {CompilerPhase} CompilerPhase
+     * @return BallerinaFile
+     */
+    public static BallerinaFile compile(String content, String tempFileId, CompilerPhase phase) {
+        return compile(content, tempFileId, phase, true);
     }
 
     /**
@@ -98,28 +116,47 @@ public class LSParserUtils {
      *
      * @param content       content of the file
      * @param tempFileId    a unique id for the temp file
-     * @param compilerPhase compiler phase
-     * @param preserveWhiteSpace preserve white-space
+     * @param phase {CompilerPhase} compiler phase
+     * @param preserveWhitespace preserve Whitespace
      * @return BallerinaFile
      */
-    public static BallerinaFile compile(String content, String tempFileId, CompilerPhase compilerPhase,
-                                        boolean preserveWhiteSpace) {
-        Path unsaved = createAndGetTempFile(untitledProjectPath, tempFileId);
+    public static BallerinaFile compile(String content, String tempFileId, CompilerPhase phase,
+                                        boolean preserveWhitespace) {
+        Path unsaved = createAndGetTempFile(tempFileId);
         synchronized (LSParserUtils.class) {
             // Since we use the same file name for all the fragment passes we need to make sure following -
             // does not run parallelly.
-            documentManager.openFile(unsaved, content);
-            BallerinaFile model = compile(content, unsaved, compilerPhase, preserveWhiteSpace);
+            String sourceRoot = TextDocumentServiceUtil.getSourceRoot(unsaved);
+            String pkgName = TextDocumentServiceUtil.getPackageNameForGivenFile(sourceRoot, unsaved.toString());
+            LSDocument sourceDocument = new LSDocument();
+            sourceDocument.setUri(unsaved.toUri().toString());
+            sourceDocument.setSourceRoot(sourceRoot);
+
+            PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, documentManager);
+            if ("".equals(pkgName)) {
+                Path filePath = unsaved.getFileName();
+                if (filePath != null) {
+                    pkgName = filePath.toString();
+                }
+            }
+            CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(pkgName, packageRepository,
+                                         sourceDocument, preserveWhitespace, documentManager, CompilerPhase.DEFINE);
+            BallerinaFile model = compile(content, unsaved, phase, context);
             documentManager.closeFile(unsaved);
             return model;
         }
     }
 
-    private static Path createAndGetTempFile(Path tempFolder, String tempFileId) {
+    /**
+     * Create and returns temp file
+     * @param tempFileId
+     * @return Path
+     */
+    public static Path createAndGetTempFile(String tempFileId) {
         if (UNTITLED_BAL.equals(tempFileId)) {
-            return Paths.get(tempFolder.toString(), tempFileId);
+            return Paths.get(untitledProjectPath.toString(), tempFileId);
         }
-        File tempInnerFolder = new File(Paths.get(tempFolder.toString(), tempFileId).toString());
+        File tempInnerFolder = new File(Paths.get(untitledProjectPath.toString(), tempFileId).toString());
         File untitledBal = new File(Paths.get(tempInnerFolder.toString(), UNTITLED_BAL).toString());
         if (!untitledBal.exists()) {
             try {
@@ -135,8 +172,8 @@ public class LSParserUtils {
     /**
      * Compile a Ballerina file.
      *
-     * @param content       file content
-     * @param path          file path
+     * @param content   file content
+     * @param path      file path
      * @param phase {CompilerPhase} set phase for the compiler.
      * @return BallerinaFile
      */
@@ -153,12 +190,6 @@ public class LSParserUtils {
      * @return BallerinaFile
      */
     public static BallerinaFile compile(String content, Path path, CompilerPhase phase, boolean preserveWhiteSpace) {
-        if (documentManager.isFileOpen(path)) {
-            documentManager.updateFile(path, content);
-        } else {
-            documentManager.openFile(path, content);
-        }
-
         String sourceRoot = TextDocumentServiceUtil.getSourceRoot(path);
         String pkgName = TextDocumentServiceUtil.getPackageNameForGivenFile(sourceRoot, path.toString());
         LSDocument sourceDocument = new LSDocument();
@@ -174,12 +205,40 @@ public class LSParserUtils {
         }
         CompilerContext context = TextDocumentServiceUtil.prepareCompilerContext(pkgName, packageRepository,
                                             sourceDocument, preserveWhiteSpace, documentManager, CompilerPhase.DEFINE);
+        return compile(content, path, phase, context);
+    }
 
+    /**
+     * Compile a Ballerina file.
+     *
+     * @param content       file content
+     * @param path          file path
+     * @param phase {CompilerPhase} set phase for the compiler.
+     * @return BallerinaFile
+     */
+    public static BallerinaFile compile(String content, Path path, CompilerPhase phase, CompilerContext context) {
+        if (documentManager.isFileOpen(path)) {
+            documentManager.updateFile(path, content);
+        } else {
+            documentManager.openFile(path, content);
+        }
+
+        String sourceRoot = TextDocumentServiceUtil.getSourceRoot(path);
+        String pkgName = TextDocumentServiceUtil.getPackageNameForGivenFile(sourceRoot, path.toString());
+        LSDocument sourceDocument = new LSDocument();
+        sourceDocument.setUri(path.toUri().toString());
+        sourceDocument.setSourceRoot(sourceRoot);
+
+        if ("".equals(pkgName)) {
+            Path filePath = path.getFileName();
+            if (filePath != null) {
+                pkgName = filePath.toString();
+            }
+        }
+        BLangPackage bLangPackage = null;
         List<Diagnostic> balDiagnostics = new ArrayList<>();
         CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
         context.put(DiagnosticListener.class, diagnosticListener);
-
-        BLangPackage bLangPackage = null;
         try {
             Compiler compiler = Compiler.getInstance(context);
             bLangPackage = compiler.compile(pkgName);
@@ -190,5 +249,15 @@ public class LSParserUtils {
         bfile.setBLangPackage(bLangPackage);
         bfile.setDiagnostics(balDiagnostics);
         return bfile;
+    }
+
+    /**
+     * Returns unsaved file id or null
+     * @param filePath file path
+     * @return file id
+     */
+    public static String getUnsavedFileIdOrNull(String filePath) {
+        Matcher pkgMatcher = untitledFilePattern.matcher(filePath);
+        return (pkgMatcher.find()) ? pkgMatcher.group(1) : null;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
@@ -148,8 +148,9 @@ public class LSParserUtils {
     }
 
     /**
-     * Create and returns temp file
-     * @param tempFileId
+     * Create and returns temp file.
+     *
+     * @param tempFileId temp file id
      * @return Path
      */
     public static Path createAndGetTempFile(String tempFileId) {
@@ -252,7 +253,8 @@ public class LSParserUtils {
     }
 
     /**
-     * Returns unsaved file id or null
+     * Returns unsaved file id or null.
+     *
      * @param filePath file path
      * @return file id
      */

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/LSParserUtils.java
@@ -32,7 +32,6 @@ import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,14 +119,17 @@ public class LSParserUtils {
         if (UNTITLED_BAL.equals(tempFileId)) {
             return Paths.get(tempFolder.toString(), tempFileId);
         }
-        tempFileId += ProjectDirConstants.BLANG_SOURCE_EXT;
-        File untitledBal = new File(Paths.get(tempFolder.toString(), tempFileId).toString());
-        try {
-            untitledBal.createNewFile();
-        } catch (IOException e) {
-            logger.error("Unable to create untitled project directory, unsaved files might not work properly.");
+        File tempInnerFolder = new File(Paths.get(tempFolder.toString(), tempFileId).toString());
+        File untitledBal = new File(Paths.get(tempInnerFolder.toString(), UNTITLED_BAL).toString());
+        if (!untitledBal.exists()) {
+            try {
+                tempInnerFolder.mkdir();
+                untitledBal.createNewFile();
+            } catch (IOException e) {
+                logger.error("Unable to create untitled project directory, unsaved files might not work properly.");
+            }
         }
-        return Paths.get(tempFolder.toString(), tempFileId);
+        return Paths.get(tempInnerFolder.toString(), UNTITLED_BAL);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceDocumentManagerImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceDocumentManagerImpl.java
@@ -21,8 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An in-memory document manager that keeps dirty files in-memory and will match the collection of files currently
@@ -32,7 +32,7 @@ public class WorkspaceDocumentManagerImpl implements WorkspaceDocumentManager {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkspaceDocumentManagerImpl.class);
 
-    private Map<Path, WorkspaceDocument> documentList = new HashMap<>();
+    private Map<Path, WorkspaceDocument> documentList = new ConcurrentHashMap<>();
 
     private static WorkspaceDocumentManagerImpl instance = new WorkspaceDocumentManagerImpl();
 

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  */
 
 public class SwaggerConverterUtils {
-    
+
     /**
      * This method will generate ballerina string from swagger definition. Since ballerina service definition is super
      * set of swagger definition we will take both swagger and ballerina definition and merge swagger changes to


### PR DESCRIPTION
## Purpose
> Currently Language Server(LS) code diagnostics are only available for the already **Saved Files**. Same functionality should be available for the Unsaved Files as well.

## Goals
> Code diagnostics, code completion and other code suggestions should be also available for the **Unsaved Files** as well.

## Approach
> Code diagnostics and other code suggestions have been failed for the unsaved files since there's no physical file created for the unsaved files and PackageLoader fails to load the current package. Thus, whenever there's a code diagnostic request for an unsaved file; it will be saved as a temp file and passed to the compiler.
> 
> <img width="742" alt="screen shot 2018-04-07 at 11 31 26 am" src="https://user-images.githubusercontent.com/1448489/38451956-4a0a22a4-3a57-11e8-9a5b-b3c3833af493.png">


## User stories
> N/A

## Release note
> Fix diagnostics and code completion for the unsaved files

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.2
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"
 
## Learning
> Had to learn about the internals of the LS and how it handles the code diagnostics and code completion.