### PR TITLE
Fix suggestion issues over http package and types

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 
@@ -194,6 +195,8 @@ public abstract class AbstractItemResolver {
             if (paramType instanceof BInvokableType) {
                 // Check for the case when we can give a function as a parameter
                 typeName = parameterDefs.get(itr).type.toString();
+            } else if (paramType instanceof BUnionType) {
+                typeName = paramType.toString();
             } else {
                 BTypeSymbol tSymbol;
                 tSymbol = (paramType instanceof BArrayType) ?

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/PackageActionFunctionAndTypesFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/PackageActionFunctionAndTypesFilter.java
@@ -166,7 +166,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
         SymbolTable symbolTable = context.get(DocumentServiceKeys.SYMBOL_TABLE_KEY);
         String variableName = CommonUtil.getPreviousDefaultToken(tokenStream, delimiterIndex).getText();
         SymbolInfo variable = this.getVariableByName(variableName, symbols);
-        String builtinPkgName = symbolTable.builtInPackageSymbol.name.getValue();
+        String builtinPkgName = symbolTable.builtInPackageSymbol.pkgID.name.getValue();
         Map<Name, Scope.ScopeEntry> entries = new HashMap<>();
         String currentPkgName = context.get(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY);
 
@@ -198,10 +198,10 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
             });
         } else {
             if (bType instanceof BArrayType) {
-                packageID = ((BArrayType) bType).eType.tsymbol.pkgID.toString();
+                packageID = ((BArrayType) bType).eType.tsymbol.pkgID.getName().getValue();
                 bTypeValue = bType.toString();
             } else {
-                packageID = bType.tsymbol.pkgID.toString();
+                packageID = bType.tsymbol.pkgID.getName().getValue();
                 bTypeValue = bType.toString();
             }
 
@@ -209,7 +209,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
             SymbolInfo packageSymbolInfo = symbols.stream().filter(item -> {
                 Scope.ScopeEntry scopeEntry = item.getScopeEntry();
                 return (scopeEntry.symbol instanceof BPackageSymbol)
-                        && scopeEntry.symbol.pkgID.toString().equals(packageID);
+                        && scopeEntry.symbol.pkgID.name.getValue().equals(packageID);
             }).findFirst().orElse(null);
 
             if (packageID.equals(builtinPkgName)) {
@@ -236,6 +236,8 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
                         actionFunctionList.add(actionFunctionSymbol);
                     }
                 } else if ((scopeEntry.symbol instanceof BTypeSymbol)
+                        && (SymbolKind.OBJECT.equals(scopeEntry.symbol.kind)
+                        || SymbolKind.RECORD.equals(scopeEntry.symbol.kind))
                         && bTypeValue.equals(scopeEntry.symbol.type.toString())) {
                     // Get the struct fields
                     Map<Name, Scope.ScopeEntry> fields = scopeEntry.symbol.scope.entries;


### PR DESCRIPTION
## Purpose
> Fix Issue of failing suggestions over http package and variables defined. Also this enables fields and functions suggestion on objects and records.

Resolves #7351 

## Goals
> 
* Enable suggestions failed over http package
* Enable fields and functions suggestion over the objects and records
* Enable functions suggestions over variables