### PR TITLE
Fix long path issue in windows

### DIFF
--- a/distribution/zip/ballerina-tools/bin/composer.bat
+++ b/distribution/zip/ballerina-tools/bin/composer.bat
@@ -138,7 +138,7 @@ rem ----------------- Execute The Requested Command ----------------------------
 cd %BALLERINA_HOME%
 
 FOR %%C in ("%BALLERINA_HOME%\resources\composer\services\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;".\resources\composer\services\%%~nC%%~xC"
-FOR %%D in ("%BALLERINA_HOME%\bre\lib\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\%%~nD%%~xD"
+set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\*"
 rem ---------- Add jars to classpath ----------------
 
 rem set BALLERINA_CLASSPATH=.\bin\bootstrap;%BALLERINA_CLASSPATH%

--- a/distribution/zip/ballerina/bin/ballerina.bat
+++ b/distribution/zip/ballerina/bin/ballerina.bat
@@ -64,7 +64,7 @@ FOR %%C in ("%BALLERINA_HOME%\bre\lib\bootstrap\*.jar") DO set BALLERINA_CLASSPA
 
 set BALLERINA_CLASSPATH="%JAVA_HOME%\lib\tools.jar";%BALLERINA_CLASSPATH%;
 
-FOR %%D in ("%BALLERINA_HOME%\bre\lib\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\%%~nD%%~xD"
+set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\*"
 
 rem ----- Process the input command -------------------------------------------
 


### PR DESCRIPTION
## Purpose
Fix long path issue in windows.
resolves #7420 
resolves #7366 

## Goals
Fix long path issue in windows when running ballerina or composer.

## Approach
Add all libraries to the ballerina class path using wildcard.