### PR TITLE
Add support for 'allOf' schema composition

### DIFF
--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
@@ -100,6 +100,9 @@ public class CodeGenerator {
     public List<GenSrcFile> generate(GenType type, String definitionPath)
             throws IOException, BallerinaOpenApiException {
         OpenAPI api = new OpenAPIV3Parser().read(definitionPath);
+        if (api == null) {
+            throw new BallerinaOpenApiException("Couldn't read the definition from file: " + definitionPath);
+        }
 
         // modelPackage is not in use at the moment. All models will be written into same package as other src files.
         // Therefore value set to modelPackage is ignored here

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -80,6 +80,11 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
     }
 
     @Override
+    public BallerinaOpenApi buildContext(OpenAPI definition, OpenAPI openAPI) throws BallerinaOpenApiException {
+        return buildContext(definition);
+    }
+
+    @Override
     public BallerinaOpenApi getDefaultValue() {
         return null;
     }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -105,7 +105,7 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
         this.paths = new LinkedHashSet<>();
         Paths pathList = openAPI.getPaths();
         for (Map.Entry<String, PathItem> path : pathList.entrySet()) {
-            BallerinaPath balPath = new BallerinaPath().buildContext(path.getValue());
+            BallerinaPath balPath = new BallerinaPath().buildContext(path.getValue(), openAPI);
             balPath.getOperations().forEach(operation -> {
                 if (operation.getValue().getOperationId() == null) {
                     String pathName = path.getKey().substring(1); // need to drop '/' prefix from the key, ex:'/path'

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -132,7 +132,7 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
         schemaMap = openAPI.getComponents().getSchemas();
         for (Map.Entry entry : schemaMap.entrySet()) {
             try {
-                BallerinaSchema schema = new BallerinaSchema().buildContext((Schema) entry.getValue());
+                BallerinaSchema schema = new BallerinaSchema().buildContext((Schema) entry.getValue(), openAPI);
                 schemas.add(new AbstractMap.SimpleEntry<>((String) entry.getKey(), schema));
             } catch (BallerinaOpenApiException e) {
                 // Ignore exception and try to build next schema. No need to break the flow for a failure of one schema.

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
     private String description;
     private ExternalDocumentation externalDocs;
     private String operationId;
-    private List<Parameter> parameters;
+    private List<BallerinaParameter> parameters;
     private RequestBody requestBody;
     private Set<Map.Entry<String, ApiResponse>> responses;
     private Set<Map.Entry<String, Callback>> callbacks;
@@ -55,7 +56,7 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
     }
 
     @Override
-    public BallerinaOperation buildContext(Operation operation) throws BallerinaOpenApiException {
+    public BallerinaOperation buildContext(Operation operation, OpenAPI openAPI) throws BallerinaOpenApiException {
         if (operation == null) {
             return getDefaultValue();
         }
@@ -63,10 +64,10 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
         this.summary = operation.getSummary();
         this.description = operation.getDescription();
         this.externalDocs = operation.getExternalDocs();
-        this.parameters = operation.getParameters();
         this.requestBody = operation.getRequestBody();
         this.security = operation.getSecurity();
         this.operationId = operation.getOperationId();
+        this.parameters = new ArrayList<>();
 
         if (operation.getResponses() != null) {
             operation.getResponses()
@@ -76,13 +77,18 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
             operation.getCallbacks()
                     .forEach((name, callback) -> callbacks.add(new AbstractMap.SimpleEntry<>(name, callback)));
         }
+        if (operation.getParameters() != null) {
+            for (Parameter parameter : operation.getParameters()) {
+                this.parameters.add(new BallerinaParameter().buildContext(parameter, openAPI));
+            }
+        }
 
         return this;
     }
 
     @Override
-    public BallerinaOperation buildContext(Operation operation, OpenAPI openAPI) throws BallerinaOpenApiException {
-        return buildContext(operation);
+    public BallerinaOperation buildContext(Operation operation) throws BallerinaOpenApiException {
+        return buildContext(operation, null);
     }
 
     @Override
@@ -110,7 +116,7 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
         return operationId;
     }
 
-    public List<Parameter> getParameters() {
+    public List<BallerinaParameter> getParameters() {
         return parameters;
     }
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
@@ -17,6 +17,7 @@
 package org.ballerinalang.swagger.model;
 
 import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.parameters.Parameter;
@@ -77,6 +78,11 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
         }
 
         return this;
+    }
+
+    @Override
+    public BallerinaOperation buildContext(Operation operation, OpenAPI openAPI) throws BallerinaOpenApiException {
+        return buildContext(operation);
     }
 
     @Override

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaParameter.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaParameter.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.model;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
+
+import java.util.Map;
+
+/**
+ * Wraps the {@link Parameter} from swagger models for easier templating.
+ *
+ * @since 0.967.0
+ */
+public class BallerinaParameter implements BallerinaSwaggerObject<BallerinaParameter, Parameter> {
+    private String name;
+    private String in;
+    private String description;
+    private Boolean required;
+    private Boolean deprecated;
+    private Boolean allowEmptyValue;
+    private String ref;
+    private Parameter.StyleEnum style;
+    private Boolean explode;
+    private Boolean allowReserved;
+    private BallerinaSchema schema;
+    private Map<String, Example> examples;
+    private Object example;
+    private Content content;
+    private Map<String, Object> extensions;
+
+    @Override
+    public BallerinaParameter buildContext(Parameter parameter) throws BallerinaOpenApiException {
+        return buildContext(parameter, null);
+    }
+
+    @Override
+    public BallerinaParameter buildContext(Parameter parameter, OpenAPI openAPI) throws BallerinaOpenApiException {
+        this.name = parameter.getName();
+        this.in = parameter.getIn();
+        this.description = parameter.getDescription();
+        this.required = parameter.getRequired();
+        this.deprecated = parameter.getDeprecated();
+        this.allowEmptyValue = parameter.getAllowEmptyValue();
+        this.ref = parameter.get$ref();
+        this.style = parameter.getStyle();
+        this.explode = parameter.getExplode();
+        this.allowReserved = parameter.getAllowReserved();
+        this.examples = parameter.getExamples();
+        this.example = parameter.getExample();
+        this.content = parameter.getContent();
+        this.extensions = parameter.getExtensions();
+        this.schema = new BallerinaSchema().buildContext(parameter.getSchema(), openAPI);
+
+        return this;
+    }
+
+    @Override
+    public BallerinaParameter getDefaultValue() {
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getIn() {
+        return in;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public Boolean getDeprecated() {
+        return deprecated;
+    }
+
+    public Boolean getAllowEmptyValue() {
+        return allowEmptyValue;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public Parameter.StyleEnum getStyle() {
+        return style;
+    }
+
+    public Boolean getExplode() {
+        return explode;
+    }
+
+    public Boolean getAllowReserved() {
+        return allowReserved;
+    }
+
+    public BallerinaSchema getSchema() {
+        return schema;
+    }
+
+    public Map<String, Example> getExamples() {
+        return examples;
+    }
+
+    public Object getExample() {
+        return example;
+    }
+
+    public Content getContent() {
+        return content;
+    }
+
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaPath.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaPath.java
@@ -38,7 +38,7 @@ public class BallerinaPath implements BallerinaSwaggerObject<BallerinaPath, Path
     private Set<Map.Entry<String, BallerinaOperation>> operations;
 
     @Override
-    public BallerinaPath buildContext(PathItem item) throws BallerinaOpenApiException {
+    public BallerinaPath buildContext(PathItem item, OpenAPI openAPI) throws BallerinaOpenApiException {
         this.ref = item.get$ref();
         this.summary = item.getSummary();
         this.description = item.getDescription();
@@ -47,44 +47,44 @@ public class BallerinaPath implements BallerinaSwaggerObject<BallerinaPath, Path
         BallerinaOperation operation;
 
         // Swagger PathItem object doesn't provide a iterable structure for operations
-        // Therefore we have to manually check if each each http verb exists
+        // Therefore we have to manually check if each http verb exists
         if (item.getGet() != null) {
-            operation = new BallerinaOperation().buildContext(item.getGet());
+            operation = new BallerinaOperation().buildContext(item.getGet(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("get", operation);
             operations.add(entry);
         }
         if (item.getPut() != null) {
-            operation = new BallerinaOperation().buildContext(item.getPut());
+            operation = new BallerinaOperation().buildContext(item.getPut(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("put", operation);
             operations.add(entry);
         }
         if (item.getPost() != null) {
-            operation = new BallerinaOperation().buildContext(item.getPost());
+            operation = new BallerinaOperation().buildContext(item.getPost(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("post", operation);
             operations.add(entry);
         }
         if (item.getDelete() != null) {
-            operation = new BallerinaOperation().buildContext(item.getDelete());
+            operation = new BallerinaOperation().buildContext(item.getDelete(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("delete", operation);
             operations.add(entry);
         }
         if (item.getOptions() != null) {
-            operation = new BallerinaOperation().buildContext(item.getOptions());
+            operation = new BallerinaOperation().buildContext(item.getOptions(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("options", operation);
             operations.add(entry);
         }
         if (item.getHead() != null) {
-            operation = new BallerinaOperation().buildContext(item.getHead());
+            operation = new BallerinaOperation().buildContext(item.getHead(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("head", operation);
             operations.add(entry);
         }
         if (item.getPatch() != null) {
-            operation = new BallerinaOperation().buildContext(item.getPatch());
+            operation = new BallerinaOperation().buildContext(item.getPatch(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("patch", operation);
             operations.add(entry);
         }
         if (item.getTrace() != null) {
-            operation = new BallerinaOperation().buildContext(item.getTrace());
+            operation = new BallerinaOperation().buildContext(item.getTrace(), openAPI);
             entry = new AbstractMap.SimpleEntry<>("trace", operation);
             operations.add(entry);
         }
@@ -93,8 +93,8 @@ public class BallerinaPath implements BallerinaSwaggerObject<BallerinaPath, Path
     }
 
     @Override
-    public BallerinaPath buildContext(PathItem item, OpenAPI openAPI) throws BallerinaOpenApiException {
-        return buildContext(item);
+    public BallerinaPath buildContext(PathItem item) throws BallerinaOpenApiException {
+        return buildContext(item, null);
     }
 
     @Override

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaPath.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaPath.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.swagger.model;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
 
@@ -89,6 +90,11 @@ public class BallerinaPath implements BallerinaSwaggerObject<BallerinaPath, Path
         }
 
         return this;
+    }
+
+    @Override
+    public BallerinaPath buildContext(PathItem item, OpenAPI openAPI) throws BallerinaOpenApiException {
+        return buildContext(item);
     }
 
     @Override

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.swagger.model;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
@@ -94,6 +95,11 @@ public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, 
 
         this.properties = newEntries;
         return this;
+    }
+
+    @Override
+    public BallerinaSchema buildContext(Schema schema, OpenAPI openAPI) throws BallerinaOpenApiException {
+        return buildContext(schema);
     }
 
     @Override

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaServer.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaServer.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.swagger.model;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.servers.ServerVariable;
 import io.swagger.v3.oas.models.servers.ServerVariables;
@@ -78,6 +79,11 @@ public class BallerinaServer implements BallerinaSwaggerObject<BallerinaServer, 
         }
 
         return this;
+    }
+
+    @Override
+    public BallerinaServer buildContext(Server server, OpenAPI openAPI) throws BallerinaOpenApiException {
+        return buildContext(server);
     }
 
     @Override

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSwaggerObject.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSwaggerObject.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.swagger.model;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
 
 /**
@@ -33,6 +34,18 @@ public interface BallerinaSwaggerObject<C, D> {
      * @throws BallerinaOpenApiException on error when parsing the Open Api definition
      */
     C buildContext(D definition) throws BallerinaOpenApiException;
+
+    /**
+     * Build the Ballerina context model {@code C} for Open API definition/component in {@code D}.
+     * <p>{@link OpenAPI} definition {@code openApi} can be used to access the parent context
+     * helpful for building the current context</p>
+     *
+     * @param definition Open Api definition or component
+     * @param openAPI parent openApi object model
+     * @return parsed context model {@code C} of Open Api definition/component {@code D}
+     * @throws BallerinaOpenApiException on error when parsing the Open Api definition
+     */
+    C buildContext(D definition, OpenAPI openAPI) throws BallerinaOpenApiException;
 
     /**
      * Retrieve the default value for this type.

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/pathParams.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/pathParams.mustache
@@ -1,1 +1,1 @@
-{{#equals in "path"}}string {{name}}{{#unless @last}}, {{/unless}}{{/equals}}
+{{#equals in "path"}}{{schema.type}} {{name}}{{#unless @last}}, {{/unless}}{{/equals}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/pathParams.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/pathParams.mustache
@@ -1,1 +1,1 @@
-{{#equals in "path"}}, string {{name}}{{/equals}}
+{{#equals in "path"}}, {{schema.type}} {{name}}{{/equals}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
@@ -126,6 +126,13 @@ components:
           type: string
         type:
           type: string
+    Dog:
+      allOf:
+      - $ref: "#/components/schemas/Pet"
+      - type: object
+        properties:
+          bark:
+            type: boolean
     Pets:
       type: array
       items:


### PR DESCRIPTION
## Purpose
> Schemas with 'allOf' OAS composition will be supported with this PR.

## Goals

- Make parent context available for model builders
- Add support for allOf Composite types
- Add codegen supprot for any parameter type
- Throw error if swagger definition is not readable 

## Samples
Consider the Pet and Dog OSA schemas with below properties,
`Pet = color, name`
`Dog = (allOf Pet), bark, loudness`

Generated Dog object will look like below
```
type Dog {
    string color,
    string name,
    boolean bark,
    int loudness,
};
```
