### PR TITLE
Introduce singleton type for Accept-Encoding config

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -97,7 +97,7 @@ public type ClientEndpointConfig {
     ConnectionThrottling? connectionThrottling,
     SecureSocket? secureSocket,
     CacheConfig cache,
-    string acceptEncoding = "auto",
+    AcceptEncoding acceptEncoding = ACCEPT_ENCODING_AUTO,
     AuthConfig? auth,
 };
 

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
@@ -95,7 +95,7 @@ public type FailoverClientEndpointConfiguration {
     ConnectionThrottling? connectionThrottling,
     TargetService[] targets,
     CacheConfig cache = {},
-    string acceptEncoding = "auto",
+    AcceptEncoding acceptEncoding = ACCEPT_ENCODING_AUTO,
     AuthConfig? auth,
     int[] failoverCodes = [501, 502, 503, 504],
     int intervalMillis,

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_commons.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_commons.bal
@@ -12,6 +12,12 @@ public type Compression "AUTO" | "ALWAYS" | "NEVER";
 @final public Compression COMPRESSION_ALWAYS = "ALWAYS";
 @final public Compression COMPRESSION_NEVER = "NEVER";
 
+public type AcceptEncoding "AUTO" | "ALWAYS" | "NEVER";
+
+@final public AcceptEncoding ACCEPT_ENCODING_AUTO = "AUTO";
+@final public AcceptEncoding ACCEPT_ENCODING_ALWAYS = "ALWAYS";
+@final public AcceptEncoding ACCEPT_ENCODING_NEVER = "NEVER";
+
 public type TransferEncoding "CHUNKING";
 
 @final public TransferEncoding TRANSFERENCODE_CHUNKING = "CHUNKING";

--- a/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
@@ -94,7 +94,7 @@ public type LoadBalanceClientEndpointConfiguration {
     ConnectionThrottling? connectionThrottling,
     TargetService[] targets,
     CacheConfig cache = {},
-    string acceptEncoding = "auto",
+    AcceptEncoding acceptEncoding = ACCEPT_ENCODING_AUTO,
     AuthConfig? auth,
     string algorithm = ROUND_ROBIN,
 };

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/AcceptEncodingConfig.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/AcceptEncodingConfig.java
@@ -23,6 +23,6 @@ package org.ballerinalang.net.http;
  */
 public enum AcceptEncodingConfig {
     AUTO,
-    ENABLE,
-    DISABLE;
+    ALWAYS,
+    NEVER
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -111,16 +111,16 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         if (epConfig == null) {
             return HttpConstants.AUTO;
         }
-        return epConfig.getStringField(HttpConstants.CLIENT_EP_ACCEPT_ENCODING);
+        return epConfig.getRefField(HttpConstants.CLIENT_EP_ACCEPT_ENCODING).getStringValue();
     }
 
     private static AcceptEncodingConfig getAcceptEncodingConfig(String acceptEncodingConfig) {
         if (HttpConstants.AUTO.equalsIgnoreCase(acceptEncodingConfig)) {
             return AcceptEncodingConfig.AUTO;
-        } else if (HttpConstants.ENABLE.equalsIgnoreCase(acceptEncodingConfig)) {
-            return AcceptEncodingConfig.ENABLE;
-        } else if (HttpConstants.DISABLE.equalsIgnoreCase(acceptEncodingConfig)) {
-            return AcceptEncodingConfig.DISABLE;
+        } else if (HttpConstants.ALWAYS.equalsIgnoreCase(acceptEncodingConfig)) {
+            return AcceptEncodingConfig.ALWAYS;
+        } else if (HttpConstants.NEVER.equalsIgnoreCase(acceptEncodingConfig)) {
+            return AcceptEncodingConfig.NEVER;
         } else {
             throw new BallerinaConnectorException(
                     "Invalid configuration found for Accept-Encoding: " + acceptEncodingConfig);
@@ -129,11 +129,11 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
 
     private void handleAcceptEncodingHeader(HTTPCarbonMessage outboundRequest,
             AcceptEncodingConfig acceptEncodingConfig) {
-        if (acceptEncodingConfig == AcceptEncodingConfig.ENABLE && (
+        if (acceptEncodingConfig == AcceptEncodingConfig.ALWAYS && (
                 outboundRequest.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString()) == null)) {
             outboundRequest
                     .setHeader(HttpHeaderNames.ACCEPT_ENCODING.toString(), ENCODING_DEFLATE + ", " + ENCODING_GZIP);
-        } else if (acceptEncodingConfig == AcceptEncodingConfig.DISABLE && (
+        } else if (acceptEncodingConfig == AcceptEncodingConfig.NEVER && (
                 outboundRequest.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString()) != null)) {
             outboundRequest.removeHeader(HttpHeaderNames.ACCEPT_ENCODING.toString());
         }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/accept-encoding-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/accept-encoding-test.bal
@@ -1,7 +1,7 @@
 import ballerina/http;
 import ballerina/mime;
 
-const string ACCEPT_ENCODING = "accept-encoding";
+@final string ACCEPT_ENCODING = "accept-encoding";
 
 endpoint http:Listener passthroughEP {
     port:9090
@@ -9,17 +9,17 @@ endpoint http:Listener passthroughEP {
 
 endpoint http:Client acceptEncodingAutoEP {
     url: "http://localhost:9092/hello",
-    acceptEncoding:"auto"
+    acceptEncoding:http:ACCEPT_ENCODING_AUTO
 };
 
 endpoint http:Client acceptEncodingEnableEP {
     url: "http://localhost:9092/hello",
-    acceptEncoding:"enable"
+    acceptEncoding:http:ACCEPT_ENCODING_ALWAYS
 };
 
 endpoint http:Client acceptEncodingDisableEP {
     url: "http://localhost:9092/hello",
-    acceptEncoding:"disable"
+    acceptEncoding:http:ACCEPT_ENCODING_NEVER
 };
 
 service<http:Service> passthrough bind passthroughEP {

--- a/tests/ballerina-test-integration/src/test/resources/testng.xml
+++ b/tests/ballerina-test-integration/src/test/resources/testng.xml
@@ -32,6 +32,7 @@
         </groups>
 
         <packages>
+            <package name="org.ballerinalang.test.service.http.configuration"/>
             <package name="org.ballerinalang.test.service.http.sample"/>
             <package name="org.ballerinalang.test.service.http2"/>
             <package name="org.ballerinalang.test.transaction"/>


### PR DESCRIPTION
## Purpose
To make the client endpoint configurations consistent.

## Automation tests
 - Integration tests - yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```java

endpoint http:Client acceptEncodingAutoEP {
    url: "http://localhost:9092/hello",
    acceptEncoding:http:ACCEPT_ENCODING_AUTO
};

endpoint http:Client acceptEncodingEnableEP {
    url: "http://localhost:9092/hello",
    acceptEncoding:http:ACCEPT_ENCODING_ALWAYS
};

endpoint http:Client acceptEncodingDisableEP {
    url: "http://localhost:9092/hello",
    acceptEncoding:http:ACCEPT_ENCODING_NEVER
};

```