### PR TITLE
Process OAS Operation model and make it iterable

### DIFF
--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
@@ -133,6 +133,7 @@ public class SwaggerConverterUtils {
     /**
      * This method will read the contents of ballerina service in {@code servicePath} and write output to
      * {@code outPath} in OAS3 format.
+     * @see #generateOAS3Definitions(String, String)
      *
      * @param servicePath path to ballerina service
      * @param outPath output path to write generated swagger file
@@ -152,6 +153,7 @@ public class SwaggerConverterUtils {
     /**
      * This method will read the contents of ballerina service in {@code servicePath} and write output to
      * {@code outPath} in Swagger (OAS2) format.
+     * @see #generateSwaggerDefinitions(String, String)
      *
      * @param servicePath path to ballerina service
      * @param outPath output path to write generated swagger file

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
@@ -98,6 +98,7 @@ public class SwaggerCmd implements BLauncherCmd {
                 break;
             case export:
                 exportFromBal();
+                msg.append("generated swagger definition");
                 break;
             default:
                 throw LauncherUtils.createUsageException(

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -20,11 +20,13 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
+import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
 
 import java.util.AbstractMap;
@@ -35,7 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Wrapper for <code>io.swagger.v3.oas.models.OpenAPI</code>
+ * Wrapper for {@link OpenAPI}.
  * <p>This class can be used to push additional context variables for handlebars</p>
  */
 public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi, OpenAPI> {
@@ -47,7 +49,7 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
     private List<BallerinaServer> servers = null;
     private Set<Map.Entry<String, String>> security = null;
     private List<Tag> tags = null;
-    private Set<Map.Entry<String, PathItem>> paths = null;
+    private Set<Map.Entry<String, BallerinaPath>> paths = null;
     private Set<Map.Entry<String, BallerinaSchema>> schemas = null;
     private Components components = null;
     private Map<String, Object> extensions = null;
@@ -69,8 +71,8 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
         this.tags = openAPI.getTags();
         this.components = openAPI.getComponents();
         this.extensions = openAPI.getExtensions();
-        this.paths = openAPI.getPaths().entrySet();
 
+        setPaths(openAPI);
         setSecurityRequirements(openAPI);
         setServers(openAPI);
         setSchemas(openAPI);
@@ -80,6 +82,34 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
     @Override
     public BallerinaOpenApi getDefaultValue() {
         return null;
+    }
+
+    /**
+     * Populate path models into iterable structure.
+     * This method will also add an operationId to each operation,
+     * if operationId not provided in swagger definition
+     *
+     * @param openAPI {@code OpenAPI} definition object with schema definition
+     * @throws BallerinaOpenApiException when context building fails
+     */
+    private void setPaths(OpenAPI openAPI) throws BallerinaOpenApiException {
+        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+            return;
+        }
+
+        this.paths = new LinkedHashSet<>();
+        Paths pathList = openAPI.getPaths();
+        for (Map.Entry<String, PathItem> path : pathList.entrySet()) {
+            BallerinaPath balPath = new BallerinaPath().buildContext(path.getValue());
+            balPath.getOperations().forEach(operation -> {
+                if (operation.getValue().getOperationId() == null) {
+                    String pathName = path.getKey().substring(1); // need to drop '/' prefix from the key, ex:'/path'
+                    String operationId = operation.getKey() + StringUtils.capitalize(pathName);
+                    operation.getValue().setOperationId(operationId);
+                }
+            });
+            paths.add(new AbstractMap.SimpleEntry<>(path.getKey(), balPath));
+        }
     }
 
     /**
@@ -198,7 +228,7 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
         return tags;
     }
 
-    public Set<Map.Entry<String, PathItem>> getPaths() {
+    public Set<Map.Entry<String, BallerinaPath>> getPaths() {
         return paths;
     }
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.model;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.callbacks.Callback;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wraps the {@link Operation} from swagger models to provide iterable child models.
+ *
+ * @since 0.967.0
+ */
+public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOperation, Operation> {
+    private List<String> tags;
+    private String summary;
+    private String description;
+    private ExternalDocumentation externalDocs;
+    private String operationId;
+    private List<Parameter> parameters;
+    private RequestBody requestBody;
+    private Set<Map.Entry<String, ApiResponse>> responses;
+    private Set<Map.Entry<String, Callback>> callbacks;
+    private List<SecurityRequirement> security;
+
+    public BallerinaOperation() {
+        this.responses = new LinkedHashSet<>();
+        this.callbacks = new LinkedHashSet<>();
+    }
+
+    @Override
+    public BallerinaOperation buildContext(Operation operation) throws BallerinaOpenApiException {
+        if (operation == null) {
+            return getDefaultValue();
+        }
+        this.tags = operation.getTags();
+        this.summary = operation.getSummary();
+        this.description = operation.getDescription();
+        this.externalDocs = operation.getExternalDocs();
+        this.parameters = operation.getParameters();
+        this.requestBody = operation.getRequestBody();
+        this.security = operation.getSecurity();
+        this.operationId = operation.getOperationId();
+
+        if (operation.getResponses() != null) {
+            operation.getResponses()
+                    .forEach((name, response) -> responses.add(new AbstractMap.SimpleEntry<>(name, response)));
+        }
+        if (operation.getCallbacks() != null) {
+            operation.getCallbacks()
+                    .forEach((name, callback) -> callbacks.add(new AbstractMap.SimpleEntry<>(name, callback)));
+        }
+
+        return this;
+    }
+
+    @Override
+    public BallerinaOperation getDefaultValue() {
+        return new BallerinaOperation();
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ExternalDocumentation getExternalDocs() {
+        return externalDocs;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
+
+    public RequestBody getRequestBody() {
+        return requestBody;
+    }
+
+    public Set<Map.Entry<String, ApiResponse>> getResponses() {
+        return responses;
+    }
+
+    public Set<Map.Entry<String, Callback>> getCallbacks() {
+        return callbacks;
+    }
+
+    public List<SecurityRequirement> getSecurity() {
+        return security;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaPath.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaPath.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.model;
+
+import io.swagger.v3.oas.models.PathItem;
+import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wraps the {@link PathItem} from swagger models to provide an iterable object model
+ * for operations.
+ *
+ * @since 0.967.0
+ */
+public class BallerinaPath implements BallerinaSwaggerObject<BallerinaPath, PathItem> {
+    private String ref;
+    private String summary;
+    private String description;
+    private Set<Map.Entry<String, BallerinaOperation>> operations;
+
+    @Override
+    public BallerinaPath buildContext(PathItem item) throws BallerinaOpenApiException {
+        this.ref = item.get$ref();
+        this.summary = item.getSummary();
+        this.description = item.getDescription();
+        this.operations = new LinkedHashSet<>();
+        Map.Entry<String, BallerinaOperation> entry;
+        BallerinaOperation operation;
+
+        // Swagger PathItem object doesn't provide a iterable structure for operations
+        // Therefore we have to manually check if each each http verb exists
+        if (item.getGet() != null) {
+            operation = new BallerinaOperation().buildContext(item.getGet());
+            entry = new AbstractMap.SimpleEntry<>("get", operation);
+            operations.add(entry);
+        }
+        if (item.getPut() != null) {
+            operation = new BallerinaOperation().buildContext(item.getPut());
+            entry = new AbstractMap.SimpleEntry<>("put", operation);
+            operations.add(entry);
+        }
+        if (item.getPost() != null) {
+            operation = new BallerinaOperation().buildContext(item.getPost());
+            entry = new AbstractMap.SimpleEntry<>("post", operation);
+            operations.add(entry);
+        }
+        if (item.getDelete() != null) {
+            operation = new BallerinaOperation().buildContext(item.getDelete());
+            entry = new AbstractMap.SimpleEntry<>("delete", operation);
+            operations.add(entry);
+        }
+        if (item.getOptions() != null) {
+            operation = new BallerinaOperation().buildContext(item.getOptions());
+            entry = new AbstractMap.SimpleEntry<>("options", operation);
+            operations.add(entry);
+        }
+        if (item.getHead() != null) {
+            operation = new BallerinaOperation().buildContext(item.getHead());
+            entry = new AbstractMap.SimpleEntry<>("head", operation);
+            operations.add(entry);
+        }
+        if (item.getPatch() != null) {
+            operation = new BallerinaOperation().buildContext(item.getPatch());
+            entry = new AbstractMap.SimpleEntry<>("patch", operation);
+            operations.add(entry);
+        }
+        if (item.getTrace() != null) {
+            operation = new BallerinaOperation().buildContext(item.getTrace());
+            entry = new AbstractMap.SimpleEntry<>("trace", operation);
+            operations.add(entry);
+        }
+
+        return this;
+    }
+
+    @Override
+    public BallerinaPath getDefaultValue() {
+        return null;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Set<Map.Entry<String, BallerinaOperation>> getOperations() {
+        return operations;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
@@ -47,8 +47,13 @@ public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, 
         if (schema instanceof ArraySchema) {
             this.properties = new LinkedHashSet<>();
             Schema propSchema = new Schema();
+            String type;
 
-            String type = getReferenceType(((ArraySchema) schema).getItems().get$ref());
+            if (((ArraySchema) schema).getItems().get$ref() != null) {
+                type = getReferenceType(((ArraySchema) schema).getItems().get$ref());
+            } else {
+                type = ((ArraySchema) schema).getItems().getType();
+            }
             String name = type.toLowerCase(Locale.ENGLISH) + LIST_SUFFIX;
             toPropertyName(name);
             type = type.isEmpty() ? UNSUPPORTED_PROPERTY_MSG : type + "[]";

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
@@ -41,13 +41,13 @@ public type {{cut info.title " "}}Client object {
     }
 
     new (clientEp) {}
-{{#paths}}{{#value}}{{#get}}
+{{#paths}}{{#value}}{{#operations}}{{#value}}
     public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
         endpoint http:Client ep = self.clientEp.client;
         http:Request request = new;
 
         //Create the required request as needed
-        var res = ep -> get("{{@key}}", request);
+        var res = ep -> {{key}}("{{../../key}}", request);
 
         match res {
             http:HttpConnectorError httpError => {
@@ -57,101 +57,5 @@ public type {{cut info.title " "}}Client object {
             http:Response resp => return resp;
         }
     }
-    {{/get}}{{#post}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
-
-        //Create the required request as needed
-        var res = ep -> post("{{@key}}", request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
-    }
-    {{/post}}{{#put}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
-
-        //Create the required request as needed
-        var res = ep -> put("{{@key}}", request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
-    }
-    {{/put}}{{#delete}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
-
-        //Create the required request as needed
-        var res = ep -> delete("{{@key}}", request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
-    }
-    {{/delete}}{{#options}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
-
-        //Create the required request as needed
-        var res = ep -> options("{{@key}}", request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
-    }
-    {{/options}}{{#head}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
-
-        //Create the required request as needed
-        var res = ep -> head("{{@key}}", request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
-    }
-    {{/head}}{{#patch}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
-
-        //Create the required request as needed
-        var res = ep -> patch("{{@key}}", request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
-    }
-{{/patch}}{{/value}}{{/paths}}
+{{/value}}{{/operations}}{{/value}}{{/paths}}
 };

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/impl.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/impl.mustache
@@ -1,5 +1,5 @@
 import ballerina/http;
-{{#paths}}{{#value}}{{#get}}
+{{#paths}}{{#value}}{{#operations}}{{#value}}
 public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
     //stub code - fill as necessary
     http:Response resp = new;
@@ -8,67 +8,4 @@ public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{
 
 	return resp;
 }
-{{/get}}{{#post}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setStringPayload(payload);
-
-	return resp;
-}
-{{/post}}{{#put}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setStringPayload(payload);
-
-	return resp;
-}
-{{/put}}{{#delete}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setStringPayload(payload);
-
-	return resp;
-}
-{{/delete}}{{#options}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setStringPayload(payload);
-
-	return resp;
-}
-{{/options}}{{#head}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setStringPayload(payload);
-
-	return resp;
-}
-{{/head}}{{#patch}}
-    public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-        //stub code - fill as necessary
-        http:Response resp = new;
-        string payload = "Sample {{operationId}} Response";
-        resp.setStringPayload(payload);
-
-	return resp;
-    }
-{{/patch}}{{#trace}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setStringPayload(payload);
-
-	return resp;
-}
-{{/trace}}{{/value}}{{/paths}}
+{{/value}}{{/operations}}{{/value}}{{/paths}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
@@ -25,7 +25,7 @@ import ballerina/swagger;
     basePath: "{{servers.0.basePath}}"{{!-- {{only one base path is allowed for all endpoints}} --}}
 }
 service<http:Service> {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unless @last}}, {{/unless}}{{/servers}} {
-{{#paths}}{{#value}}{{#get}}
+{{#paths}}{{#value}}{{#operations}}{{#value}}
     @swagger:ResourceInfo {
         tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
         summary: "{{summary}}",
@@ -43,195 +43,13 @@ service<http:Service> {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unl
         ]
     }
     @http:ResourceConfig {
-        methods:["GET"],
-        path:"{{key}}"
+        methods:["{{upper key}}"],
+        path:"{{../../key}}"
     }{{#deprecated}}
     deprecated {}{{/deprecated}}
     {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
         http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
         _ = outboundEp -> respond(res);
     }
-{{/get}}{{#post}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["POST"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/post}}{{#put}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["PUT"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/put}}{{#delete}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["DELETE"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/delete}}{{#options}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["OPTIONS"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/options}}{{#head}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["HEAD"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/head}}{{#patch}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["PATCH"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/patch}}{{#trace}}
-    @swagger:ResourceInfo {
-        tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],
-        summary: "{{summary}}",
-        description: "{{description}}",
-        externalDocs: {{>doc}},
-        parameters: [{{#parameters}}
-            {
-                name: "{{name}}",
-                inInfo: "{{in}}",
-                description: "{{description}}", {{#required}}
-                required: {{required}},{{/required}} {{#deprecated}}
-                discontinued: {{deprecated}},{{/deprecated}}
-                allowEmptyValue: "{{allowEmptyValue}}"
-            }{{#unless @last}},{{/unless}}{{/parameters}}
-        ]
-    }
-    @http:ResourceConfig {
-        methods:["TRACE"],
-        path:"{{key}}"
-    }{{#deprecated}}
-    deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
-    }
-{{/trace}}{{/value}}{{/paths}}
+{{/value}}{{/operations}}{{/value}}{{/paths}}
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
@@ -73,7 +73,6 @@ paths:
                 $ref: "#/components/schemas/Error"
     post:
       summary: Create a pet
-      operationId: createPets
       tags:
         - pets
       responses:


### PR DESCRIPTION
## Purpose
> This PR enables us to iterate over OAS operations and make templates more simple. This fix will also add `operationId` attribute to operations where it is missing.

## Goals

- Add see also to javadoc
- Add ballerina models for OAS3 operations
- Identify non reference type array schemas 