### PR TITLE
Rename ballerina.sdk to ballerina.home

### DIFF
--- a/composer/modules/web/webpack.config.composer-library.js
+++ b/composer/modules/web/webpack.config.composer-library.js
@@ -170,8 +170,8 @@ const config = [{
                 codepoints[obj.name] = obj.unicode;
             },
             dest: {
-                fontsDir: path.resolve(__dirname, './font/dist/font-ballerina/fonts'),
-                stylesDir: path.resolve(__dirname, './font/dist/font-ballerina/css'),
+                fontsDir: path.join(__dirname, 'library/dist/font-ballerina/fonts'),
+                stylesDir: path.join(__dirname, 'library/dist/font-ballerina/css'),
                 outputFilename: 'font-ballerina.css',
             },
             hash: new Date().getTime(),
@@ -179,7 +179,7 @@ const config = [{
             apply: function(compiler) {
                 compiler.plugin('compile', function(compilation, callback) {
                     fs.writeFile(
-                        path.resolve(__dirname, './font/dist/font-ballerina/codepoints.json'),
+                        path.join(__dirname, 'library/dist/font-ballerina/codepoints.json'),
                         JSON.stringify(codepoints),
                         'utf8',
                         callback
@@ -208,7 +208,7 @@ const config = [{
     devtool: 'source-map',
     resolve: {
         extensions: ['.js', '.json', '.jsx'],
-        modules: ['src', 'public/lib', 'font/dist', 'node_modules', path.resolve(__dirname)],
+        modules: ['src', 'public/lib', 'library/dist', 'node_modules', path.resolve(__dirname)],
         alias: {
             // ///////////////////////
             // third party modules //

--- a/tool-plugins/vscode/plugin/messages.js
+++ b/tool-plugins/vscode/plugin/messages.js
@@ -1,0 +1,8 @@
+module.exports = {
+    NO_BIN_IN_HOME: 'Couldn\'t find a bin directory inside the configured \"balleria.home\".',
+    HOME_NOT_SET: '\"balleria.home\" is not configured.',
+    DEBUG_HOME_NOT_SET: 'To start debugging please configure \"balleria.home\".',
+    HOME_INCORRECT: 'The configured \"balleria.home\" seems incorrect.',
+    HOME_CHANGED: '\"balleria.home\" configuration changed. Please restart vscode for changes to take effect.',
+    SHOW_LSERRORS_CHANGED: 'Configuration for displaying output from language server changed. Please restart vscode for changes to take effect.',
+}

--- a/tool-plugins/vscode/plugin/pom.xml
+++ b/tool-plugins/vscode/plugin/pom.xml
@@ -162,6 +162,24 @@
                             </target>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target name="copy resources">
+                                <mkdir dir="${project.basedir}/renderer/resources" />
+                                <copy todir="${project.basedir}/renderer/resources" overwrite="true" flatten="true">
+                                    <fileset dir="${project.build.directory}/temp">
+                                        <include name="**/*.js" />
+                                        <include name="**/*.css" />
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -204,32 +222,6 @@
                             <useSubDirectoryPerArtifact>false</useSubDirectoryPerArtifact>
                             <stripVersion>true</stripVersion>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="copy resources">
-                                <mkdir dir="${project.basedir}/renderer/resources" />
-                                <copy todir="${project.basedir}/renderer/resources" overwrite="true" flatten="true">
-                                    <fileset dir="${project.build.directory}/temp">
-                                        <include name="**/*.js" />
-                                        <include name="**/*.css" />
-                                    </fileset>
-                                </copy>
-                            </target>
-                        </configuration>
-
                     </execution>
                 </executions>
             </plugin>

--- a/tool-plugins/vscode/plugin/renderer/content-provider.js
+++ b/tool-plugins/vscode/plugin/renderer/content-provider.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const fs = require('fs');
+const path = require('path');
 const { render, activate } = require('./renderer');
 
 class DiagramProvider {
@@ -31,4 +32,13 @@ class DiagramProvider {
     }
 }
 
-module.exports = DiagramProvider;
+class StaticProvider {
+    provideTextDocumentContent(uri) {
+        return require(`.${uri.path}`);
+    }
+}
+
+module.exports = {
+    DiagramProvider,
+    StaticProvider,
+};

--- a/tool-plugins/vscode/plugin/renderer/index.js
+++ b/tool-plugins/vscode/plugin/renderer/index.js
@@ -21,7 +21,7 @@ const { workspace, commands, window, Uri, ViewColumn } = require('vscode');
 const path = require('path');
 const _ = require('lodash');
 
-const DiagramProvider = require('./content-provider');
+const { DiagramProvider, StaticProvider } = require('./content-provider');
 let diagramProvider;
 const DEBOUNCE_WAIT = 500;
 
@@ -51,5 +51,17 @@ exports.activate = function(context) {
 	});
 
 	provider.activate();
+	context.subscriptions.push(diagramRenderDisposable, registration);
+}
+
+exports.errored = function(context) {
+	const provider = new StaticProvider();
+	let registration = workspace.registerTextDocumentContentProvider('ballerina-static', provider);
+
+	const diagramRenderDisposable = commands.registerCommand('ballerina.showDiagram', () => {
+		let uri = Uri.parse('ballerina-static:///pages/error.html');
+		commands.executeCommand('vscode.previewHtml', uri, ViewColumn.Two, 'Ballerina Diagram');
+	});
+
 	context.subscriptions.push(diagramRenderDisposable, registration);
 }

--- a/tool-plugins/vscode/plugin/renderer/pages/error.html.js
+++ b/tool-plugins/vscode/plugin/renderer/pages/error.html.js
@@ -1,0 +1,26 @@
+module.exports = `
+    <!DOCTYPE html>
+    <html>
+
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="file://${__dirname}/../resources/bundle.css" />
+        <style>
+            .warning {
+                color:rgb(255, 255, 0);
+            }
+        </style>
+    </head>
+
+    <body>
+    <div class="ballerina-editor design-view-container" id="diagram">
+        <br/>
+        <span class="warning fw fw-warning"></span> Ballerina sdk path is not configured</p>
+        <p>Please configure Ballerina SDK path for diagram rendering to work.</p>
+        <a href="command:workbench.action.openGlobalSettings">Open Settings</a>
+    </div>
+    </body>
+    </html>
+`;

--- a/tool-plugins/vscode/plugin/renderer/pages/error.html.js
+++ b/tool-plugins/vscode/plugin/renderer/pages/error.html.js
@@ -17,8 +17,8 @@ module.exports = `
     <body>
     <div class="ballerina-editor design-view-container" id="diagram">
         <br/>
-        <span class="warning fw fw-warning"></span> Ballerina sdk path is not configured</p>
-        <p>Please configure Ballerina SDK path for diagram rendering to work.</p>
+        <span class="warning fw fw-warning"></span> "ballerina.home" is not configured</p>
+        <p>Please configure "ballerina.home" for diagram rendering to work.</p>
         <a href="command:workbench.action.openGlobalSettings">Open Settings</a>
     </div>
     </body>

--- a/tool-plugins/vscode/plugin/serverStarter.js
+++ b/tool-plugins/vscode/plugin/serverStarter.js
@@ -33,7 +33,7 @@ let parserService;
 
 function getClassPath() {
     const customClassPath = workspace.getConfiguration('ballerina').get('classpath');
-    const sdkPath = workspace.getConfiguration('ballerina').get('sdk');
+    const sdkPath = workspace.getConfiguration('ballerina').get('home');
     const jarPath = path.join(__dirname, 'server-build', 'plugin-vscode-server.jar');
 	// in windows class path seperated by ';'
 	const sep = process.platform === 'win32' ? ';' : ':';

--- a/tool-plugins/vscode/plugin/serverStarter.js
+++ b/tool-plugins/vscode/plugin/serverStarter.js
@@ -72,6 +72,7 @@ function startServices() {
             // Server is closed so that no more connections will be accepted
             server.close();
             onLSStarted({ reader: stream, writer: stream });
+            console.log('Ballerina Language Server connected on port: ', LSPort);
         });
         server.on('error', onLSError);
         server.listen(LSPort, () => {
@@ -81,9 +82,11 @@ function startServices() {
             const args = ['-cp', getClassPath()]
 
             if (process.env.LSDEBUG === "true") {
+                console.log('LSDEBUG is set to "true". Services will run on debug mode');
                 args.push('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005,quiet=y')
             }
 
+            console.log('Starting parser service on: ', parserPort);
             serverProcess = spawn('java', [...args, main, LSPort, parserPort]);
 
             serverProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
## Purpose
The configuration option in vscode indicating the ballerina installation path is renamed to ballerina.home