### PR TITLE
Rename Proxy type to ProxyConfig

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -93,7 +93,7 @@ public type ClientEndpointConfig {
     string forwarded = "disable",
     FollowRedirects? followRedirects,
     Retry? retry,
-    Proxy? proxyConfig,
+    ProxyConfig? proxy,
     ConnectionThrottling? connectionThrottling,
     TargetService[] targets,
     string|FailoverConfig lbMode = ROUND_ROBIN,
@@ -144,12 +144,12 @@ public type FollowRedirects {
     int maxCount = 5,
 };
 
-@Description { value:"Proxy struct represents proxy server configurations to be used for HTTP client invocation" }
+@Description { value:"ProxyConfig struct represents proxy server configurations to be used for HTTP client invocation" }
 @Field {value:"proxyHost: host name of the proxy server"}
 @Field {value:"proxyPort: proxy server port"}
 @Field {value:"proxyUserName: Proxy server user name"}
 @Field {value:"proxyPassword: proxy server password"}
-public type Proxy {
+public type ProxyConfig {
     string host,
     int port,
     string userName,

--- a/stdlib/ballerina-http/src/main/ballerina/http/simple_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/simple_client_endpoint.bal
@@ -76,7 +76,7 @@ documentation {
     F{{chunking}} - The chunking behaviour of the request
     F{{followRedirects}} - Redirect related options
     F{{retry}} - Retry related options
-    F{{proxyConfig}} - Proxy related options
+    F{{proxy}} - Proxy related options
     F{{connectionThrottling}} - The configurations for controlling the number of connections allowed concurrently
     F{{cache}} - The configurations for controlling the caching behaviour
 }
@@ -92,7 +92,7 @@ public type SimpleClientEndpointConfiguration {
     Chunking chunking = "AUTO",
     FollowRedirects? followRedirects,
     Retry? retry,
-    Proxy? proxyConfig,
+    ProxyConfig? proxy,
     ConnectionThrottling? connectionThrottling,
     CacheConfig cache = {},
 };
@@ -122,7 +122,7 @@ public function SimpleClient::init(SimpleClientEndpointConfiguration simpleConfi
     self.httpEP.config.chunking = simpleConfig.chunking;
     self.httpEP.config.followRedirects = simpleConfig.followRedirects;
     self.httpEP.config.retry = simpleConfig.retry;
-    self.httpEP.config.proxyConfig = simpleConfig.proxyConfig;
+    self.httpEP.config.proxy = simpleConfig.proxy;
     self.httpEP.config.connectionThrottling = simpleConfig.connectionThrottling;
 
     var cbConfig = simpleConfig.circuitBreaker;

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -331,7 +331,7 @@ public class HttpConstants {
     public static final String FOLLOW_REDIRECT_MAXCOUNT = "maxCount";
 
     //Proxy Indexed
-    public static final String PROXY_STRUCT_REFERENCE = "proxyConfig";
+    public static final String PROXY_STRUCT_REFERENCE = "proxy";
     public static final String PROXY_HOST = "host";
     public static final String PROXY_PORT = "port";
     public static final String PROXY_USERNAME = "userName";


### PR DESCRIPTION
## Purpose
Rename Proxy type to ProxyConfig. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```
import ballerina/http;
import ballerina/io;
import ballerina/mime;

endpoint http:Client clientEP {
    targets: [{
        url: "http://localhost:9095"
    }],
    proxy : {
	 host:"localhost",
	 port: 8080,
	 userName:"username",
	 password:"password"	
   }
};

function main (string[] args) {
    http:Request req = new;
    var resp = clientEP -> get("/echo/", req);
    match resp {
        http:HttpConnectorError err => io:println(err.message);
        http:Response response => {
             match (response.getStringPayload()) {
                http:PayloadError payloadError => io:println(payloadError.message);
                string res => io:println(res);
             }
        }
    }
}
```

Related Issue : https://github.com/ballerina-platform/ballerina-lang/issues/6888