### PR TITLE
Ignore b7a files in the test directory during build 

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -28,6 +28,7 @@ import static org.ballerinalang.compiler.CompilerOptionName.BUILD_COMPILED_PACKA
 import static org.ballerinalang.compiler.CompilerOptionName.COMPILER_PHASE;
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
+import static org.ballerinalang.compiler.CompilerOptionName.TEST_ENABLED;
 
 /**
  * This class provides util methods for building Ballerina programs and packages.
@@ -47,6 +48,7 @@ public class BuilderUtils {
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
         options.put(BUILD_COMPILED_PACKAGE, Boolean.toString(buildCompiledPkg));
         options.put(OFFLINE, Boolean.toString(offline));
+        options.put(TEST_ENABLED, "true");
 
         Compiler compiler = Compiler.getInstance(context);
         compiler.build(packagePath, targetPath);
@@ -58,6 +60,7 @@ public class BuilderUtils {
         options.put(PROJECT_DIR, sourceRootPath.toString());
         options.put(OFFLINE, Boolean.toString(offline));
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
+        options.put(TEST_ENABLED, "true");
 
         Compiler compiler = Compiler.getInstance(context);
         compiler.build();

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -24,7 +24,11 @@ import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
 import java.nio.file.Path;
 
-import static org.ballerinalang.compiler.CompilerOptionName.*;
+import static org.ballerinalang.compiler.CompilerOptionName.BUILD_COMPILED_PACKAGE;
+import static org.ballerinalang.compiler.CompilerOptionName.COMPILER_PHASE;
+import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
+import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
+import static org.ballerinalang.compiler.CompilerOptionName.TEST_ENABLED;
 
 /**
  * This class provides util methods for building Ballerina programs and packages.

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -28,7 +28,6 @@ import static org.ballerinalang.compiler.CompilerOptionName.BUILD_COMPILED_PACKA
 import static org.ballerinalang.compiler.CompilerOptionName.COMPILER_PHASE;
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
-import static org.ballerinalang.compiler.CompilerOptionName.TEST_ENABLED;
 
 /**
  * This class provides util methods for building Ballerina programs and packages.
@@ -41,27 +40,24 @@ public class BuilderUtils {
                                        String packagePath,
                                        String targetPath,
                                        boolean buildCompiledPkg,
-                                       boolean offline,
-                                       boolean testEnabled) {
+                                       boolean offline) {
         CompilerContext context = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, sourceRootPath.toString());
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
         options.put(BUILD_COMPILED_PACKAGE, Boolean.toString(buildCompiledPkg));
         options.put(OFFLINE, Boolean.toString(offline));
-        options.put(TEST_ENABLED, Boolean.toString(testEnabled));
 
         Compiler compiler = Compiler.getInstance(context);
         compiler.build(packagePath, targetPath);
     }
 
-    public static void compileAndWrite(Path sourceRootPath, boolean offline, boolean testEnabled) {
+    public static void compileAndWrite(Path sourceRootPath, boolean offline) {
         CompilerContext context = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, sourceRootPath.toString());
         options.put(OFFLINE, Boolean.toString(offline));
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
-        options.put(TEST_ENABLED, Boolean.toString(testEnabled));
 
         Compiler compiler = Compiler.getInstance(context);
         compiler.build();

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -24,10 +24,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
 import java.nio.file.Path;
 
-import static org.ballerinalang.compiler.CompilerOptionName.BUILD_COMPILED_PACKAGE;
-import static org.ballerinalang.compiler.CompilerOptionName.COMPILER_PHASE;
-import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
-import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
+import static org.ballerinalang.compiler.CompilerOptionName.*;
 
 /**
  * This class provides util methods for building Ballerina programs and packages.
@@ -40,24 +37,27 @@ public class BuilderUtils {
                                        String packagePath,
                                        String targetPath,
                                        boolean buildCompiledPkg,
-                                       boolean offline) {
+                                       boolean offline,
+                                       boolean testEnabled) {
         CompilerContext context = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, sourceRootPath.toString());
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
         options.put(BUILD_COMPILED_PACKAGE, Boolean.toString(buildCompiledPkg));
         options.put(OFFLINE, Boolean.toString(offline));
+        options.put(TEST_ENABLED, Boolean.toString(testEnabled));
 
         Compiler compiler = Compiler.getInstance(context);
         compiler.build(packagePath, targetPath);
     }
 
-    public static void compileAndWrite(Path sourceRootPath, boolean offline) {
+    public static void compileAndWrite(Path sourceRootPath, boolean offline, boolean testEnabled) {
         CompilerContext context = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, sourceRootPath.toString());
         options.put(OFFLINE, Boolean.toString(offline));
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
+        options.put(TEST_ENABLED, Boolean.toString(testEnabled));
 
         Compiler compiler = Compiler.getInstance(context);
         compiler.build();

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -77,7 +77,7 @@ public class BuildCommand implements BLauncherCmd {
         Path sourceRootPath = Paths.get(System.getProperty(USER_DIR));
         if (argList == null || argList.size() == 0) {
             // ballerina build
-            BuilderUtils.compileAndWrite(sourceRootPath, offline);
+            BuilderUtils.compileAndWrite(sourceRootPath, offline, testEnabled);
         } else {
             // ballerina build pkgName [-o outputFileName]
             String targetFileName;
@@ -88,7 +88,8 @@ public class BuildCommand implements BLauncherCmd {
                 targetFileName = pkgName;
             }
 
-            BuilderUtils.compileAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg, offline);
+            BuilderUtils.compileAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg, offline,
+                                         testEnabled);
         }
 
         Runtime.getRuntime().exit(0);

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -50,9 +50,6 @@ public class BuildCommand implements BLauncherCmd {
     @Parameter(names = {"--offline"})
     private boolean offline;
 
-    @Parameter(names = {"--testEnabled"})
-    private boolean testEnabled;
-
     @Parameter(arity = 1)
     private List<String> argList;
 
@@ -77,7 +74,7 @@ public class BuildCommand implements BLauncherCmd {
         Path sourceRootPath = Paths.get(System.getProperty(USER_DIR));
         if (argList == null || argList.size() == 0) {
             // ballerina build
-            BuilderUtils.compileAndWrite(sourceRootPath, offline, testEnabled);
+            BuilderUtils.compileAndWrite(sourceRootPath, offline);
         } else {
             // ballerina build pkgName [-o outputFileName]
             String targetFileName;
@@ -88,8 +85,7 @@ public class BuildCommand implements BLauncherCmd {
                 targetFileName = pkgName;
             }
 
-            BuilderUtils.compileAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg, offline,
-                                         testEnabled);
+            BuilderUtils.compileAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg, offline);
         }
 
         Runtime.getRuntime().exit(0);

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -50,6 +50,9 @@ public class BuildCommand implements BLauncherCmd {
     @Parameter(names = {"--offline"})
     private boolean offline;
 
+    @Parameter(names = {"--testEnabled"})
+    private boolean testEnabled;
+
     @Parameter(arity = 1)
     private List<String> argList;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
@@ -36,6 +36,8 @@ public enum CompilerOptionName {
 
     BUILD_COMPILED_PACKAGE("buildCompiledPackage"),
 
+    TEST_ENABLED("testEnabled"),
+
     TARGET_BINARY_PATH("targetBinaryPath");
 
     public final String name;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageLoader.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageLoader.java
@@ -77,6 +77,7 @@ import java.util.stream.StreamSupport;
 
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
+import static org.ballerinalang.compiler.CompilerOptionName.TEST_ENABLED;
 import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
 import static org.wso2.ballerinalang.compiler.packaging.RepoHierarchyBuilder.node;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.PACKAGE_MD_FILE_NAME;
@@ -93,6 +94,7 @@ public class PackageLoader {
             new CompilerContext.Key<>();
     private final RepoHierarchy repos;
     private final boolean offline;
+    private final boolean testEnabled;
     private final Manifest manifest;
 
     private final CompilerOptions options;
@@ -130,6 +132,7 @@ public class PackageLoader {
         this.names = Names.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.offline = Boolean.parseBoolean(options.get(OFFLINE));
+        this.testEnabled = Boolean.parseBoolean(options.get(TEST_ENABLED));
         this.repos = genRepoHierarchy(Paths.get(options.get(PROJECT_DIR)));
         this.manifest = ManifestProcessor.parseTomlContentAsStream(sourceDirectory.getManifestContent());
     }
@@ -160,7 +163,7 @@ public class PackageLoader {
         RepoHierarchyBuilder.RepoNode fullRepoGraph;
         if (converter != null) {
             Repo programingSource = new ProgramingSourceRepo(converter);
-            Repo projectSource = new ProjectSourceRepo(converter);
+            Repo projectSource = new ProjectSourceRepo(converter, testEnabled);
             fullRepoGraph = node(programingSource,
                                  node(projectSource,
                                       nonLocalRepos));
@@ -384,7 +387,7 @@ public class PackageLoader {
 
         // Get the list of source entries.
         Path projectPath = this.sourceDirectory.getPath();
-        ProjectSourceRepo projectSourceRepo = new ProjectSourceRepo(projectPath);
+        ProjectSourceRepo projectSourceRepo = new ProjectSourceRepo(projectPath, testEnabled);
         Patten packageIDPattern = projectSourceRepo.calculate(packageID);
         if (packageIDPattern != Patten.NULL) {
             Stream<Path> srcPathStream = packageIDPattern.convert(projectSourceRepo.getConverterInstance());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/Patten.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/Patten.java
@@ -68,7 +68,7 @@ public class Patten {
                 aggregate = aggregate.flatMap(converter::expandBal);
             } else if (part == WILDCARD_SOURCE_WITH_TEST) {
                 //TODO: add test patten converter
-                aggregate = aggregate.flatMap(converter::expandBal);
+                aggregate = aggregate.flatMap(converter::expandBalWithTest);
             } else {
                 aggregate = aggregate.map(t -> callReduceForEach(t, part.values, converter));
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/Converter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/Converter.java
@@ -20,6 +20,8 @@ public interface Converter<T> {
 
     Stream<T> latest(T t);
 
+    Stream<T> expandBalWithTest(T t);
+
     Stream<T> expandBal(T t);
 
     T start();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
@@ -1,0 +1,73 @@
+package org.wso2.ballerinalang.compiler.packaging.converters;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Filters directories.
+ */
+class FilterSearch extends SimpleFileVisitor {
+
+    private final Path excludeDir;
+    private List<Path> pathList = new ArrayList<>();
+
+    FilterSearch(Path exclude) {
+        this.excludeDir = exclude;
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Object dir, BasicFileAttributes attrs) throws IOException {
+        if (!isExcluded((Path) dir)) {
+            return FileVisitResult.CONTINUE;
+        } else {
+            return FileVisitResult.SKIP_SUBTREE;
+        }
+    }
+
+    @Override
+    public FileVisitResult visitFile(Object file, BasicFileAttributes attrs) throws IOException {
+        if (isBal((Path) file, Files.readAttributes((Path) file, BasicFileAttributes.class))) {
+            pathList.add((Path) file);
+        }
+        return FileVisitResult.CONTINUE;
+    }
+
+    /**
+     * Exclude the given directory when traversing through the directories.
+     *
+     * @param path directory path to be traversed
+     * @return if the directory is to be excluded or not
+     * @throws IOException exception
+     */
+    private boolean isExcluded(Path path) throws IOException {
+        Path name = path.getFileName();
+        return (name != null) && name.equals(excludeDir);
+    }
+
+    /**
+     * Checks if the file is a bal file.
+     *
+     * @param path       file path
+     * @param attributes basic file attributes
+     * @return if a file is a bal file or not
+     */
+    private boolean isBal(Path path, BasicFileAttributes attributes) {
+        Path fileName = path.getFileName();
+        return attributes.isRegularFile() && fileName != null && fileName.toString().endsWith(".bal");
+    }
+
+    /**
+     * Get all paths of files inside the directory.
+     *
+     * @return list of paths
+     */
+    public List<Path> getPathList() {
+        return pathList;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -3,6 +3,7 @@ package org.wso2.ballerinalang.compiler.packaging.converters;
 import com.sun.nio.zipfs.ZipFileSystem;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.repository.CompilerInput;
+import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -66,7 +67,7 @@ public class PathConverter implements Converter<Path> {
     public Stream<Path> expandBal(Path path) {
         if (Files.isDirectory(path)) {
             try {
-                FilterSearch filterSearch = new FilterSearch(Paths.get("test"));
+                FilterSearch filterSearch = new FilterSearch(Paths.get(ProjectDirConstants.TEST_DIR_NAME));
                 Files.walkFileTree(path, filterSearch);
                 return filterSearch.getPathList().stream();
             } catch (IOException ignore) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -23,9 +23,18 @@ public class PathConverter implements Converter<Path> {
         this.root = root;
     }
 
-    private static boolean isBal(Path path, BasicFileAttributes attributes) {
+    private static boolean isBalWithTest(Path path, BasicFileAttributes attributes) {
         Path fileName = path.getFileName();
         return attributes.isRegularFile() && fileName != null && fileName.toString().endsWith(".bal");
+    }
+
+    private static boolean isBal(Path path, BasicFileAttributes attributes) {
+        Path fileName = path.getFileName();
+        Path parentFolder = path.getParent();
+        Path parentFolderName = parentFolder != null ? parentFolder.getFileName() : null;
+        return attributes.isRegularFile() && parentFolderName != null &&
+                !parentFolderName.toString().equals("test") && fileName != null &&
+                fileName.toString().endsWith(".bal");
     }
 
     @Override
@@ -51,7 +60,18 @@ public class PathConverter implements Converter<Path> {
     }
 
     @Override
-    public Stream<Path> expandBal(Path path) {
+    public Stream<Path> expandBalWithTest(Path path) {
+        if (Files.isDirectory(path)) {
+            try {
+                return Files.find(path, Integer.MAX_VALUE, PathConverter::isBalWithTest);
+            } catch (IOException ignore) {
+            }
+        }
+        return Stream.of();
+    }
+
+    @Override
+    public Stream<Path> expandBal(Path path) { // without tests
         if (Files.isDirectory(path)) {
             try {
                 return Files.find(path, Integer.MAX_VALUE, PathConverter::isBal);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/StringConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/StringConverter.java
@@ -21,8 +21,13 @@ public class StringConverter implements Converter<String> {
     }
 
     @Override
-    public Stream<String> expandBal(String t) {
+    public Stream<String> expandBalWithTest(String t) {
         return Stream.of(t + "/**~test~resources/*.bal");
+    }
+
+    @Override
+    public Stream<String> expandBal(String s) {
+        return Stream.of(s + "/**~resources/*.bal");
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
@@ -60,6 +60,11 @@ public class URIConverter implements Converter<URI> {
     }
 
     @Override
+    public Stream<URI> expandBalWithTest(URI uri) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Stream<URI> expandBal(URI u) {
         throw new UnsupportedOperationException();
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProjectSourceRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/ProjectSourceRepo.java
@@ -12,16 +12,23 @@ import java.nio.file.Path;
  */
 public class ProjectSourceRepo extends NonSysRepo<Path> {
 
-    public ProjectSourceRepo(Converter<Path> converter) {
+    private final boolean testEnabled;
+
+    public ProjectSourceRepo(Converter<Path> converter, boolean testEnabled) {
         super(converter);
+        this.testEnabled = testEnabled;
     }
 
-    public ProjectSourceRepo(Path projectRoot) {
-        this(new PathConverter(projectRoot));
+    public ProjectSourceRepo(Path projectRoot, boolean testEnabled) {
+        this(new PathConverter(projectRoot), testEnabled);
     }
 
     @Override
     public Patten calculateNonSysPkg(PackageID pkg) {
+        if (testEnabled) {
+            return new Patten(Patten.path(pkg.getName().value),
+                              Patten.WILDCARD_SOURCE_WITH_TEST);
+        }
         return new Patten(Patten.path(pkg.getName().value),
                           Patten.WILDCARD_SOURCE);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -38,12 +38,11 @@ public class ProjectDirConstants {
     public static final String DOT_BALLERINA_REPO_DIR_NAME = "repo";
     public static final String TARGET_DIR_NAME = "target";
     public static final String RESOURCE_DIR_NAME = "resource";
-    public static final String TEST_DIR_NAME = "test";
+    public static final String TEST_DIR_NAME = "tests";
     public static final String CACHES_DIR_NAME = "caches";
     public static final String BALLERINA_CENTRAL_DIR_NAME = "central.ballerina.io";
 
     public static final String HOME_REPO_ENV_KEY = "BALLERINA_HOME_DIR";
     public static final String HOME_REPO_DEFAULT_DIRNAME = ".ballerina";
     public static final String SETTINGS_FILE_NAME = "Settings.toml";
-    public static final String DOT_GIT_DIR_NAME = ".git";
 }

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSProjectSourceRepo.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSProjectSourceRepo.java
@@ -27,8 +27,10 @@ import java.nio.file.Path;
  * Language Server Source Repo.
  */
 class LSProjectSourceRepo extends ProjectSourceRepo {
+    // TODO: By default b7a test files are not included during the build hence the flag is false.
+    // If you want to include test files make the flag true.
     private LSProjectSourceRepo(PathConverter converter) {
-        super(converter);
+        super(converter, false);
     }
 
     LSProjectSourceRepo(Path projectRoot, WorkspaceDocumentManager documentManager) {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
@@ -21,7 +21,8 @@ public class PattenTest {
     private static <I> Converter<I> mockResolver(I start,
                                                  BiFunction<I, String, I> combine,
                                                  Function<I, Stream<I>> expand,
-                                                 Function<I, Stream<I>> expandBal) {
+                                                 Function<I, Stream<I>> expandBal,
+                                                 Function<I, Stream<I>> expandBalWithTest ) {
         return new Converter<I>() {
             @Override
             public I combine(I i, String pathPart) {
@@ -31,6 +32,11 @@ public class PattenTest {
             @Override
             public Stream<I> latest(I i) {
                 return expand.apply(i);
+            }
+
+            @Override
+            public Stream<I> expandBalWithTest(I i) {
+                return expandBalWithTest.apply(i);
             }
 
             @Override
@@ -55,7 +61,7 @@ public class PattenTest {
         Converter<String> mock = mockResolver("root-dir",
                                               (a, b) -> a + " > " + b,
                                               null,
-                                              null);
+                                              null, null);
         Patten subject = new Patten(path("hello", "world"));
 
         List<String> strings = subject.convert(mock).collect(Collectors.toList());
@@ -70,7 +76,7 @@ public class PattenTest {
                                               s -> Stream.of(s + " > cache1",
                                                              s + " > cache2",
                                                              s + " > cache3"),
-                                              null);
+                                              null, null);
         Patten subject = new Patten(Patten.LATEST_VERSION_DIR);
 
         List<String> strings = subject.convert(mock).collect(Collectors.toList());
@@ -105,7 +111,7 @@ public class PattenTest {
                                               null,
                                               s -> Stream.of(s + " > dir1 > x.bal",
                                                              s + " > y.bal",
-                                                             s + " > dir2 > dir3 > f.bal"));
+                                                             s + " > dir2 > dir3 > f.bal"), null);
         Patten subject = new Patten(Patten.WILDCARD_SOURCE);
 
         List<String> strings = subject.convert(mock).collect(Collectors.toList());
@@ -128,7 +134,7 @@ public class PattenTest {
                                                                      Assert.fail("method called. Hence not lazy.");
                                                                      return "";
                                                                  })),
-                                              null);
+                                              null, null);
         Patten subject = new Patten(Patten.LATEST_VERSION_DIR);
 
         List<String> strings = subject.convert(mock).limit(1).collect(Collectors.toList());
@@ -145,7 +151,7 @@ public class PattenTest {
                                                              s + " > cache3"),
                                               q -> Stream.of(q + " > dir1 > x.bal",
                                                              q + " > y.bal",
-                                                             q + " > dir2 > dir3 > f.bal"));
+                                                             q + " > dir2 > dir3 > f.bal"), null);
         Patten subject = new Patten(path("hello"), Patten.LATEST_VERSION_DIR, path("world"), Patten.WILDCARD_SOURCE);
 
         List<String> strings = subject.convert(mock).collect(Collectors.toList());

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/packaging/PattenTest.java
@@ -22,7 +22,7 @@ public class PattenTest {
                                                  BiFunction<I, String, I> combine,
                                                  Function<I, Stream<I>> expand,
                                                  Function<I, Stream<I>> expandBal,
-                                                 Function<I, Stream<I>> expandBalWithTest ) {
+                                                 Function<I, Stream<I>> expandBalWithTest) {
         return new Converter<I>() {
             @Override
             public I combine(I i, String pathPart) {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/packaging/RepoTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/packaging/RepoTest.java
@@ -28,7 +28,17 @@ public class RepoTest {
     @Test
     public void testProjectSourceRepo() {
         PackageID pkg = newPackageID("best_org", "this.pkg", "1.8.3");
-        ProjectSourceRepo subject = new ProjectSourceRepo((PathConverter) null);
+        ProjectSourceRepo subject = new ProjectSourceRepo((PathConverter) null, false);
+
+        Patten prospect = subject.calculate(pkg);
+
+        Assert.assertEquals(prospect.toString(), "$/this.pkg/**~resources/*.bal");
+    }
+
+    @Test
+    public void testProjectSourceRepoWithTests() {
+        PackageID pkg = newPackageID("best_org", "this.pkg", "1.8.3");
+        ProjectSourceRepo subject = new ProjectSourceRepo((PathConverter) null, true);
 
         Patten prospect = subject.calculate(pkg);
 
@@ -42,7 +52,7 @@ public class RepoTest {
 
         Patten patten = subject.calculate(pkg);
 
-        Assert.assertEquals(patten.toString(), "$/repo/my_org/my.pkg/10.2.3/src/**~test~resources/*.bal");
+        Assert.assertEquals(patten.toString(), "$/repo/my_org/my.pkg/10.2.3/src/**~resources/*.bal");
     }
 
     @Test
@@ -53,7 +63,7 @@ public class RepoTest {
         Patten patten = subject.calculate(pkg);
 
         Assert.assertEquals(patten.toString(), "$/caches/test/nice_org/any.pkg/10.2.3/any.pkg.zip/src/" +
-                "**~test~resources/*.bal");
+                "**~resources/*.bal");
     }
 
     @Test


### PR DESCRIPTION
## Purpose
> This PR will ignore the b7a test files in the test directory during build. If the test directory needs to be included in the balo "--testEnabled" flag should be provided