### PR TITLE
Allow configuring maxFrameSize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1543,7 +1543,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.146</transport.http.version>
+        <transport.http.version>6.0.148</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/ballerina/http/annotation.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/annotation.bal
@@ -68,12 +68,14 @@ public type Versioning {
 @Field {value:"basePath: Path of the WebSocket service"}
 @Field {value:"subProtocols: Negotiable sub protocol by the service"}
 @Field {value:"idleTimeoutInSeconds: Idle timeout for the client connection. This can be triggered by putting onIdleTimeout resource in WS service."}
+@Field {value:"maxFrameSize: The maximum payload size of a WebSocket frame in bytes"}
 public type WSServiceConfig {
     Listener[] endpoints,
     WebSocketListener[] webSocketEndpoints,
     string path,
     string[] subProtocols,
     int idleTimeoutInSeconds,
+    int maxFrameSize,
 };
 
 //@Description {value:"This specifies the possible ways in which a service can be used when serving requests."}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -37,6 +37,7 @@ public class WebSocketConstants {
     public static final String ANNOTATION_ATTR_PATH = "path";
     public static final String ANNOTATION_ATTR_SUB_PROTOCOLS = "subProtocols";
     public static final String ANNOTATION_ATTR_IDLE_TIMEOUT = "idleTimeoutInSeconds";
+    public static final String ANNOTATION_ATTR_MAX_FRAME_SIZE = "maxFrameSize";
     public static final String ANN_CONFIG_ATTR_WSS_PORT = "wssPort";
 
     public static final String RESOURCE_NAME_ON_OPEN = "onOpen";
@@ -50,7 +51,6 @@ public class WebSocketConstants {
     public static final String WEBSOCKET_MESSAGE = "WEBSOCKET_MESSAGE";
 
     public static final String NATIVE_DATA_WEBSOCKET_CONNECTION = "NATIVE_DATA_WEBSOCKET_CONNECTION";
-    public static final String NATIVE_DATA_UPGRADE_HEADERS = "NATIVE_DATA_UPGRADE_HEADERS";
 
     public static final String NATIVE_DATA_QUERY_PARAMS = "NATIVE_DATA_QUERY_PARAMS";
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketService.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketService.java
@@ -38,9 +38,11 @@ public class WebSocketService implements Service {
     private final Service service;
     private final String[] negotiableSubProtocols;
     private final int idleTimeoutInSeconds;
+    private final int maxFrameSize;
     private final Map<String, Resource> resourceMap = new ConcurrentHashMap<>();
     private String basePath;
     private Resource upgradeResource;
+    private static final int DEFAULT_MAX_FRAME_SIZE = 65536;
 
     public WebSocketService(Service service) {
         this.service = service;
@@ -50,13 +52,15 @@ public class WebSocketService implements Service {
 
         Annotation configAnnotation =
                 WebSocketUtil.getServiceConfigAnnotation(service, HttpConstants.PROTOCOL_PACKAGE_HTTP);
-        Struct val;
-        if (configAnnotation != null && (val = configAnnotation.getValue()) != null) {
-            negotiableSubProtocols = findNegotiableSubProtocols(val);
-            idleTimeoutInSeconds = findIdleTimeoutInSeconds(val);
+        Struct configAnnotationStruct;
+        if (configAnnotation != null && (configAnnotationStruct = configAnnotation.getValue()) != null) {
+            negotiableSubProtocols = findNegotiableSubProtocols(configAnnotationStruct);
+            idleTimeoutInSeconds = findIdleTimeoutInSeconds(configAnnotationStruct);
+            maxFrameSize = findMaxFrameSize(configAnnotationStruct);
         } else {
             negotiableSubProtocols = null;
             idleTimeoutInSeconds = 0;
+            maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
         }
         basePath = findFullWebSocketUpgradePath(this);
         upgradeResource = null;
@@ -126,6 +130,10 @@ public class WebSocketService implements Service {
         return idleTimeoutInSeconds;
     }
 
+    public int getMaxFrameSize() {
+        return maxFrameSize;
+    }
+
     private String[] findNegotiableSubProtocols(Struct annAttrSubProtocols) {
         if (annAttrSubProtocols == null) {
             return null;
@@ -145,10 +153,15 @@ public class WebSocketService implements Service {
     }
 
     private int findIdleTimeoutInSeconds(Struct annAttrIdleTimeout) {
-        if (annAttrIdleTimeout == null) {
-            return 0;
-        }
         return (int) annAttrIdleTimeout.getIntField(WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT);
+    }
+
+    private int findMaxFrameSize(Struct annotation) {
+        int size = (int) annotation.getIntField(WebSocketConstants.ANNOTATION_ATTR_MAX_FRAME_SIZE);
+        if (size <= 0) {
+            size = DEFAULT_MAX_FRAME_SIZE;
+        }
+        return size;
     }
 
     public String getBasePath() {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -85,7 +85,9 @@ public abstract class WebSocketUtil {
                                        CallableUnitCallback callback) {
         String[] subProtocols = wsService.getNegotiableSubProtocols();
         int idleTimeoutInSeconds = wsService.getIdleTimeoutInSeconds();
-        HandshakeFuture future = initMessage.handshake(subProtocols, true, idleTimeoutInSeconds * 1000, headers);
+        int maxFrameSize = wsService.getMaxFrameSize();
+        HandshakeFuture future = initMessage.handshake(subProtocols, true, idleTimeoutInSeconds * 1000, headers,
+                                                       maxFrameSize);
         future.setHandshakeListener(new HandshakeListener() {
             @Override
             public void onSuccess(WebSocketConnection webSocketConnection) {


### PR DESCRIPTION
## Purpose
> Resolve #7622

## Goals
> Gives user flexibility to configure WebSocket frame size
> Setting this value to user's application's requirement may reduce denial of service attacks using long data frames.
## Approach
> >  Adds a WebSocket config to set max the frame size