### PR TITLE
Change more to final in WebSocket resources

### DIFF
--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -95,7 +95,7 @@ public class WebSocketDispatcher {
         bValues[0] = connectionInfo.getWebSocketEndpoint();
         bValues[1] = new BString(textMessage.getText());
         if (paramDetails.size() == 3) {
-            bValues[2] = new BBoolean(!textMessage.isFinalFragment());
+            bValues[2] = new BBoolean(textMessage.isFinalFragment());
         }
         //TODO handle BallerinaConnectorException
         Executor.submit(onTextMessageResource, new WebSocketResourceCallableUnitCallback(webSocketConnection), null,
@@ -117,7 +117,7 @@ public class WebSocketDispatcher {
         bValues[0] = connectionInfo.getWebSocketEndpoint();
         bValues[1] = new BBlob(binaryMessage.getByteArray());
         if (paramDetails.size() == 3) {
-            bValues[2] = new BBoolean(!binaryMessage.isFinalFragment());
+            bValues[2] = new BBoolean(binaryMessage.isFinalFragment());
         }
         //TODO handle BallerinaConnectorException
         Executor.submit(onBinaryMessageResource, new WebSocketResourceCallableUnitCallback(webSocketConnection), null,

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_client_bound_to_endpoint.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_client_bound_to_endpoint.bal
@@ -10,7 +10,7 @@ service<http:WebSocketClientService> echo bind wsClientEp {
     onText(endpoint conn, string text) {
     }
 
-    onBinary(endpoint conn, blob text, boolean more) {
+    onBinary(endpoint conn, blob text, boolean final) {
 
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onClose.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onClose.bal
@@ -11,6 +11,6 @@ endpoint http:WebSocketListener echoEP {
 }
 service<http:WebSocketService> echo bind echoEP {
 
-    onClose(endpoint conn, int status, boolean more) {
+    onClose(endpoint conn, int status, boolean final) {
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText.bal
@@ -11,6 +11,6 @@ endpoint http:WebSocketListener echoEP {
 }
 service<http:WebSocketService> echo bind echoEP {
 
-    onText(endpoint conn, int text, boolean more) {
+    onText(endpoint conn, int text, boolean final) {
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText_param_count.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText_param_count.bal
@@ -11,6 +11,6 @@ endpoint http:WebSocketListener echoEP {
 }
 service<http:WebSocketService> echo bind echoEP {
 
-    onText(endpoint conn, string text, boolean more, string name) {
+    onText(endpoint conn, string text, boolean final, string name) {
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success.bal
@@ -16,7 +16,7 @@ service<http:WebSocketService> echo bind echoEP {
     onText(endpoint conn, string text) {
     }
 
-    onBinary(endpoint conn, blob text, boolean more) {
+    onBinary(endpoint conn, blob text, boolean final) {
 
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success_client.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success_client.bal
@@ -10,7 +10,7 @@ service<http:WebSocketClientService> echo {
     onText(endpoint conn, string text) {
     }
 
-    onBinary(endpoint conn, blob text, boolean more) {
+    onBinary(endpoint conn, blob text, boolean final) {
 
     }
 


### PR DESCRIPTION
## Purpose
> Change more to final in WebSocket resources

## Goals
> Earlier the boolean value more(meaning more frames) was passed to WebSocket resources onText and onBinary. This is changed to final(finalFragment) here.