### PR TITLE
Support returning different constrained tables from call sql action

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/sql/sql_client.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/sql/sql_client.bal
@@ -166,7 +166,7 @@ public type SQLClient object {
     @Param {value:"parameters: Parameters used with the SQL query"}
     @Return {value:"Result set(s) for the given query"}
     @Return {value:"The Error occured during SQL client invocation"}
-    public native function call(@sensitive string sqlQuery, (typedesc|()) recordType, Parameter... parameters)
+    public native function call(@sensitive string sqlQuery, (typedesc[]|()) recordType, Parameter... parameters)
         returns @tainted (table[]|error);
 
     @Description {value:"The select action implementation for SQL connector to select data from tables."}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/sql/actions/Call.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/sql/actions/Call.java
@@ -18,7 +18,6 @@
 package org.ballerinalang.nativeimpl.sql.actions;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BStruct;
@@ -63,7 +62,7 @@ public class Call extends AbstractSQLAction {
         try {
             BStruct bConnector = (BStruct) context.getRefArgument(0);
             String query = context.getStringArgument(0);
-            BStructType structType = getStructType(context, 1);
+            BRefValueArray structTypes = (BRefValueArray) context.getNullableRefArgument(1);
             BRefValueArray parameters = (BRefValueArray) context.getNullableRefArgument(2);
 
             SQLDatasource datasource = (SQLDatasource) bConnector.getNativeData(Constants.SQL_CLIENT);
@@ -72,7 +71,7 @@ public class Call extends AbstractSQLAction {
             observerContext.addTag(TAG_KEY_DB_STATEMENT, query);
             observerContext.addTag(TAG_KEY_DB_TYPE, TAG_DB_TYPE_SQL);
 
-            executeProcedure(context, datasource, query, parameters, structType);
+            executeProcedure(context, datasource, query, parameters, structTypes);
         } catch (Throwable e) {
             context.setReturnValues(SQLDatasourceUtils.getSQLConnectorError(context, e));
             SQLDatasourceUtils.handleErrorOnTransaction(context);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
@@ -148,8 +148,35 @@ public class SQLActionsTest {
         final String expected = "Peter";
         BString retValue2 = (BString) returns[1];
         final String expected2 = "John";
+        BString retValue3 = (BString) returns[2];
+        final String expected3 = "Watson";
         Assert.assertEquals(retValue.stringValue(), expected);
         Assert.assertEquals(retValue2.stringValue(), expected2);
+        Assert.assertEquals(retValue3.stringValue(), expected3);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testCallProcedureWithMultipleResultSetsAndLowerConstraintCount() {
+        BValue[] returns = BRunUtil
+                .invoke(resultNegative, "testCallProcedureWithMultipleResultSetsAndLowerConstraintCount");
+        Assert.assertTrue(returns[0].stringValue().contains("message:\"execute stored procedure failed: Mismatching "
+                + "record type count: 1 and returned result set count: 2 from the stored procedure\""));
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testCallProcedureWithMultipleResultSetsAndNilConstraintCount() {
+        BValue[] returns = BRunUtil
+                .invoke(resultNegative, "testCallProcedureWithMultipleResultSetsAndNilConstraintCount");
+        Assert.assertTrue(returns[0].stringValue().contains("message:\"execute stored procedure failed: Mismatching "
+                + "record type count: 0 and returned result set count: 2 from the stored procedure\""));
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testCallProcedureWithMultipleResultSetsAndHigherConstraintCount() {
+        BValue[] returns = BRunUtil
+                .invoke(resultNegative, "testCallProcedureWithMultipleResultSetsAndHigherConstraintCount");
+        Assert.assertTrue(returns[0].stringValue().contains("message:\"execute stored procedure failed: Mismatching "
+                + "record type count: 3 and returned result set count: 2 from the stored procedure\""));
     }
 
     @Test(groups = "ConnectorTest")

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
@@ -70,7 +70,8 @@ CREATE PROCEDURE SelectPersonDataMultiple()
   READS SQL DATA DYNAMIC RESULT SETS 2
   BEGIN ATOMIC
   DECLARE result1 CURSOR WITH RETURN FOR SELECT firstName FROM Customers where registrationID = 1 FOR READ ONLY;
-  DECLARE result2 CURSOR WITH RETURN FOR SELECT firstName FROM Customers where registrationID = 2 FOR READ ONLY;
+  DECLARE result2 CURSOR WITH RETURN FOR SELECT firstName, lastName FROM Customers where registrationID = 2 FOR READ
+  ONLY;
   open result1;
   open result2;
   END

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/h2/h2-client-actions-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/h2/h2-client-actions-test.bal
@@ -65,7 +65,7 @@ function testCall() returns (string) {
         dbOptions:()
     };
 
-    var dtsRet = testDB -> call("{call JAVAFUNC('select * from Customers where customerId=1')}", Customer);
+    var dtsRet = testDB -> call("{call JAVAFUNC('select * from Customers where customerId=1')}", [Customer]);
     table[] dts = check dtsRet;
 
     string name;

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions-negative.bal
@@ -1,6 +1,20 @@
 import ballerina/sql;
 import ballerina/io;
 
+type ResultCustomers {
+    string FIRSTNAME,
+};
+
+type Person {
+    int id,
+    string name,
+};
+
+type ResultCustomers2 {
+    string FIRSTNAME,
+    string LASTNAME,
+};
+
 function testSelectData() returns (string) {
     endpoint sql:Client testDB {
         url:"hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
@@ -152,4 +166,105 @@ function testInvalidArrayofQueryParameters() returns (string) {
         _ = testDB -> close();
     }
     return returnData;
+}
+
+function testCallProcedureWithMultipleResultSetsAndLowerConstraintCount() returns ((string, string)|error) {
+    endpoint sql:Client testDB {
+        url:"hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
+        username:"SA",
+        poolOptions:{maximumPoolSize:1}
+    };
+
+    var dtsRet = testDB -> call("{call SelectPersonDataMultiple()}", [ResultCustomers]);
+
+    match dtsRet {
+        table[] dts => {
+            string firstName1;
+            string firstName2;
+
+            while (dts[0].hasNext()) {
+                ResultCustomers rs = check <ResultCustomers>dts[0].getNext();
+                firstName1 = rs.FIRSTNAME;
+            }
+
+            while (dts[1].hasNext()) {
+                ResultCustomers rs = check <ResultCustomers>dts[1].getNext();
+                firstName2 = rs.FIRSTNAME;
+            }
+
+            _ = testDB -> close();
+            return (firstName1, firstName2);
+        }
+        error e => {
+            _ = testDB -> close();
+            return e;
+        }
+    }
+}
+
+function testCallProcedureWithMultipleResultSetsAndHigherConstraintCount() returns ((string, string)|error) {
+    endpoint sql:Client testDB {
+        url:"hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
+        username:"SA",
+        poolOptions:{maximumPoolSize:1}
+    };
+
+    var dtsRet = testDB -> call("{call SelectPersonDataMultiple()}", [ResultCustomers, ResultCustomers2, Person]);
+
+    match dtsRet {
+        table[] dts => {
+            string firstName1;
+            string firstName2;
+
+            while (dts[0].hasNext()) {
+                ResultCustomers rs = check <ResultCustomers>dts[0].getNext();
+                firstName1 = rs.FIRSTNAME;
+            }
+
+            while (dts[1].hasNext()) {
+                ResultCustomers rs = check <ResultCustomers>dts[1].getNext();
+                firstName2 = rs.FIRSTNAME;
+            }
+
+            _ = testDB -> close();
+            return (firstName1, firstName2);
+        }
+        error e => {
+            _ = testDB -> close();
+            return e;
+        }
+    }
+}
+
+function testCallProcedureWithMultipleResultSetsAndNilConstraintCount() returns ((string, string)|error) {
+    endpoint sql:Client testDB {
+        url:"hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
+        username:"SA",
+        poolOptions:{maximumPoolSize:1}
+    };
+
+    var dtsRet = testDB -> call("{call SelectPersonDataMultiple()}", ());
+
+    match dtsRet {
+        table[] dts => {
+            string firstName1;
+            string firstName2;
+
+            while (dts[0].hasNext()) {
+                ResultCustomers rs = check <ResultCustomers>dts[0].getNext();
+                firstName1 = rs.FIRSTNAME;
+            }
+
+            while (dts[1].hasNext()) {
+                ResultCustomers rs = check <ResultCustomers>dts[1].getNext();
+                firstName2 = rs.FIRSTNAME;
+            }
+
+            return (firstName1, firstName2);
+        }
+        error e => {
+            _ = testDB -> close();
+            return e;
+        }
+    }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions-test.bal
@@ -6,6 +6,11 @@ type ResultCustomers {
     string FIRSTNAME,
 };
 
+type ResultCustomers2 {
+    string FIRSTNAME,
+    string LASTNAME,
+};
+
 type ResultIntType {
     int INT_TYPE,
 };
@@ -209,7 +214,7 @@ function testCallProcedureWithResultSet() returns (string) {
         poolOptions:{maximumPoolSize:1}
     };
 
-    var dtsRet = testDB -> call("{call SelectPersonData()}", ResultCustomers);
+    var dtsRet = testDB -> call("{call SelectPersonData()}", [ResultCustomers]);
     table[] dts = check dtsRet;
 
     string firstName;
@@ -221,18 +226,19 @@ function testCallProcedureWithResultSet() returns (string) {
     return firstName;
 }
 
-function testCallProcedureWithMultipleResultSets() returns (string, string) {
+function testCallProcedureWithMultipleResultSets() returns (string, string, string) {
     endpoint sql:Client testDB {
         url:"hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
         username:"SA",
         poolOptions:{maximumPoolSize:1}
     };
 
-    var dtsRet = testDB -> call("{call SelectPersonDataMultiple()}", ResultCustomers);
+    var dtsRet = testDB -> call("{call SelectPersonDataMultiple()}", [ResultCustomers, ResultCustomers2]);
     table[] dts = check dtsRet;
 
     string firstName1;
     string firstName2;
+    string lastName;
 
     while (dts[0].hasNext()) {
         ResultCustomers rs = check <ResultCustomers>dts[0].getNext();
@@ -240,12 +246,13 @@ function testCallProcedureWithMultipleResultSets() returns (string, string) {
     }
 
     while (dts[1].hasNext()) {
-        ResultCustomers rs = check <ResultCustomers>dts[1].getNext();
+        ResultCustomers2 rs = check <ResultCustomers2>dts[1].getNext();
         firstName2 = rs.FIRSTNAME;
+        lastName = rs.LASTNAME;
     }
 
     _ = testDB -> close();
-    return (firstName1, firstName2);
+    return (firstName1, firstName2, lastName);
 }
 
 function testQueryParameters() returns (string) {


### PR DESCRIPTION
## Purpose
Support returning different constrained tables from call sql action
Fixes ballerina-platform/ballerina-lang#7172

## Samples

```ballerina
type ResultCustomers {
    string FIRSTNAME,
};

type ResultCustomers2 {
    string FIRSTNAME,
    string LASTNAME,
};

var dts = testDB -> call("{call SelectPersonDataMultiple()}", [ResultCustomers, ResultCustomers2]);
```
