### PR TITLE
Fix MicroTransactionsTestCase failing on some machines

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions/2pc_transaction.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions/2pc_transaction.bal
@@ -138,14 +138,15 @@ type TwoPhaseCommitTransaction object {
     function prepareParticipants(string protocol) returns boolean {
         boolean successful = true;
         foreach _, participant in self.participants {
-            Protocol[] protocols = participant.participantProtocols;
-            foreach proto in protocols {
-                if (proto.name == protocol) {
-                    match proto.protocolFn {
-                        (function (string, int, string) returns boolean)protocolFn => {
+            LocalProtocol[] | RemoteProtocol[] protocols = getProtocols(participant);
+            match protocols {
+                LocalProtocol[] localProtocols => {
+                    foreach localProto in localProtocols {
+                        if(localProto.name == protocol) {
+                            (function (string, int, string) returns boolean) protocolFn = localProto.protocolFn;
                             // if the participant is a local participant, i.e. protoFn is set, then call that fn
                             log:printInfo("Preparing local participant: " + participant.participantId);
-                            if (!protocolFn(self.transactionId, proto.transactionBlockId, COMMAND_PREPARE)) {
+                            if (!protocolFn(self.transactionId, localProto.transactionBlockId, COMMAND_PREPARE)) {
                                 // Don't send notify to participants who have failed or rejected prepare
                                 boolean removed = self.participants.remove(participant.participantId);
                                 if (!removed){
@@ -154,8 +155,13 @@ type TwoPhaseCommitTransaction object {
                                 successful = false;
                             }
                         }
-                        () => {
-                            if (!self.prepareRemoteParticipant(participant, proto.url)) {
+                    }
+                }
+
+                RemoteProtocol[] remoteProtocols => {
+                    foreach remoteProto in remoteProtocols {
+                        if(remoteProto.name == protocol) {
+                            if (!self.prepareRemoteParticipant(participant, remoteProto.url)) {
                                 successful = false;
                             }
                         }
@@ -169,13 +175,21 @@ type TwoPhaseCommitTransaction object {
     function notifyAbortToVolatileParticipants() returns boolean {
         map<Participant> participants = self.participants;
         foreach _, participant in participants {
-            Protocol[] protocols = participant.participantProtocols;
-            foreach proto in protocols {
-                if (proto.name == PROTOCOL_VOLATILE) {
-                    var ret = self.notifyRemoteParticipant(participant, COMMAND_ABORT);
-                    match ret {
-                        error err => return false;
-                        string s => return true;
+            LocalProtocol[] | RemoteProtocol[] protocols = getProtocols(participant);
+            match protocols {
+                LocalProtocol[] localProtocols => {
+                    //TODO: check this
+                }
+                RemoteProtocol[]  remoteProtocols => {
+                    foreach proto in remoteProtocols {
+                        if (proto.name == PROTOCOL_VOLATILE) {
+                            RemoteParticipant remoteParticipant = check <RemoteParticipant>participant;
+                            var ret = self.notifyRemoteParticipant(remoteParticipant, COMMAND_ABORT);
+                            match ret {
+                                error err => return false;
+                                string s => return true;
+                            }
+                        }
                     }
                 }
             }
@@ -188,21 +202,26 @@ type TwoPhaseCommitTransaction object {
         string|error ret = OUTCOME_ABORTED;
         boolean isHazardOutcome = false;
         foreach _, participant in participants {
-            Protocol[] protocols = participant.participantProtocols;
-            foreach proto in protocols {
-                match proto.protocolFn {
-                    (function (string, int, string) returns boolean)protocolFn => {
+            LocalProtocol[] | RemoteProtocol[] protocols = getProtocols(participant);
+            match protocols {
+                LocalProtocol[] localProtocols => {
+                    foreach localProto in localProtocols {
+                        (function (string, int, string) returns boolean) protocolFn = localProto.protocolFn;
                         // if the participant is a local participant, i.e. protoFn is set, then call that fn
                         log:printInfo("Notify(abort) local participant: " + participant.participantId);
-                        boolean successful = protocolFn(self.transactionId, proto.transactionBlockId, COMMAND_ABORT);
+                        boolean successful = protocolFn(self.transactionId, localProto.transactionBlockId, COMMAND_ABORT);
                         if (!successful) {
                             error e = {message:OUTCOME_HAZARD};
                             ret = e;
                             isHazardOutcome = true;
                         }
                     }
-                    () => {
-                        var result = self.notifyRemoteParticipant(participant, COMMAND_ABORT);
+                }
+
+                RemoteProtocol[] remoteProtocols => {
+                    foreach _ in remoteProtocols {
+                        RemoteParticipant remoteParticipant = check <RemoteParticipant> participant;
+                        var result = self.notifyRemoteParticipant(remoteParticipant, COMMAND_ABORT);
                         match result {
                             string status => {
                                 if (!isHazardOutcome && status == OUTCOME_COMMITTED) {
@@ -277,18 +296,23 @@ type TwoPhaseCommitTransaction object {
     function notify(string message) returns boolean {
         boolean successful = true;
         foreach _, participant in self.participants {
-            Protocol[] protocols = participant.participantProtocols;
-            foreach proto in protocols {
-                match proto.protocolFn {
-                    (function (string, int, string) returns boolean)protocolFn => {
+            LocalProtocol[] | RemoteProtocol[] protocols = getProtocols(participant);
+            match protocols {
+                LocalProtocol[] localProtocols => {
+                    foreach localProto in localProtocols {
+                        (function (string, int, string) returns boolean)protocolFn = localProto.protocolFn;
                         // if the participant is a local participant, i.e. protoFn is set, then call that fn
                         log:printInfo("Notify(" + message + ") local participant: " + participant.participantId);
-                        if (!protocolFn(self.transactionId, proto.transactionBlockId, message)) {
+                        if (!protocolFn(self.transactionId, localProto.transactionBlockId, message)) {
                             successful = false;
                         }
                     }
-                    () => {
-                        var result = self.notifyRemoteParticipant(participant, message);
+                }
+
+                RemoteProtocol[] remoteProtocols => {
+                    foreach _ in remoteProtocols {
+                        RemoteParticipant remoteParticipant = check <RemoteParticipant> participant;
+                        var result = self.notifyRemoteParticipant(remoteParticipant, message);
                         match result {
                             error err => successful = false;
                             string s => successful = true;
@@ -300,15 +324,15 @@ type TwoPhaseCommitTransaction object {
         return successful;
     }
 
-    function notifyRemoteParticipant(Participant participant, string message) returns string|error {
+    function notifyRemoteParticipant(RemoteParticipant participant, string message) returns string|error {
         endpoint Participant2pcClientEP participantEP;
 
         string|error ret = "";
         string participantId = participant.participantId;
         log:printInfo("Notify(" + message + ") remote participant: " + participantId);
-
-        foreach protocol in participant.participantProtocols {
-            string protoURL = protocol.url;
+        RemoteProtocol[] protocols = participant.participantProtocols;
+        foreach remoteProto in protocols {
+            string protoURL = remoteProto.url;
             participantEP = getParticipant2pcClientEP(protoURL);
             var result = participantEP -> notify(self.transactionId, message);
             match result {

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions/api.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions/api.bal
@@ -37,14 +37,13 @@ function beginTransaction (string? transactionId, int transactionBlockId, string
                            string coordinationType) returns TransactionContext|error {
     match transactionId {
         string txnId => {
-            io:println(typeof txnId);
             if (initiatedTransactions.hasKey(txnId)) { // if participant & initiator are in the same process
                 // we don't need to do a network call and can simply do a local function call
                 return registerParticipantWithLocalInitiator(txnId, transactionBlockId, registerAtUrl);
             } else {
                 //TODO: set the proper protocol
                 string protocolName = PROTOCOL_DURABLE;
-                Protocol[] protocols = [{name:protocolName, url:getParticipantProtocolAt(protocolName, transactionBlockId)}];
+                RemoteProtocol[] protocols = [{name:protocolName, url:getParticipantProtocolAt(protocolName, transactionBlockId)}];
                 return registerParticipantWithRemoteInitiator(txnId, transactionBlockId, registerAtUrl, protocols);
             }
         }

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions/commons.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions/commons.bal
@@ -156,6 +156,19 @@ function respondToBadRequest (http:Listener conn, string msg) {
     }
 }
 
+function getProtocols(Participant participant) returns LocalProtocol[] | RemoteProtocol[] {
+    if(typeof participant == typeof LocalParticipant) {
+        LocalParticipant localParticipant = check <LocalParticipant> participant;
+        return localParticipant.participantProtocols;
+    } else if (typeof participant == typeof RemoteParticipant) {
+        RemoteParticipant remoteParticipant = check <RemoteParticipant> participant;
+        return remoteParticipant.participantProtocols;
+    } else {
+        error err = {message: "Invalid participant type"};
+        throw err;
+    }
+}
+
 function createNewTransaction (string coordinationType, int transactionBlockId) returns TwoPhaseCommitTransaction {
     if (coordinationType == TWO_PHASE_COMMIT) {
         TwoPhaseCommitTransaction twopcTxn = new (util:uuid(), transactionBlockId, coordinationType = coordinationType);
@@ -207,8 +220,8 @@ function registerParticipantWithLocalInitiator (string transactionId,
                                                 string registerAtURL) returns TransactionContext|error {
     string participantId = getParticipantId(transactionBlockId);
     //TODO: Protocol name should be passed down from the transaction statement
-    Protocol participantProtocol = {name:PROTOCOL_DURABLE, transactionBlockId:transactionBlockId,
-                                       protocolFn:localParticipantProtocolFn};
+    LocalProtocol participantProtocol = {name:PROTOCOL_DURABLE, transactionBlockId:transactionBlockId,
+                                                    protocolFn:localParticipantProtocolFn};
     if (!initiatedTransactions.hasKey(transactionId)) {
         error err = {message:"Transaction-Unknown. Invalid TID:" + transactionId};
         return err;
@@ -221,14 +234,14 @@ function registerParticipantWithLocalInitiator (string transactionId,
             error err = {message:"Invalid-Protocol. TID:" + transactionId + ",participant ID:" + participantId};
             return err;
         } else {
-            Participant participant = {participantId:participantId};
+            LocalParticipant participant = {participantId:participantId};
             participant.participantProtocols = [participantProtocol];
             txn.participants[participantId] = participant;
 
             //Set initiator protocols
             TwoPhaseCommitTransaction twopcTxn = new (transactionId, transactionBlockId);
-            Protocol initiatorProto = {name: PROTOCOL_DURABLE, transactionBlockId:transactionBlockId};
-            twopcTxn.coordinatorProtocols = [initiatorProto];
+            //Protocol initiatorProto = {name: PROTOCOL_DURABLE, transactionBlockId:transactionBlockId};
+            //twopcTxn.coordinatorProtocols = [initiatorProto];
 
             string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
             participatedTransactions[participatedTxnId] = twopcTxn;
@@ -334,7 +347,7 @@ documentation {
 public function registerParticipantWithRemoteInitiator (string transactionId,
                                                         int transactionBlockId,
                                                         string registerAtURL,
-                                                        Protocol[] participantProtocols) returns TransactionContext|error {
+                                                        RemoteProtocol[] participantProtocols) returns TransactionContext|error {
     endpoint InitiatorClientEP initiatorEP;
     initiatorEP = getInitiatorClientEP(registerAtURL);
     string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
@@ -357,9 +370,9 @@ public function registerParticipantWithRemoteInitiator (string transactionId,
             return err;
         }
         RegistrationResponse regRes => {
-            Protocol[] coordinatorProtocols = regRes.coordinatorProtocols;
+            RemoteProtocol[] coordinatorProtocols = regRes.coordinatorProtocols;
             TwoPhaseCommitTransaction twopcTxn = new (transactionId, transactionBlockId);
-            twopcTxn.coordinatorProtocols = coordinatorProtocols;
+            twopcTxn.coordinatorProtocols = toProtocolArray(coordinatorProtocols);
             participatedTransactions[participatedTxnId] = twopcTxn;
             TransactionContext txnCtx = {transactionId:transactionId, transactionBlockId:transactionBlockId,
                                             coordinationType: TWO_PHASE_COMMIT, registerAtURL:registerAtURL};

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions/connector_initiator.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions/connector_initiator.bal
@@ -56,11 +56,11 @@ type InitiatorClient object {
 
 
     function register(string transactionId, int transactionBlockId,
-                        Protocol[] participantProtocols) returns RegistrationResponse|error {
+                        RemoteProtocol[] participantProtocols) returns RegistrationResponse|error {
         endpoint http:Client httpClient = self.clientEP.httpClient;
         string participantId = getParticipantId(transactionBlockId);
-        RegistrationRequest regReq = {transactionId:transactionId, participantId:participantId};
-        regReq.participantProtocols = participantProtocols;
+        RegistrationRequest regReq = {transactionId:transactionId, participantId:participantId,
+                                        participantProtocols:participantProtocols};
 
         json reqPayload = regRequestToJson(regReq);
         http:Request req = new;

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions/data.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions/data.bal
@@ -52,7 +52,39 @@ public type TransactionContext {
 
 type Participant {
     string participantId;
-    Protocol[] participantProtocols;
+};
+
+type LocalParticipant {
+    string participantId;
+    LocalProtocol[] participantProtocols;
+};
+
+type RemoteParticipant {
+    string participantId;
+    RemoteProtocol[] participantProtocols;
+};
+
+documentation {
+    This represents the protocol associated with the coordination type.
+
+    F{{name}} - protocol name
+}
+public type Protocol {
+    @readonly string name;
+};
+
+documentation {
+    This represents the protocol associated with the coordination type.
+
+    F{{name}} - protocol name
+    F{{protocolFn}} - This function will be called only if the participant is local. This avoid calls over the network.
+}
+public type LocalProtocol {
+    @readonly string name;
+    @readonly int transactionBlockId;
+    @readonly (function (string transactionId,
+                            int transactionBlockId,
+                            string protocolAction) returns boolean) protocolFn;
 };
 
 documentation {
@@ -61,21 +93,16 @@ documentation {
     F{{name}} - protocol name
     F{{url}}  - protocol URL. This URL will have a value only if the participant is remote. If the participant is local,
                 the `protocolFn` will be called
-    F{{protocolFn}} - This function will be called only if the participant is local. This avoid calls over the network.
 }
-public type Protocol {
+public type RemoteProtocol {
     @readonly string name;
     @readonly string url;
-    @readonly int transactionBlockId;
-    @readonly (function (string transactionId,
-                           int transactionBlockId,
-                           string protocolAction) returns boolean)? protocolFn;
 };
 
 public type RegistrationRequest {
     string transactionId;
     string participantId;
-    Protocol[] participantProtocols;
+    RemoteProtocol[] participantProtocols;
 };
 
 public function regRequestToJson (RegistrationRequest req) returns json {
@@ -93,7 +120,7 @@ public function regRequestToJson (RegistrationRequest req) returns json {
 
 public type RegistrationResponse {
     string transactionId;
-    Protocol[] coordinatorProtocols;
+    RemoteProtocol[] coordinatorProtocols;
 };
 
 public function regResponseToJson (RegistrationResponse res) returns json {
@@ -111,15 +138,24 @@ public function regResponseToJson (RegistrationResponse res) returns json {
 public function jsonToRegResponse (json j) returns RegistrationResponse {
     string transactionId = <string>jsonToAny(j.transactionId);
     RegistrationResponse res = {transactionId:transactionId};
-    Protocol[] protocols;
+    RemoteProtocol[] protocols;
     foreach proto in j.coordinatorProtocols {
         string name = <string>jsonToAny(proto.name);
         string url = <string>jsonToAny(proto.url);
-        Protocol p = {name:name, url:url};
+        RemoteProtocol p = {name:name, url:url};
         protocols[lengthof protocols] = p;
     }
     res.coordinatorProtocols = protocols;
     return res;
+}
+
+function toProtocolArray(RemoteProtocol[] remoteProtocols) returns Protocol[] {
+    Protocol[] protocols;
+    foreach remoteProtocol in remoteProtocols {
+        Protocol proto = {name: remoteProtocol.name};
+        protocols[lengthof protocols] = proto;
+    }
+    return protocols;
 }
 
 // TODO: temp function. Remove when =? is fixed for json

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions/service_initiator.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions/service_initiator.bal
@@ -84,25 +84,24 @@ service InitiatorService bind coordinatorListener {
             if (isRegisteredParticipant(participantId, txn.participants)) { // Already-Registered
                 respondToBadRequest(conn, "Already-Registered. TID:" + txnId + ",participant ID:" + participantId);
             } else if (!protocolCompatible(txn.coordinationType,
-                                           regReq.participantProtocols)) { // Invalid-Protocol
+                                           toProtocolArray(regReq.participantProtocols))) { // Invalid-Protocol
                 respondToBadRequest(conn, "Invalid-Protocol. TID:" + txnId + ",participant ID:" + participantId);
             } else {
-                Participant participant = {participantId:participantId,
-                                              participantProtocols:regReq.participantProtocols};
+                RemoteProtocol[] participantProtocols = regReq.participantProtocols;
+                RemoteParticipant participant = {participantId: participantId,
+                                                 participantProtocols: participantProtocols};
                 txn.participants[participantId] = participant;
-                Protocol[] participantProtocols = regReq.participantProtocols;
-                Protocol[] coordinatorProtocols = [];
+                RemoteProtocol[] coordinatorProtocols = [];
                 int i = 0;
                 foreach participantProtocol in participantProtocols {
-                    Protocol coordinatorProtocol = {name:participantProtocol.name,
+                    RemoteProtocol coordinatorProtocol = {name:participantProtocol.name,
                                                        url:getCoordinatorProtocolAt(participantProtocol.name,
                                                                                     transactionBlockId)};
                     coordinatorProtocols[i] = coordinatorProtocol;
                     i = i + 1;
                 }
 
-                RegistrationResponse regRes = {transactionId:txnId,
-                                                  coordinatorProtocols:coordinatorProtocols};
+                RegistrationResponse regRes = {transactionId:txnId, coordinatorProtocols:coordinatorProtocols};
                 json resPayload = regResponseToJson(regRes);
                 http:Response res = new; res.statusCode = http:OK_200;
                 res.setJsonPayload(resPayload);


### PR DESCRIPTION
The suspected reason is records having function pointers not being
properly populated during HTTP data binding. So different records for
LocalProtocol and RemoteProtocol was defined, and the data bound
RemoteProtocol doesn't have the function pointer, so this change should