### PR TITLE
Update observability context sharing to use own http headers

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/BallerinaTracingObserver.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/BallerinaTracingObserver.java
@@ -33,7 +33,6 @@ import static org.ballerinalang.util.tracer.TraceConstants.LOG_EVENT_TYPE_ERROR;
 import static org.ballerinalang.util.tracer.TraceConstants.LOG_KEY_ERROR_KIND;
 import static org.ballerinalang.util.tracer.TraceConstants.LOG_KEY_EVENT_TYPE;
 import static org.ballerinalang.util.tracer.TraceConstants.LOG_KEY_MESSAGE;
-import static org.ballerinalang.util.tracer.TraceConstants.TRACE_PREFIX_LENGTH;
 
 /**
  * Observe the runtime and start/stop tracing.
@@ -48,8 +47,8 @@ public class BallerinaTracingObserver implements BallerinaObserver {
         Map<String, String> httpHeaders = (Map<String, String>) observerContext.getProperty(PROPERTY_TRACE_PROPERTIES);
         if (httpHeaders != null) {
             httpHeaders.entrySet().stream()
-                    .filter(c -> c.getKey().startsWith(TraceConstants.TRACE_PREFIX))
-                    .forEach(e -> span.addProperty(e.getKey().substring(TRACE_PREFIX_LENGTH), e.getValue()));
+                    .filter(c -> c.getKey().equals(TraceConstants.TRACE_HEADER))
+                    .forEach(e -> span.addProperty(e.getKey(), e.getValue()));
         }
         TraceUtil.setBSpan(executionContext, span);
         span.startSpan();

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/OpenTracerBallerinaWrapper.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/OpenTracerBallerinaWrapper.java
@@ -44,7 +44,7 @@ public class OpenTracerBallerinaWrapper {
     private final boolean enabled;
 
     public OpenTracerBallerinaWrapper() {
-        enabled = Boolean.parseBoolean(ConfigRegistry.getInstance().getAsString(CONFIG_TRACING_ENABLED));
+        enabled = ConfigRegistry.getInstance().getAsBoolean(CONFIG_TRACING_ENABLED);
         if (enabled) {
             tracerStore = TracersStore.getInstance();
             spanStore = new SpanStore();
@@ -58,10 +58,10 @@ public class OpenTracerBallerinaWrapper {
     /**
      * Method to create an entry in span store by extracting a spanContext from a Map carrier.
      *
-     * @param spanHeaders map of headers used to extract a spanContext
+     * @param encodedHeader map of headers used to extract a spanContext
      * @return the map of span contexts for each tracer implementation
      */
-    public Map<String, SpanContext> extract(Map<String, String> spanHeaders) {
+    public Map<String, SpanContext> extract(String encodedHeader) {
         if (enabled) {
             Map<String, SpanContext> spanContextMap = new HashMap<>();
             Map<String, Tracer> tracers = tracerStore.getTracers(DEFAULT_TRACER);
@@ -69,7 +69,7 @@ public class OpenTracerBallerinaWrapper {
 
             for (Map.Entry<String, Tracer> tracerEntry : tracers.entrySet()) {
                 spanContextMap.put(tracerEntry.getKey(), tracerEntry.getValue().extract(Format.Builtin.HTTP_HEADERS,
-                        new RequestExtractor(spanHeaders)));
+                        new RequestExtractor(encodedHeader)));
                 if (spanContextMap.get(tracerEntry.getKey()) == null) {
                     hasParent = false;
                 }
@@ -88,7 +88,7 @@ public class OpenTracerBallerinaWrapper {
      * @param spanId the span Id of the span to be injected
      * @return the map carrier holding the span context
      */
-    public Map<String, String> inject(String prefix, String spanId) {
+    public Map<String, String> inject(String suffix, String spanId) {
         if (enabled) {
             Map<String, String> carrierMap = new HashMap<>();
             Map<String, Span> activeSpanMap = spanStore.getSpan(spanId);
@@ -96,8 +96,11 @@ public class OpenTracerBallerinaWrapper {
                 Map<String, Tracer> tracers = tracerStore.getTracers(DEFAULT_TRACER);
                 Tracer tracer = tracers.get(activeSpanEntry.getKey());
                 if (tracer != null && activeSpanEntry.getValue() != null) {
-                    tracer.inject(activeSpanEntry.getValue().context(),
-                            Format.Builtin.HTTP_HEADERS, new RequestInjector(prefix, carrierMap));
+                    Map<String, String> tracerSpecificCarrier = new HashMap<>();
+                    RequestInjector requestInjector = new RequestInjector(tracerSpecificCarrier);
+                    tracer.inject(activeSpanEntry.getValue().context(), Format.Builtin.HTTP_HEADERS, requestInjector);
+                    String value = requestInjector.getCarrierString();
+                    carrierMap.put(TraceConstants.USER_TRACE_HEADER + suffix, value);
                 }
             }
             return carrierMap;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/RequestExtractor.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/RequestExtractor.java
@@ -20,6 +20,8 @@ package org.ballerinalang.util.tracer;
 
 import io.opentracing.propagation.TextMap;
 
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -30,8 +32,15 @@ public class RequestExtractor implements TextMap {
 
     private Map<String, String> headers;
 
-    public RequestExtractor(Map<String, String> headers) {
-        this.headers = headers;
+    public RequestExtractor(String headers) {
+        this.headers = new HashMap<>();
+        if (headers != null) {
+            String decodedString = new String(Base64.getDecoder().decode(headers));
+            for (String keyValueHeader: decodedString.split(",")) {
+                String[] splitKeyValueHeader = keyValueHeader.split("=");
+                this.headers.put(splitKeyValueHeader[0], splitKeyValueHeader[1]);
+            }
+        }
     }
 
     @Override

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/RequestInjector.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/RequestInjector.java
@@ -20,6 +20,7 @@ package org.ballerinalang.util.tracer;
 
 import io.opentracing.propagation.TextMap;
 
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -29,10 +30,8 @@ import java.util.Map;
 public class RequestInjector implements TextMap {
 
     private final Map<String, String> carrier;
-    private final String prefix;
 
-    public RequestInjector(String prefix, Map<String, String> carrier) {
-        this.prefix = prefix;
+    public RequestInjector(Map<String, String> carrier) {
         this.carrier = carrier;
     }
 
@@ -44,6 +43,12 @@ public class RequestInjector implements TextMap {
 
     @Override
     public void put(String key, String value) {
-        carrier.put(prefix + key, value);
+        carrier.put(key, value);
+    }
+
+    public String getCarrierString() {
+        byte[] encoded = Base64.getEncoder()
+                .encode(carrier.toString().substring(1, carrier.toString().length() - 1).getBytes());
+        return new String(encoded);
     }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TraceConstants.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TraceConstants.java
@@ -31,6 +31,8 @@ public class TraceConstants {
     static final String DEFAULT_CONNECTOR_NAME = "BallerinaConnector";
     static final String DEFAULT_ACTION_NAME = "BallerinaAction";
     public static final String TRACE_PREFIX = "trace___";
+    public static final String TRACE_HEADER = "x-b7a-trace";
+    public static final String USER_TRACE_HEADER = "x-b7a-utrace-";
     public static final String KEY_SPAN = "_span_";
 
     public static final String TAG_KEY_SPAN_KIND = "span.kind";
@@ -47,10 +49,7 @@ public class TraceConstants {
     public static final String LOG_ERROR_KIND_EXCEPTION = "Exception";
     public static final String LOG_EVENT_TYPE_ERROR = "error";
 
-    public static final int TRACE_PREFIX_LENGTH = TRACE_PREFIX.length();
-
-    public static final String BALLERINA_TRACE_CONFIG_KEY = "trace.config";
-    public static final String DEFAULT_USER_API_GROUP = "user_trace_";
+    public static final String DEFAULT_USER_API_GROUP = "default-group";
 
     public static final String JAEGER = "jaeger";
     public static final String ENABLED_CONFIG = "enabled";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracingLaunchListener.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracingLaunchListener.java
@@ -33,7 +33,7 @@ public class TracingLaunchListener implements LaunchListener {
     @Override
     public void beforeRunProgram(boolean service) {
         ConfigRegistry configRegistry = ConfigRegistry.getInstance();
-        if (Boolean.valueOf(configRegistry.getConfigOrDefault(CONFIG_TRACING_ENABLED, String.valueOf(Boolean.FALSE)))) {
+        if (configRegistry.getAsBoolean(CONFIG_TRACING_ENABLED)) {
             ObservabilityUtils.addObserver(new BallerinaTracingObserver());
             TracersStore.getInstance().loadTracers();
         }

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -311,9 +311,9 @@ public class LauncherUtils {
 
             if (observeFlag) {
                 ConfigRegistry.getInstance()
-                        .addConfiguration(ObservabilityConstants.CONFIG_METRICS_ENABLED, String.valueOf(Boolean.TRUE));
+                        .addConfiguration(ObservabilityConstants.CONFIG_METRICS_ENABLED, Boolean.TRUE);
                 ConfigRegistry.getInstance()
-                        .addConfiguration(ObservabilityConstants.CONFIG_TRACING_ENABLED, String.valueOf(Boolean.TRUE));
+                        .addConfiguration(ObservabilityConstants.CONFIG_TRACING_ENABLED, Boolean.TRUE);
                 metricsParams.forEach(
                         (key, value) -> ConfigRegistry.getInstance()
                                 .addConfiguration(ObservabilityConstants.CONFIG_TABLE_METRICS + "." + key, value));

--- a/stdlib/ballerina-builtin/src/main/ballerina/observe/tracing.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/observe/tracing.bal
@@ -125,7 +125,7 @@ public function extractSpanContextFromHttpHeader (http:Request req, string trace
     string[] headerNames = req.getHeaderNames();
     foreach headerName in headerNames {
         if (req.hasHeader(headerName)) {
-            string[] headerValues = req.getHeaders(headerName);
+            string[] headerValues = req.getHeaders(untaint headerName);
             headers[headerName] = headerValues;
         }
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/ExtractSpanContext.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/ExtractSpanContext.java
@@ -66,8 +66,8 @@ public class ExtractSpanContext extends BlockingNativeCallableUnit {
             Set headerSet = headers.keySet();
             for (Object aKey : headerSet) {
                 String key = aKey.toString();
-                if (key.startsWith(group)) {
-                    returnMap.put(key.substring(group.length()),
+                if (key.equals(TraceConstants.USER_TRACE_HEADER + group)) {
+                    returnMap.put(TraceConstants.USER_TRACE_HEADER,
                             new BString(((BStringArray) headers.get(aKey)).get(0)));
                 }
             }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/StartSpanWithParentContext.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/StartSpanWithParentContext.java
@@ -29,6 +29,7 @@ import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.util.tracer.OpenTracerBallerinaWrapper;
 import org.ballerinalang.util.tracer.ReferenceType;
+import org.ballerinalang.util.tracer.TraceConstants;
 
 import java.io.PrintStream;
 import java.util.Collections;
@@ -70,7 +71,8 @@ public class StartSpanWithParentContext extends BlockingNativeCallableUnit {
 
             Map<String, String> parentSpanContextMap =
                     Utils.toStringMap((BMap) parentSpanContextStruct.getRefField(0));
-            extractedSpanContextMap = OpenTracerBallerinaWrapper.getInstance().extract(parentSpanContextMap);
+            extractedSpanContextMap = OpenTracerBallerinaWrapper.getInstance()
+                    .extract(parentSpanContextMap.get(TraceConstants.USER_TRACE_HEADER));
         } else {
             extractedSpanContextMap = Collections.emptyMap();
         }


### PR DESCRIPTION
## Purpose
When sharing span context among services, ootb tracing will use `x-b7a-trace` as http header key and user api tracing will use `x-b7a-utrace-<group> as the http header key