### PR TITLE
Add getName and getModifiedTime PATH operations 

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/file/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/file/natives.bal
@@ -16,6 +16,8 @@
 
 package ballerina.file;
 
+import ballerina/time;
+
 @Description { value: "Represents an I/O error which could occur when processing a file."}
 public type IOError {
     string message;
@@ -42,6 +44,10 @@ public type Path object{
     @Description { value: "Retreives the absolut path from the provided location"}
     @Return {value:"Returns the absolute path string value"}
     public native function getPathValue() returns (string);
+
+    @Description {value: "Retreives the name of the file from the provided location"}
+    @Return {value:"Returns the name of the file"}
+    public native function getName() returns (string);
 };
 
 @Description { value: "Check for existance of the file"}
@@ -73,3 +79,7 @@ public native function createDirectory(Path path) returns (boolean | IOError);
 @Param {value: "path: Refernce to the file path location"}
 @Return {value : "error if the file could not be created"}
 public native function createFile(Path path) returns (boolean | IOError);
+
+@Description {value: "Rereives the last modified time of the Path"}
+@Return {value : "Last modified time or an error if the path cannot be resolved"}
+public native function getModifiedTIme() returns (time:Time | IOError);

--- a/stdlib/ballerina-builtin/src/main/ballerina/file/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/file/natives.bal
@@ -82,4 +82,4 @@ public native function createFile(Path path) returns (boolean | IOError);
 
 @Description {value: "Rereives the last modified time of the Path"}
 @Return {value : "Last modified time or an error if the path cannot be resolved"}
-public native function getModifiedTIme() returns (time:Time | IOError);
+public native function getModifiedTime(Path path) returns (time:Time | IOError);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/file/GetModifiedTime.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/file/GetModifiedTime.java
@@ -21,18 +21,16 @@ package org.ballerinalang.nativeimpl.file;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BLangVMErrors;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
-import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.Utils;
+import org.ballerinalang.nativeimpl.file.utils.Constants;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.natives.annotations.ReturnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.time.ZonedDateTime;
 
@@ -42,14 +40,11 @@ import static org.ballerinalang.nativeimpl.Utils.getTimeZoneStructInfo;
 /**
  * Retrieves the last modified time of the specified file.
  *
- * @since 0.94.1
+ * @since 0.970.0-alpha4
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "file",
         functionName = "getModifiedTime",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "File", structPackage = "ballerina.file"),
-        returnType = {@ReturnType(type = TypeKind.STRUCT), @ReturnType(type = TypeKind.STRUCT),
-                @ReturnType(type = TypeKind.STRUCT)},
         isPublic = true
 )
 public class GetModifiedTime extends BlockingNativeCallableUnit {
@@ -58,12 +53,11 @@ public class GetModifiedTime extends BlockingNativeCallableUnit {
 
     @Override
     public void execute(Context context) {
-        BStruct fileStruct = (BStruct) context.getRefArgument(0);
-        String path = fileStruct.getStringField(0);
-
+        BStruct pathStruct = (BStruct) context.getRefArgument(0);
+        Path path = (Path) pathStruct.getNativeData(Constants.PATH_DEFINITION_NAME);
         BStruct lastModifiedStruct;
         try {
-            FileTime lastModified = Files.getLastModifiedTime(Paths.get(path));
+            FileTime lastModified = Files.getLastModifiedTime(path);
             ZonedDateTime zonedDateTime = ZonedDateTime.parse(lastModified.toString());
             lastModifiedStruct = Utils.createTimeStruct(getTimeZoneStructInfo(context), getTimeStructInfo(context),
                     lastModified.toMillis(), zonedDateTime.getZone().toString());

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/file/GetName.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/file/GetName.java
@@ -23,31 +23,36 @@ import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.nativeimpl.file.utils.Constants;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
- * Retrieves the name of the file given by the struct.
+ * Creates the file at the path specified in the File struct.
  *
- * @since 0.94.1
+ * @since 0.970.0-alpha3
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "file",
-        functionName = "getName",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "File", structPackage = "ballerina.file"),
+        functionName = "Path.getName",
+        args = {
+                @Argument(name = "path", type = TypeKind.STRUCT, structType = "Path", structPackage = "ballerina.file")
+        },
         returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )
 public class GetName extends BlockingNativeCallableUnit {
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void execute(Context context) {
-        BStruct fileStruct = (BStruct) context.getRefArgument(0);
-        Path fileName = Paths.get(fileStruct.getStringField(0)).getFileName();
+        BStruct pathStruct = (BStruct) context.getRefArgument(0);
+        Path path = (Path) pathStruct.getNativeData(Constants.PATH_DEFINITION_NAME);
+        Path fileName = path.getFileName();
         context.setReturnValues(new BString(fileName == null ? "" : fileName.toString()));
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/file/FileOperationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/file/FileOperationTest.java
@@ -166,6 +166,26 @@ public class FileOperationTest {
     }
 
     @Test(description = "Test 'newByteChannel' function in ballerina.file package",
+            dependsOnMethods = {"testCreateFile", "testListDirectory"})
+    public void testFileMetaData() throws URISyntaxException {
+        final String fileName = "test.txt";
+        final String emptyString = "";
+        String path = currentDirectoryPath + "/parent/child1/" + fileName;
+        BString result;
+        //Will initialize the channel
+        BValue[] args = {new BString(path)};
+        BValue[] returns = BRunUtil.invoke(fileOperationProgramFile, "testGetFileName", args);
+        result = (BString) returns[0];
+
+        Assert.assertTrue(fileName.equals(result.stringValue()));
+
+        returns = BRunUtil.invoke(fileOperationProgramFile, "testGetModifiedTime", args);
+        result = (BString) returns[0];
+
+        Assert.assertFalse(emptyString.equals(result.stringValue()));
+    }
+
+    @Test(description = "Test 'newByteChannel' function in ballerina.file package",
             dependsOnMethods = {"testCreateFile", "testListDirectory", "testWriteBytesToFile"})
     public void testDirectoryExistanceAndDeletion() {
         BBoolean result;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
@@ -263,8 +263,6 @@ public class IOTest {
     public void testRecordOperationPermissionError() throws URISyntaxException {
         String resourceToRead = "datafiles/io/records/sample.csv";
         BStruct records;
-        BBoolean hasNextRecord;
-        int expectedRecordLength = 3;
 
         //Will initialize the channel with write permissions
         BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("w"), new BString("UTF-8"),
@@ -405,7 +403,7 @@ public class IOTest {
     private String readFileContent(String filePath) throws URISyntaxException {
         Path path = Paths.get(getAbsoluteFilePath(filePath));
         StringBuilder data = new StringBuilder();
-        Stream<String> lines = null;
+        Stream<String> lines;
         try {
             lines = Files.lines(path);
         } catch (IOException e) {

--- a/tests/ballerina-test/src/test/resources/test-src/file/file_ops.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/file/file_ops.bal
@@ -1,5 +1,6 @@
 import ballerina/io;
 import ballerina/file;
+import ballerina/time;
 
 function testAbsolutePath(string pathValue) returns (string){
     file:Path filePath = new(pathValue);
@@ -54,6 +55,17 @@ function testCreateFile(string pathValue) returns (string){
    }
 
    return pathValues[0];
+}
+
+function testGetFileName(string pathValue) returns (string){
+    file:Path path = new (pathValue);
+    return path.getName();
+}
+
+function testGetModifiedTime(string pathValue) returns (string){
+    file:Path path = new(pathValue);
+    time:Time modifiedTime =check file:getModifiedTime(path);
+    return modifiedTime.toString();
 }
 
 function testWriteFile(string pathValue,string accessMode,blob content) returns (blob|io:IOError){


### PR DESCRIPTION
## Purpose
Add getName() and getModifiedTime() PATH operations. 

## Goals
 - Add the methods getName() and getModifiedTime()
-  Include the relevant test cases

## Approach

Added the following ballerina functions which will return a name of the given file location and the modified time

```
public native function getModifiedTime(Path path) returns (time:Time | IOError);
```

and

```
public native function getName() returns (string);
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8