### PR TITLE
Restrict usage of 'var' assignment.

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/auth.jwtAuth/jwt-authenticator.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/auth.jwtAuth/jwt-authenticator.bal
@@ -16,13 +16,12 @@
 
 package ballerina.auth.jwtAuth;
 
-import ballerina/runtime;
-import ballerina/jwt;
-import ballerina/time;
-import ballerina/config;
-import ballerina/caching;
-import ballerina/log;
 import ballerina/auth.utils;
+import ballerina/caching;
+import ballerina/config;
+import ballerina/jwt;
+import ballerina/log;
+import ballerina/runtime;
 
 @Description {value:"Represents a JWT Authenticator"}
 @Field {value:"jwtValidatorConfig: JWTValidatorConfig object"}
@@ -70,13 +69,11 @@ public function createAuthenticator () returns (JWTAuthenticator) {
 @Return {value:"boolean: true if authentication is a success, else false"}
 @Return {value:"error: If error occured in authentication"}
 public function JWTAuthenticator::authenticate (string jwtToken) returns (boolean|error) {
-    boolean isCacheHit;
-    boolean isAuthenticated;
     int size = authCache.capacity ?: 0;
     if (size > 0) {
         match self.authenticateFromCache(jwtToken) {
             (boolean, boolean) cacheHit => {
-                (isCacheHit, isAuthenticated) = cacheHit;
+                var (isCacheHit, isAuthenticated) = cacheHit;
                 if (isCacheHit) {
                     return isAuthenticated;
                 }
@@ -90,7 +87,7 @@ public function JWTAuthenticator::authenticate (string jwtToken) returns (boolea
     }
     match jwt:validate(jwtToken, jwtValidatorConfig) {
         jwt:Payload authResult => {
-            isAuthenticated = true;
+            boolean isAuthenticated = true;
             setAuthContext(authResult, jwtToken);
             size = authCache.capacity ?: 0;
             if (size > 0) {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
@@ -137,19 +137,6 @@ public class VarDeclaredAssignmentStmtTest {
         Assert.assertEquals(((BString) returns[3]).stringValue(), "name_4");
     }
 
-    @Test(description = "Test var with at least non declared ref in LHS expr.")
-    public void testVarDeclarationWithAtLeaseOneNonDeclaredSymbol() {
-        BValue[] returns = BRunUtil.invoke(result, "testVarDeclarationWithAtLeaseOneNonDeclaredSymbol",
-                new BValue[]{});
-
-        Assert.assertEquals(returns.length, 2);
-        Assert.assertSame(returns[0].getClass(), BInteger.class);
-        Assert.assertSame(returns[1].getClass(), BStruct.class);
-
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
-        Assert.assertEquals(returns[1].stringValue(), "{message:\"\", cause:[]}");
-    }
-
     @Test(description = "Test boolean to var assignment.")
     public void testBooleanToVarAssignment() {
         BValue[] returns = BRunUtil.invoke(result, "testBooleanToVarAssignment",
@@ -206,8 +193,10 @@ public class VarDeclaredAssignmentStmtTest {
     @Test
     public void testVarDeclarationWithAllDeclaredSymbols() {
         CompileResult res = BCompileUtil.compile("test-src/types/var/var-declared-symbols-negative.bal");
-        Assert.assertEquals(res.getErrorCount(), 1);
-        BAssertUtil.validateError(res, 0, "no new variables on left side", 4, 5);
+        Assert.assertEquals(res.getErrorCount(), 3);
+        BAssertUtil.validateError(res, 0, "redeclared symbol 'a'", 4, 10);
+        BAssertUtil.validateError(res, 1, "redeclared symbol 's'", 4, 13);
+        BAssertUtil.validateError(res, 2, "redeclared symbol 'a'", 14, 10);
     }
 
     @Test

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytes_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytes_io.bal
@@ -11,7 +11,7 @@ function readBytes (int numberOfBytes) returns (blob|io:IOError) {
     var result = channel.read(numberOfBytes);
     match result {
         (blob,int) content =>{
-            var (bytes, numberOfBytes) = content;
+            var (bytes, _) = content;
             return bytes;
         }
         io:IOError err =>{

--- a/tests/ballerina-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -90,7 +90,6 @@ function testIgnoredValue1 () returns string {
 
 function testIgnoredValue2 () returns string {
     (string, int, int) x = ("foo", 1, 2);
-    string a;
     var (a, _, c) = x;
     return a;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/types/var/var-declared-symbols-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/var/var-declared-symbols-negative.bal
@@ -8,3 +8,15 @@ function testVarDeclarationWithAllDeclaredSymbols () returns (int, string) {
 function unionReturnTest() returns (int, string) {
     return (5, "hello");
 }
+
+function testVarDeclarationWithAtLeaseOneNonDeclaredSymbol () returns (int, error) {
+    int a;
+    var (a, err) = returnTupleForVarAssignment();
+    return (a, err);
+}
+
+function returnTupleForVarAssignment() returns (int, error) {
+    int a = 10;
+    error er = {};
+    return (a, er);
+}

--- a/tests/ballerina-test/src/test/resources/test-src/types/var/var-type-assign-stmt.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/var/var-type-assign-stmt.bal
@@ -10,18 +10,6 @@ type Person {
     boolean alive;
 };
 
-function testVarDeclarationWithAtLeaseOneNonDeclaredSymbol () returns (int, error) {
-    int a;
-    var (a, err) = returnTupleForVarAssignment();
-    return (a, err);
-}
-
-function returnTupleForVarAssignment() returns (int, error) {
-    int a = 10;
-    error er = {};
-    return (a, er);
-}
-
 function testIntToVarAssignment() returns (int) {
     var age = 81;
     return age;


### PR DESCRIPTION
Now var requires an undefined variable. Following is invalid.

```
   int a;
   var (a, b) = ("foo", 5);
```


