### PR TITLE
Change observability configurations

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/observability/ObservabilityConstants.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/observability/ObservabilityConstants.java
@@ -53,7 +53,7 @@ public class ObservabilityConstants {
     public static final String PROPERTY_BSTRUCT_ERROR = "bstruct_error";
 
     // TOML Configs
-    public static final String CONFIG_TABLE_OBSERVABILITY = "observability";
+    public static final String CONFIG_TABLE_OBSERVABILITY = "b7a.observability";
     public static final String CONFIG_TABLE_METRICS = CONFIG_TABLE_OBSERVABILITY + ".metrics";
     public static final String CONFIG_TABLE_TRACING = CONFIG_TABLE_OBSERVABILITY + ".tracing";
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/OpenTracer.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/OpenTracer.java
@@ -20,8 +20,6 @@ package org.ballerinalang.util.tracer;
 import io.opentracing.Tracer;
 import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
 
-import java.util.Map;
-
 /**
  * This represents the Java SPI interface that OpenTracerManager will be using
  * to obtain the {@link Tracer} implementation.
@@ -31,9 +29,9 @@ public interface OpenTracer {
     /**
      * Initializes the {@link Tracer} implementation with configurations.
      *
-     * @param configProperties properties used to initialize the {@link Tracer} implementation
+     * throws {@link InvalidConfigurationException}
      */
-    void init(Map<String, String> configProperties);
+    void init() throws InvalidConfigurationException;
 
     /**
      * Returns the specific tracer implementation of the analytics engine based
@@ -41,11 +39,10 @@ public interface OpenTracer {
      *
      * @param tracerName name of the tracer
      * @param serviceName name of the service of the trace
-     * @return Specific {@link Tracer} instance throws {@link InvalidConfigurationException}
+     * @return Specific {@link Tracer} instance
      * if the configuration or tracer name is invalid.
      */
-    Tracer getTracer(String tracerName, String serviceName)
-            throws InvalidConfigurationException;
+    Tracer getTracer(String tracerName, String serviceName);
 
     /**
      * Returns the name of the tracer. This will be used when loading the tracer by name.

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TraceConstants.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TraceConstants.java
@@ -18,6 +18,8 @@
 
 package org.ballerinalang.util.tracer;
 
+import static org.ballerinalang.util.observability.ObservabilityConstants.CONFIG_TABLE_TRACING;
+
 /**
  * {@code TraceConstants} define tracer constants.
  *
@@ -30,7 +32,6 @@ public class TraceConstants {
 
     static final String DEFAULT_CONNECTOR_NAME = "BallerinaConnector";
     static final String DEFAULT_ACTION_NAME = "BallerinaAction";
-    public static final String TRACE_PREFIX = "trace___";
     public static final String TRACE_HEADER = "x-b7a-trace";
     public static final String USER_TRACE_HEADER = "x-b7a-utrace-";
     public static final String KEY_SPAN = "_span_";
@@ -52,7 +53,6 @@ public class TraceConstants {
     public static final String DEFAULT_USER_API_GROUP = "default-group";
 
     public static final String JAEGER = "jaeger";
-    public static final String ENABLED_CONFIG = "enabled";
-    public static final String TRACER_NAME_CONFIG = "name";
+    public static final String TRACER_NAME_CONFIG = CONFIG_TABLE_TRACING + ".name";
 
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracersStore.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracersStore.java
@@ -22,6 +22,7 @@ import io.opentracing.Tracer;
 import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,8 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import static org.ballerinalang.util.observability.ObservabilityConstants.CONFIG_TABLE_TRACING;
-import static org.ballerinalang.util.tracer.TraceConstants.ENABLED_CONFIG;
+import static org.ballerinalang.util.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
 import static org.ballerinalang.util.tracer.TraceConstants.JAEGER;
 import static org.ballerinalang.util.tracer.TraceConstants.TRACER_NAME_CONFIG;
 
@@ -41,8 +41,7 @@ class TracersStore {
 
     private List<TracerGenerator> tracers;
     private Map<String, Map<String, Tracer>> tracerStore;
-    private Map<String, String> tracingConfigs;
-
+    private static final PrintStream consoleError = System.err;
     private static TracersStore instance = new TracersStore();
 
     public static TracersStore getInstance() {
@@ -50,25 +49,32 @@ class TracersStore {
     }
 
     private TracersStore() {
-        tracingConfigs = ConfigRegistry.getInstance().getConfigTable(CONFIG_TABLE_TRACING);
     }
 
     public void loadTracers() {
-        if (Boolean.parseBoolean(tracingConfigs.get(ENABLED_CONFIG))) {
+        ConfigRegistry configRegistry = ConfigRegistry.getInstance();
+        if (configRegistry.getAsBoolean(CONFIG_TRACING_ENABLED)) {
 
             this.tracers = new ArrayList<>();
             this.tracerStore = new HashMap<>();
 
             ServiceLoader<OpenTracer> openTracers = ServiceLoader.load(OpenTracer.class);
             HashMap<String, OpenTracer> tracerMap = new HashMap<>();
-            openTracers.forEach(t -> tracerMap.put(t.getName(), t));
+            openTracers.forEach(t -> tracerMap.put(t.getName().toLowerCase(), t));
 
-            String tracerName = tracingConfigs.getOrDefault(TRACER_NAME_CONFIG, JAEGER);
+            String tracerName = configRegistry.getConfigOrDefault(TRACER_NAME_CONFIG, JAEGER);
 
-            OpenTracer tracer = tracerMap.get(tracerName);
+            OpenTracer tracer = tracerMap.get(tracerName.toLowerCase());
             if (tracer != null) {
-                tracer.init(tracingConfigs);
-                this.tracers.add(new TracerGenerator(tracer.getName(), tracer, tracingConfigs));
+                try {
+                    tracer.init();
+                    this.tracers.add(new TracerGenerator(tracer.getName(), tracer));
+                } catch (InvalidConfigurationException e) {
+                    consoleError.println("ballerina: error in observability tracing configurations: " + e.getMessage());
+                }
+            } else {
+                consoleError.println(
+                        "ballerina: observability enabled but no tracing extension found for name " + tracerName);
             }
         } else {
             this.tracers = Collections.emptyList();
@@ -91,9 +97,9 @@ class TracersStore {
                 try {
                     Tracer tracer = tracerGenerator.generate(serviceName);
                     tracerMap.put(tracerGenerator.name, tracer);
-                } catch (Throwable ignored) {
-                    //Tracers will get added only of there's no errors.
-                    //If tracers contains errors, tracer will be ignored.
+                } catch (Throwable e) {
+                    consoleError.println("ballerina: error getting tracer for "
+                            + tracerGenerator.name + ". " + e.getMessage());
                 }
             }
             tracerStore.put(serviceName, tracerMap);
@@ -107,15 +113,13 @@ class TracersStore {
     private static class TracerGenerator {
         String name;
         OpenTracer tracer;
-        Map<String, String> properties;
 
-        TracerGenerator(String name, OpenTracer tracer, Map<String, String> properties) {
+        TracerGenerator(String name, OpenTracer tracer) {
             this.name = name;
             this.tracer = tracer;
-            this.properties = properties;
         }
 
-        Tracer generate(String serviceName) throws InvalidConfigurationException {
+        Tracer generate(String serviceName) {
             return tracer.getTracer(name, serviceName);
         }
     }

--- a/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/java/org/ballerinalang/observe/metrics/extension/prometheus/PrometheusMeterRegistryProvider.java
+++ b/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/java/org/ballerinalang/observe/metrics/extension/prometheus/PrometheusMeterRegistryProvider.java
@@ -58,7 +58,12 @@ public class PrometheusMeterRegistryProvider implements MeterRegistryProvider {
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(new BallerinaPrometheusConfig());
         String hostname = configRegistry.getAsString(METRICS_HOSTNAME);
         boolean hostnameAvailable = hostname != null && !hostname.isEmpty();
-        int configuredPort = Math.toIntExact(configRegistry.getAsInt(METRICS_PORT));
+        int configuredPort;
+        try {
+            configuredPort = Integer.parseInt(configRegistry.getConfigOrDefault(METRICS_PORT, String.valueOf(0)));
+        } catch (IllegalArgumentException e) {
+            configuredPort = 0;
+        }
         // Start in default port if there is no configured port.
         int port = configuredPort > 0 ? configuredPort : DEFAULT_PORT;
         InetSocketAddress socketAddress = hostnameAvailable ? new InetSocketAddress(hostname, port) :

--- a/misc/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/Constants.java
+++ b/misc/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/Constants.java
@@ -19,6 +19,8 @@
 
 package org.ballerinalang.observe.trace.extension.jaeger;
 
+import static org.ballerinalang.util.observability.ObservabilityConstants.CONFIG_TABLE_TRACING;
+
 /**
  * This is the constants class that defines all the constants
  * that are used by the {@link OpenTracingExtension}.
@@ -30,17 +32,16 @@ public class Constants {
 
     static final String TRACER_NAME = "jaeger";
 
-    static final String SAMPLER_TYPE_CONFIG = "sampler.type";
-    static final String SAMPLER_PARAM_CONFIG = "sampler.param";
-    static final String REPORTER_LOG_SPANS_CONFIG = "reporter.log.spans";
-    static final String REPORTER_HOST_NAME_CONFIG = "reporter.hostname";
-    static final String REPORTER_PORT_CONFIG = "reporter.port";
-    static final String REPORTER_FLUSH_INTERVAL_MS_CONFIG = "reporter.flush.interval.ms";
-    static final String REPORTER_MAX_BUFFER_SPANS_CONFIG = "reporter.max.buffer.spans";
+    private static final String JAEGER_CONFIG_TABLE = CONFIG_TABLE_TRACING + ".jaeger";
+    static final String SAMPLER_TYPE_CONFIG = JAEGER_CONFIG_TABLE + ".sampler.type";
+    static final String SAMPLER_PARAM_CONFIG = JAEGER_CONFIG_TABLE + ".sampler.param";
+    static final String REPORTER_HOST_NAME_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.hostname";
+    static final String REPORTER_PORT_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.port";
+    static final String REPORTER_FLUSH_INTERVAL_MS_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.flush.interval.ms";
+    static final String REPORTER_MAX_BUFFER_SPANS_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.max.buffer.spans";
 
     static final String DEFAULT_SAMPLER_TYPE = "const";
     static final int DEFAULT_SAMPLER_PARAM = 1;
-    static final boolean DEFAULT_REPORTER_LOG_SPANS = true;
     static final String DEFAULT_REPORTER_HOSTNAME = "localhost";
     static final int DEFAULT_REPORTER_PORT = 5775;
     static final int DEFAULT_REPORTER_FLUSH_INTERVAL = 1000;

--- a/misc/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/OpenTracingExtension.java
+++ b/misc/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/OpenTracingExtension.java
@@ -15,28 +15,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.observe.trace.extension.jaeger;
 
 import com.uber.jaeger.Configuration;
+import com.uber.jaeger.samplers.ConstSampler;
+import com.uber.jaeger.samplers.ProbabilisticSampler;
+import com.uber.jaeger.samplers.RateLimitingSampler;
 import io.opentracing.Tracer;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.util.tracer.OpenTracer;
 import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
 
 import java.io.PrintStream;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_FLUSH_INTERVAL;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_HOSTNAME;
-import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_LOG_SPANS;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_MAX_BUFFER_SPANS;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_PORT;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_SAMPLER_PARAM;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_SAMPLER_TYPE;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_FLUSH_INTERVAL_MS_CONFIG;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_HOST_NAME_CONFIG;
-import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_LOG_SPANS_CONFIG;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_MAX_BUFFER_SPANS_CONFIG;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_PORT_CONFIG;
 import static org.ballerinalang.observe.trace.extension.jaeger.Constants.SAMPLER_PARAM_CONFIG;
@@ -49,43 +51,59 @@ import static org.ballerinalang.observe.trace.extension.jaeger.Constants.TRACER_
 @JavaSPIService("org.ballerinalang.util.tracer.OpenTracer")
 public class OpenTracingExtension implements OpenTracer {
 
+    private ConfigRegistry configRegistry;
+    private String hostname;
+    private int port;
+    private String samplerType;
+    private Number samplerParam;
+    private int reporterFlushInterval;
+    private int reporterBufferSize;
+
     private static final PrintStream console = System.out;
     private static final PrintStream consoleError = System.err;
-    private Map<String, String> configProperties;
 
     @Override
-    public void init(Map<String, String> configProperties) {
-        console.println("ballerina: started publishing tracers to Jaeger on "
-                + configProperties.getOrDefault(REPORTER_HOST_NAME_CONFIG, DEFAULT_REPORTER_HOSTNAME) + ":" +
-                getValidIntegerConfig(configProperties.get(REPORTER_PORT_CONFIG),
-                        DEFAULT_REPORTER_PORT, REPORTER_PORT_CONFIG));
-        this.configProperties = configProperties;
+    public void init() throws InvalidConfigurationException {
+        configRegistry = ConfigRegistry.getInstance();
+
+        try {
+            port = Integer.parseInt(
+                    configRegistry.getConfigOrDefault(REPORTER_PORT_CONFIG, String.valueOf(DEFAULT_REPORTER_PORT)));
+            hostname = configRegistry.getConfigOrDefault(REPORTER_HOST_NAME_CONFIG, DEFAULT_REPORTER_HOSTNAME);
+
+            samplerType = configRegistry.getConfigOrDefault(SAMPLER_TYPE_CONFIG, DEFAULT_SAMPLER_TYPE);
+            if (!(samplerType.equals(ConstSampler.TYPE) || samplerType.equals(RateLimitingSampler.TYPE)
+                    || samplerType.equals(ProbabilisticSampler.TYPE))) {
+                samplerType = DEFAULT_SAMPLER_TYPE;
+                consoleError.println(
+                        "ballerina: Jaeger configuration: \"sampler type\" invalid. Defaulted to const sampling");
+            }
+
+            samplerParam = Float.valueOf(
+                    configRegistry.getConfigOrDefault(SAMPLER_PARAM_CONFIG, String.valueOf(DEFAULT_SAMPLER_PARAM)));
+            reporterFlushInterval = Integer.parseInt(configRegistry.getConfigOrDefault(
+                    REPORTER_FLUSH_INTERVAL_MS_CONFIG, String.valueOf(DEFAULT_REPORTER_FLUSH_INTERVAL)));
+            reporterBufferSize = Integer.parseInt(configRegistry.getConfigOrDefault
+                    (REPORTER_MAX_BUFFER_SPANS_CONFIG, String.valueOf(DEFAULT_REPORTER_MAX_BUFFER_SPANS)));
+
+        } catch (IllegalArgumentException | ArithmeticException e) {
+            throw new InvalidConfigurationException(e.getMessage());
+        }
+        console.println("ballerina: started publishing tracers to Jaeger on " + hostname + ":" + port);
     }
 
     @Override
-    public Tracer getTracer(String tracerName, String serviceName) throws InvalidConfigurationException {
+    public Tracer getTracer(String tracerName, String serviceName) {
 
-        if (Objects.isNull(configProperties)) {
-            throw new InvalidConfigurationException("Tracer not initialized with configurations");
+        if (Objects.isNull(configRegistry)) {
+            throw new IllegalStateException("Tracer not initialized with configurations");
         }
 
         return new Configuration(
                 serviceName,
-                new Configuration.SamplerConfiguration(
-                        configProperties.getOrDefault(SAMPLER_TYPE_CONFIG, DEFAULT_SAMPLER_TYPE),
-                        getValidIntegerConfig(configProperties.get(SAMPLER_PARAM_CONFIG),
-                                DEFAULT_SAMPLER_PARAM, SAMPLER_PARAM_CONFIG)
-                ),
+                new Configuration.SamplerConfiguration(samplerType, samplerParam),
                 new Configuration.ReporterConfiguration(
-                        Boolean.parseBoolean(String.valueOf(configProperties
-                                .getOrDefault(REPORTER_LOG_SPANS_CONFIG, String.valueOf(DEFAULT_REPORTER_LOG_SPANS)))),
-                        configProperties.getOrDefault(REPORTER_HOST_NAME_CONFIG, DEFAULT_REPORTER_HOSTNAME),
-                        getValidIntegerConfig(configProperties.get(REPORTER_PORT_CONFIG),
-                                DEFAULT_REPORTER_PORT, REPORTER_PORT_CONFIG),
-                        getValidIntegerConfig(configProperties.get(REPORTER_FLUSH_INTERVAL_MS_CONFIG),
-                                DEFAULT_REPORTER_FLUSH_INTERVAL, REPORTER_FLUSH_INTERVAL_MS_CONFIG),
-                        getValidIntegerConfig(configProperties.get(REPORTER_MAX_BUFFER_SPANS_CONFIG),
-                                DEFAULT_REPORTER_MAX_BUFFER_SPANS, REPORTER_MAX_BUFFER_SPANS_CONFIG)
+                        Boolean.FALSE, hostname, port, reporterFlushInterval, reporterBufferSize
                 )
         ).getTracerBuilder().withScopeManager(NoOpScopeManager.INSTANCE).build();
     }
@@ -95,17 +113,4 @@ public class OpenTracingExtension implements OpenTracer {
         return TRACER_NAME;
     }
 
-    private int getValidIntegerConfig(String config, int defaultValue, String configName) {
-        if (config == null) {
-            return defaultValue;
-        } else {
-            try {
-                return Integer.parseInt(config);
-            } catch (NumberFormatException ex) {
-                consoleError.println("ballerina: observability tracing configuration " + configName
-                        + " is invalid. Default value of " + defaultValue + " will be used.");
-                return defaultValue;
-            }
-        }
-    }
 }

--- a/tests/observability-test-utils/src/main/java/org/ballerina/testing/extension/BMockTracer.java
+++ b/tests/observability-test-utils/src/main/java/org/ballerina/testing/extension/BMockTracer.java
@@ -26,7 +26,6 @@ import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Tracer extension that returns an instance of Mock tracer.
@@ -38,14 +37,14 @@ public class BMockTracer implements OpenTracer {
     private static final String NAME = "BMockTracer";
 
     @Override
-    public Tracer getTracer(String tracerName, String serviceName) throws InvalidConfigurationException {
+    public Tracer getTracer(String tracerName, String serviceName) {
         MockTracer mockTracer = new MockTracer();
         BMockTracer.tracerMap.add(mockTracer);
         return mockTracer;
     }
 
     @Override
-    public void init(Map<String, String> configProperties) {
+    public void init() throws InvalidConfigurationException {
         // Do Nothing
     }
 

--- a/tests/observability-test-utils/src/main/java/org/ballerina/testing/extension/BNoopTracer.java
+++ b/tests/observability-test-utils/src/main/java/org/ballerina/testing/extension/BNoopTracer.java
@@ -24,8 +24,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.util.tracer.OpenTracer;
 import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
 
-import java.util.Map;
-
 /**
  * Tracer extension that returns an instance of Mock tracer.
  */
@@ -35,12 +33,12 @@ public class BNoopTracer implements OpenTracer {
     private static final String NAME = "noop";
 
     @Override
-    public Tracer getTracer(String tracerName, String serviceName) throws InvalidConfigurationException {
+    public Tracer getTracer(String tracerName, String serviceName) {
         return NoopTracer.INSTANCE;
     }
 
     @Override
-    public void init(Map<String, String> configProperties) {
+    public void init() throws InvalidConfigurationException {
         // Do Nothing
     }
 


### PR DESCRIPTION
Observability configurations will come under b7a.observability header
Use ConfigRegistry directly in tracing extensions instead of config map

```
[b7a.observability.metrics]
enabled=true
port=9797
hostname="0.0.0.0"
descriptions=false
step="PT1M"

[b7a.observability.tracing]
enabled=true
name="jaeger"

[b7a.observability.tracing.jaeger]
reporter.hostname="localhost"
reporter.port=5775
sampler.param=1.0
sampler.type="const"
reporter.flush.interval.ms=2000
reporter.log.spans=true
reporter.max.buffer.spans=1000
```