### PR TITLE
Fix struct types not rendered as a tree in debugger

### DIFF
--- a/composer/modules/web/src/plugins/debugger/views/Frames/index.jsx
+++ b/composer/modules/web/src/plugins/debugger/views/Frames/index.jsx
@@ -66,7 +66,8 @@ class Frames extends React.Component {
                     const label = <span className='node'><strong>{name}</strong>{` (${type})`}</span>;
                     if (type.toLowerCase().includes('json')
                         || type.toLowerCase().includes('struct')
-                        || type.toLowerCase().includes('map')) {
+                        || type.toLowerCase().includes('map')
+                        || variable.value.startsWith('struct')) {
                         return (
                             <TreeView key={name} nodeLabel={label} defaultCollapsed>
                                 <div className='node'>Value:</div>


### PR DESCRIPTION
## Purpose
Fix struct types not rendered as a tree in debugger frames view.

## Approach
![selection_156](https://user-images.githubusercontent.com/1552869/38994710-bc462aa0-4404-11e8-8f95-b6aae4519187.png)

