### PR TITLE
[HTTP] Refactor rejectPromise function

### DIFF
--- a/docs/ballerina-by-example/examples/http-2.0-server-push/http-2.0-server-push.bal
+++ b/docs/ballerina-by-example/examples/http-2.0-server-push/http-2.0-server-push.bal
@@ -116,7 +116,7 @@ function main (string[] args) {
 
         if (pushPromise.path == "/resource2") {
             // Client is not interested of getting '/resource2', So reject the promise.
-            _ = clientEP -> rejectPromise(pushPromise);
+            clientEP -> rejectPromise(pushPromise);
             io:println("Push promise for resource2 rejected");
         } else {
             // Store required promises.

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover-connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover-connector.bal
@@ -158,8 +158,7 @@ public type Failover object {
 
     @Description { value:"The rejectPromise implementation of the Failover Connector."}
     @Param { value:"promise: The Push Promise need to be rejected" }
-    @Return { value:"Whether operation is successful" }
-    public function rejectPromise(PushPromise promise) returns (boolean);
+    public function rejectPromise(PushPromise promise);
 };
 
 
@@ -292,9 +291,7 @@ public function Failover::getPromisedResponse(PushPromise promise) returns (Resp
 
 @Description { value:"The rejectPromise implementation of the Failover Connector."}
 @Param { value:"promise: The Push Promise need to be rejected" }
-@Return { value:"Whether operation is successful" }
-public function Failover::rejectPromise(PushPromise promise) returns (boolean) {
-    return false;
+public function Failover::rejectPromise(PushPromise promise) {
 }
 
 // Performs execute action of the Failover connector. extract the corresponding http integer value representation

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_caching_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_caching_client.bal
@@ -177,8 +177,7 @@ public type HttpCachingClient object {
 
     @Description {value:"Rejects a push promise."}
     @Param {value:"promise: The Push Promise need to be rejected"}
-    @Return {value:"Whether operation is successful"}
-    public function rejectPromise (PushPromise promise) returns boolean;
+    public function rejectPromise (PushPromise promise);
 };
 
 @Description {value:"Creates an HTTP client capable of caching HTTP responses."}
@@ -301,8 +300,8 @@ public function HttpCachingClient::getPromisedResponse (PushPromise promise) ret
     return self.httpClient.getPromisedResponse(promise);
 }
 
-public function HttpCachingClient::rejectPromise (PushPromise promise) returns boolean {
-    return self.httpClient.rejectPromise(promise);
+public function HttpCachingClient::rejectPromise (PushPromise promise) {
+    self.httpClient.rejectPromise(promise);
 }
 
 function getCachedResponse (HttpCache cache, HttpClient httpClient, Request req, string httpMethod, string path,

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_circuit_breaker.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_circuit_breaker.bal
@@ -223,8 +223,7 @@ public type CircuitBreakerClient object {
 
     @Description { value:"The rejectPromise implementation of Circuit Breaker."}
     @Param { value:"promise: The Push Promise need to be rejected" }
-    @Return { value:"Whether operation is successful" }
-    public function rejectPromise (PushPromise promise) returns (boolean); 
+    public function rejectPromise (PushPromise promise);
 };
 
 public function CircuitBreakerClient::post (string path, Request request) returns (Response | HttpConnectorError) {
@@ -503,9 +502,7 @@ public function CircuitBreakerClient::getPromisedResponse (PushPromise promise) 
 
 @Description { value:"The rejectPromise implementation of Circuit Breaker."}
 @Param { value:"promise: The Push Promise need to be rejected" }
-@Return { value:"Whether operation is successful" }
-public function CircuitBreakerClient::rejectPromise (PushPromise promise) returns (boolean) {
-   return false;
+public function CircuitBreakerClient::rejectPromise (PushPromise promise) {
 }
 
 public function updateCircuitState (CircuitHealth circuitHealth, CircuitState currentStateValue,

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
@@ -122,8 +122,7 @@ public type HttpClient object {
 
     @Description { value:"Rejects a push promise."}
     @Param { value:"promise: The Push Promise need to be rejected" }
-    @Return { value:"Whether operation is successful" }
-    public native function rejectPromise(PushPromise promise) returns (boolean);
+    public native function rejectPromise(PushPromise promise);
 };
 
 @Description { value:"HttpConnectorError record represents an error occured during the HTTP client invocation" }

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
@@ -128,8 +128,7 @@ public type LoadBalancer object {
 
     @Description { value:"The rejectPromise implementation of the LoadBalancer Connector."}
     @Param { value:"promise: The Push Promise need to be rejected" }
-    @Return { value:"Whether operation is successful" }
-    public function rejectPromise (PushPromise promise) returns (boolean);
+    public function rejectPromise (PushPromise promise);
 
 };
 
@@ -276,9 +275,7 @@ public function LoadBalancer::getPromisedResponse (PushPromise promise) returns 
 
 @Description { value:"The rejectPromise implementation of the LoadBalancer Connector."}
 @Param { value:"promise: The Push Promise need to be rejected" }
-@Return { value:"Whether operation is successful" }
-public function LoadBalancer::rejectPromise (PushPromise promise) returns (boolean) {
-    return false;
+public function LoadBalancer::rejectPromise (PushPromise promise) {
 }
 
 // Performs execute action of the Load Balance connector. extract the corresponding http integer value representation

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal
@@ -138,7 +138,7 @@ public type RetryClient object {
 
         P{{promise}} - The Push Promise need to be rejected.
     }
-    public function rejectPromise (PushPromise promise) returns (boolean);
+    public function rejectPromise (PushPromise promise);
 };
 
 public function RetryClient::post (string path, Request request) returns (Response | HttpConnectorError) {
@@ -209,8 +209,7 @@ public function RetryClient::getPromisedResponse (PushPromise promise) returns (
 	return httpConnectorError;
 }
 
-public function RetryClient::rejectPromise (PushPromise promise) returns (boolean) {
-	return false;
+public function RetryClient::rejectPromise (PushPromise promise) {
 }
 
 // Performs execute action of the retry client. extract the corresponding http integer value representation

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
@@ -44,7 +44,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
-                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpFuture",
+                @Argument(name = "httpFuture", type = TypeKind.STRUCT, structType = "HttpFuture",
                         structPackage = "ballerina.http")
         },
         returnType = {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
@@ -43,7 +43,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
-                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpFuture",
+                @Argument(name = "httpFuture", type = TypeKind.STRUCT, structType = "HttpFuture",
                         structPackage = "ballerina.http")
         },
         returnType = {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
@@ -41,7 +41,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
-                @Argument(name = "handle", type = TypeKind.STRUCT, structType = "HttpFuture",
+                @Argument(name = "httpFuture", type = TypeKind.STRUCT, structType = "HttpFuture",
                         structPackage = "ballerina.http")
         },
         returnType = {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/RejectPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/RejectPromise.java
@@ -19,12 +19,10 @@ package org.ballerinalang.net.http.actions.httpclient;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -43,9 +41,6 @@ import org.wso2.transport.http.netty.message.Http2PushPromise;
                 @Argument(name = "client", type = TypeKind.STRUCT),
                 @Argument(name = "promise", type = TypeKind.STRUCT, structType = "PushPromise",
                         structPackage = "ballerina.http")
-        },
-        returnType = {
-                @ReturnType(type = TypeKind.BOOLEAN)
         }
 )
 public class RejectPromise extends AbstractHTTPAction {
@@ -62,7 +57,6 @@ public class RejectPromise extends AbstractHTTPAction {
         HttpClientConnector clientConnector =
                 (HttpClientConnector) bConnector.getNativeData(HttpConstants.HTTP_CLIENT);
         clientConnector.rejectPushResponse(http2PushPromise);
-        context.setReturnValues(new BBoolean(true)); // TODO: Implement a listener to see the progress
         callback.notifySuccess();
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
@@ -277,8 +277,7 @@ public type MockClient object {
         return httpConnectorError;
     }
 
-    public function rejectPromise (http:PushPromise promise) returns (boolean) {
-        return false;
+    public function rejectPromise (http:PushPromise promise) {
     }
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
@@ -170,8 +170,7 @@ public type MockClient object {
         return httpConnectorError;
     }
 
-    public function rejectPromise (http:PushPromise promise) returns (boolean) {
-        return false;
+    public function rejectPromise (http:PushPromise promise) {
     }
 };
 


### PR DESCRIPTION
## Purpose
rejectPromise function invocation never guarantees a given promise is rejected successfully or not at the network level. 
Promised resource may have already arrived even before rejecting the associated promise.
So need to refactor rejectPromise native function to remove unnecessary return values.

## Goals
Remove return values of rejectPromise native function.

## Approach
Refactored RejectPromise function by removing return values.
Updated samples and test cases.

## User stories

## Release note

## Documentation

## Training

## Certification

## Marketing

## Automation tests

## Security checks

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 1.8
 
## Learning
