### PR TITLE
Disable testConnectorWithIdentifierLiteral test case

### DIFF
--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/expressions/identifierliteral/IdentifierLiteralTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/expressions/identifierliteral/IdentifierLiteralTest.java
@@ -153,7 +153,7 @@ public class IdentifierLiteralTest {
         Assert.assertEquals(actualString, "sample test");
     }
 
-    @Test(description = "Test connector name with identifier literal")
+    @Test(description = "Test connector name with identifier literal", enabled = false)
     public void testConnectorWithIdentifierLiteral() {
         BValue[] returns = BRunUtil.invoke(result, "testConnectorNameWithIL");
 


### PR DESCRIPTION
This was enabled accidentally and disabling it until it is fixed properly.