### PR TITLE
Change WebSocket Upgrade Function Names

### DIFF
--- a/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.bal
+++ b/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.bal
@@ -21,7 +21,7 @@ service<http:Service> ChatAppUpgrader bind ep {
     upgrader(endpoint ep, http:Request req, string name) {
         endpoint http:WebSocketListener wsEp;
         map<string> headers;
-        wsEp = ep -> upgradeToWebSocket(headers);
+        wsEp = ep -> acceptWebSocketUpgrade(headers);
         wsEp.attributes[NAME] = name;
         wsEp.attributes[AGE] = req.getQueryParams()["age"];
         string msg = "Hi " + name + "! You have succesfully connected to the chat";

--- a/docs/ballerina-by-example/examples/websocket-proxy-server/websocket-proxy-server.bal
+++ b/docs/ballerina-by-example/examples/websocket-proxy-server/websocket-proxy-server.bal
@@ -23,7 +23,7 @@ service <http:Service> proxy bind serviceEndpoint {
             callbackService:typeof ClientService
         };
         endpoint http:WebSocketListener wsServerEp;
-        wsServerEp = ep -> upgradeToWebSocket({"custom":"header"});
+        wsServerEp = ep -> acceptWebSocketUpgrade({"custom":"header"});
         wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsServerEp;
         wsServerEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
     }

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_connection.bal
@@ -52,12 +52,12 @@ public type Connection object {
 
     @Description {value:"Sends a upgrade request with custom headers"}
     @Param {value:"headers: a map of custom headers for handshake."}
-    public native function upgradeToWebSocket(map headers) returns WebSocketListener;
+    public native function acceptWebSocketUpgrade(map headers) returns WebSocketListener;
 
     @Description {value:"Cancels the handshake"}
     @Param {value:"statusCode: Status code for closing the connection"}
     @Param {value:"reason: Reason for closing the connection"}
-    public native function cancelUpgradeToWebSocket(int status, string reason);
+    public native function cancelWebSocketUpgrade(int status, string reason);
 
     public function respondContinue() returns (HttpConnectorError | ());
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/AcceptWebSocketUpgrade.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/AcceptWebSocketUpgrade.java
@@ -16,44 +16,73 @@
 
 package org.ballerinalang.net.http.actions.websocketconnector;
 
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.net.http.WebSocketConnectionManager;
 import org.ballerinalang.net.http.WebSocketConstants;
+import org.ballerinalang.net.http.WebSocketService;
+import org.ballerinalang.net.http.WebSocketUtil;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
+
+import java.util.Set;
 
 /**
  * {@code Get} is the GET action implementation of the HTTP Connector.
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
-        functionName = "cancelUpgradeToWebSocket",
+        functionName = "acceptWebSocketUpgrade",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CONNECTION,
                              structPackage = "ballerina.http"),
         args = {
-                @Argument(name = "status", type = TypeKind.INT),
-                @Argument(name = "reason", type = TypeKind.STRING)
+                @Argument(name = "headers", type = TypeKind.MAP)
         },
         isPublic = true
 )
-public class CancelUpgradeToWebSocket extends BlockingNativeCallableUnit {
+public class AcceptWebSocketUpgrade implements NativeCallableUnit {
+
     @Override
-    public void execute(Context context) {
+    public void execute(Context context, CallableUnitCallback callback) {
         BStruct httpConnection = (BStruct) context.getRefArgument(0);
-        int statusCode = (int) context.getIntArgument(0);
-        String reason = context.getStringArgument(0);
+
         WebSocketInitMessage initMessage =
                 (WebSocketInitMessage) httpConnection.getNativeData(WebSocketConstants.WEBSOCKET_MESSAGE);
+        WebSocketConnectionManager connectionManager = (WebSocketConnectionManager) httpConnection
+                .getNativeData(WebSocketConstants.WEBSOCKET_CONNECTION_MANAGER);
         if (initMessage == null) {
-            throw new BallerinaConnectorException("Not a WebSocket upgrade request. Cannot cancel the request");
+            throw new BallerinaConnectorException("Not a WebSocket upgrade request. Cannot upgrade from HTTP to WS");
         }
-        initMessage.cancelHandShake(statusCode, reason);
-        context.setReturnValues();
+        if (connectionManager == null) {
+            throw new BallerinaConnectorException("Cannot accept a WebSocket upgrade without WebSocket " +
+                                                          "connection manager");
+        }
+
+        WebSocketService webSocketService = (WebSocketService) httpConnection.getNativeData(
+                WebSocketConstants.WEBSOCKET_SERVICE);
+
+        BMap<String, BString> headers = (BMap<String, BString>) context.getRefArgument(1);
+        DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
+        Set<String> keys = headers.keySet();
+        for (String key : keys) {
+            httpHeaders.add(key, headers.get(key));
+        }
+
+        WebSocketUtil.handleHandshake(webSocketService, connectionManager, httpHeaders, initMessage, context, callback);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/CancelWebSocketUpgrade.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/CancelWebSocketUpgrade.java
@@ -16,73 +16,44 @@
 
 package org.ballerinalang.net.http.actions.websocketconnector;
 
-import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
-import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BMap;
-import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.WebSocketConnectionManager;
 import org.ballerinalang.net.http.WebSocketConstants;
-import org.ballerinalang.net.http.WebSocketService;
-import org.ballerinalang.net.http.WebSocketUtil;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
-
-import java.util.Set;
 
 /**
  * {@code Get} is the GET action implementation of the HTTP Connector.
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
-        functionName = "upgradeToWebSocket",
+        functionName = "cancelWebSocketUpgrade",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CONNECTION,
                              structPackage = "ballerina.http"),
         args = {
-                @Argument(name = "headers", type = TypeKind.MAP)
+                @Argument(name = "status", type = TypeKind.INT),
+                @Argument(name = "reason", type = TypeKind.STRING)
         },
         isPublic = true
 )
-public class UpgradeToWebSocket implements NativeCallableUnit {
-
+public class CancelWebSocketUpgrade extends BlockingNativeCallableUnit {
     @Override
-    public void execute(Context context, CallableUnitCallback callback) {
+    public void execute(Context context) {
         BStruct httpConnection = (BStruct) context.getRefArgument(0);
-
+        int statusCode = (int) context.getIntArgument(0);
+        String reason = context.getStringArgument(0);
         WebSocketInitMessage initMessage =
                 (WebSocketInitMessage) httpConnection.getNativeData(WebSocketConstants.WEBSOCKET_MESSAGE);
-        WebSocketConnectionManager connectionManager = (WebSocketConnectionManager) httpConnection
-                .getNativeData(WebSocketConstants.WEBSOCKET_CONNECTION_MANAGER);
         if (initMessage == null) {
-            throw new BallerinaConnectorException("Not a WebSocket upgrade request. Cannot upgrade from HTTP to WS");
+            throw new BallerinaConnectorException("Not a WebSocket upgrade request. Cannot cancel the request");
         }
-        if (connectionManager == null) {
-            throw new BallerinaConnectorException("Cannot accept a WebSocket upgrade without WebSocket " +
-                                                          "connection manager");
-        }
-
-        WebSocketService webSocketService = (WebSocketService) httpConnection.getNativeData(
-                WebSocketConstants.WEBSOCKET_SERVICE);
-
-        BMap<String, BString> headers = (BMap<String, BString>) context.getRefArgument(1);
-        DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
-        Set<String> keys = headers.keySet();
-        for (String key : keys) {
-            httpHeaders.add(key, headers.get(key));
-        }
-
-        WebSocketUtil.handleHandshake(webSocketService, connectionManager, httpHeaders, initMessage, context, callback);
-    }
-
-    @Override
-    public boolean isBlocking() {
-        return false;
+        initMessage.cancelHandShake(statusCode, reason);
+        context.setReturnValues();
     }
 }


### PR DESCRIPTION
## Purpose
> Change WebSocket upgrade method names to be for clear

## Goals
> Make user clear about the functionalities via function names
## Approach
> 
- Rename **upgradeToWebSocket()** to **acceptWebSocketUpgrade()**
- Rename **cancelUpgradeToWebSocket()** to **cancelWebSocketUpgrade()**
