### PR TITLE
Update exported swagger file name

### DIFF
--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerBallerinaConstants.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerBallerinaConstants.java
@@ -23,6 +23,7 @@ import org.ballerinalang.net.http.HttpConstants;
  */
 public class SwaggerBallerinaConstants {
     public static final String YAML_EXTENSION = ".yaml";
+    public static final String SWAGGER_SUFFIX = ".swagger";
 
     public static final String RESOURCE_UUID_NAME = "x-UniqueResourceKey";
     public static final String VARIABLE_UUID_NAME = "x-UniqueVariableKey";

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
@@ -20,6 +20,7 @@ import io.swagger.models.Swagger;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.parser.converter.SwaggerConverter;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.ballerina.swagger.convertor.Constants;
 import org.ballerinalang.compiler.CompilerPhase;
@@ -142,12 +143,10 @@ public class SwaggerConverterUtils {
      */
     public static void generateOAS3Definitions(Path servicePath, Path outPath, String serviceName) throws IOException {
         String balSource = readFromFile(servicePath);
-        Path file = servicePath.getFileName();
-        String fileName = file != null ? file.toString() : null;
-        String swaggerName = StringUtils.isNotBlank(serviceName) ? serviceName : fileName;
+        String swaggerName = getSwaggerFileName(servicePath, serviceName);
 
-        String swagger = generateOAS3Definitions(balSource, serviceName);
-        writeFile(outPath.resolve(swaggerName + SwaggerBallerinaConstants.YAML_EXTENSION), swagger);
+        String swaggerSource = generateOAS3Definitions(balSource, serviceName);
+        writeFile(outPath.resolve(swaggerName), swaggerSource);
     }
 
     /**
@@ -163,12 +162,10 @@ public class SwaggerConverterUtils {
     public static void generateSwaggerDefinitions(Path servicePath, Path outPath, String serviceName)
             throws IOException {
         String balSource = readFromFile(servicePath);
-        Path file = servicePath.getFileName();
-        String fileName = file != null ? file.toString() : null;
-        String swaggerName = StringUtils.isNotBlank(serviceName) ? serviceName : fileName;
+        String swaggerName = getSwaggerFileName(servicePath, serviceName);
 
-        String swagger = generateSwaggerDefinitions(balSource, serviceName);
-        writeFile(outPath.resolve(swaggerName + SwaggerBallerinaConstants.YAML_EXTENSION), swagger);
+        String swaggerSource = generateSwaggerDefinitions(balSource, serviceName);
+        writeFile(outPath.resolve(swaggerName), swaggerSource);
     }
 
     private static String readFromFile(Path servicePath) throws IOException {
@@ -188,6 +185,21 @@ public class SwaggerConverterUtils {
                 writer.close();
             }
         }
+    }
+
+    private static String getSwaggerFileName(Path servicePath, String serviceName) {
+        Path file = servicePath.getFileName();
+        String swaggerFile;
+
+        if (StringUtils.isNotBlank(serviceName)) {
+            swaggerFile = serviceName + SwaggerBallerinaConstants.SWAGGER_SUFFIX;
+        } else {
+            swaggerFile = file != null ?
+                    FilenameUtils.removeExtension(file.toString()) + SwaggerBallerinaConstants.SWAGGER_SUFFIX :
+                    null;
+        }
+
+        return swaggerFile + SwaggerBallerinaConstants.YAML_EXTENSION;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Fixes ballerina-platform/ballerina-lang#7356

exported swagger file name had the format of `xxx.bal.yaml`. `.bal` doesn't need to be there in the swagger file name. Format is updated to `xxx.swagger.yaml`

## Goals
- Update exported swagger file name 
