### PR TITLE
Changed the Summary and Timer APIs to get percentile values 

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/Summary.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/Summary.java
@@ -20,6 +20,7 @@ package org.ballerinalang.util.metrics;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 
 /**
  * Track the sample distribution of events.
@@ -114,10 +115,12 @@ public interface Summary extends Metric {
     double max();
 
     /**
-     * @param percentile A percentile in the domain [0, 1]. For example, 0.5 represents the 50th percentile of the
-     *                   distribution.
-     * @return The value at a specific percentile. This value is non-aggregable across dimensions.
+     * Return a sorted map of percentile values. The percentile is the key, which is in the domain [0, 1]. For example,
+     * 0.5 represents the 50th percentile of the distribution. The keys will be specific to underlying implementation.
+     * These value are non-aggregable across dimensions.
+     *
+     * @return A map of values at specific percentiles.
      */
-    double percentile(double percentile);
+    SortedMap<Double, Double> percentileValues();
 
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/Timer.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/Timer.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -128,11 +129,13 @@ public interface Timer extends Metric {
     double max(TimeUnit unit);
 
     /**
-     * @param percentile A percentile in the domain [0, 1]. For example, 0.5 represents the 50th percentile of the
-     *                   distribution.
-     * @param unit       The base unit of time to scale the percentile value to.
-     * @return The latency at a specific percentile. This value is non-aggregable across dimensions.
+     * Return a sorted map of latencies at specific percentiles. The percentile is the key, which is in the domain
+     * [0, 1]. For example, 0.5 represents the 50th percentile of the distribution. The keys will be specific to
+     * underlying implementation. These value are non-aggregable across dimensions.
+     *
+     * @param unit The base unit of time to scale the percentile value to.
+     * @return A map of latencies at specific percentiles.
      */
-    double percentile(double percentile, TimeUnit unit);
+    SortedMap<Double, Double> percentileValues(TimeUnit unit);
 
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/noop/NoOpSummary.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/noop/NoOpSummary.java
@@ -21,6 +21,9 @@ import org.ballerinalang.util.metrics.AbstractMetric;
 import org.ballerinalang.util.metrics.MetricId;
 import org.ballerinalang.util.metrics.Summary;
 
+import java.util.Collections;
+import java.util.SortedMap;
+
 /**
  * Implementation of No-Op {@link Summary}.
  */
@@ -51,7 +54,8 @@ public class NoOpSummary extends AbstractMetric implements Summary {
     }
 
     @Override
-    public double percentile(double percentile) {
-        return 0;
+    public SortedMap<Double, Double> percentileValues() {
+        return Collections.emptySortedMap();
     }
+
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/noop/NoOpTimer.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/metrics/noop/NoOpTimer.java
@@ -21,6 +21,8 @@ import org.ballerinalang.util.metrics.AbstractMetric;
 import org.ballerinalang.util.metrics.MetricId;
 import org.ballerinalang.util.metrics.Timer;
 
+import java.util.Collections;
+import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -53,7 +55,7 @@ public class NoOpTimer extends AbstractMetric implements Timer {
     }
 
     @Override
-    public double percentile(double percentile, TimeUnit unit) {
-        return 0;
+    public SortedMap<Double, Double> percentileValues(TimeUnit unit) {
+        return Collections.emptySortedMap();
     }
 }

--- a/misc/metrics-extensions/modules/ballerina-micrometer-extension/src/main/java/org/ballerinalang/observe/metrics/extension/micrometer/MicrometerSummary.java
+++ b/misc/metrics-extensions/modules/ballerina-micrometer-extension/src/main/java/org/ballerinalang/observe/metrics/extension/micrometer/MicrometerSummary.java
@@ -19,10 +19,15 @@ package org.ballerinalang.observe.metrics.extension.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import org.ballerinalang.util.metrics.AbstractMetric;
 import org.ballerinalang.util.metrics.MetricId;
 import org.ballerinalang.util.metrics.Summary;
 
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -63,7 +68,13 @@ public class MicrometerSummary extends AbstractMetric implements Summary {
     }
 
     @Override
-    public double percentile(double percentile) {
-        return summary.percentile(percentile);
+    public SortedMap<Double, Double> percentileValues() {
+        SortedMap<Double, Double> result = new TreeMap<>();
+        HistogramSnapshot snapshot = summary.takeSnapshot();
+        for (ValueAtPercentile valueAtPercentile : snapshot.percentileValues()) {
+            result.put(valueAtPercentile.percentile(), valueAtPercentile.value());
+        }
+        return Collections.unmodifiableSortedMap(result);
     }
+
 }

--- a/misc/metrics-extensions/modules/ballerina-micrometer-extension/src/main/java/org/ballerinalang/observe/metrics/extension/micrometer/MicrometerTimer.java
+++ b/misc/metrics-extensions/modules/ballerina-micrometer-extension/src/main/java/org/ballerinalang/observe/metrics/extension/micrometer/MicrometerTimer.java
@@ -19,10 +19,15 @@ package org.ballerinalang.observe.metrics.extension.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import org.ballerinalang.util.metrics.AbstractMetric;
 import org.ballerinalang.util.metrics.MetricId;
 import org.ballerinalang.util.metrics.Timer;
 
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -64,7 +69,12 @@ public class MicrometerTimer extends AbstractMetric implements Timer {
     }
 
     @Override
-    public double percentile(double percentile, TimeUnit unit) {
-        return timer.percentile(percentile, unit);
+    public SortedMap<Double, Double> percentileValues(TimeUnit unit) {
+        SortedMap<Double, Double> result = new TreeMap<>();
+        HistogramSnapshot snapshot = timer.takeSnapshot();
+        for (ValueAtPercentile valueAtPercentile : snapshot.percentileValues()) {
+            result.put(valueAtPercentile.percentile(), valueAtPercentile.value(unit));
+        }
+        return Collections.unmodifiableSortedMap(result);
     }
 }

--- a/stdlib/ballerina-builtin/src/main/ballerina/observe/metrics.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/observe/metrics.bal
@@ -37,7 +37,7 @@ public type Counter object {
     public native function increment(float amount);
 
     @Description {value:"Return the value of the counter."}
-    @Return {value:"The value of a counter"}
+    @Return {value:"The value of a counter."}
     public native function count() returns (float);
 };
 
@@ -73,7 +73,7 @@ public type Gauge object {
     public native function setValue(float value);
 
     @Description {value:"Return the value of the gauge."}
-    @Return {value:"The value of a gauge"}
+    @Return {value:"The value of a gauge."}
     public native function value() returns (float);
 };
 
@@ -151,7 +151,7 @@ public type Timer object {
 
     @Description {value: "Return a map of latencies scaled with the given base unit of time at specific percentiles."}
     @Param {value: "timeUnit: The base unit of time to scale the percentile value to."}
-    @Return {value: "A map of latencies at specific percentiles"}
+    @Return {value: "A map of latencies at specific percentiles."}
     public native function percentileValues(TimeUnit timeUnit) returns (map);
 
     @Description {value: "Returns the number of times recorded in the timer."}

--- a/stdlib/ballerina-builtin/src/main/ballerina/observe/metrics.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/observe/metrics.bal
@@ -102,10 +102,9 @@ public type Summary object {
     @Return {value: "The distribution average for all recorded events."}
     public native function mean() returns (float);
 
-    @Description {value: "Return the value at a specific percentile."}
-    @Param {value: "percentile: A percentile in the domain."}
-    @Return {value: "The value at a specific percentile."}
-    public native function percentile(float percentile) returns (float);
+    @Description {value: "Return a map of percentile values."}
+    @Return {value: "A map of values at specific percentiles."}
+    public native function percentileValues() returns (map);
 
     @Description {value: "Return the number of values recorded in the summary."}
     @Return {value: "The number of times that record has been called since this timer was created."}
@@ -150,11 +149,10 @@ public type Timer object {
     @Return {value: "The distribution average for all recorded events."}
     public native function mean(TimeUnit timeUnit) returns (float);
 
-    @Description {value: "Return the latency at a specific percentile."}
-    @Param {value: "percentiles: A percentile in the domain."}
+    @Description {value: "Return a map of latencies scaled with the given base unit of time at specific percentiles."}
     @Param {value: "timeUnit: The base unit of time to scale the percentile value to."}
-    @Return {value: "The latency at a specific percentile."}
-    public native function percentile(float percentiles, TimeUnit timeUnit) returns (float);
+    @Return {value: "A map of latencies at specific percentiles"}
+    public native function percentileValues(TimeUnit timeUnit) returns (map);
 
     @Description {value: "Returns the number of times recorded in the timer."}
     @Return {value: "The number of times that stop has been called on this timer."}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/summary/PercentileSummary.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/summary/PercentileSummary.java
@@ -60,10 +60,8 @@ public class PercentileSummary extends BlockingNativeCallableUnit {
             for (Object key : tagsMap.keySet()) {
                 tags.add(new Tag(key.toString(), tagsMap.get(key).stringValue()));
             }
-
             context.setReturnValues(buildPercentileValuesMap(Summary.builder(name).description(description).tags(tags)
                     .register()));
-
         } else {
             context.setReturnValues(buildPercentileValuesMap(Summary.builder(name).description(description)
                     .register()));

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/summary/PercentileSummary.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/summary/PercentileSummary.java
@@ -32,18 +32,19 @@ import org.ballerinalang.util.metrics.Tag;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedMap;
 
 /**
- * Returns the value at a specific percentile.
+ * Return a map of percentile values.
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "observe",
-        functionName = "percentile",
+        functionName = "percentileValues",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Summary",
                 structPackage = "ballerina.observe"),
         args = {@Argument(name = "summary", type = TypeKind.STRUCT, structType = "Summary",
-                structPackage = "ballerina.observe"), @Argument(name = "percentile", type = TypeKind.FLOAT)},
-        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+                structPackage = "ballerina.observe")},
+        returnType = {@ReturnType(type = TypeKind.MAP)},
         isPublic = true
 )
 public class PercentileSummary extends BlockingNativeCallableUnit {
@@ -52,7 +53,6 @@ public class PercentileSummary extends BlockingNativeCallableUnit {
         BStruct summaryStruct = (BStruct) context.getRefArgument(0);
         String name = summaryStruct.getStringField(0);
         String description = summaryStruct.getStringField(1);
-        float percentile = (float) context.getFloatArgument(0);
         BMap tagsMap = (BMap) summaryStruct.getRefField(0);
 
         if (tagsMap != null) {
@@ -60,12 +60,20 @@ public class PercentileSummary extends BlockingNativeCallableUnit {
             for (Object key : tagsMap.keySet()) {
                 tags.add(new Tag(key.toString(), tagsMap.get(key).stringValue()));
             }
-            context.setReturnValues(new BFloat(Summary.builder(name).description(description).tags(tags).register()
-                    .percentile(percentile)));
+
+            context.setReturnValues(buildPercentileValuesMap(Summary.builder(name).description(description).tags(tags)
+                    .register()));
 
         } else {
-            context.setReturnValues(new BFloat(Summary.builder(name).description(description).register()
-                    .percentile(percentile)));
+            context.setReturnValues(buildPercentileValuesMap(Summary.builder(name).description(description)
+                    .register()));
         }
+    }
+
+    private BMap<BFloat, BFloat> buildPercentileValuesMap(Summary summary) {
+        BMap<BFloat, BFloat> map = new BMap<>();
+        SortedMap<Double, Double> percentileValues = summary.percentileValues();
+        percentileValues.forEach((percentile, value) -> map.put(new BFloat(percentile), new BFloat(value)));
+        return map;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/timer/PercentileTimer.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/timer/PercentileTimer.java
@@ -68,7 +68,6 @@ public class PercentileTimer extends BlockingNativeCallableUnit {
             }
             context.setReturnValues(buildPercentileValuesMap(Timer.builder(name).description(description).tags(tags).
                     register(), timeUnit));
-
         } else {
             context.setReturnValues(buildPercentileValuesMap(Timer.builder(name).description(description).register(),
                     timeUnit));

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/timer/PercentileTimer.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/observe/metrics/timer/PercentileTimer.java
@@ -33,20 +33,21 @@ import org.ballerinalang.util.metrics.Timer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Returns the latency at a specific percentile. This value is non-aggregable across dimensions.
+ * Return a map of latencies scaled with the given base unit of time at specific percentiles.
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "observe",
-        functionName = "percentile",
+        functionName = "percentileValues",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Timer",
                 structPackage = "ballerina.observe"),
         args = {@Argument(name = "timer", type = TypeKind.STRUCT, structType = "Timer",
-                structPackage = "ballerina.observe"), @Argument(name = "percentile", type = TypeKind.FLOAT),
+                structPackage = "ballerina.observe"),
                 @Argument(name = "timeUnit", type = TypeKind.STRING)},
-        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.MAP)},
         isPublic = true
 )
 public class PercentileTimer extends BlockingNativeCallableUnit {
@@ -56,7 +57,6 @@ public class PercentileTimer extends BlockingNativeCallableUnit {
         String name = timerStruct.getStringField(0);
         String description = timerStruct.getStringField(1);
         BMap tagsMap = (BMap) timerStruct.getRefField(0);
-        float percentile = (float) context.getFloatArgument(0);
         BString timeUnitType = (BString) context.getRefArgument(1);
 
         TimeUnit timeUnit = TimeUnit.valueOf(timeUnitType.stringValue());
@@ -66,12 +66,19 @@ public class PercentileTimer extends BlockingNativeCallableUnit {
             for (Object key : tagsMap.keySet()) {
                 tags.add(new Tag(key.toString(), tagsMap.get(key).stringValue()));
             }
-            context.setReturnValues(new BFloat(Timer.builder(name).description(description).tags(tags).register()
-                    .percentile(percentile, timeUnit)));
+            context.setReturnValues(buildPercentileValuesMap(Timer.builder(name).description(description).tags(tags).
+                    register(), timeUnit));
 
         } else {
-            context.setReturnValues(new BFloat(Timer.builder(name).description(description).register()
-                    .percentile(percentile, timeUnit)));
+            context.setReturnValues(buildPercentileValuesMap(Timer.builder(name).description(description).register(),
+                    timeUnit));
         }
+    }
+
+    private BMap<BFloat, BFloat> buildPercentileValuesMap(Timer timer, TimeUnit timeUnit) {
+        BMap<BFloat, BFloat> map = new BMap<>();
+        SortedMap<Double, Double> percentileValues = timer.percentileValues(timeUnit);
+        percentileValues.forEach((percentile, value) -> map.put(new BFloat(percentile), new BFloat(value)));
+        return map;
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/metrics/SummaryTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/metrics/SummaryTest.java
@@ -22,10 +22,13 @@ import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 /**
  * Tests for summary metric.
@@ -59,7 +62,13 @@ public class SummaryTest extends MetricTest {
     @Test
     public void testPercentileSummary() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testPercentileSummary");
-        Assert.assertNotEquals(returns[0], new BFloat(0));
+        BMap<BFloat, BFloat> bMap = (BMap) returns[0];
+        Assert.assertEquals(bMap.size(), 5);
+        Map<BFloat, BFloat> map = bMap.getMap();
+        map.forEach((percentile, value) -> {
+            Assert.assertTrue(percentile.floatValue() >= 0 && percentile.floatValue() <= 1);
+            Assert.assertTrue(value.floatValue() > 0);
+        });
     }
 
     @Test

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/metrics/TimerTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/metrics/TimerTest.java
@@ -22,10 +22,13 @@ import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 /**
  * Tests for timer metric.
@@ -59,7 +62,13 @@ public class TimerTest extends MetricTest {
     @Test
     public void testPercentileTimer() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testPercentileTimer");
-        Assert.assertNotEquals(returns[0], new BFloat(0));
+        BMap<BFloat, BFloat> bMap = (BMap) returns[0];
+        Assert.assertEquals(bMap.size(), 5);
+        Map<BFloat, BFloat> map = bMap.getMap();
+        map.forEach((percentile, value) -> {
+            Assert.assertTrue(percentile.floatValue() >= 0 && percentile.floatValue() <= 1);
+            Assert.assertTrue(value.floatValue() > 0);
+        });
     }
 
     @Test

--- a/tests/ballerina-test/src/test/resources/test-src/metrics/summary-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/metrics/summary-test.bal
@@ -35,14 +35,14 @@ function testMeanSummary() returns (float) {
     return summary3.mean();
 }
 
-function testPercentileSummary() returns (float) {
+function testPercentileSummary() returns (map) {
     summary4.record(1);
     summary4.record(2);
     summary4.record(3);
     summary4.record(4);
     summary4.record(5);
     summary4.record(6);
-    return summary4.percentile(0.5);
+    return summary4.percentileValues();
 }
 
 function testSummaryWithoutTags() returns (float) {

--- a/tests/ballerina-test/src/test/resources/test-src/metrics/timer-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/metrics/timer-test.bal
@@ -38,13 +38,13 @@ function testMeanTimer() returns (float) {
     return timer3.mean(observe:TIME_UNIT_NANOSECONDS);
 }
 
-function testPercentileTimer() returns (float) {
+function testPercentileTimer() returns (map) {
     timer4.record(1000, observe:TIME_UNIT_NANOSECONDS);
     timer4.record(2000, observe:TIME_UNIT_NANOSECONDS);
     timer4.record(3000, observe:TIME_UNIT_NANOSECONDS);
     timer4.record(4000, observe:TIME_UNIT_NANOSECONDS);
     timer4.record(5000, observe:TIME_UNIT_NANOSECONDS);
-    return timer4.percentile(0.5, observe:TIME_UNIT_NANOSECONDS);
+    return timer4.percentileValues(observe:TIME_UNIT_NANOSECONDS);
 }
 
 function testTimerWithoutTags() returns (float) {


### PR DESCRIPTION
## Purpose
Earlier way of getting percentile value by giving a specific percentile had issues in Ballerina level as the specific percentile value was not matched correctly. For example, for 0.98 percentile, Ballerina native API tries to get the percentile value for 0.980000XXX.
Micrometer has also deprecated the `io.micrometer.core.instrument.DistributionSummary#percentile` and `io.micrometer.core.instrument.Timer#percentile` methods.

## Goals
Return a map of percentile values with `percentileValues()` API

## Automation tests
 - Unit tests 
Updated Unit Tests and Metrics tests were passed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Java 1.8.0_162 on Ubuntu 17.10