### PR TITLE
Fix issue #6843 and refactor io apis

### DIFF
--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Close.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Close.java
@@ -50,15 +50,14 @@ public class Close implements NativeCallableUnit {
     private static final int BYTE_CHANNEL_INDEX = 0;
 
     private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
         }
-        context.setReturnValues(errorStruct);
         callback.notifySuccess();
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseCharacterChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseCharacterChannel.java
@@ -50,15 +50,14 @@ public class CloseCharacterChannel implements NativeCallableUnit {
     private static final int CHARACTER_CHANNEL_INDEX = 0;
 
     private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
         }
-        context.setReturnValues(errorStruct);
         callback.notifySuccess();
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
@@ -52,15 +52,14 @@ public class CloseDelimitedRecordChannel implements NativeCallableUnit {
     private static final int RECORD_CHANNEL_INDEX = 0;
 
     private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
         }
-        context.setReturnValues(errorStruct);
         callback.notifySuccess();
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
@@ -59,16 +59,15 @@ public class NextTextRecord implements NativeCallableUnit {
      * @return the response obtained after reading record.
      */
     private static EventResult response(EventResult<String[], EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
-        String[] fields = result.getResponse();
         CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
             context.setReturnValues(errorStruct);
         } else {
+            String[] fields = result.getResponse();
             context.setReturnValues(new BStringArray(fields));
         }
         callback.notifySuccess();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Read.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Read.java
@@ -75,18 +75,17 @@ public class Read implements NativeCallableUnit {
      * @return Once the callback is processed we further return back the result.
      */
     private static EventResult readResponse(EventResult<Integer, EventContext> result) {
-        BStruct errorStruct;
         BRefValueArray contentTuple = new BRefValueArray(readTupleType);
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         Throwable error = eventContext.getError();
-        Integer numberOfBytes = result.getResponse();
         CallableUnitCallback callback = eventContext.getCallback();
         byte[] content = (byte[]) eventContext.getProperties().get(ReadBytesEvent.CONTENT_PROPERTY);
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
             context.setReturnValues(errorStruct);
         } else {
+            Integer numberOfBytes = result.getResponse();
             contentTuple.add(0, new BBlob(content));
             contentTuple.add(1, new BInteger(numberOfBytes));
             context.setReturnValues(contentTuple);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ReadCharacters.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ReadCharacters.java
@@ -65,16 +65,15 @@ public class ReadCharacters implements NativeCallableUnit {
      * @return the processed event result.
      */
     private static EventResult readCharactersResponse(EventResult<String, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         CallableUnitCallback callback = eventContext.getCallback();
-        String readChars = result.getResponse();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
             context.setReturnValues(errorStruct);
         } else {
+            String readChars = result.getResponse();
             context.setReturnValues(new BString(readChars));
         }
         callback.notifySuccess();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Write.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Write.java
@@ -72,16 +72,15 @@ public class Write implements NativeCallableUnit {
      * @return Once the callback is processed we further return back the result.
      */
     private static EventResult writeResponse(EventResult<Integer, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         Throwable error = eventContext.getError();
-        Integer numberOfBytesWritten = result.getResponse();
         CallableUnitCallback callback = eventContext.getCallback();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
             context.setReturnValues(errorStruct);
         } else {
+            Integer numberOfBytesWritten = result.getResponse();
             context.setReturnValues(new BInteger(numberOfBytesWritten));
         }
         callback.notifySuccess();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteCharacters.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteCharacters.java
@@ -70,16 +70,15 @@ public class WriteCharacters implements NativeCallableUnit {
      * @return the response returned from the event.
      */
     private static EventResult writeResponse(EventResult<Integer, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
-        Integer numberOfCharactersWritten = result.getResponse();
         Context context = eventContext.getContext();
         CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
             context.setReturnValues(errorStruct);
         } else {
+            Integer numberOfCharactersWritten = result.getResponse();
             context.setReturnValues(new BInteger(numberOfCharactersWritten));
         }
         callback.notifySuccess();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteTextRecord.java
@@ -66,15 +66,14 @@ public class WriteTextRecord implements NativeCallableUnit {
      * @return the result context.
      */
     private static EventResult writeResponse(EventResult<Integer, EventContext> result) {
-        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
         CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
-            errorStruct = IOUtils.createError(context, error.getMessage());
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
         }
-        context.setReturnValues(errorStruct);
         callback.notifySuccess();
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/readers/AsyncReader.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/readers/AsyncReader.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.NonReadableChannelException;
 
 /**
  * <p>
@@ -46,7 +47,7 @@ public class AsyncReader implements Reader {
     public int read(ByteBuffer content, ByteChannel channel) throws IOException {
         try {
             return channel.read(content);
-        } catch (IOException e) {
+        } catch (IOException | NonReadableChannelException e) {
             String message = "could not read from the channel";
             log.error(message, e);
             throw new IOException(message, e);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/readers/BlockingReader.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/readers/BlockingReader.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.NonReadableChannelException;
 
 /**
  * Attempts to fill the entire buffer with content.
@@ -67,7 +68,7 @@ public class BlockingReader implements Reader {
                 }
             }
             return totalNumberOfReadBytes;
-        } catch (IOException e) {
+        } catch (IOException | NonReadableChannelException e) {
             String message = "Could not read from the channel";
             log.error(message, e);
             throw new IOException(message, e);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/writers/AsyncWriter.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/writers/AsyncWriter.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.NonWritableChannelException;
 
 /**
  * Writes bytes to a given channel asynchronously.
@@ -44,7 +45,7 @@ public class AsyncWriter implements Writer {
             if (log.isTraceEnabled()) {
                 log.trace("Number of bytes " + numberOfBytesWritten + " written to channel " + channel.hashCode());
             }
-        } catch (IOException e) {
+        } catch (IOException | NonWritableChannelException e) {
             String message = "Error occurred while writing to channel ";
             throw new BallerinaIOException(message, e);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/writers/BlockingWriter.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/writers/BlockingWriter.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.NonWritableChannelException;
 
 /**
  * Read bytes in blocking mode.
@@ -53,7 +54,7 @@ public class BlockingWriter implements Writer {
             if (log.isDebugEnabled()) {
                 log.debug("Number of bytes " + numberOfBytesWritten + " to the channel " + channel.hashCode());
             }
-        } catch (IOException e) {
+        } catch (IOException | NonWritableChannelException e) {
             String message = "Error occurred while writing to channel ";
             throw new BallerinaIOException(message, e);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/CloseByteChannelEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/CloseByteChannelEvent.java
@@ -44,10 +44,6 @@ public class CloseByteChannelEvent implements Event {
 
     private static final Logger log = LoggerFactory.getLogger(CloseByteChannelEvent.class);
 
-    public CloseByteChannelEvent(Channel channel) {
-        this.channel = channel;
-    }
-
     public CloseByteChannelEvent(Channel channel, EventContext context) {
         this.channel = channel;
         this.context = context;
@@ -60,7 +56,11 @@ public class CloseByteChannelEvent implements Event {
             channel.close();
             result = new BooleanResult(true, context);
         } catch (IOException e) {
-            log.error("Error occurred while closing channel", e);
+            log.error("Error occurred while closing byte channel", e);
+            context.setError(e);
+            result = new BooleanResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while closing byte channel", e);
             context.setError(e);
             result = new BooleanResult(context);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
@@ -95,6 +95,10 @@ public class ReadBytesEvent implements Event {
             log.error("Error occurred while reading bytes", e);
             context.setError(e);
             result = new NumericResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while reading bytes", e);
+            context.setError(e);
+            result = new NumericResult(context);
         }
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/WriteBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/WriteBytesEvent.java
@@ -48,20 +48,6 @@ public class WriteBytesEvent implements Event {
 
     private static final Logger log = LoggerFactory.getLogger(WriteBytesEvent.class);
 
-    /**
-     * Context of the event which will be called upon completion.
-     *
-     * @param byteChannel byte channel
-     * @param content     content
-     * @param startOffset start offset
-     */
-    public WriteBytesEvent(Channel byteChannel, byte[] content, int startOffset) {
-        this.byteChannel = byteChannel;
-        writeBuffer = ByteBuffer.wrap(content);
-        //If a larger position is set, the position would be disregarded
-        writeBuffer.position(startOffset);
-    }
-
     public WriteBytesEvent(Channel byteChannel, byte[] content, int startOffset, EventContext context) {
         this.byteChannel = byteChannel;
         writeBuffer = ByteBuffer.wrap(content);
@@ -81,6 +67,10 @@ public class WriteBytesEvent implements Event {
             result = new NumericResult(numberOfBytesWritten, context);
         } catch (IOException e) {
             log.error("Error occurred while reading bytes", e);
+            context.setError(e);
+            result = new NumericResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while writing bytes", e);
             context.setError(e);
             result = new NumericResult(context);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/CloseCharacterChannelEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/CloseCharacterChannelEvent.java
@@ -44,10 +44,6 @@ public class CloseCharacterChannelEvent implements Event {
 
     private static final Logger log = LoggerFactory.getLogger(CloseCharacterChannel.class);
 
-    public CloseCharacterChannelEvent(CharacterChannel channel) {
-        this.channel = channel;
-    }
-
     public CloseCharacterChannelEvent(CharacterChannel channel, EventContext context) {
         this.channel = channel;
         this.context = context;
@@ -64,6 +60,10 @@ public class CloseCharacterChannelEvent implements Event {
             result = new BooleanResult(true, context);
         } catch (IOException e) {
             log.error("Error occurred while closing character channel", e);
+            context.setError(e);
+            result = new BooleanResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while closing character channel", e);
             context.setError(e);
             result = new BooleanResult(context);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/ReadCharactersEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/ReadCharactersEvent.java
@@ -66,7 +66,11 @@ public class ReadCharactersEvent implements Event {
             String content = channel.read(numberOfCharacters);
             result = new AlphaResult(content, context);
         } catch (IOException e) {
-            log.error("Error occurred while closing character channel", e);
+            log.error("Error occurred while reading from character channel", e);
+            context.setError(e);
+            result = new AlphaResult(context);
+        } catch (Throwable e) {
+            log.error("IO error occurred while reading from character channel", e);
             context.setError(e);
             result = new AlphaResult(context);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/WriteCharactersEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/WriteCharactersEvent.java
@@ -77,6 +77,10 @@ public class WriteCharactersEvent implements Event {
             log.error("Error occurred while writing characters", e);
             context.setError(e);
             result = new NumericResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while writing characters", e);
+            context.setError(e);
+            result = new NumericResult(context);
         }
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/CloseDelimitedRecordEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/CloseDelimitedRecordEvent.java
@@ -43,10 +43,6 @@ public class CloseDelimitedRecordEvent implements Event {
 
     private static final Logger log = LoggerFactory.getLogger(CloseDelimitedRecordEvent.class);
 
-    public CloseDelimitedRecordEvent(DelimitedRecordChannel channel) {
-        this.channel = channel;
-    }
-
     public CloseDelimitedRecordEvent(DelimitedRecordChannel channel, EventContext context) {
         this.channel = channel;
         this.context = context;
@@ -63,6 +59,10 @@ public class CloseDelimitedRecordEvent implements Event {
             result = new BooleanResult(true, context);
         } catch (IOException e) {
             log.error("Error occurred while closing delimited record channel", e);
+            context.setError(e);
+            result = new BooleanResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while closing delimited record channel", e);
             context.setError(e);
             result = new BooleanResult(context);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordReadAllEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordReadAllEvent.java
@@ -70,6 +70,11 @@ public class DelimitedRecordReadAllEvent implements Event {
             context.setError(e);
             result = new ListResult(context);
             return result;
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while reading all delimited records", e);
+            context.setError(e);
+            result = new ListResult(context);
+            return result;
         } finally {
             try {
                 channel.close();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordReadEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordReadEvent.java
@@ -66,6 +66,10 @@ public class DelimitedRecordReadEvent implements Event {
             log.error("Error occurred while reading from record channel", e);
             context.setError(e);
             result = new AlphaCollectionResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while reading delimited records", e);
+            context.setError(e);
+            result = new AlphaCollectionResult(context);
         }
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordWriteEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordWriteEvent.java
@@ -72,6 +72,10 @@ public class DelimitedRecordWriteEvent implements Event {
             log.error("Error occurred while reading from record channel", e);
             context.setError(e);
             result = new NumericResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while writing delimited records", e);
+            context.setError(e);
+            result = new NumericResult(context);
         }
         return result;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/HasNextDelimitedRecordEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/HasNextDelimitedRecordEvent.java
@@ -43,10 +43,6 @@ public class HasNextDelimitedRecordEvent implements Event {
 
     private static final Logger log = LoggerFactory.getLogger(HasNextDelimitedRecordEvent.class);
 
-    public HasNextDelimitedRecordEvent(DelimitedRecordChannel channel) {
-        this.channel = channel;
-    }
-
     public HasNextDelimitedRecordEvent(DelimitedRecordChannel channel, EventContext context) {
         this.channel = channel;
         this.context = context;
@@ -64,6 +60,10 @@ public class HasNextDelimitedRecordEvent implements Event {
         } catch (IOException e) {
             String message = "Error occurred while reading bytes for hasNext()";
             log.error(message, e);
+            context.setError(e);
+            result = new BooleanResult(context);
+        } catch (Throwable e) {
+            log.error("Unidentified error occurred while performing hasNext()", e);
             context.setError(e);
             result = new BooleanResult(context);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/result/AlphaCollectionResult.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/result/AlphaCollectionResult.java
@@ -39,12 +39,6 @@ public class AlphaCollectionResult implements EventResult<String[], EventContext
         this.context = context;
     }
 
-    public AlphaCollectionResult(String[] response) {
-        //We need to clone here since we cannot expose the internal representation
-        //Causes security vulnerability
-        this.response = response.clone();
-    }
-
     public AlphaCollectionResult(String[] response, EventContext context) {
         this.response = response.clone();
         this.context = context;

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/result/AlphaResult.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/result/AlphaResult.java
@@ -35,10 +35,6 @@ public class AlphaResult implements EventResult<String, EventContext> {
      */
     private EventContext context;
 
-    public AlphaResult(String content) {
-        this.content = content;
-    }
-
     public AlphaResult(EventContext context) {
         this.context = context;
     }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXML;
 import org.testng.Assert;
@@ -108,6 +109,26 @@ public class IOTest {
         BRunUtil.invoke(bytesInputOutputProgramFile, "close");
     }
 
+    @Test(description = "Test permission errors in byte read operations")
+    public void testByteOperationPermissionError() throws URISyntaxException {
+        int numberOfBytesToRead = 3;
+        String resourceToRead = "datafiles/io/text/6charfile.txt";
+        BStruct readBytes;
+
+        //Will initialize the channel with write permission
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("w")};
+        BRunUtil.invoke(bytesInputOutputProgramFile, "initFileChannel", args);
+
+        //We try to read bytes
+        args = new BValue[]{new BInteger(numberOfBytesToRead)};
+        BValue[] returns = BRunUtil.invoke(bytesInputOutputProgramFile, "readBytes", args);
+        readBytes = (BStruct) returns[0];
+
+        Assert.assertTrue(readBytes.toString().startsWith("{message:\"could not read"));
+
+        BRunUtil.invoke(bytesInputOutputProgramFile, "close");
+    }
+
     @Test(description = "Test 'readCharacters' function in ballerina.io package")
     public void testReadCharacters() throws URISyntaxException {
         String resourceToRead = "datafiles/io/text/utf8file.txt";
@@ -141,6 +162,59 @@ public class IOTest {
 
         BRunUtil.invoke(characterInputOutputProgramFile, "close");
 
+    }
+
+    @Test(description = "Test permission errors in byte read operations")
+    public void testCharacterOperationPermissionError() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/text/utf8file.txt";
+        int numberOfCharactersToRead = 3;
+        BStruct readCharacters;
+
+        //Will initialize the channel with write permissions
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("w"), new BString("UTF-8")};
+        BRunUtil.invoke(characterInputOutputProgramFile, "initCharacterChannel", args);
+
+        args = new BValue[]{new BInteger(numberOfCharactersToRead)};
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "readCharacters", args);
+        readCharacters = (BStruct) returns[0];
+
+        Assert.assertTrue(readCharacters.toString().startsWith("{message:\"Error occurred"));
+
+        BRunUtil.invoke(characterInputOutputProgramFile, "close");
+    }
+
+    @Test(description = "Test 'readCharacters' function in ballerina.io package")
+    public void testReadAllCharacters() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/text/fileThatExceeds2MB.txt";
+        BString readCharacters;
+
+        //Will initialize the channel
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("r"), new BString("UTF-8")};
+        BRunUtil.invoke(characterInputOutputProgramFile, "initCharacterChannel", args);
+
+        int expectedNumberOfCharacters = 2265223;
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "readAllCharacters");
+        readCharacters = (BString) returns[0];
+
+        String returnedString = readCharacters.stringValue();
+        Assert.assertEquals(returnedString.length(), expectedNumberOfCharacters);
+    }
+
+    @Test(description = "Test 'readCharacters' function in ballerina.io package")
+    public void testReadAllCharactersFromEmptyFile() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/text/emptyFile.txt";
+        BString readCharacters;
+
+        //Will initialize the channel
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("r"), new BString("UTF-8")};
+        BRunUtil.invoke(characterInputOutputProgramFile, "initCharacterChannel", args);
+
+        int expectedNumberOfCharacters = 0;
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "readAllCharacters");
+        readCharacters = (BString) returns[0];
+
+        String returnedString = readCharacters.stringValue();
+        Assert.assertEquals(returnedString.length(), expectedNumberOfCharacters);
     }
 
     @Test(description = "Test 'readRecords' function in ballerina.io package")
@@ -183,6 +257,27 @@ public class IOTest {
 
         BRunUtil.invoke(recordsInputOutputProgramFile, "close");
     }
+
+    @Test(description = "Test permission errors in record read operations")
+    public void testRecordOperationPermissionError() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/records/sample.csv";
+        BStruct records;
+        BBoolean hasNextRecord;
+        int expectedRecordLength = 3;
+
+        //Will initialize the channel with write permissions
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("w"), new BString("UTF-8"),
+                new BString("\n"), new BString(",")};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initDelimitedRecordChannel", args);
+
+        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStruct) returns[0];
+
+        Assert.assertTrue(records.toString().startsWith("{message:\"Error occurred"));
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
 
     @Test(description = "Test 'writeBytes' function in ballerina.io package")
     public void testWriteBytes() {

--- a/tests/ballerina-test/src/test/resources/test-src/io/char_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/char_io.bal
@@ -28,6 +28,21 @@ function readCharacters (int numberOfCharacters) returns (string|io:IOError) {
     }
 }
 
+function readAllCharacters() returns (string|io:IOError){
+    int fixedSize = 500;
+    boolean isDone = false;
+    string result;
+    while(!isDone){
+        string value = check readCharacters(fixedSize);
+        if(lengthof value == 0){
+            isDone = true;
+        }else{
+            result = result + value;
+        }
+    }
+    return result;
+}
+
 function writeCharacters (string content, int startOffset) returns (int|io:IOError) {
     var result = characterChannel.writeCharacters(content, startOffset);
     match result {


### PR DESCRIPTION
## Purpose
Fixes the issue described in #6843. Make async io framework to have more robust control over the unchecked exceptions.

## Goals
1. Fix issue #6843
2. Make robust error handling 
3. Define readAll character operation in Ballerina
4. Add relevant test cases.

## Approach
IO operations are performed as async. Hence at an event where unchecked exceptions are thrown the whole executor stagnates. Resulting in the sequential event not being processed. 

Hence during the event call both checked/unchecked exceptions will be identified and will be proper-gated further  as ballerina errors.   

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8