### PR TITLE
Update json-arrays.description

### DIFF
--- a/docs/ballerina-by-example/examples/json-arrays/json-arrays.description
+++ b/docs/ballerina-by-example/examples/json-arrays/json-arrays.description
@@ -1,1 +1,2 @@
-// JSON array literals are written exactly the same way as Ballerina arrays except that they’re 1-dimensional only.
+//JSON array literals are written exactly the same way as Ballerina arrays.
+//JSON array values must be of type string, number, object, array, boolean or null.


### PR DESCRIPTION
## Purpose
TCC review: minor change

## Goals
Added possible value types. 
Removed the statement indicating that it is "1-dimensional" because both JSON and ballerina arrays are multi dimensional e.g. json j1 = [ [1],[2] ]
@manuranga 
