### PR TITLE
Fix pattern ordering issue when matching results with a HttpFuture

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/http_future.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_future.bal
@@ -2,4 +2,7 @@ package ballerina.http;
 
 @Description { value:"Represents a future for aynchronous http invocation"}
 public type HttpFuture object {
+    private {
+       int value; // dummy value to prevent pattern ordering issue when matching results
+    }
 };


### PR DESCRIPTION
## Purpose
 
Since the HttpFuture object does not contain any fields, when it is used to match a result, 
unless we put it at the very bottom like the following config, compiler gives the error:

> unreachable pattern: preceding patterns are too general or the pattern ordering is not correct
> compilation contains errors
> 

    var submissionResult = clientEP -> submit("GET", "/http2Service/main", serviceReq);
    match submissionResult {
        http:HttpConnectorError err => {
            io:println("Error occurred while submitting a request");
            return;
        }
        http:HttpFuture resultantFuture => {
            httpFuture = resultantFuture;
        }
   }



## Goals
Fix pattern ordering issue when matching results with a HttpFuture

## Approach
Include a dummy filed to the HttpFuture object.

