### PR TITLE
Rename HttpClient to CallerActions

### DIFF
--- a/misc/testerina/modules/testerina-core/src/test/resources/servicemocktest/service-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/servicemocktest/service-test.bal
@@ -23,11 +23,11 @@ service<http:Service> EventServiceMock bind eventEP {
         methods:["GET"],
         path:"/"
     }
-    getEvents (endpoint client, http:Request req) {
+    getEvents (endpoint caller, http:Request req) {
         http:Response res = new;
         json j = {"a":"b"};
         res.setJsonPayload(j);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 

--- a/misc/testerina/modules/testerina-core/src/test/resources/servicemocktest2/service.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/servicemocktest2/service.bal
@@ -14,7 +14,7 @@ service PortalService bind portalEP {
     @http:ResourceConfig {
         path:"events"
     }
-    getEvents (endpoint client, http:Request req) {
-        _ = client -> respond(hadleGetEvents());
+    getEvents (endpoint caller, http:Request req) {
+        _ = caller -> respond(hadleGetEvents());
     }
 }

--- a/misc/testerina/samples/mock/helloWorldService.bal
+++ b/misc/testerina/samples/mock/helloWorldService.bal
@@ -15,10 +15,10 @@ service<http:Service> HelloServiceMock bind helloEP {
         methods:["GET"],
         path:"/"
     }
-    getEvents (endpoint client, http:Request req) {
+    getEvents (endpoint caller, http:Request req) {
         http:Response res = new;
         json j = {"Hello":"World"};
         res.setJsonPayload(j);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/stdlib/ballerina-grpc/src/main/ballerina/grpc/grpc_commons.bal
+++ b/stdlib/ballerina-grpc/src/main/ballerina/grpc/grpc_commons.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-package ballerina.grpc;
 
 public type Chunking "AUTO"|"ALWAYS"|"NEVER";
 

--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -27,7 +27,7 @@ public type Client object {
     public {
         string epName;
         ClientEndpointConfig config;
-        HttpClient httpClient;
+        CallerActions httpClient;
     }
 
     @Description {value:"Gets called when the endpoint is being initialized during the package initialization."}
@@ -44,7 +44,7 @@ public type Client object {
 
     @Description { value:"Returns the connector that client code uses"}
     @Return { value:"The connector that client code uses" }
-    public function getCallerActions() returns HttpClient {
+    public function getCallerActions() returns CallerActions {
         return self.httpClient;
     }
 
@@ -100,9 +100,9 @@ public type ClientEndpointConfig {
     AuthConfig? auth,
 };
 
-public native function createHttpClient(string uri, ClientEndpointConfig config) returns HttpClient;
+public native function createHttpClient(string uri, ClientEndpointConfig config) returns CallerActions;
 
-public native function createSimpleHttpClient(string uri, ClientEndpointConfig config) returns HttpClient;
+public native function createSimpleHttpClient(string uri, ClientEndpointConfig config) returns CallerActions;
 
 @Description { value:"RetryConfig struct represents retry related options for HTTP client invocation" }
 @Field {value:"count: Number of retry attempts before giving up"}
@@ -234,13 +234,13 @@ public function Client::init(ClientEndpointConfig config) {
     }
 }
 
-function createCircuitBreakerClient (string uri, ClientEndpointConfig configuration) returns HttpClient {
+function createCircuitBreakerClient (string uri, ClientEndpointConfig configuration) returns CallerActions {
     var cbConfig = configuration.circuitBreaker;
     match cbConfig {
         CircuitBreakerConfig cb => {
             validateCircuitBreakerConfiguration(cb);
             boolean [] statusCodes = populateErrorCodeIndex(cb.statusCodes);
-            HttpClient cbHttpClient = new;
+            CallerActions cbHttpClient = new;
             var retryConfigVal = configuration.retryConfig;
             match retryConfigVal {
                 RetryConfig retryConfig => {
@@ -285,7 +285,7 @@ function createCircuitBreakerClient (string uri, ClientEndpointConfig configurat
     }
 }
 
-function createRetryClient (string url, ClientEndpointConfig configuration) returns HttpClient {
+function createRetryClient (string url, ClientEndpointConfig configuration) returns CallerActions {
     var retryConfigVal = configuration.retryConfig;
     match retryConfigVal {
         RetryConfig retryConfig => {

--- a/stdlib/ballerina-http/src/main/ballerina/http/commons.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/commons.bal
@@ -30,7 +30,7 @@ public type HttpOperation "FORWARD" | "GET" | "POST" | "DELETE" | "OPTIONS" | "P
 
 // makes the actual endpoints call according to the http operation passed in.
 public function invokeEndpoint (string path, Request outRequest,
-                                HttpOperation requestAction, HttpClient httpClient) returns Response|HttpConnectorError {
+                                HttpOperation requestAction, CallerActions httpClient) returns Response|HttpConnectorError {
     if (HTTP_GET == requestAction) {
         return httpClient.get(path, request = outRequest);
     } else if (HTTP_POST == requestAction) {

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover-connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover-connector.bal
@@ -42,7 +42,7 @@ public type FailoverConnectorError {
 
 // Represents inferred failover configurations passed to Failover connector.
 public type FailoverInferredConfig {
-    HttpClient[] failoverClientsArray,
+    CallerActions[] failoverClientsArray,
     boolean[] failoverCodesIndex,
     int failoverInterval,
 };
@@ -320,8 +320,8 @@ function performFailoverAction (string path, Request request, HttpOperation requ
 
     //TODO: workaround to initialize a type inside a function. Change this once fix is aailable.
     FailoverConnectorError failoverConnectorError = {statusCode:500};
-    HttpClient[] failoverClients = failoverInferredConfig.failoverClientsArray;
-    HttpClient failoverClient = failoverClients[currentIndex];
+    CallerActions[] failoverClients = failoverInferredConfig.failoverClientsArray;
+    CallerActions failoverClient = failoverClients[currentIndex];
     Response inResponse = new;
     Request failoverRequest = request;
     failoverConnectorError.httpConnectorError = [];

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
@@ -49,7 +49,7 @@ public type FailoverClient object {
     documentation {
         Returns the backing HTTP client used by the endpoint.
     }
-    public function getCallerActions() returns HttpClient {
+    public function getCallerActions() returns CallerActions {
         return httpEP.httpClient;
     }
 
@@ -144,11 +144,11 @@ function createClientEPConfigFromFailoverEPConfig(FailoverClientEndpointConfigur
 }
 
 
-function createFailOverClient(FailoverClientEndpointConfiguration failoverClientConfig) returns HttpClient {
+function createFailOverClient(FailoverClientEndpointConfiguration failoverClientConfig) returns CallerActions {
     ClientEndpointConfig config = createClientEPConfigFromFailoverEPConfig(
                                       failoverClientConfig,
                                       failoverClientConfig.targets[0]);
-    HttpClient[] clients = createFailoverHttpClientArray(failoverClientConfig);
+    CallerActions[] clients = createFailoverHttpClientArray(failoverClientConfig);
     boolean[] failoverCodes = populateErrorCodeIndex(failoverClientConfig.failoverCodes);
     FailoverInferredConfig failoverInferredConfig = {
         failoverClientsArray:clients,
@@ -158,8 +158,8 @@ function createFailOverClient(FailoverClientEndpointConfiguration failoverClient
     return new Failover(config.url, config, failoverInferredConfig);
 }
 
-function createFailoverHttpClientArray (FailoverClientEndpointConfiguration failoverClientConfig) returns HttpClient[] {
-    HttpClient[] httpClients = [];
+function createFailoverHttpClientArray (FailoverClientEndpointConfiguration failoverClientConfig) returns CallerActions[] {
+    CallerActions[] httpClients = [];
     int i = 0;
     boolean httpClientRequired = false;
     string uri = failoverClientConfig.targets[0].url;

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_caching_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_caching_client.bal
@@ -69,7 +69,7 @@ public type HttpCachingClient object {
     public {
         string serviceUri;
         ClientEndpointConfig config;
-        HttpClient httpClient;
+        CallerActions httpClient;
         HttpCache cache;
         CacheConfig cacheConfig;
     }
@@ -181,7 +181,7 @@ public type HttpCachingClient object {
 
 @Description {value:"Creates an HTTP client capable of caching HTTP responses."}
 public function createHttpCachingClient(string url, ClientEndpointConfig config, CacheConfig cacheConfig)
-                                                                                                returns HttpClient {
+                                                                                                returns CallerActions {
     HttpCachingClient httpCachingClient = new(url, config, cacheConfig);
     log:printDebug("Created HTTP caching client: " + io:sprintf("%r", httpCachingClient));
     return httpCachingClient;
@@ -327,7 +327,7 @@ public function HttpCachingClient::rejectPromise(PushPromise promise) {
     self.httpClient.rejectPromise(promise);
 }
 
-function getCachedResponse(HttpCache cache, HttpClient httpClient, Request req, string httpMethod, string path,
+function getCachedResponse(HttpCache cache, CallerActions httpClient, Request req, string httpMethod, string path,
                            boolean isShared) returns Response|HttpConnectorError {
     time:Time currentT = time:currentTime();
     req.parseCacheControlHeader();
@@ -390,7 +390,7 @@ function getCachedResponse(HttpCache cache, HttpClient httpClient, Request req, 
     }
 }
 
-function getValidationResponse(HttpClient httpClient, Request req, Response cachedResponse, HttpCache cache,
+function getValidationResponse(CallerActions httpClient, Request req, Response cachedResponse, HttpCache cache,
                                time:Time currentT, string path, string httpMethod, boolean isFreshResponse)
                                                                                 returns Response|HttpConnectorError {
     // If the no-cache directive is set, always validate the response before serving
@@ -581,7 +581,7 @@ function isStaleResponseAccepted(RequestCacheControl? requestCacheControl, Respo
 }
 
 // Based https://tools.ietf.org/html/rfc7234#section-4.3.1
-function sendValidationRequest(HttpClient httpClient, string path, Response cachedResponse)
+function sendValidationRequest(CallerActions httpClient, string path, Response cachedResponse)
                                                                                 returns Response|HttpConnectorError {
     Request validationRequest = new;
 
@@ -602,7 +602,7 @@ function sendValidationRequest(HttpClient httpClient, string path, Response cach
     }
 }
 
-function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod)
+function sendNewRequest(CallerActions httpClient, Request request, string path, string httpMethod)
                                                                                 returns Response|HttpConnectorError {
     if (httpMethod == GET) {
         return httpClient.get(path, request = request);

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_circuit_breaker.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_circuit_breaker.bal
@@ -110,13 +110,13 @@ public type CircuitBreakerClient object {
         string serviceUri;
         ClientEndpointConfig config;
         CircuitBreakerInferredConfig circuitBreakerInferredConfig;
-        HttpClient httpClient;
+        CallerActions httpClient;
         CircuitHealth circuitHealth;
         CircuitState currentCircuitState = CB_CLOSED_STATE;
     }
 
     public new (string serviceUri, ClientEndpointConfig config, CircuitBreakerInferredConfig circuitBreakerInferredConfig,
-                                                                            HttpClient httpClient, CircuitHealth circuitHealth) {
+                                                                            CallerActions httpClient, CircuitHealth circuitHealth) {
         self.serviceUri = serviceUri;
         self.config = config;
         self.circuitBreakerInferredConfig = circuitBreakerInferredConfig;
@@ -225,7 +225,7 @@ public type CircuitBreakerClient object {
 };
 
 public function CircuitBreakerClient::post (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -247,7 +247,7 @@ public function CircuitBreakerClient::post (string path, Request? request = ()) 
 }
 
 public function CircuitBreakerClient::head (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -269,7 +269,7 @@ public function CircuitBreakerClient::head (string path, Request? request = ()) 
 }
 
 public function CircuitBreakerClient::put (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -297,7 +297,7 @@ public function CircuitBreakerClient::put (string path, Request? request = ()) r
 @Return {value:"The Response struct"}
 @Return {value:"Error occurred during the action invocation, if any"}
 public function CircuitBreakerClient::execute (string httpVerb, string path, Request request) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -324,7 +324,7 @@ public function CircuitBreakerClient::execute (string httpVerb, string path, Req
 @Return {value:"The Response struct"}
 @Return {value:"Error occurred during the action invocation, if any"}
 public function CircuitBreakerClient::patch (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -351,7 +351,7 @@ public function CircuitBreakerClient::patch (string path, Request? request = ())
 @Return {value:"The Response struct"}
 @Return {value:"Error occurred during the action invocation, if any"}
 public function CircuitBreakerClient::delete (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -378,7 +378,7 @@ public function CircuitBreakerClient::delete (string path, Request? request = ()
 @Return {value:"The Response struct"}
 @Return {value:"Error occurred during the action invocation, if any"}
 public function CircuitBreakerClient::get (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-    HttpClient httpClient = self.httpClient;
+    CallerActions httpClient = self.httpClient;
     CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
     self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -405,7 +405,7 @@ public function CircuitBreakerClient::get (string path, Request? request = ()) r
 @Return {value:"The Response struct"}
 @Return {value:"Error occurred during the action invocation, if any"}
 public function CircuitBreakerClient::options (string path, Request? request = ()) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -432,7 +432,7 @@ public function CircuitBreakerClient::options (string path, Request? request = (
 @Return {value:"The Response struct"}
 @Return {value:"Error occurred during the action invocation, if any"}
 public function CircuitBreakerClient::forward (string path, Request request) returns (Response | HttpConnectorError) {
-   HttpClient httpClient = self.httpClient;
+   CallerActions httpClient = self.httpClient;
    CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
    self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 
-@Description { value:"An HTTP client for interacting with an HTTP server."}
-public type HttpClient object {
+@Description { value:"The Caller actions for interacting with an HTTP server."}
+public type CallerActions object {
     //These properties are populated from the init call to the client connector as these were needed later stage
     //for retry and other few places.
     public {

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
@@ -23,7 +23,7 @@ public type LoadBalancer object {
    public {
        string serviceUri;
        ClientEndpointConfig config;
-       HttpClient[] loadBalanceClientsArray;
+       CallerActions[] loadBalanceClientsArray;
        string algorithm;
        int nextIndex; // Keeps to index which needs to be take the next load balance endpoint.
        boolean failover;
@@ -317,7 +317,7 @@ function performLoadBalanceAction (LoadBalancer lb, string path, Request outRequ
     loadBalanceConnectorError.httpConnectorError = [];
 
     while (loadBalanceTermination < lengthof lb.loadBalanceClientsArray) {
-        HttpClient loadBalanceClient = roundRobin(lb, lb.loadBalanceClientsArray);
+        CallerActions loadBalanceClient = roundRobin(lb, lb.loadBalanceClientsArray);
 
         match invokeEndpoint(path, outRequest, requestAction, loadBalanceClient) {
             Response inResponse => return inResponse;
@@ -336,8 +336,8 @@ function performLoadBalanceAction (LoadBalancer lb, string path, Request outRequ
 }
 
 // Round Robin Algorithm implementation with respect to load balancing endpoints.
-public function roundRobin(LoadBalancer lb, HttpClient[] loadBalanceConfigArray) returns (HttpClient) {
-    HttpClient httpClient = new;
+public function roundRobin(LoadBalancer lb, CallerActions[] loadBalanceConfigArray) returns (CallerActions) {
+    CallerActions httpClient = new;
 
     lock {
         if (lb.nextIndex == ((lengthof (loadBalanceConfigArray)) - 1)) {

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal
@@ -17,7 +17,7 @@ public type RetryClient object {
         string serviceUri;
         ClientEndpointConfig config;
         RetryConfig retryConfig;
-        HttpClient httpClient;
+        CallerActions httpClient;
     }
 
     public new (serviceUri, config, retryConfig, httpClient) {}
@@ -249,7 +249,7 @@ function performRetryAction (@sensitive string path, Request request, HttpOperat
     if (maxWaitInterval == 0) {
         maxWaitInterval = 60000;
     }
-    HttpClient httpClient = retryClient.httpClient;
+    CallerActions httpClient = retryClient.httpClient;
     Response response = new;
     //TODO : Initialize the record type correctly once it is fixed.
     HttpConnectorError httpConnectorError = {statusCode:501};

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_secure_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_secure_client.bal
@@ -33,7 +33,7 @@ public type HttpSecureClient object {
     public {
         string serviceUri;
         ClientEndpointConfig config;
-        HttpClient httpClient;
+        CallerActions httpClient;
     }
 
     public new(serviceUri, config) {
@@ -228,14 +228,14 @@ public type HttpSecureClient object {
 };
 
 @Description {value:"Creates an HTTP client capable of securing HTTP requests with authentication."}
-public function createHttpSecureClient(string url, ClientEndpointConfig config) returns HttpClient {
+public function createHttpSecureClient(string url, ClientEndpointConfig config) returns CallerActions {
     match config.auth {
         AuthConfig => {
             HttpSecureClient httpSecureClient = new(url, config);
             return httpSecureClient;
         }
         () => {
-            HttpClient httpClient = createSimpleHttpClient(url, config);
+            CallerActions httpClient = createSimpleHttpClient(url, config);
             return httpClient;
         }
     }
@@ -299,7 +299,7 @@ function getAccessTokenFromRefreshToken(ClientEndpointConfig config) returns (st
     string clientId = config.auth.clientId but { () => EMPTY_STRING };
     string clientSecret = config.auth.clientSecret but { () => EMPTY_STRING };
     string refreshUrl = config.auth.refreshUrl but { () => EMPTY_STRING };
-    HttpClient refreshTokenClient = createHttpSecureClient(refreshUrl, {});
+    CallerActions refreshTokenClient = createHttpSecureClient(refreshUrl, {});
     string refreshTokenRequestPath = "/oauth2/v3/token";
     string requestParams = "refresh_token=" + refreshToken + "&grant_type=refresh_token&client_secret=" + clientSecret + "&client_id=" + clientId;
     string base64ClientIdSecret;

--- a/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
@@ -49,7 +49,7 @@ public type LoadBalanceClient object {
     documentation {
         Returns the backing HTTP client used by the load balance client endpoint.
     }
-    public function getCallerActions() returns HttpClient {
+    public function getCallerActions() returns CallerActions {
         return httpEP.httpClient;
     }
 
@@ -143,17 +143,17 @@ function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientEndpointCo
     return clientEPConfig;
 }
 
-function createLoadBalancerClient(LoadBalanceClientEndpointConfiguration loadBalanceClientConfig) returns HttpClient {
+function createLoadBalancerClient(LoadBalanceClientEndpointConfiguration loadBalanceClientConfig) returns CallerActions {
     ClientEndpointConfig config = createClientEPConfigFromLoalBalanceEPConfig(loadBalanceClientConfig,
                                                                             loadBalanceClientConfig.targets[0]);
-    HttpClient[] lbClients = createLoadBalanceHttpClientArray(loadBalanceClientConfig);
+    CallerActions[] lbClients = createLoadBalanceHttpClientArray(loadBalanceClientConfig);
     return new LoadBalancer(loadBalanceClientConfig.targets[0].url, config, lbClients,
                                             loadBalanceClientConfig.algorithm, 0, loadBalanceClientConfig.failover);
 }
 
 function createLoadBalanceHttpClientArray (LoadBalanceClientEndpointConfiguration loadBalanceClientConfig)
-                                                                                                returns HttpClient[] {
-    HttpClient[] httpClients = [];
+                                                                                                returns CallerActions[] {
+    CallerActions[] httpClients = [];
     int i = 0;
     boolean httpClientRequired = false;
     string uri = loadBalanceClientConfig.targets[0].url;

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -141,7 +141,7 @@ public class HttpConstants {
     public static final String RESOURCES_CORS = "RESOURCES_CORS";
     public static final String LISTENER_INTERFACE_ID = "listener.interface.id";
 
-    public static final String HTTP_CLIENT = "HttpClient";
+    public static final String CALLER_ACTIONS = "CallerActions";
 
     public static final String REQUEST_URL = "REQUEST_URL";
     public static final String SRC_HANDLER = "SRC_HANDLER";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -295,7 +295,8 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
     private void send(DataContext dataContext, HTTPCarbonMessage outboundRequestMsg, boolean async) throws Exception {
         BStruct bConnector = (BStruct) dataContext.context.getRefArgument(0);
         Struct httpClient = BLangConnectorSPIUtil.toStruct(bConnector);
-        HttpClientConnector clientConnector = (HttpClientConnector) httpClient.getNativeData(HttpConstants.HTTP_CLIENT);
+        HttpClientConnector clientConnector = (HttpClientConnector)
+                httpClient.getNativeData(HttpConstants.CALLER_ACTIONS);
         String contentType = HttpUtil.getContentTypeFromTransportMessage(outboundRequestMsg);
         String boundaryString = null;
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Delete.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Delete.java
@@ -36,7 +36,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "delete",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -60,7 +60,7 @@ public class Delete extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(dataContext.context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'delete' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), dataContext.context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), dataContext.context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Execute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Execute.java
@@ -43,7 +43,7 @@ import static org.wso2.transport.http.netty.common.Constants.ENCODING_GZIP;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "execute",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -68,7 +68,7 @@ public class Execute extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'execute' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Forward.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Forward.java
@@ -42,7 +42,7 @@ import java.util.Locale;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "forward",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -66,7 +66,7 @@ public class Forward extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'forward' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Get.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Get.java
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "get",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -61,7 +61,7 @@ public class Get extends AbstractHTTPAction {
         } catch (ClientConnectorException clientConnectorException) {
             // This is should be a JavaError. Need to handle this properly.
             BallerinaException exception = new BallerinaException("Failed to invoke 'get' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
@@ -40,7 +40,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "getNextPromise",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -66,7 +66,7 @@ public class GetNextPromise extends AbstractHTTPAction {
         }
         BStruct bConnector = (BStruct) context.getRefArgument(0);
         HttpClientConnector clientConnector =
-                (HttpClientConnector) bConnector.getNativeData(HttpConstants.HTTP_CLIENT);
+                (HttpClientConnector) bConnector.getNativeData(HttpConstants.CALLER_ACTIONS);
         clientConnector.getNextPushPromise(responseHandle).
                 setPushPromiseListener(new PromiseListener(dataContext));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetPromisedResponse.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetPromisedResponse.java
@@ -41,7 +41,7 @@ import org.wso2.transport.http.netty.message.Http2PushPromise;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "getPromisedResponse",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -67,7 +67,7 @@ public class GetPromisedResponse extends AbstractHTTPAction {
         }
         BStruct bConnector = (BStruct) context.getRefArgument(0);
         HttpClientConnector clientConnector =
-                (HttpClientConnector) bConnector.getNativeData(HttpConstants.HTTP_CLIENT);
+                (HttpClientConnector) bConnector.getNativeData(HttpConstants.CALLER_ACTIONS);
         clientConnector.getPushResponse(http2PushPromise).
                 setPushResponseListener(new PushResponseListener(dataContext), http2PushPromise.getPromisedStreamId());
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
@@ -39,7 +39,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "getResponse",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -66,7 +66,7 @@ public class GetResponse extends AbstractHTTPAction {
         }
         BStruct bConnector = (BStruct) context.getRefArgument(0);
         HttpClientConnector clientConnector =
-                (HttpClientConnector) bConnector.getNativeData(HttpConstants.HTTP_CLIENT);
+                (HttpClientConnector) bConnector.getNativeData(HttpConstants.CALLER_ACTIONS);
         clientConnector.getResponse(responseHandle).
                 setHttpConnectorListener(new ResponseListener(dataContext));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "hasPromise",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -61,7 +61,7 @@ public class HasPromise extends AbstractHTTPAction {
         }
         BStruct bConnector = (BStruct) context.getRefArgument(0);
         HttpClientConnector clientConnector =
-                (HttpClientConnector) bConnector.getNativeData(HttpConstants.HTTP_CLIENT);
+                (HttpClientConnector) bConnector.getNativeData(HttpConstants.CALLER_ACTIONS);
         clientConnector.hasPushPromise(responseHandle).
                 setPromiseAvailabilityListener(new PromiseAvailabilityCheckListener(context, callback));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Head.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Head.java
@@ -39,7 +39,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "head",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.CONNECTOR),
@@ -63,7 +63,7 @@ public class Head extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'head' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Options.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Options.java
@@ -39,7 +39,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "options",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.CONNECTOR),
@@ -62,7 +62,7 @@ public class Options extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'options' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Patch.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Patch.java
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "patch",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.CONNECTOR),
@@ -61,7 +61,7 @@ public class Patch extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'patch' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Post.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Post.java
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "post",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -61,7 +61,7 @@ public class Post extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'post' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Put.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Put.java
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "put",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.CONNECTOR),
@@ -61,7 +61,7 @@ public class Put extends AbstractHTTPAction {
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             BallerinaException exception = new BallerinaException("Failed to invoke 'put' action in " +
-                    HttpConstants.HTTP_CLIENT + ". " + clientConnectorException.getMessage(), context);
+                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
             dataContext.notifyReply(null, HttpUtil.getHttpConnectorError(context, exception));
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/RejectPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/RejectPromise.java
@@ -35,7 +35,7 @@ import org.wso2.transport.http.netty.message.Http2PushPromise;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "rejectPromise",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -55,7 +55,7 @@ public class RejectPromise extends AbstractHTTPAction {
         }
         BStruct bConnector = (BStruct) context.getRefArgument(0);
         HttpClientConnector clientConnector =
-                (HttpClientConnector) bConnector.getNativeData(HttpConstants.HTTP_CLIENT);
+                (HttpClientConnector) bConnector.getNativeData(HttpConstants.CALLER_ACTIONS);
         clientConnector.rejectPushResponse(http2PushPromise);
         callback.notifySuccess();
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
@@ -34,7 +34,7 @@ import org.wso2.transport.http.netty.contract.ClientConnectorException;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
         functionName = "submit",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.HTTP_CLIENT,
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
                 structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
@@ -58,7 +58,7 @@ public class Submit extends Execute {
             // Execute the operation
             executeNonBlockingAction(dataContext, createOutboundRequestMsg(context), true);
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'executeAsync' action in " + HttpConstants.HTTP_CLIENT
+            throw new BallerinaException("Failed to invoke 'executeAsync' action in " + HttpConstants.CALLER_ACTIONS
                                          + ". " + clientConnectorException.getMessage(), context);
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.ballerinalang.net.http.HttpConstants.HTTP_CLIENT;
+import static org.ballerinalang.net.http.HttpConstants.CALLER_ACTIONS;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
 
 /**
@@ -121,8 +121,8 @@ public class CreateHttpClient extends BlockingNativeCallableUnit {
         HttpClientConnector httpClientConnector = httpConnectorFactory
                 .createHttpClientConnector(properties, senderConfiguration);
         BStruct httpClient = BLangConnectorSPIUtil.createBStruct(context.getProgramFile(), HTTP_PACKAGE_PATH,
-                HTTP_CLIENT, urlString, clientEndpointConfig);
-        httpClient.addNativeData(HttpConstants.HTTP_CLIENT, httpClientConnector);
+                CALLER_ACTIONS, urlString, clientEndpointConfig);
+        httpClient.addNativeData(HttpConstants.CALLER_ACTIONS, httpClientConnector);
         httpClient.addNativeData(HttpConstants.CLIENT_ENDPOINT_CONFIG, clientEndpointConfig);
         context.setReturnValues(httpClient);
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.ballerinalang.net.http.HttpConstants.HTTP_CLIENT;
+import static org.ballerinalang.net.http.HttpConstants.CALLER_ACTIONS;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
 
 /**
@@ -122,8 +122,8 @@ public class CreateSimpleHttpClient extends BlockingNativeCallableUnit {
         HttpClientConnector httpClientConnector = httpConnectorFactory
                 .createHttpClientConnector(properties, senderConfiguration);
         BStruct httpClient = BLangConnectorSPIUtil.createBStruct(context.getProgramFile(), HTTP_PACKAGE_PATH,
-                HTTP_CLIENT, urlString, clientEndpointConfig);
-        httpClient.addNativeData(HttpConstants.HTTP_CLIENT, httpClientConnector);
+                CALLER_ACTIONS, urlString, clientEndpointConfig);
+        httpClient.addNativeData(HttpConstants.CALLER_ACTIONS, httpClientConnector);
         httpClient.addNativeData(HttpConstants.CLIENT_ENDPOINT_CONFIG, clientEndpointConfig);
         context.setReturnValues(httpClient);
     }

--- a/tests/ballerina-test-integration/src/test/resources/http2/http-2.0-server-push-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/http2/http-2.0-server-push-test.bal
@@ -20,7 +20,7 @@ service<http:Service> frontendHttpService bind frontendEP {
         methods:["GET"],
         path:"/"
     }
-    frontendHttpResource (endpoint client, http:Request clientRequest) {
+    frontendHttpResource (endpoint caller, http:Request clientRequest) {
 
         http:Request serviceReq = new;
         http:HttpFuture httpFuture = new;
@@ -32,7 +32,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while submitting a request"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
                 done;
             }
             http:HttpFuture resultantFuture => {
@@ -57,7 +57,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                     http:Response errorResponse = new;
                     json errMsg = {"error":"error occurred while fetching a push promise"};
                     errorResponse.setJsonPayload(errMsg);
-                    _ = client -> respond(errorResponse);
+                    _ = caller -> respond(errorResponse);
                     done;
                 }
             }
@@ -73,7 +73,7 @@ service<http:Service> frontendHttpService bind frontendEP {
             http:Response errorResponse = new;
             json errMsg = {"error":"expected number of promises not received"};
             errorResponse.setJsonPayload(errMsg);
-            _ = client -> respond(errorResponse);
+            _ = caller -> respond(errorResponse);
             done;
         }
         io:println("Number of promises received : " + promiseCount);
@@ -90,7 +90,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while fetching response"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
                 done;
             }
         }
@@ -105,7 +105,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"expected response message not received"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
                 done;
             }
         }
@@ -115,7 +115,7 @@ service<http:Service> frontendHttpService bind frontendEP {
             http:Response errorResponse = new;
             json errMsg = {"error":"expected response message not received"};
             errorResponse.setJsonPayload(errMsg);
-            _ = client -> respond(errorResponse);
+            _ = caller -> respond(errorResponse);
             done;
         }
         io:println("Response : " + responseStringPayload);
@@ -133,7 +133,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                     http:Response errorResponse = new;
                     json errMsg = {"error":"error occurred while fetching promised response"};
                     errorResponse.setJsonPayload(errMsg);
-                    _ = client -> respond(errorResponse);
+                    _ = caller -> respond(errorResponse);
                     done;
                 }
             }
@@ -148,7 +148,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                     http:Response errorResponse = new;
                     json errMsg = {"error":"expected promised response not received"};
                     errorResponse.setJsonPayload(errMsg);
-                    _ = client -> respond(errorResponse);
+                    _ = caller -> respond(errorResponse);
                     done;
                 }
             }
@@ -160,7 +160,7 @@ service<http:Service> frontendHttpService bind frontendEP {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"expected promised response not received"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
                 done;
             }
             io:println("Promised resource : " + promisedStringPayload);
@@ -170,7 +170,7 @@ service<http:Service> frontendHttpService bind frontendEP {
         http:Response successResponse = new;
         json successMsg = {"status":"successful"};
         successResponse.setJsonPayload(successMsg);
-        _ = client -> respond(successResponse);
+        _ = caller -> respond(successResponse);
     }
 }
 
@@ -188,23 +188,23 @@ service<http:Service> backendHttp2Service bind backendEP {
   @http:ResourceConfig {
      path:"/main"
   }
-  backendHttp2Resource (endpoint client, http:Request req) {
+  backendHttp2Resource (endpoint caller, http:Request req) {
 
     io:println("Request received");
 
     // Send a Push Promise
     http:PushPromise promise1 = new (path = "/resource1", method = "POST");
-    _ = client -> promise(promise1);
+    _ = caller -> promise(promise1);
 
     // Send another Push Promise
     http:PushPromise promise2 = new (path = "/resource2", method = "POST");
-    _ = client -> promise(promise2);
+    _ = caller -> promise(promise2);
 
     // Send one more Push Promise
     http:PushPromise promise3 = new;   // create with default params
     promise3.path = "/resource3";      // set parameters
     promise3.method = "POST";
-    _ = client -> promise(promise3);
+    _ = caller -> promise(promise3);
 
     // Construct requested resource
     http:Response response = new;
@@ -212,7 +212,7 @@ service<http:Service> backendHttp2Service bind backendEP {
     response.setJsonPayload(msg);
 
     // Send the requested resource
-    _ = client -> respond(response);
+    _ = caller -> respond(response);
 
     // Construct promised resource1
     http:Response push1 = new;
@@ -220,20 +220,20 @@ service<http:Service> backendHttp2Service bind backendEP {
     push1.setJsonPayload(msg);
 
     // Push promised resource1
-    _ = client -> pushPromisedResponse(promise1, push1);
+    _ = caller -> pushPromisedResponse(promise1, push1);
 
     http:Response push2 = new;
     msg = {"push":{"name":"resource2"}};
     push2.setJsonPayload(msg);
 
     // Push promised resource2
-    _ = client -> pushPromisedResponse(promise2, push2);
+    _ = caller -> pushPromisedResponse(promise2, push2);
 
     http:Response push3 = new;
     msg = {"push":{"name":"resource3"}};
     push3.setJsonPayload(msg);
 
     // Push promised resource3
-    _ = client -> pushPromisedResponse(promise3, push3);
+    _ = caller -> pushPromisedResponse(promise3, push3);
   }
 }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/ATMLocatorService.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/ATMLocatorService.bal
@@ -22,7 +22,7 @@ service<http:Service> ATMLocator bind serviceEnpoint {
     @http:ResourceConfig {
         methods:["POST"]
     }
-    locator (endpoint outboundEP, http:Request req) {
+    locator (endpoint caller, http:Request req) {
 
         http:Request backendServiceReq = new;
         var jsonLocatorReq = req.getJsonPayload();
@@ -76,7 +76,7 @@ service<http:Service> ATMLocator bind serviceEnpoint {
                 io:println("Error occurred while writing info response");
             }
         }
-        _ = outboundEP -> respond(infomationResponse);
+        _ = caller -> respond(infomationResponse);
     }
 }
 
@@ -89,7 +89,7 @@ service<http:Service> Bankinfo bind serviceEnpoint {
     @http:ResourceConfig {
         methods:["POST"]
     }
-    product (endpoint outboundEP, http:Request req) {
+    product (endpoint caller, http:Request req) {
         http:Response res = new;
         var jsonRequest = req.getJsonPayload();
         match jsonRequest {
@@ -110,7 +110,7 @@ service<http:Service> Bankinfo bind serviceEnpoint {
             }
         }
 
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -123,7 +123,7 @@ service<http:Service> Banklocator bind serviceEnpoint {
     @http:ResourceConfig {
         methods:["POST"]
     }
-    product (endpoint outboundEP, http:Request req) {
+    product (endpoint caller, http:Request req) {
         http:Response res = new;
         var jsonRequest = req.getJsonPayload();
         match jsonRequest {
@@ -143,7 +143,7 @@ service<http:Service> Banklocator bind serviceEnpoint {
             }
         }
 
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 

--- a/tests/ballerina-test-integration/src/test/resources/httpService/accept-encoding-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/accept-encoding-test.bal
@@ -8,17 +8,17 @@ endpoint http:Listener passthroughEP {
 };
 
 endpoint http:Client acceptEncodingAutoEP {
-    url: "http://localhost:9092/hello",
+    url: "http://localhost:9090/hello",
     acceptEncoding:http:ACCEPT_ENCODING_AUTO
 };
 
 endpoint http:Client acceptEncodingEnableEP {
-    url: "http://localhost:9092/hello",
+    url: "http://localhost:9090/hello",
     acceptEncoding:http:ACCEPT_ENCODING_ALWAYS
 };
 
 endpoint http:Client acceptEncodingDisableEP {
-    url: "http://localhost:9092/hello",
+    url: "http://localhost:9090/hello",
     acceptEncoding:http:ACCEPT_ENCODING_NEVER
 };
 
@@ -26,63 +26,59 @@ service<http:Service> passthrough bind passthroughEP {
     @http:ResourceConfig {
         path:"/"
     }
-    passthrough (endpoint outboundEP, http:Request req) {
+    passthrough (endpoint caller, http:Request req) {
         if (req.getHeader("AcceptValue") == "auto") {
             var clientResponse = acceptEncodingAutoEP -> post("/", request = req);
             match clientResponse {
                 http:Response res => {
-                    _ = outboundEP -> respond(res);
+                    _ = caller -> respond(res);
                 }
                 http:HttpConnectorError err => {
                     http:Response res = new;
                     res.statusCode = 500;
                     res.setStringPayload(err.message);
-                    _ = outboundEP -> respond(res);
+                    _ = caller -> respond(res);
                 }
             }
         } else if (req.getHeader("AcceptValue") == "enable") {
             var clientResponse = acceptEncodingEnableEP -> post("/", request = req);
             match clientResponse {
                 http:Response res => {
-                    _ = outboundEP -> respond(res);
+                    _ = caller -> respond(res);
                 }
                 http:HttpConnectorError err => {
                     http:Response res = new;
                     res.statusCode = 500;
                     res.setStringPayload(err.message);
-                    _ = outboundEP -> respond(res);
+                    _ = caller -> respond(res);
                 }
             }
         } else if (req.getHeader("AcceptValue") == "disable") {
             var clientResponse = acceptEncodingDisableEP -> post("/", request = req);
             match clientResponse {
                 http:Response res => {
-                    _ = outboundEP -> respond(res);
+                    _ = caller -> respond(res);
                 }
                 http:HttpConnectorError err => {
                     http:Response res = new;
                     res.statusCode = 500;
                     res.setStringPayload(err.message);
-                    _ = outboundEP -> respond(res);
+                    _ = caller -> respond(res);
                 }
             }
         }
     }
 }
 
-endpoint http:Listener helloEP {
-    port:9092
-};
-
 @Description {value:"Sample hello world service."}
-service<http:Service> hello bind helloEP {
+service<http:Service> hello bind passthroughEP {
 
     @Description {value:"The helloResource only accepts requests made using the specified HTTP methods"}
     @http:ResourceConfig {
         methods:["POST", "PUT", "GET"],
         path:"/"
     }
-    helloResource (endpoint outboundEP, http:Request req) {
+    helloResource (endpoint caller, http:Request req) {
         http:Response res = new;
         json payload = {};
         boolean hasHeader = req.hasHeader(ACCEPT_ENCODING);
@@ -92,6 +88,6 @@ service<http:Service> hello bind helloEP {
             payload = {acceptEncoding:"Accept-Encoding hdeaer not present."};
         }
         res.setJsonPayload(payload);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/common_backend.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/common_backend.bal
@@ -14,14 +14,14 @@ service<http:Service> echo bind echoEP{
         methods:["POST"],
         path:"/"
     }
-    echo (endpoint outboundEP, http:Request req) {
+    echo (endpoint caller, http:Request req) {
         http:Response resp = new;
         var result = req.getStringPayload();
         match result {
             http:PayloadError payloadError => io:println(payloadError.message);
             string payload => {
                 resp.setStringPayload(payload);
-                _ = outboundEP -> respond(resp);
+                _ = caller -> respond(resp);
             }
         }
     }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/echo_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/echo_service.bal
@@ -14,13 +14,13 @@ service<http:Service> echo bind echoEP {
         methods:["POST"],
         path:"/"
     }
-    echo (endpoint outboundEP, http:Request req) {
+    echo (endpoint caller, http:Request req) {
         var payload = req.getStringPayload();
         match payload {
             string payloadValue => {
                 http:Response resp = new;
                 resp.setStringPayload(payloadValue);
-                _ = outboundEP -> respond(resp);
+                _ = caller -> respond(resp);
             }
             any | () => {
                 io:println("Error while fetching string payload");

--- a/tests/ballerina-test-integration/src/test/resources/httpService/ecommerceService.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/ecommerceService.bal
@@ -14,7 +14,7 @@ service<http:Service> CustomerMgtService bind serviceEndpoint {
     @http:ResourceConfig {
         methods:["GET", "POST"]
     }
-    customers (endpoint outboundEP, http:Request req) {
+    customers (endpoint caller, http:Request req) {
         json payload = {};
         string httpMethod = req.method;
         if (httpMethod.equalsIgnoreCase("GET")) {
@@ -25,7 +25,7 @@ service<http:Service> CustomerMgtService bind serviceEndpoint {
 
         http:Response res = new;
         res.setJsonPayload(payload);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -42,7 +42,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
         methods:["GET"],
         path:"/products/{prodId}"
     }
-    productsInfo (endpoint outboundEP, http:Request req, string prodId) {
+    productsInfo (endpoint caller, http:Request req, string prodId) {
         string reqPath = "/productsservice/" + untaint prodId;
         http:Request clientRequest = new;
         var clientResponse = productsService -> get(untaint reqPath, request = clientRequest);
@@ -52,7 +52,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
                 io:println("Error occurred while reading product response");
             }
             http:Response product => {
-                _ = outboundEP -> respond(product);
+                _ = caller -> respond(product);
             }
         }
 
@@ -62,7 +62,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
         methods:["POST"],
         path:"/products"
     }
-    productMgt (endpoint outboundEP, http:Request req) {
+    productMgt (endpoint caller, http:Request req) {
         http:Request clientRequest = new;
         var jsonReq = req.getJsonPayload();
         match jsonReq {
@@ -84,14 +84,14 @@ service<http:Service> Ecommerce bind serviceEndpoint {
                 clientResponse = prod;
             }
         }
-        _ = outboundEP -> respond(clientResponse);
+        _ = caller -> respond(clientResponse);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/orders"
     }
-    ordersInfo (endpoint outboundEP, http:Request req) {
+    ordersInfo (endpoint caller, http:Request req) {
         http:Request clientRequest = new;
         var clientResponse = productsService -> get("/orderservice/orders", request = clientRequest);
         match clientResponse {
@@ -99,7 +99,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
                 io:println("Error occurred while reading orders response");
             }
             http:Response orders => {
-                _ = outboundEP -> respond(orders);
+                _ = caller -> respond(orders);
             }
         }
     }
@@ -108,7 +108,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
         methods:["POST"],
         path:"/orders"
     }
-    ordersMgt (endpoint outboundEP, http:Request req) {
+    ordersMgt (endpoint caller, http:Request req) {
         http:Request clientRequest = new;
         var clientResponse = productsService -> post("/orderservice/orders", request = clientRequest);
         match clientResponse {
@@ -116,7 +116,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
                 io:println("Error occurred while writing orders response");
             }
             http:Response orders => {
-                _ = outboundEP -> respond(orders);
+                _ = caller -> respond(orders);
             }
         }
 
@@ -126,7 +126,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
         methods:["GET"],
         path:"/customers"
     }
-    customersInfo (endpoint outboundEP, http:Request req) {
+    customersInfo (endpoint caller, http:Request req) {
         http:Request clientRequest = new;
         var clientResponse = productsService -> get("/customerservice/customers", request = clientRequest);
         match clientResponse {
@@ -134,7 +134,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
                 io:println("Error occurred while reading customers response");
             }
             http:Response customer => {
-                _ = outboundEP -> respond(customer);
+                _ = caller -> respond(customer);
             }
         }
 
@@ -144,7 +144,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
         methods:["POST"],
         path:"/customers"
     }
-    customerMgt (endpoint outboundEP, http:Request req) {
+    customerMgt (endpoint caller, http:Request req) {
         http:Request clientRequest = new;
         var clientResponse = productsService -> post("/customerservice/customers", request = clientRequest);
         match clientResponse {
@@ -152,7 +152,7 @@ service<http:Service> Ecommerce bind serviceEndpoint {
                 io:println("Error occurred while writing customers response");
             }
             http:Response customer => {
-                _ = outboundEP -> respond(customer);
+                _ = caller -> respond(customer);
             }
         }
     }
@@ -166,7 +166,7 @@ service<http:Service> OrderMgtService bind serviceEndpoint {
     @http:ResourceConfig {
         methods:["GET", "POST"]
     }
-    orders (endpoint outboundEP, http:Request req) {
+    orders (endpoint caller, http:Request req) {
         json payload = {};
         string httpMethod = req.method;
         if (httpMethod.equalsIgnoreCase("GET")) {
@@ -177,7 +177,7 @@ service<http:Service> OrderMgtService bind serviceEndpoint {
 
         http:Response res = new;
         res.setJsonPayload(payload);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -192,20 +192,20 @@ service<http:Service> productmgt bind serviceEndpoint {
         methods:["GET"],
         path:"/{prodId}"
     }
-    product (endpoint outboundEP, http:Request req, string prodId) {
+    product (endpoint caller, http:Request req, string prodId) {
         json payload = {};
         payload = check <json>productsMap[prodId];
 
         http:Response res = new;
         res.setJsonPayload(payload);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/"
     }
-    addProduct (endpoint outboundEP, http:Request req) {
+    addProduct (endpoint caller, http:Request req) {
         var jsonReq = req.getJsonPayload();
 
         match jsonReq {
@@ -219,7 +219,7 @@ service<http:Service> productmgt bind serviceEndpoint {
 
                 http:Response res = new;
                 res.setJsonPayload(payload);
-                _ = outboundEP -> respond(res);
+                _ = caller -> respond(res);
             }
         }
     }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/helloWorldService.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/helloWorldService.bal
@@ -13,10 +13,10 @@ service<http:Service> helloWorld bind helloWorldEp {
         methods:["GET"],
         path:"/"
     }
-    sayHello (endpoint client, http:Request req) {
+    sayHello (endpoint caller, http:Request req) {
         http:Response resp = new;
         resp.setStringPayload("Hello, World!");
-        _ = client -> respond(resp);
+        _ = caller -> respond(resp);
     }
 }
 

--- a/tests/ballerina-test-integration/src/test/resources/httpService/httpMethodTest.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/httpMethodTest.bal
@@ -16,20 +16,20 @@ service<http:Service> headQuoteService bind serviceEndpoint {
     @http:ResourceConfig {
         path:"/default"
     }
-    defaultResource (endpoint client, http:Request req) {
+    defaultResource (endpoint caller, http:Request req) {
         string method = req.method;
         http:Request clientRequest = new;
 
         var response = endPoint -> execute(untaint method, "/getQuote/stocks", clientRequest);
         match response {
             http:Response httpResponse => {
-                _ = client -> respond(httpResponse);
+                _ = caller -> respond(httpResponse);
             }
             http:HttpConnectorError err => {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while invoking the service"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
             }
         }
     }
@@ -37,17 +37,17 @@ service<http:Service> headQuoteService bind serviceEndpoint {
     @http:ResourceConfig {
         path:"/forward11"
     }
-    forwardRes11 (endpoint client, http:Request req) {
+    forwardRes11 (endpoint caller, http:Request req) {
         var response = endPoint -> forward("/getQuote/stocks", req);
         match response {
             http:Response httpResponse => {
-                _ = client -> respond(httpResponse);
+                _ = caller -> respond(httpResponse);
             }
             http:HttpConnectorError err => {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while invoking the service"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
             }
         }
     }
@@ -55,17 +55,17 @@ service<http:Service> headQuoteService bind serviceEndpoint {
     @http:ResourceConfig {
         path:"/forward22"
     }
-    forwardRes22 (endpoint client, http:Request req) {
+    forwardRes22 (endpoint caller, http:Request req) {
         var response = endPoint -> forward("/getQuote/stocks", req);
         match response {
             http:Response httpResponse => {
-                _ = client -> respond(httpResponse);
+                _ = caller -> respond(httpResponse);
             }
             http:HttpConnectorError err => {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while invoking the service"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
             }
         }
     }
@@ -73,18 +73,18 @@ service<http:Service> headQuoteService bind serviceEndpoint {
     @http:ResourceConfig {
         path:"/getStock/{method}"
     }
-    commonResource (endpoint client, http:Request req, string method) {
+    commonResource (endpoint caller, http:Request req, string method) {
         http:Request clientRequest = new;
         var response = endPoint -> execute(untaint method, "/getQuote/stocks", clientRequest);
         match response {
             http:Response httpResponse => {
-                _ = client -> respond(httpResponse);
+                _ = caller -> respond(httpResponse);
             }
             http:HttpConnectorError err => {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while invoking the service"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
             }
         }
     }
@@ -99,18 +99,18 @@ service<http:Service> testClientConHEAD bind serviceEndpoint {
         methods:["HEAD"],
         path:"/"
     }
-    passthrough (endpoint client, http:Request req) {
+    passthrough (endpoint caller, http:Request req) {
         http:Request clientRequest = new;
         var response = endPoint -> get("/getQuote/stocks", request = clientRequest);
         match response {
             http:Response httpResponse => {
-                _ = client -> respond(httpResponse);
+                _ = caller -> respond(httpResponse);
             }
             http:HttpConnectorError err => {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while invoking the service"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = client -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
             }
         }
     }
@@ -125,39 +125,39 @@ service<http:Service> quoteService bind serviceEndpoint {
         methods:["GET"],
         path:"/stocks"
     }
-    company (endpoint client, http:Request req) {
+    company (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("wso2");
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/stocks"
     }
-    product (endpoint client, http:Request req) {
+    product (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("ballerina");
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/stocks"
     }
-    defaultStock (endpoint client, http:Request req) {
+    defaultStock (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setHeader("Method", "any");
         res.setStringPayload("default");
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         body:"person"
     }
-    employee (endpoint client, http:Request req, json person) {
+    employee (endpoint caller, http:Request req, json person) {
         http:Response res = new;
         res.setJsonPayload(person);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/http_echo_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/http_echo_service.bal
@@ -16,10 +16,10 @@ service<http:Service> echo bind echoEP1 {
         methods:["POST"],
         path:"/"
     }
-    echo (endpoint outboundEP, http:Request req) {
+    echo (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello world");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -31,10 +31,10 @@ service<http:Service> echoOne bind echoEP1 {
         methods:["POST"],
         path:"/abc"
     }
-    echoAbc (endpoint outboundEP, http:Request req) {
+    echoAbc (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello world");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -47,19 +47,19 @@ service<http:Service> echoDummy bind echoEP2 {
         methods:["POST"],
         path:"/"
     }
-    echoDummy (endpoint outboundEP, http:Request req) {
+    echoDummy (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello world");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["OPTIONS"],
         path:"/getOptions"
     }
-    echoOptions (endpoint outboundEP, http:Request req) {
+    echoOptions (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello Options");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/https_echo_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/https_echo_service.bal
@@ -27,10 +27,10 @@ service<http:Service> echo bind echoEP {
         methods:["POST"],
         path:"/"
     }
-    echo (endpoint outboundEP, http:Request req) {
+    echo (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello world");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -42,10 +42,10 @@ service<http:Service> echoOne bind echoEP, echoHttpEP {
         methods:["POST"],
         path:"/abc"
     }
-    echoAbc (endpoint outboundEP, http:Request req) {
+    echoAbc (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello world");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -58,9 +58,9 @@ service<http:Service> echoDummy bind echoDummyEP {
         methods:["POST"],
         path:"/"
     }
-    echoDummy (endpoint outboundEP, http:Request req) {
+    echoDummy (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("hello world");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test-integration/src/test/resources/httpService/passthrough_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/passthrough_service.bal
@@ -15,17 +15,17 @@ service<http:Service> passthroughService bind passthroughEP {
         methods:["GET"],
         path:"/"
     }
-    passthrough (endpoint outboundEP, http:Request clientRequest) {
+    passthrough (endpoint caller, http:Request clientRequest) {
         var response = nyseEP -> get("/nyseStock/stocks", request = clientRequest);
         match response {
             http:Response httpResponse => {
-                _ = outboundEP -> respond(httpResponse);
+                _ = caller -> respond(httpResponse);
             }
             http:HttpConnectorError err => {
                 http:Response errorResponse = new;
                 json errMsg = {"error":"error occurred while invoking the service"};
                 errorResponse.setJsonPayload(errMsg);
-                _ = outboundEP -> respond(errorResponse);
+                _ = caller -> respond(errorResponse);
             }
         }
     }
@@ -38,10 +38,10 @@ service<http:Service> nyseStockQuote bind passthroughEP {
         methods:["GET"],
         path:"/stocks"
     }
-    stocks (endpoint outboundEP, http:Request clientRequest) {
+    stocks (endpoint caller, http:Request clientRequest) {
         http:Response res = new;
         json payload = {"exchange":"nyse", "name":"IBM", "value":"127.50"};
         res.setJsonPayload(payload);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/config/service_configuration.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/config/service_configuration.bal
@@ -14,10 +14,10 @@ service<http:Service> hello bind backendEP{
         methods:["GET"],
         path:"/"
     }
-    sayHello (endpoint outboundEP, http:Request request) {
+    sayHello (endpoint caller, http:Request request) {
         http:Response response = {};
         response.setStringPayload("Hello World!!!");
-        _ = outboundEP -> respond(response);
+        _ = caller -> respond(response);
     }
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointWithService.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointWithService.bal
@@ -63,7 +63,7 @@ endpoint DummyEndpoint ep { conf1 : "test1"};
 
 
 service<DummyServiceType> foo bind ep {
-    getAction (endpoint client, string x, float y){
-        client -> invoke1("t", 1);
+    getAction (endpoint caller, string x, float y){
+        caller -> invoke1("t", 1);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint.bal
@@ -61,7 +61,7 @@ function test1 () returns (string) {
 
 
 service<DummyServiceType> foo bind  { conf1 : "test1"} {
-    getAction (endpoint client, string x, float y){
-        client -> invoke1("t", 1);
+    getAction (endpoint caller, string x, float y){
+        caller -> invoke1("t", 1);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint_negative.bal
@@ -60,7 +60,7 @@ function test1 () returns (string) {
 }
 
 service<DummyServiceType> foo bind  { confX : "test1"} {
-    getAction (endpoint client, string x, float y){
-        client -> invoke1("t", 1);
+    getAction (endpoint caller, string x, float y){
+        caller -> invoke1("t", 1);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-service.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-service.bal
@@ -20,22 +20,22 @@ service<http:Service> ^"sample Service" bind testEP{
         methods:["GET"],
         path:"/resource"
     }
-    ^"sample resource" (endpoint outboundEp, http:Request req) {
+    ^"sample resource" (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"key":"keyVal", "value":"valueOfTheString"};
         res.setJsonPayload(responseJson);
-        _ = outboundEp -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/resource2"
     }
-    ^"sample resource2" (endpoint outboundEp, http:Request req) {
+    ^"sample resource2" (endpoint caller, http:Request req) {
         http:Response res = new;
         string ^"a a" = "hello";
         res.setStringPayload(^"a a");
-        _ = outboundEp -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
@@ -258,7 +258,7 @@ service<http:Service> echo bind mockEP {
         methods:["POST"],
         path:"/largepayload"
     }
-    getPayloadFromFileChannel (endpoint client, http:Request request) {
+    getPayloadFromFileChannel (endpoint caller, http:Request request) {
         http:Response response = new;
         mime:Entity responseEntity = new;
         match request.getByteChannel() {
@@ -266,7 +266,7 @@ service<http:Service> echo bind mockEP {
             io:ByteChannel byteChannel => responseEntity.setByteChannel(byteChannel);
         }
         response.setEntity(responseEntity);
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/mime/multipart-request.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/mime/multipart-request.bal
@@ -18,7 +18,7 @@ service<http:Service> test bind mockEP {
         methods:["POST"],
         path:"/textbodypart"
     }
-    multipart1 (endpoint client, http:Request request) {
+    multipart1 (endpoint caller, http:Request request) {
         http:Response response = new;
         match request.getBodyParts() {
             mime:EntityError err => {
@@ -37,14 +37,14 @@ service<http:Service> test bind mockEP {
                 }
             }
         }
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/jsonbodypart"
     }
-    multipart2 (endpoint client, http:Request request) {
+    multipart2 (endpoint caller, http:Request request) {
         http:Response response = new;
         match request.getBodyParts() {
             mime:EntityError err => {
@@ -59,14 +59,14 @@ service<http:Service> test bind mockEP {
                 }
             }
         }
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/xmlbodypart"
     }
-    multipart3 (endpoint client, http:Request request) {
+    multipart3 (endpoint caller, http:Request request) {
         http:Response response = new;
         match request.getBodyParts() {
             mime:EntityError err => {
@@ -81,14 +81,14 @@ service<http:Service> test bind mockEP {
                }
             }
          }
-         _ = client -> respond(response);
+         _ = caller -> respond(response);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/binarybodypart"
     }
-    multipart4 (endpoint client, http:Request request) {
+    multipart4 (endpoint caller, http:Request request) {
         http:Response response = new;
         match request.getBodyParts() {
             mime:EntityError err => {
@@ -103,14 +103,14 @@ service<http:Service> test bind mockEP {
                 }
             }
         }
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/multipleparts"
     }
-    multipart5 (endpoint client, http:Request request) {
+    multipart5 (endpoint caller, http:Request request) {
         http:Response response = new;
         match request.getBodyParts() {
             mime:EntityError err => {
@@ -127,14 +127,14 @@ service<http:Service> test bind mockEP {
                 response.setStringPayload(content);
             }
         }
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/emptyparts"
     }
-    multipart6 (endpoint client, http:Request request) {
+    multipart6 (endpoint caller, http:Request request) {
         http:Response response = new;
         match (request.getBodyParts()) {
             mime:EntityError err => {
@@ -144,14 +144,14 @@ service<http:Service> test bind mockEP {
                 response.setStringPayload("Body parts detected!");
             }
         }
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/nestedparts"
     }
-    multipart7 (endpoint client, http:Request request) {
+    multipart7 (endpoint caller, http:Request request) {
         http:Response response = new;
         match request.getBodyParts() {
             mime:EntityError err => {
@@ -168,7 +168,7 @@ service<http:Service> test bind mockEP {
                 response.setStringPayload(payload);
             }
         }
-        _ = client -> respond(response);
+        _ = caller -> respond(response);
     }
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
@@ -44,7 +44,7 @@ function testTypicalScenario () returns (http:Response[] , http:HttpConnectorErr
     int counter = 0;
     http:CircuitBreakerClient cbClient = check <http:CircuitBreakerClient>backendClientEP.getCallerActions();
     MockClient mockClient = new;
-    cbClient.httpClient = <http:HttpClient> mockClient;
+    cbClient.httpClient = <http:CallerActions> mockClient;
 
     while (counter < 8) {
        http:Request request = new;
@@ -88,7 +88,7 @@ function testTrialRunFailure () returns (http:Response[] , http:HttpConnectorErr
     int counter = 0;
     http:CircuitBreakerClient cbClient = check <http:CircuitBreakerClient>backendClientEP.getCallerActions();
     MockClient mockClient = new;
-    cbClient.httpClient = <http:HttpClient> mockClient;
+    cbClient.httpClient = <http:CallerActions> mockClient;
 
     while (counter < 8) {
         http:Request request = new;
@@ -132,7 +132,7 @@ function testHttpStatusCodeFailure () returns (http:Response[] , http:HttpConnec
     int counter = 0;
     http:CircuitBreakerClient cbClient = check <http:CircuitBreakerClient>backendClientEP.getCallerActions();
     MockClient mockClient = new;
-    cbClient.httpClient = <http:HttpClient> mockClient;
+    cbClient.httpClient = <http:CallerActions> mockClient;
 
     while (counter < 8) {
         http:Request request = new;

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
@@ -32,7 +32,7 @@ function testSuccessScenario () returns (http:Response | http:HttpConnectorError
     http:Failover foClient = check <http:Failover>backendClientEP.getCallerActions();
     MockClient mockClient1 = new;
     MockClient mockClient2 = new;
-    http:HttpClient[] httpClients = [<http:HttpClient> mockClient1, <http:HttpClient> mockClient2];
+    http:CallerActions[] httpClients = [<http:CallerActions> mockClient1, <http:CallerActions> mockClient2];
     foClient.failoverInferredConfig.failoverClientsArray = httpClients;
 
     while (counter < 2) {
@@ -62,7 +62,7 @@ function testFailureScenario () returns (http:Response | http:HttpConnectorError
     http:Failover foClient = check <http:Failover>backendClientEP.getCallerActions();
     MockClient mockClient1 = new;
     MockClient mockClient2 = new;
-    http:HttpClient[] httpClients = [<http:HttpClient> mockClient1, <http:HttpClient> mockClient2];
+    http:CallerActions[] httpClients = [<http:CallerActions> mockClient1, <http:CallerActions> mockClient2];
     foClient.failoverInferredConfig.failoverClientsArray = httpClients;
 
     while (counter < 1) {

--- a/tests/ballerina-test/src/test/resources/test-src/parser/resource-with-reply-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/parser/resource-with-reply-negative.bal
@@ -2,7 +2,7 @@ import ballerina/http;
 
 service<http:Service> echo1 {
 
-passthru (endpoint outboundEP, http:Request request) {
+passthru (endpoint caller, http:Request request) {
     reply;
   }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/parser/service-without-resource-name-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/parser/service-without-resource-name-negative.bal
@@ -3,7 +3,7 @@ import ballerina/http;
 service<http:Service> HelloService {
 
 
-    (endpoint outboundEP, http:Request request) {
+    (endpoint caller, http:Request request) {
       int b;
       ;
   }

--- a/tests/ballerina-test/src/test/resources/test-src/services/dispatching/data-binding-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/dispatching/data-binding-test.bal
@@ -14,11 +14,11 @@ service<http:Service> echo bind testEP {
     @http:ResourceConfig {
         body:"person"
     }
-     body1 (endpoint client, http:Request req, string person) {
+     body1 (endpoint caller, http:Request req, string person) {
         json responseJson = {"Person":person};
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
@@ -26,65 +26,65 @@ service<http:Service> echo bind testEP {
         path:"/body2/{key}",
         body:"person"
     }
-     body2 (endpoint client, http:Request req, string key, string person) {
+     body2 (endpoint caller, http:Request req, string key, string person) {
         json responseJson = {Key:key , Person:person};
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET","POST"],
         body:"person"
     }
-     body3 (endpoint client, http:Request req, json person) {
+     body3 (endpoint caller, http:Request req, json person) {
         json name = person.name;
         json team = person.team;
         http:Response res = new;
         res.setJsonPayload({Key:name , Team:team});
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         body:"person"
     }
-     body4 (endpoint client, http:Request req, xml person) {
+     body4 (endpoint caller, http:Request req, xml person) {
         string name = person.getElementName();
         string team = person.getTextValue();
         http:Response res = new;
         res.setJsonPayload({Key:name , Team:team});
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         body:"person"
     }
-     body5 (endpoint client, http:Request req, blob person) {
+     body5 (endpoint caller, http:Request req, blob person) {
         string name = person.toString("UTF-8");
         http:Response res = new;
         res.setJsonPayload({Key:name});
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         body:"person"
     }
-     body6 (endpoint client, http:Request req, Person person) {
+     body6 (endpoint caller, http:Request req, Person person) {
         string name = person.name;
         int age = person.age;
         http:Response res = new;
         res.setJsonPayload({Key:name , Age:age});
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         body:"person"
     }
-     body7 (endpoint client, http:Request req, http:HttpConnectorError person) {
-        _ = client -> respond(new);
+     body7 (endpoint caller, http:Request req, http:HttpConnectorError person) {
+        _ = caller -> respond(new);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/services/dispatching/uri-matrix-param-matching.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/dispatching/uri-matrix-param-matching.bal
@@ -14,7 +14,7 @@ service<http:Service> testService bind testEP {
         methods:["GET"],
         path:"/t1/{person}/bar/{yearParam}/foo"
     }
-     test1 (endpoint client, http:Request req, string person, string yearParam) {
+     test1 (endpoint caller, http:Request req, string person, string yearParam) {
         http:Response res = new;
         json outJson = {};
         outJson.pathParams = string `{{person}}, {{yearParam}}`;
@@ -40,14 +40,14 @@ service<http:Service> testService bind testEP {
         outJson.queryParams = string `x={{x}}&y={{y}}`;
 
         res.setJsonPayload(outJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/t2/{person}/foo;a=5;b=10"
     }
-     testEncoded (endpoint client, http:Request req, string person) {
+     testEncoded (endpoint caller, http:Request req, string person) {
         http:Response res = new;
         json outJson = {};
         outJson.person = person;
@@ -59,6 +59,6 @@ service<http:Service> testService bind testEP {
         outJson.fooParamSize = lengthof fooMParams;
 
         res.setJsonPayload(outJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/services/dispatching/uri-template-matching-negative-1.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/dispatching/uri-template-matching-negative-1.bal
@@ -14,21 +14,21 @@ service<http:Service> negativeTemplateURI bind testEP {
         methods:["POST"],
         path:"/echo/{abc}/bar"
     }
-     echo1 (endpoint client, http:Request req, string abc) {
+     echo1 (endpoint caller, http:Request req, string abc) {
         http:Response res = new;
         json responseJson = {"first":abc, "echo":"echo"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path:"/echo/{xyz}/bar"
     }
-     echo2 (endpoint client, http:Request req, string xyz) {
+     echo2 (endpoint caller, http:Request req, string xyz) {
         http:Response res = new;
         json responseJson = {"first":xyz, "echo":"echo"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/services/dispatching/uri-template.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/dispatching/uri-template.bal
@@ -13,7 +13,7 @@ service<http:Service> Ecommerce bind testEP {
         methods:["GET"],
         path:"/products/{productId}/{regId}"
     }
-     productsInfo1 (endpoint client, http:Request req, string productId, string regId) {
+     productsInfo1 (endpoint caller, http:Request req, string productId, string regId) {
         string orderId = req.getHeader("X-ORDER-ID");
         io:println("Order ID " + orderId);
         io:println("Product ID " + productId);
@@ -23,14 +23,14 @@ service<http:Service> Ecommerce bind testEP {
 
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/products2/{productId}/{regId}/item"
     }
-     productsInfo2 (endpoint client, http:Request req, string productId, string regId) {
+     productsInfo2 (endpoint caller, http:Request req, string productId, string regId) {
         json responseJson;
         io:println("Product ID " + productId);
         io:println("Reg ID " + regId);
@@ -39,14 +39,14 @@ service<http:Service> Ecommerce bind testEP {
 
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/products3/{productId}/{regId}/*"
     }
-     productsInfo3 (endpoint client, http:Request req, string productId, string regId) {
+     productsInfo3 (endpoint caller, http:Request req, string productId, string regId) {
         json responseJson;
         io:println("Product ID " + productId);
         io:println("Reg ID " + regId);
@@ -55,14 +55,14 @@ service<http:Service> Ecommerce bind testEP {
 
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/products/{productId}"
     }
-     productsInfo4 (endpoint client, http:Request req, string productId) {
+     productsInfo4 (endpoint caller, http:Request req, string productId) {
         json responseJson;
         string rID = req.getQueryParams().regID;
         io:println("Product ID " + productId);
@@ -72,14 +72,14 @@ service<http:Service> Ecommerce bind testEP {
 
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/products"
     }
-     productsInfo6 (endpoint client, http:Request req) {
+     productsInfo6 (endpoint caller, http:Request req) {
         json responseJson;
         map<string> params = req.getQueryParams();
         string prdID = params.prodID;
@@ -91,14 +91,14 @@ service<http:Service> Ecommerce bind testEP {
 
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET"],
         path:"/products5/{productId}/reg"
     }
-     productsInfo5 (endpoint client, http:Request req, string productId) {
+     productsInfo5 (endpoint caller, http:Request req, string productId) {
         json responseJson;
         string rID = req.getQueryParams().regID;
         io:println("Product ID " + productId);
@@ -108,17 +108,17 @@ service<http:Service> Ecommerce bind testEP {
 
         http:Response res = new;
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:""
     }
-     echo1 (endpoint client, http:Request req) {
+     echo1 (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"echo11":"echo11"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -131,29 +131,29 @@ service<http:Service> echo111 bind testEP {
         methods:["POST", "UPDATE"],
         path : "/test"
     }
-     productsInfo99 (endpoint client, http:Request req) {
+     productsInfo99 (endpoint caller, http:Request req) {
         http:Response res = new;
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["OPTIONS"],
         path : "/hi"
     }
-     productsOptions (endpoint client, http:Request req) {
+     productsOptions (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"echo":"wso2"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["GET", "PUT"],
         path : "/test"
     }
-     productsInfo98 (endpoint client, http:Request req) {
+     productsInfo98 (endpoint caller, http:Request req) {
         http:Response res = new;
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
 
     }
 
@@ -161,33 +161,33 @@ service<http:Service> echo111 bind testEP {
         methods:["GET"],
         path : "/getme"
     }
-     productsGet (endpoint client, http:Request req) {
+     productsGet (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"echo":"get"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["POST"],
         path : "/post"
     }
-     productsPOST (endpoint client, http:Request req) {
+     productsPOST (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"echo":"post"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         methods:["PUT"],
         path : "/put"
     }
-     productsPUT (endpoint client, http:Request req) {
+     productsPUT (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"echo":"put"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -206,11 +206,11 @@ service<http:Service> serviceHello bind testEP {
         methods:["GET"],
         path:"/test/"
     }
-     productsInfo (endpoint client, http:Request req) {
+     productsInfo (endpoint caller, http:Request req) {
         http:Response res = new;
         json responseJson = {"echo":"sanitized"};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -223,11 +223,11 @@ service<http:Service> echo113 bind testEP {
         methods:["GET"],
         path:"/ech[o/{foo}"
     }
-     productsInfo (endpoint client, http:Request req, string foo) {
+     productsInfo (endpoint caller, http:Request req, string foo) {
         http:Response res = new;
         json responseJson = {"echo113": foo};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }
 
@@ -240,10 +240,10 @@ service<http:Service> echo114 bind testEP {
         methods:["GET"],
         path:"/ech%5Bo14/{foo}"
     }
-     productsInfo (endpoint client, http:Request req, string foo) {
+     productsInfo (endpoint caller, http:Request req, string foo) {
         http:Response res = new;
         json responseJson = {"echo114": foo};
         res.setJsonPayload(responseJson);
-        _ = client -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/endpoint/service-endpoint-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/endpoint/service-endpoint-test.bal
@@ -11,23 +11,23 @@ service<http:Service> hello bind mockEP {
         path:"/protocol",
         methods:["GET"]
     }
-    protocol (endpoint outboundEP, http:Request req) {
+    protocol (endpoint caller, http:Request req) {
         http:Response res = {};
-        json connectionJson = {protocol:outboundEP.protocol};
+        json connectionJson = {protocol:caller.protocol};
         res.statusCode = 200;
         res.setJsonPayload(connectionJson);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/local",
         methods:["GET"]
     }
-    local (endpoint outboundEP, http:Request req) {
+    local (endpoint caller, http:Request req) {
         http:Response res = {};
-        json connectionJson = {local:{host:outboundEP.local.host, port:outboundEP.local.port}};
+        json connectionJson = {local:{host:caller.local.host, port:caller.local.port}};
         res.statusCode = 200;
         res.setJsonPayload(connectionJson);
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/request/in-request-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/request/in-request-native-function.bal
@@ -102,53 +102,53 @@ service<http:Service> hello bind mockEP {
     @http:ResourceConfig {
         path:"/addheader/{key}/{value}"
     }
-    addheader (endpoint conn, http:Request inReq, string key, string value) {
+    addheader (endpoint caller, http:Request inReq, string key, string value) {
         http:Request req = new;
         req.addHeader(key, value);
         string result = req.getHeader(key);
         http:Response res = new;
         res.setJsonPayload({lang:result});
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/11"
     }
-    echo1 (endpoint conn, http:Request req) {
+    echo1 (endpoint caller, http:Request req) {
         http:Response res = new;
         string method = req.method;
         res.setStringPayload(method);
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/12"
     }
-    echo2 (endpoint conn, http:Request req) {
+    echo2 (endpoint caller, http:Request req) {
         http:Response res = new;
         string url = req.rawPath;
         res.setStringPayload(url);
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/13"
     }
-    echo3 (endpoint conn, http:Request req) {
+    echo3 (endpoint caller, http:Request req) {
         http:Response res = new;
         string url = req.rawPath;
         res.setStringPayload(url);
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/getHeader"
     }
-    getHeader (endpoint conn, http:Request req) {
+    getHeader (endpoint caller, http:Request req) {
         http:Response res = new;
         string header = req.getHeader("content-type");
         res.setJsonPayload({value:header});
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     //Enable this once the getContentLength is added back
@@ -165,7 +165,7 @@ service<http:Service> hello bind mockEP {
     @http:ResourceConfig {
         path:"/getJsonPayload"
     }
-    GetJsonPayload (endpoint conn, http:Request req) {
+    GetJsonPayload (endpoint caller, http:Request req) {
         http:Response res = new;
         var returnResult = req.getJsonPayload();
         match returnResult {
@@ -177,13 +177,13 @@ service<http:Service> hello bind mockEP {
                 res.setJsonPayload(payload.lang);
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/GetStringPayload"
     }
-    GetStringPayload (endpoint conn, http:Request req) {
+    GetStringPayload (endpoint caller, http:Request req) {
         http:Response res = new;
         match req.getStringPayload() {
             http:PayloadError err => {
@@ -192,13 +192,13 @@ service<http:Service> hello bind mockEP {
             }
              string payload =>  res.setStringPayload(payload);
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/GetXmlPayload"
     }
-    GetXmlPayload (endpoint conn, http:Request req) {
+    GetXmlPayload (endpoint caller, http:Request req) {
         http:Response res = new;
         match req.getXmlPayload() {
             http:PayloadError err => {
@@ -210,13 +210,13 @@ service<http:Service> hello bind mockEP {
                 res.setStringPayload(name);
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/GetBinaryPayload"
     }
-    GetBinaryPayload (endpoint conn, http:Request req) {
+    GetBinaryPayload (endpoint caller, http:Request req) {
         http:Response res = new;
         match req.getBinaryPayload() {
             http:PayloadError err => {
@@ -228,13 +228,13 @@ service<http:Service> hello bind mockEP {
                 res.setStringPayload(name);
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/GetByteChannel"
     }
-    GetByteChannel (endpoint conn, http:Request req) {
+    GetByteChannel (endpoint caller, http:Request req) {
         http:Response res = new;
         match req.getByteChannel() {
             http:PayloadError err => {
@@ -245,13 +245,13 @@ service<http:Service> hello bind mockEP {
                 res.setByteChannel(byteChannel);
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/RemoveHeader"
     }
-    RemoveHeader (endpoint conn, http:Request inReq) {
+    RemoveHeader (endpoint caller, http:Request inReq) {
         http:Request req = new;
         req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.removeHeader("Content-Type");
@@ -261,13 +261,13 @@ service<http:Service> hello bind mockEP {
         }
         http:Response res = new;
         res.setJsonPayload({value:header});
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/RemoveAllHeaders"
     }
-    RemoveAllHeaders (endpoint conn, http:Request inReq) {
+    RemoveAllHeaders (endpoint caller, http:Request inReq) {
         http:Request req = new;
         req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.setHeader("Expect", "100-continue");
@@ -279,13 +279,13 @@ service<http:Service> hello bind mockEP {
         }
         http:Response res = new;
         res.setJsonPayload({value:header});
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/setHeader/{key}/{value}"
     }
-    setHeader (endpoint conn, http:Request inReq, string key, string value) {
+    setHeader (endpoint caller, http:Request inReq, string key, string value) {
         http:Request req = new;
         req.setHeader(key, "abc");
         req.setHeader(key, value);
@@ -293,13 +293,13 @@ service<http:Service> hello bind mockEP {
 
         http:Response res = new;
         res.setJsonPayload({value:result});
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/SetJsonPayload/{value}"
     }
-    SetJsonPayload (endpoint conn, http:Request inReq, string value) {
+    SetJsonPayload (endpoint caller, http:Request inReq, string value) {
         http:Request req = new;
         json jsonStr = {lang:value};
         req.setJsonPayload(jsonStr);
@@ -314,13 +314,13 @@ service<http:Service> hello bind mockEP {
                 res.setJsonPayload(payload);
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/SetStringPayload/{value}"
     }
-    SetStringPayload (endpoint conn, http:Request inReq, string value) {
+    SetStringPayload (endpoint caller, http:Request inReq, string value) {
         http:Request req = new;
         req.setStringPayload(value);
         http:Response res = new;
@@ -331,13 +331,13 @@ service<http:Service> hello bind mockEP {
             }
             string payload =>  res.setJsonPayload({lang:payload});
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/SetXmlPayload"
     }
-    SetXmlPayload (endpoint conn, http:Request inReq) {
+    SetXmlPayload (endpoint caller, http:Request inReq) {
         http:Request req = new;
         xml xmlStr = xml `<name>Ballerina</name>`;
         req.setXmlPayload(xmlStr);
@@ -352,13 +352,13 @@ service<http:Service> hello bind mockEP {
                 res.setJsonPayload({lang:name});
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 
     @http:ResourceConfig {
         path:"/SetBinaryPayload"
     }
-    SetBinaryPayload (endpoint conn, http:Request inReq) {
+    SetBinaryPayload (endpoint caller, http:Request inReq) {
         http:Request req = new;
         string text = "Ballerina";
         blob payload = text.toBlob("UTF-8");
@@ -374,6 +374,6 @@ service<http:Service> hello bind mockEP {
                 res.setJsonPayload({lang:name});
             }
         }
-        _ = conn -> respond(res);
+        _ = caller -> respond(res);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/http-service.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/http-service.bal
@@ -9,7 +9,7 @@ service<http:Service> sample bind helloWorldEP {
         methods:["GET"],
         path:"/path/{foo}"
     }
-    params (endpoint outboundEP, http:Request req, string foo) {
+    params (endpoint caller, http:Request req, string foo) {
         map paramsMap = req.getQueryParams();
         var bar = paramsMap.bar;
 

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables-negative.bal
@@ -12,7 +12,7 @@ service<http:Service> sample bind helloWorldEP {
         methods:["GET"],
         path:"/path/{foo}"
     }
-    params (endpoint outboundEP, http:Request req, string foo) {
+    params (endpoint caller, http:Request req, string foo) {
         map paramsMap = req.getQueryParams();
         var bar = paramsMap.bar;
 

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables.bal
@@ -12,7 +12,7 @@ service<http:Service> sample bind helloWorldEP {
         methods:["GET"],
         path:"/path/{foo}"
     }
-    params (endpoint outboundEP, http:Request req, string foo) {
+    params (endpoint caller, http:Request req, string foo) {
         map paramsMap = req.getQueryParams();
         var bar = paramsMap.bar;
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/service/service_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/service/service_test.bal
@@ -6,9 +6,9 @@ function testServiceType () returns (typedesc) {
 }
 
 service<http:Service> HelloWorld {
-    hello (endpoint outboundEP, http:Request req) {
+    hello (endpoint caller, http:Request req) {
         http:Response res = new;
         res.setStringPayload("Hello, World!");
-        _ = outboundEP -> respond(res);
+        _ = caller -> respond(res);
     }
 }


### PR DESCRIPTION
## Purpose
Rename HttClient to CallerActions
Use caller as the name for endpoints in resource arguments i.e passthrough (endpoint caller, http: Request req) { ... }. Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/7607