### PR TITLE
Rename basePath to path for subscriber services

### DIFF
--- a/stdlib/ballerina-websub/src/main/ballerina/websub/annotation.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/annotation.bal
@@ -20,7 +20,7 @@ package ballerina.websub;
 ///////////////////////////
 @Description {value:"Configuration for a WebSubSubscriber service"}
 @Field {value:"endpoints: Array of endpoints the service would be attached to"}
-@Field {value:"basePath: Path of the WebSubSubscriber service"}
+@Field {value:"path: Path of the WebSubSubscriber service"}
 @Field {value:"subscribeOnStartUp: Whether a subscription request is expected to be sent on start up"}
 @Field {value:"resourceUrl: The resource URL for which discovery will be initiated to identify hub and topic if not
 specified."}
@@ -31,7 +31,7 @@ specified."}
 @Field {value:"callback: The callback to use when registering, if unspecified host:port/path will be used."}
 public type SubscriberServiceConfiguration {
     Listener[] endpoints,
-    string basePath,
+    string path,
     boolean subscribeOnStartUp,
     string resourceUrl,
     string hub,

--- a/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/WebSubHttpService.java
+++ b/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/WebSubHttpService.java
@@ -70,7 +70,7 @@ public class WebSubHttpService extends HttpService {
 
         Struct serviceConfig = serviceConfigAnnotation.getValue();
 
-        websubHttpService.setBasePath(serviceConfig.getStringField(BASE_PATH_FIELD));
+        websubHttpService.setBasePath(serviceConfig.getStringField(WebSubSubscriberConstants.PATH_FIELD));
 
         List<HttpResource> resources = new ArrayList<>();
         for (Resource resource : websubHttpService.getBallerinaService().getResources()) {

--- a/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
+++ b/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
@@ -32,9 +32,6 @@ public class WebSubSubscriberConstants {
     public static final String ANN_NAME_WEBSUB_SUBSCRIBER_SERVICE_CONFIG = "SubscriberServiceConfig";
     public static final String WEBSUB_PACKAGE_PATH = "ballerina.websub";
 
-    static final String RESOURCE_NAME_ON_INTENT_VERIFICATION = "onIntentVerification";
-    static final String RESOURCE_NAME_ON_NOTIFICATION = "onNotification";
-
     public static final String ANN_WEBSUB_ATTR_SUBSCRIBE_ON_STARTUP = "subscribeOnStartUp";
     public static final String ANN_WEBSUB_ATTR_RESOURCE_URL = "resourceUrl";
     public static final String ANN_WEBSUB_ATTR_HUB = "hub";
@@ -55,5 +52,10 @@ public class WebSubSubscriberConstants {
 
     static final String STRUCT_WEBSUB_INTENT_VERIFICATION_REQUEST = "IntentVerificationRequest";
     static final String STRUCT_WEBSUB_NOTIFICATION_REQUEST = "NotificationRequest";
+
+    static final String RESOURCE_NAME_ON_INTENT_VERIFICATION = "onIntentVerification";
+    static final String RESOURCE_NAME_ON_NOTIFICATION = "onNotification";
+
+    static final String PATH_FIELD = "path";
 
 }

--- a/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RetrieveSubscriptionParameters.java
+++ b/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RetrieveSubscriptionParameters.java
@@ -85,7 +85,7 @@ public class RetrieveSubscriptionParameters extends AbstractHttpNativeFunction {
 
         if (callback.isEmpty()) {
             //TODO: intro methods to return host+port and change instead of using connector ID, and fix http:// hack
-            callback = httpService.getBasePath() + httpService.getResources().get(0).getPath();
+            callback = httpService.getBasePath();
             BStruct serviceEndpointConfig = ((BStruct) ((BStruct) serviceEndpoint.getVMValue()).getRefField(3));
             if (!serviceEndpointConfig.getStringField(0).equals("") &&
                     serviceEndpointConfig.getIntField(0) != 0) {

--- a/tests/ballerina-test-integration/src/test/resources/websub/websub_test_subscriber.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websub/websub_test_subscriber.bal
@@ -8,7 +8,7 @@ endpoint websub:Listener websubEP {
 };
 
 @websub:SubscriberServiceConfig {
-    basePath:"/websub",
+    path:"/websub",
     subscribeOnStartUp:true,
     topic: "http://www.websubpubtopic.com",
     hub: "https://localhost:9292/websub/hub",


### PR DESCRIPTION
## Purpose
WebSub subscriber services do not allow resource level annotations (no sub paths), and thus it does not make sense to call the path specified at service level as basePath.