### PR TITLE
Rename HttpHandle to HttpFuture

### DIFF
--- a/docs/ballerina-by-example/examples/http-2.0-server-push/http-2.0-server-push.bal
+++ b/docs/ballerina-by-example/examples/http-2.0-server-push/http-2.0-server-push.bal
@@ -82,7 +82,7 @@ endpoint http:ClientEndpoint clientEP {
 function main (string[] args) {
 
     http:Request serviceReq = new;
-    http:HttpHandle handle = new;
+    http:HttpFuture httpFuture = new;
     // Submit a request.
     var submissionResult = clientEP -> submit("GET", "/http2Service/main", serviceReq);
     match submissionResult {
@@ -90,19 +90,19 @@ function main (string[] args) {
             io:println("Error occurred while submitting a request");
             return;
         }
-        http:HttpHandle resultantHandle => {
-            handle = resultantHandle;
+        http:HttpFuture resultantFuture => {
+            httpFuture = resultantFuture;
         }
     }
 
     http:PushPromise[] promises = [];
     int promiseCount = 0;
     // Check whether promises exists.
-    boolean hasPromise = clientEP -> hasPromise(handle);
+    boolean hasPromise = clientEP -> hasPromise(httpFuture);
     while (hasPromise) {
         http:PushPromise pushPromise = new;
         // Get the next promise.
-        var nextPromiseResult = clientEP -> getNextPromise(handle);
+        var nextPromiseResult = clientEP -> getNextPromise(httpFuture);
         match nextPromiseResult {
             http:PushPromise resultantPushPromise => {
                 pushPromise = resultantPushPromise;
@@ -123,12 +123,12 @@ function main (string[] args) {
             promises[promiseCount] = pushPromise;
             promiseCount = promiseCount + 1;
         }
-        hasPromise = clientEP -> hasPromise(handle);
+        hasPromise = clientEP -> hasPromise(httpFuture);
     }
 
     http:Response res = new;
     // Get the requested resource.
-    var result = clientEP -> getResponse(handle);
+    var result = clientEP -> getResponse(httpFuture);
     match result {
         http:Response resultantResponse => {
             res = resultantResponse;

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover-connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover-connector.bal
@@ -129,26 +129,26 @@ public type Failover object {
     @Param { value:"httpVerb: The HTTP verb value" }
     @Param { value:"path: The Resource path " }
     @Param { value:"req: An HTTP outbound request message" }
-    @Return { value:"The Handle for further interactions" }
+    @Return { value:"The Future for further interactions" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function submit(string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError);
+    public function submit(string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError);
 
     @Description { value:"The getResponse implementation of the Failover Connector."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP response message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function getResponse(HttpHandle handle) returns (HttpConnectorError);
+    public function getResponse(HttpFuture httpFuture) returns (HttpConnectorError);
 
     @Description { value:"The hasPromise implementation of the Failover Connector."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"Whether push promise exists" }
-    public function hasPromise(HttpHandle handle) returns (boolean);
+    public function hasPromise(HttpFuture httpFuture) returns (boolean);
 
     @Description { value:"The getNextPromise implementation of the Failover Connector."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP Push Promise message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function getNextPromise(HttpHandle handle) returns (PushPromise | HttpConnectorError);
+    public function getNextPromise(HttpFuture httpFuture) returns (PushPromise | HttpConnectorError);
 
     @Description { value:"The getPromisedResponse implementation of the Failover Connector."}
     @Param { value:"promise: The related Push Promise message" }
@@ -249,34 +249,34 @@ public function Failover::get(string path, Request request) returns (Response | 
 @Param { value:"httpVerb: The HTTP verb value" }
 @Param { value:"path: The Resource path " }
 @Param { value:"req: An HTTP outbound request message" }
-@Return { value:"The Handle for further interactions" }
+@Return { value:"The Future for further interactions" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function Failover::submit(string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError) {
+public function Failover::submit(string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError) {
     HttpConnectorError httpConnectorError = {message:"Unsupported action for Failover client."};
     return httpConnectorError;
 }
 
 @Description { value:"The getResponse implementation of the Failover Connector."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"The HTTP response message" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function Failover::getResponse(HttpHandle handle) returns (HttpConnectorError) {
+public function Failover::getResponse(HttpFuture httpFuture) returns (HttpConnectorError) {
     HttpConnectorError httpConnectorError = {message:"Unsupported action for Failover client."};
     return httpConnectorError;
 }
 
 @Description { value:"The hasPromise implementation of the Failover Connector."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"Whether push promise exists" }
-public function Failover::hasPromise(HttpHandle handle) returns (boolean) {
+public function Failover::hasPromise(HttpFuture httpFuture) returns (boolean) {
     return false;
 }
 
 @Description { value:"The getNextPromise implementation of the Failover Connector."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"The HTTP Push Promise message" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function Failover::getNextPromise(HttpHandle handle) returns (PushPromise | HttpConnectorError) {
+public function Failover::getNextPromise(HttpFuture httpFuture) returns (PushPromise | HttpConnectorError) {
     HttpConnectorError httpConnectorError = {message:"Unsupported action for Failover client."};
     return httpConnectorError;
 }

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_caching_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_caching_client.bal
@@ -148,26 +148,26 @@ public type HttpCachingClient object {
     @Param {value:"httpVerb: The HTTP verb value"}
     @Param {value:"path: The Resource path "}
     @Param {value:"req: An HTTP outbound request message"}
-    @Return {value:"The Handle for further interactions"}
+    @Return {value:"The Future for further interactions"}
     @Return {value:"The Error occured during HTTP client invocation"}
-    public function submit (string httpVerb, string path, Request req) returns (HttpHandle|HttpConnectorError);
+    public function submit (string httpVerb, string path, Request req) returns (HttpFuture|HttpConnectorError);
 
     @Description {value:"Retrieves response for a previously submitted request."}
-    @Param {value:"handle: The Handle which relates to previous async invocation"}
+    @Param {value:"httpFuture: The Future which relates to previous async invocation"}
     @Return {value:"The HTTP response message"}
     @Return {value:"The Error occured during HTTP client invocation"}
-    public function getResponse (HttpHandle handle) returns (Response|HttpConnectorError);
+    public function getResponse (HttpFuture httpFuture) returns (Response|HttpConnectorError);
 
     @Description {value:"Checks whether server push exists for a previously submitted request."}
-    @Param {value:"handle: The Handle which relates to previous async invocation"}
+    @Param {value:"httpFuture: The Future which relates to previous async invocation"}
     @Return {value:"Whether push promise exists"}
-    public function hasPromise (HttpHandle handle) returns boolean;
+    public function hasPromise (HttpFuture httpFuture) returns boolean;
 
     @Description {value:"Retrieves the next available push promise for a previously submitted request."}
-    @Param {value:"handle: The Handle which relates to previous async invocation"}
+    @Param {value:"httpFuture: The Future which relates to previous async invocation"}
     @Return {value:"The HTTP Push Promise message"}
     @Return {value:"The Error occured during HTTP client invocation"}
-    public function getNextPromise (HttpHandle handle) returns (PushPromise|HttpConnectorError);
+    public function getNextPromise (HttpFuture httpFuture) returns (PushPromise|HttpConnectorError);
 
     @Description {value:"Retrieves the promised server push response."}
     @Param {value:"promise: The related Push Promise message"}
@@ -281,20 +281,20 @@ public function HttpCachingClient::forward (string path, Request req) returns (R
     }
 }
 
-public function HttpCachingClient::submit (string httpVerb, string path, Request req) returns (HttpHandle|HttpConnectorError) {
+public function HttpCachingClient::submit (string httpVerb, string path, Request req) returns (HttpFuture|HttpConnectorError) {
     return self.httpClient.submit(httpVerb, path, req);
 }
 
-public function HttpCachingClient::getResponse (HttpHandle handle) returns (Response|HttpConnectorError) {
-    return self.httpClient.getResponse(handle);
+public function HttpCachingClient::getResponse (HttpFuture httpFuture) returns (Response|HttpConnectorError) {
+    return self.httpClient.getResponse(httpFuture);
 }
 
-public function HttpCachingClient::hasPromise (HttpHandle handle) returns boolean {
-    return self.httpClient.hasPromise(handle);
+public function HttpCachingClient::hasPromise (HttpFuture httpFuture) returns boolean {
+    return self.httpClient.hasPromise(httpFuture);
 }
 
-public function HttpCachingClient::getNextPromise (HttpHandle handle) returns (PushPromise|HttpConnectorError) {
-    return self.httpClient.getNextPromise(handle);
+public function HttpCachingClient::getNextPromise (HttpFuture httpFuture) returns (PushPromise|HttpConnectorError) {
+    return self.httpClient.getNextPromise(httpFuture);
 }
 
 public function HttpCachingClient::getPromisedResponse (PushPromise promise) returns (Response|HttpConnectorError) {

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_circuit_breaker.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_circuit_breaker.bal
@@ -193,26 +193,26 @@ public type CircuitBreakerClient object {
     @Param { value:"httpVerb: The HTTP verb value" }
     @Param { value:"path: The Resource path " }
     @Param { value:"req: An HTTP outbound request message" }
-    @Return { value:"The Handle for further interactions" }
+    @Return { value:"The Future for further interactions" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function submit (string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError);
+    public function submit (string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError);
 
     @Description { value:"The getResponse implementation of Circuit Breaker."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP response message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function getResponse (HttpHandle handle) returns (Response | HttpConnectorError);
+    public function getResponse (HttpFuture httpFuture) returns (Response | HttpConnectorError);
 
     @Description { value:"The hasPromise implementation of Circuit Breaker."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"Whether push promise exists" }
-    public function hasPromise (HttpHandle handle) returns (boolean);
+    public function hasPromise (HttpFuture httpFuture) returns (boolean);
 
     @Description { value:"The getNextPromise implementation of Circuit Breaker."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP Push Promise message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function getNextPromise (HttpHandle handle) returns (PushPromise | HttpConnectorError);
+    public function getNextPromise (HttpFuture httpFuture) returns (PushPromise | HttpConnectorError);
 
     @Description { value:"The getPromisedResponse implementation of Circuit Breaker."}
     @Param { value:"promise: The related Push Promise message" }
@@ -459,34 +459,34 @@ public function CircuitBreakerClient::forward (string path, Request request) ret
 @Param { value:"httpVerb: The HTTP verb value" }
 @Param { value:"path: The Resource path " }
 @Param { value:"req: An HTTP outbound request message" }
-@Return { value:"The Handle for further interactions" }
+@Return { value:"The Future for further interactions" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function CircuitBreakerClient::submit (string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError) {
+public function CircuitBreakerClient::submit (string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError) {
    HttpConnectorError httpConnectorError = {message:"Unsupported action for Circuit breaker"};
    return httpConnectorError;
 }
 
 @Description { value:"The getResponse implementation of Circuit Breaker."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"The HTTP response message" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function CircuitBreakerClient::getResponse (HttpHandle handle) returns (Response | HttpConnectorError) {
+public function CircuitBreakerClient::getResponse (HttpFuture httpFuture) returns (Response | HttpConnectorError) {
    HttpConnectorError httpConnectorError = {message:"Unsupported action for Circuit breaker"};
    return httpConnectorError;
 }
 
 @Description { value:"The hasPromise implementation of Circuit Breaker."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"Whether push promise exists" }
-public function CircuitBreakerClient::hasPromise (HttpHandle handle) returns (boolean) {
+public function CircuitBreakerClient::hasPromise (HttpFuture httpFuture) returns (boolean) {
    return false;
 }
 
 @Description { value:"The getNextPromise implementation of Circuit Breaker."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"The HTTP Push Promise message" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function CircuitBreakerClient::getNextPromise (HttpHandle handle) returns (PushPromise | HttpConnectorError) {
+public function CircuitBreakerClient::getNextPromise (HttpFuture httpFuture) returns (PushPromise | HttpConnectorError) {
    HttpConnectorError httpConnectorError = {message:"Unsupported action for Circuit breaker"};
    return httpConnectorError;
 }

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
@@ -93,26 +93,26 @@ public type HttpClient object {
     @Param { value:"httpVerb: The HTTP verb value" }
     @Param { value:"path: The Resource path " }
     @Param { value:"req: An HTTP outbound request message" }
-    @Return { value:"The Handle for further interactions" }
+    @Return { value:"The Future for further interactions" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public native function submit(string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError);
+    public native function submit(string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError);
 
     @Description { value:"Retrieves response for a previously submitted request."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP response message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public native function getResponse(HttpHandle handle) returns (Response | HttpConnectorError);
+    public native function getResponse(HttpFuture httpFuture) returns (Response | HttpConnectorError);
 
     @Description { value:"Checks whether server push exists for a previously submitted request."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"Whether push promise exists" }
-    public native function hasPromise(HttpHandle handle) returns (boolean);
+    public native function hasPromise(HttpFuture httpFuture) returns (boolean);
 
     @Description { value:"Retrieves the next available push promise for a previously submitted request."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP Push Promise message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public native function getNextPromise(HttpHandle handle) returns (PushPromise | HttpConnectorError);
+    public native function getNextPromise(HttpFuture httpFuture) returns (PushPromise | HttpConnectorError);
 
     @Description { value:"Retrieves the promised server push response."}
     @Param { value:"promise: The related Push Promise message" }

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_connection.bal
@@ -35,10 +35,10 @@ public type Connection object {
     @Return {value:"Returns null if any error does not exist."}
     public native function forward(Response res) returns (HttpConnectorError | ());
 
-    @Description { value:"Sends a push promise to the caller."}
+    @Description { value:"Pushes a promise to the caller."}
     @Param { value:"conn: The server connector connection" }
     @Param { value:"promise: Push promise message" }
-    @Return { value:"Error occured during HTTP server connector forward" }
+    @Return { value:"Error occured during HTTP server connector promise function invocation" }
     @Return {value:"Returns null if any error does not exist."}
     public native function promise(PushPromise promise) returns (HttpConnectorError | ());
 
@@ -46,7 +46,7 @@ public type Connection object {
     @Param { value:"conn: The server connector connection" }
     @Param { value:"promise: Push promise message" }
     @Param { value:"res: The outbound response message" }
-    @Return { value:"Error occured during HTTP server connector forward" }
+    @Return { value:"Error occured during HTTP server connector pushPromisedResponse function invocation" }
     @Return {value:"Returns null if any error does not exist."}
     public native function pushPromisedResponse(PushPromise promise, Response res) returns (HttpConnectorError | ());
 

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_future.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_future.bal
@@ -1,0 +1,5 @@
+package ballerina.http;
+
+@Description { value:"Represents a future for aynchronous http invocation"}
+public type HttpFuture object {
+};

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_handle.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_handle.bal
@@ -1,5 +1,0 @@
-package ballerina.http;
-
-@Description { value:"Represents a handle for aynchronous http invocation"}
-public type HttpHandle object {
-};

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
@@ -99,26 +99,26 @@ public type LoadBalancer object {
     @Param { value:"httpVerb: The HTTP verb value" }
     @Param { value:"path: The Resource path " }
     @Param { value:"req: An HTTP outbound request message" }
-    @Return { value:"The Handle for further interactions" }
+    @Return { value:"The Future for further interactions" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function submit (string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError);
+    public function submit (string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError);
 
     @Description { value:"The getResponse implementation of the LoadBalancer Connector."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP response message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function getResponse (HttpHandle handle) returns (Response | HttpConnectorError);
+    public function getResponse (HttpFuture httpFuture) returns (Response | HttpConnectorError);
 
     @Description { value:"The hasPromise implementation of the LoadBalancer Connector."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"Whether push promise exists" }
-    public function hasPromise (HttpHandle handle) returns (boolean);
+    public function hasPromise (HttpFuture httpFuture) returns (boolean);
 
     @Description { value:"The getNextPromise implementation of the LoadBalancer Connector."}
-    @Param { value:"handle: The Handle which relates to previous async invocation" }
+    @Param { value:"httpFuture: The Future which relates to previous async invocation" }
     @Return { value:"The HTTP Push Promise message" }
     @Return { value:"The Error occured during HTTP client invocation" }
-    public function getNextPromise (HttpHandle handle) returns (PushPromise | HttpConnectorError);
+    public function getNextPromise (HttpFuture httpFuture) returns (PushPromise | HttpConnectorError);
 
     @Description { value:"The getPromisedResponse implementation of the LoadBalancer Connector."}
     @Param { value:"promise: The related Push Promise message" }
@@ -233,34 +233,34 @@ public function LoadBalancer::get (string path, Request request) returns (Respon
 @Param { value:"httpVerb: The HTTP verb value" }
 @Param { value:"path: The Resource path " }
 @Param { value:"req: An HTTP outbound request message" }
-@Return { value:"The Handle for further interactions" }
+@Return { value:"The Future for further interactions" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function LoadBalancer::submit (string httpVerb, string path, Request req) returns (HttpHandle | HttpConnectorError) {
+public function LoadBalancer::submit (string httpVerb, string path, Request req) returns (HttpFuture | HttpConnectorError) {
     HttpConnectorError httpConnectorError = {message:"Unsupported action for LoadBalancer client."};
     return httpConnectorError;
 }
 
 @Description { value:"The getResponse implementation of the LoadBalancer Connector."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"The HTTP response message" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function LoadBalancer::getResponse (HttpHandle handle) returns (Response | HttpConnectorError) {
+public function LoadBalancer::getResponse (HttpFuture httpFuture) returns (Response | HttpConnectorError) {
     HttpConnectorError httpConnectorError = {message:"Unsupported action for LoadBalancer client."};
     return httpConnectorError;
 }
 
 @Description { value:"The hasPromise implementation of the LoadBalancer Connector."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"Whether push promise exists" }
-public function LoadBalancer::hasPromise (HttpHandle handle) returns (boolean) {
+public function LoadBalancer::hasPromise (HttpFuture httpFuture) returns (boolean) {
     return false;
 }
 
 @Description { value:"The getNextPromise implementation of the LoadBalancer Connector."}
-@Param { value:"handle: The Handle which relates to previous async invocation" }
+@Param { value:"httpFuture: The Future which relates to previous async invocation" }
 @Return { value:"The HTTP Push Promise message" }
 @Return { value:"The Error occured during HTTP client invocation" }
-public function LoadBalancer::getNextPromise (HttpHandle handle) returns (PushPromise | HttpConnectorError) {
+public function LoadBalancer::getNextPromise (HttpFuture httpFuture) returns (PushPromise | HttpConnectorError) {
     HttpConnectorError httpConnectorError = {message:"Unsupported action for LoadBalancer client."};
     return httpConnectorError;
 }

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal
@@ -103,28 +103,28 @@ public type RetryClient object {
         P{{path}} - Target service url.
         P{{request}}  - A request message.
     }
-    public function submit (string httpVerb, string path, Request request) returns (HttpHandle | HttpConnectorError);
+    public function submit (string httpVerb, string path, Request request) returns (HttpFuture | HttpConnectorError);
 
     documentation {
         The getResponse function implementation of the HTTP retry client.
 
-        P{{handle}} -The Handle which relates to previous async invocation.
+        P{{httpFuture}} -The Future which relates to previous async invocation.
     }
-    public function getResponse (HttpHandle handle) returns (Response | HttpConnectorError);
+    public function getResponse (HttpFuture httpFuture) returns (Response | HttpConnectorError);
 
     documentation {
         The hasPromise function implementation of the HTTP retry client.
 
-        P{{handle}} -The Handle which relates to previous async invocation.
+        P{{httpFuture}} -The Future which relates to previous async invocation.
     }
-    public function hasPromise (HttpHandle handle) returns (boolean);
+    public function hasPromise (HttpFuture httpFuture) returns (boolean);
 
     documentation {
         The getNextPromise function implementation of the HTTP retry client.
 
-        P{{handle}} -The Handle which relates to previous async invocation.
+        P{{httpFuture}} -The Future which relates to previous async invocation.
     }
-    public function getNextPromise (HttpHandle handle) returns (PushPromise | HttpConnectorError);
+    public function getNextPromise (HttpFuture httpFuture) returns (PushPromise | HttpConnectorError);
 
     documentation {
         The getPromisedResponse function implementation of the HTTP retry client.
@@ -177,25 +177,25 @@ public function RetryClient::options (string path, Request request) returns (Res
 	return performRetryAction(path, request, HTTP_OPTIONS, self);
 }
 
-public function RetryClient::submit (string httpVerb, string path, Request request) returns (HttpHandle | HttpConnectorError) {
+public function RetryClient::submit (string httpVerb, string path, Request request) returns (HttpFuture | HttpConnectorError) {
     //TODO : Initialize the record type correctly once it is fixed.
 	HttpConnectorError httpConnectorError = {statusCode:501};
 	httpConnectorError.message = "Unsupported action for Circuit breaker";
 	return httpConnectorError;
 }
 
-public function RetryClient::getResponse (HttpHandle handle) returns (Response | HttpConnectorError) {
+public function RetryClient::getResponse (HttpFuture httpFuture) returns (Response | HttpConnectorError) {
     //TODO : Initialize the record type correctly once it is fixed.
 	HttpConnectorError httpConnectorError = {statusCode:501};
 	httpConnectorError.message = "Unsupported action for Circuit breaker";
 	return httpConnectorError;
 }
 
-public function RetryClient::hasPromise (HttpHandle handle) returns (boolean) {
+public function RetryClient::hasPromise (HttpFuture httpFuture) returns (boolean) {
 	return false;
 }
 
-public function RetryClient::getNextPromise (HttpHandle handle) returns (PushPromise | HttpConnectorError) {
+public function RetryClient::getNextPromise (HttpFuture httpFuture) returns (PushPromise | HttpConnectorError) {
     //TODO : Initialize the record type once it is fixed.
 	HttpConnectorError httpConnectorError = {statusCode:501};
 	httpConnectorError.message = "Unsupported action for Circuit breaker";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -165,7 +165,7 @@ public class HttpConstants {
     public static final String LOCAL = "Local";
     public static final String REQUEST = "Request";
     public static final String RESPONSE = "Response";
-    public static final String HTTP_HANDLE = "HttpHandle";
+    public static final String HTTP_FUTURE = "HttpFuture";
     public static final String PUSH_PROMISE = "PushPromise";
     public static final String ENTITY = "Entity";
     public static final String RESPONSE_CACHE_CONTROL = "ResponseCacheControl";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -412,10 +412,10 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
 
         @Override
         public void onResponseHandle(ResponseHandle responseHandle) {
-            BStruct httpHandle = createStruct(this.dataContext.context, HttpConstants.HTTP_HANDLE,
+            BStruct httpFuture = createStruct(this.dataContext.context, HttpConstants.HTTP_FUTURE,
                                               HttpConstants.PROTOCOL_PACKAGE_HTTP);
-            httpHandle.addNativeData(HttpConstants.TRANSPORT_HANDLE, responseHandle);
-            this.dataContext.notifyReply(httpHandle, null);
+            httpFuture.addNativeData(HttpConstants.TRANSPORT_HANDLE, responseHandle);
+            this.dataContext.notifyReply(httpFuture, null);
         }
 
         @Override

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
@@ -44,7 +44,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
-                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpHandle",
+                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpFuture",
                         structPackage = "ballerina.http")
         },
         returnType = {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
@@ -43,7 +43,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
-                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpHandle",
+                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpFuture",
                         structPackage = "ballerina.http")
         },
         returnType = {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
@@ -41,7 +41,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
-                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpHandle",
+                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpFuture",
                         structPackage = "ballerina.http")
         },
         returnType = {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
@@ -44,7 +44,7 @@ import org.wso2.transport.http.netty.contract.ClientConnectorException;
                         structPackage = "ballerina.http")
         },
         returnType = {
-                @ReturnType(type = TypeKind.STRUCT, structType = "HttpHandle", structPackage = "ballerina.http"),
+                @ReturnType(type = TypeKind.STRUCT, structType = "HttpFuture", structPackage = "ballerina.http"),
                 @ReturnType(type = TypeKind.STRUCT, structType = "HttpConnectorError",
                         structPackage = "ballerina.http"),
         }

--- a/tests/ballerina-test-integration/src/test/resources/http2/http-2.0-server-push-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/http2/http-2.0-server-push-test.bal
@@ -27,7 +27,7 @@ service<http:Service> frontendHttpService bind frontendEP {
     frontendHttpResource (endpoint client, http:Request clientRequest) {
 
         http:Request serviceReq = new;
-        http:HttpHandle handle = new;
+        http:HttpFuture httpFuture = new;
         // Submit a request
         var submissionResult = backendClientEP -> submit("GET", "/backend/main", serviceReq);
         match submissionResult {
@@ -38,19 +38,19 @@ service<http:Service> frontendHttpService bind frontendEP {
                 errorResponse.setJsonPayload(errMsg);
                 _ = client -> respond(errorResponse);
             }
-            http:HttpHandle resultantHandle => {
-                handle = resultantHandle;
+            http:HttpFuture resultantFuture => {
+                httpFuture = resultantFuture;
             }
         }
 
         // Check whether promises exists
         http:PushPromise[] promises = [];
         int promiseCount = 0;
-        boolean hasPromise = backendClientEP -> hasPromise(handle);
+        boolean hasPromise = backendClientEP -> hasPromise(httpFuture);
         while (hasPromise) {
             http:PushPromise pushPromise = new;
             // Get the next promise
-            var nextPromiseResult = backendClientEP -> getNextPromise(handle);
+            var nextPromiseResult = backendClientEP -> getNextPromise(httpFuture);
             match nextPromiseResult {
                 http:PushPromise resultantPushPromise => {
                     pushPromise = resultantPushPromise;
@@ -68,7 +68,7 @@ service<http:Service> frontendHttpService bind frontendEP {
             // Store required promises
             promises[promiseCount] = pushPromise;
             promiseCount = promiseCount + 1;
-            hasPromise = backendClientEP -> hasPromise(handle);
+            hasPromise = backendClientEP -> hasPromise(httpFuture);
         }
         // By this time 3 promises should be received, if not send an error response
         if (promiseCount != 3) {
@@ -81,7 +81,7 @@ service<http:Service> frontendHttpService bind frontendEP {
 
         // Get the requested resource
         http:Response res = new;
-        var result = backendClientEP -> getResponse(handle);
+        var result = backendClientEP -> getResponse(httpFuture);
         match result {
             http:Response resultantResponse => {
                 res = resultantResponse;

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
@@ -253,21 +253,21 @@ public type MockClient object {
         return httpConnectorError;
     }
 
-    public function submit (string httpVerb, string path, http:Request req) returns (http:HttpHandle | http:HttpConnectorError) {
+    public function submit (string httpVerb, string path, http:Request req) returns (http:HttpFuture | http:HttpConnectorError) {
         http:HttpConnectorError httpConnectorError = {message:"Unsupported fuction for MockClient"};
         return httpConnectorError;
     }
 
-    public function getResponse (http:HttpHandle handle)  returns (http:Response | http:HttpConnectorError) {
+    public function getResponse (http:HttpFuture httpFuture)  returns (http:Response | http:HttpConnectorError) {
         http:HttpConnectorError httpConnectorError = {message:"Unsupported fuction for MockClient"};
         return httpConnectorError;
     }
 
-    public function hasPromise (http:HttpHandle handle) returns (boolean) {
+    public function hasPromise (http:HttpFuture httpFuture) returns (boolean) {
         return false;
     }
 
-    public function getNextPromise (http:HttpHandle handle) returns (http:PushPromise | http:HttpConnectorError) {
+    public function getNextPromise (http:HttpFuture httpFuture) returns (http:PushPromise | http:HttpConnectorError) {
         http:HttpConnectorError httpConnectorError = {message:"Unsupported fuction for MockClient"};
         return httpConnectorError;
     }

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
@@ -146,21 +146,21 @@ public type MockClient object {
         return httpConnectorError;
     }
 
-    public function submit (string httpVerb, string path, http:Request req) returns (http:HttpHandle | http:HttpConnectorError) {
+    public function submit (string httpVerb, string path, http:Request req) returns (http:HttpFuture | http:HttpConnectorError) {
         http:HttpConnectorError httpConnectorError = {message:"Unsupported fuction for MockClient"};
         return httpConnectorError;
     }
 
-    public function getResponse (http:HttpHandle handle)  returns (http:Response | http:HttpConnectorError) {
+    public function getResponse (http:HttpFuture httpFuture)  returns (http:Response | http:HttpConnectorError) {
         http:HttpConnectorError httpConnectorError = {message:"Unsupported fuction for MockClient"};
         return httpConnectorError;
     }
 
-    public function hasPromise (http:HttpHandle handle) returns (boolean) {
+    public function hasPromise (http:HttpFuture httpFuture) returns (boolean) {
         return false;
     }
 
-    public function getNextPromise (http:HttpHandle handle) returns (http:PushPromise | http:HttpConnectorError) {
+    public function getNextPromise (http:HttpFuture httpFuture) returns (http:PushPromise | http:HttpConnectorError) {
         http:HttpConnectorError httpConnectorError = {message:"Unsupported fuction for MockClient"};
         return httpConnectorError;
     }


### PR DESCRIPTION
## Purpose
As per HTTP API review meeting held on 3rd April 2018, we need to rename HttpHandle to HttpFuture.

## Goals
Rename HttpHandle to HttpFuture.

## Approach
All ballerina files uses HttpHandle is updated.
Http actions are refactored.
Samples are updated.
Test cases are updated.

## User stories

## Release note

## Documentation

## Training


## Certification


## Marketing

## Automation tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 1.8
 
## Learning
