### PR TITLE
Add CB configuration to the Simple Client Endpoint

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/simple_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/simple_client_endpoint.bal
@@ -66,6 +66,7 @@ documentation {
     The configurations possible with the SimpleClientEndpoint. This endpoint excludes the resiliency related configurations.
 
     F{{url}} - The URL of the HTTP endpoint to connect to
+    F{{circuitBreaker}} - Circuit Breaker configuration
     F{{secureSocket}} - The SSL configurations for the endpoint
     F{{endpointTimeout}} - The maximum time to wait (in milli seconds) for a response before closing the connection
     F{{httpVersion}} - The HTTP version to be used to communicate with the endpoint
@@ -81,6 +82,7 @@ documentation {
 }
 public type SimpleClientEndpointConfiguration {
     string url,
+    CircuitBreakerConfig? circuitBreaker,
     SecureSocket? secureSocket,
     int endpointTimeout = 60000,
     string httpVersion = "1.1",
@@ -110,6 +112,7 @@ public function SimpleClientEndpoint::init(SimpleClientEndpointConfiguration sim
     self.httpEP.config = {};
     self.httpEP.config.targets = [];
 
+    self.httpEP.config.circuitBreaker = simpleConfig.circuitBreaker;
     self.httpEP.config.targets[0] = {url: simpleConfig.url, secureSocket: simpleConfig.secureSocket};
     self.httpEP.config.endpointTimeout = simpleConfig.endpointTimeout;
     self.httpEP.config.httpVersion = simpleConfig.httpVersion;
@@ -122,10 +125,18 @@ public function SimpleClientEndpoint::init(SimpleClientEndpointConfiguration sim
     self.httpEP.config.proxyConfig = simpleConfig.proxyConfig;
     self.httpEP.config.connectionThrottling = simpleConfig.connectionThrottling;
 
-    if (simpleConfig.cacheConfig.enabled) {
-        self.httpEP.config.cacheConfig = simpleConfig.cacheConfig;
-        self.httpEP.httpClient = createHttpCachingClient(url, self.httpEP.config, self.httpEP.config.cacheConfig);
-    } else {
-        self.httpEP.httpClient = createHttpClient(url, self.httpEP.config);
+    var cbConfig = simpleConfig.circuitBreaker;
+    match cbConfig  {
+        CircuitBreakerConfig cb => {
+            self.httpEP.httpClient = createCircuitBreakerClient(url, self.httpEP.config);
+        }
+        () => {
+            if (simpleConfig.cacheConfig.enabled) {
+                self.httpEP.config.cacheConfig = simpleConfig.cacheConfig;
+                self.httpEP.httpClient = createHttpCachingClient(url, self.httpEP.config, self.httpEP.config.cacheConfig);
+            } else {
+                self.httpEP.httpClient = createHttpClient(url, self.httpEP.config);
+            }
+        }
     }
 }


### PR DESCRIPTION
This will provide the circuit breaking functionality to the simple client endpoint.

## Purpose
Include the Circuit Breaker in the simple client endpoint.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```java
import ballerina/http;
import ballerina/runtime;
import ballerina/io;

endpoint http:ServiceEndpoint passthruEP {
    port:9090
};

endpoint http:ServiceEndpoint backendEP {
    port:8080
};

endpoint http:SimpleClientEndpoint backendClientEP {
    url:"http://localhost:8080",
    circuitBreaker: {
        rollingWindow: {
            timeWindow:10000,
            bucketSize:2000
        },
        failureThreshold:0.2,
        resetTimeout:10000,
        statusCodes:[400, 404, 500]
    },
    endpointTimeout:2000
};

@http:ServiceConfig {
    basePath:"/cb"
}
service<http:Service> circuitbreaker bind passthruEP {

    @http:ResourceConfig {
        methods:["GET"],
        path:"/"
    }
    passthru (endpoint client, http:Request request) {
        http:Response response = new;
        var backendRes = backendClientEP -> forward("/hello", request);
        match backendRes {
            http:Response res => {
            _ = client -> forward(res);}
            http:HttpConnectorError err1 => {
             response = new;
            response.statusCode = 500;
            response.setStringPayload(err1.message);
            _ = client -> respond(response);}
        }
    }
}


public  int counter = 1;

// This sample service can be used to mock connection timeouts and service outages. Service outage can be mocked by stopping/starting this service.
// This should be run separately from the circuitBreakerDemo service.
@http:ServiceConfig {basePath:"/hello"}
service<http:Service> helloWorld bind backendEP {
    @http:ResourceConfig {
        methods:["GET"],
        path:"/"
    }
    sayHello (endpoint client, http:Request req) {
        if (counter % 5 == 0) {
            runtime:sleepCurrentWorker(5000);
            counter = counter + 1;
            http:Response res = new;
            res.setStringPayload("Hello World!!!");
            _ = client -> respond(res);
        } else if (counter % 5 == 3) {
            counter = counter + 1;
            http:Response res = new;
            res.statusCode = 500;
            res.setStringPayload("Internal erro r occurred while processing the request.");
            _ = client -> respond(res);
        } else {
            counter = counter + 1;
            http:Response res = new;
            res.setStringPayload("Hello World!!!");
            _ = client -> respond(res);
        }
    }
}
```