### PR TITLE
Upgrade hsqldb, h2, hikariCP versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1549,9 +1549,9 @@
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
         <org.snakeyaml.version>1.16.0.wso2v1</org.snakeyaml.version>
         <jcommander.version>1.60</jcommander.version>
-        <com.zaxxer.hikaricp.version>2.5.1</com.zaxxer.hikaricp.version>
-        <hyperSQL.version>2.3.4</hyperSQL.version>
-        <h2.version>1.3.175</h2.version>
+        <com.zaxxer.hikaricp.version>3.1.0</com.zaxxer.hikaricp.version>
+        <hyperSQL.version>2.4.0</hyperSQL.version>
+        <h2.version>1.4.197</h2.version>
         <gson.version>2.7</gson.version>
         <maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
         <lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
## Purpose
Upgrade hsqldb, h2, hikaridatasource versions to 2.4.0, .4.197 and 3.10 respectively.

