### PR TITLE
Support distributed transactions enable/disable through config

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/BLangProgramRunner.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/BLangProgramRunner.java
@@ -28,7 +28,6 @@ import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.debugger.Debugger;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.program.BLangFunctions;
-import org.wso2.ballerinalang.compiler.util.CompilerUtils;
 
 /**
  * This class contains utilities to execute Ballerina main and service programs.
@@ -51,9 +50,6 @@ public class BLangProgramRunner {
         Debugger debugger = new Debugger(programFile);
         initDebugger(programFile, debugger);
 
-        boolean distributedTxEnabled = CompilerUtils.isDistributedTransactionsEnabled();
-        programFile.setDistributedTransactionEnabled(distributedTxEnabled);
-
         // Invoke package init function
         BLangFunctions.invokePackageInitFunction(servicesPackage.getInitFunctionInfo());
 
@@ -70,9 +66,6 @@ public class BLangProgramRunner {
         }
         Debugger debugger = new Debugger(programFile);
         initDebugger(programFile, debugger);
-
-        boolean distributedTxEnabled = CompilerUtils.isDistributedTransactionsEnabled();
-        programFile.setDistributedTransactionEnabled(distributedTxEnabled);
 
         FunctionInfo mainFuncInfo = getMainFunction(mainPkgInfo);
         try {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/WorkerExecutionContext.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/WorkerExecutionContext.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.bre.bvm;
 
+import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.util.codegen.CallableUnitInfo;
 import org.ballerinalang.util.codegen.Instruction;
@@ -74,11 +75,15 @@ public class WorkerExecutionContext {
 
     private DebugContext debugContext;
 
+    private static final String DISTRIBUTED_TRANSACTIONS = "b7a.distributed.transactions.enabled";
+
+    private static final String FALSE = "false";
+
     public WorkerExecutionContext(ProgramFile programFile) {
         this.programFile = programFile;
         this.globalProps = new HashMap<>();
         this.runInCaller = true;
-        setGlobalTransactionEnabled(programFile.isDistributedTransactionEnabled());
+        setGlobalTransactionsEnabled();
     }
     
     public WorkerExecutionContext(BStruct error) {
@@ -162,10 +167,6 @@ public class WorkerExecutionContext {
         return BLangVMUtils.getTransactionInfo(this);
     }
 
-    public void setGlobalTransactionEnabled(boolean isGlobalTransactionEnabled) {
-        BLangVMUtils.setGlobalTransactionEnabledStatus(this, isGlobalTransactionEnabled);
-    }
-
     public boolean getGlobalTransactionEnabled() {
         return BLangVMUtils.getGlobalTransactionenabled(this);
     }
@@ -196,5 +197,14 @@ public class WorkerExecutionContext {
     public boolean equals(Object rhs) {
         return this == rhs;
     }
-    
+
+    private void setGlobalTransactionsEnabled() {
+        String distributedTransactionsEnabledConfig = ConfigRegistry.getInstance()
+                .getAsString(DISTRIBUTED_TRANSACTIONS);
+        boolean distributedTransactionEnabled = true;
+        if (distributedTransactionsEnabledConfig != null && distributedTransactionsEnabledConfig.equals(FALSE)) {
+            distributedTransactionEnabled = false;
+        }
+        BLangVMUtils.setGlobalTransactionEnabledStatus(this, distributedTransactionEnabled);
+    }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/WorkerExecutionContext.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/WorkerExecutionContext.java
@@ -83,7 +83,7 @@ public class WorkerExecutionContext {
         this.programFile = programFile;
         this.globalProps = new HashMap<>();
         this.runInCaller = true;
-        setGlobalTransactionsEnabled();
+        configureDistributedTransactions();
     }
     
     public WorkerExecutionContext(BStruct error) {
@@ -198,7 +198,7 @@ public class WorkerExecutionContext {
         return this == rhs;
     }
 
-    private void setGlobalTransactionsEnabled() {
+    private void configureDistributedTransactions() {
         String distributedTransactionsEnabledConfig = ConfigRegistry.getInstance()
                 .getAsString(DISTRIBUTED_TRANSACTIONS);
         boolean distributedTransactionEnabled = true;

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
@@ -32,7 +32,6 @@ import org.wso2.ballerinalang.compiler.SourceDirectory;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
-import org.wso2.ballerinalang.compiler.util.CompilerUtils;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.programfile.CompiledBinaryFile;
@@ -221,10 +220,6 @@ public class BCompileUtil {
         if (programFile != null) {
             ProgramFile pFile = LauncherUtils.getExecutableProgram(programFile);
             comResult.setProgFile(pFile);
-            if (pFile != null) {
-                boolean distributedTxEnabled = CompilerUtils.isDistributedTransactionsEnabled();
-                pFile.setDistributedTransactionEnabled(distributedTxEnabled);
-            }
         }
 
         return comResult;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -2108,25 +2108,22 @@ public class BLangPackageBuilder {
         transactionNode.setOnRetryBody(onretryBlock);
     }
 
-    public void endTransactionStmt(DiagnosticPos pos, Set<Whitespace> ws, boolean distributedTransactionEnabled) {
+    public void endTransactionStmt(DiagnosticPos pos, Set<Whitespace> ws) {
         BLangTransaction transaction = (BLangTransaction) transactionNodeStack.pop();
         transaction.pos = pos;
         transaction.addWS(ws);
         addStmtToCurrentBlock(transaction);
 
-        if (distributedTransactionEnabled) {
-            // TODO This is a temporary workaround to flag coordinator service start
-            String value = compilerOptions.get(CompilerOptionName.TRANSACTION_EXISTS);
-            if (value != null) {
-                return;
-            }
-
-            compilerOptions.put(CompilerOptionName.TRANSACTION_EXISTS, "true");
-            List<String> nameComps = getPackageNameComps(Names.TRANSACTION_PACKAGE.value);
-            addImportPackageDeclaration(pos, null, Names.TRANSACTION_ORG.value,
-                    nameComps, Names.DEFAULT_VERSION.value,
-                    Names.DOT.value + nameComps.get(nameComps.size() - 1));
+        // TODO This is a temporary workaround to flag coordinator service start
+        String value = compilerOptions.get(CompilerOptionName.TRANSACTION_EXISTS);
+        if (value != null) {
+            return;
         }
+
+        compilerOptions.put(CompilerOptionName.TRANSACTION_EXISTS, "true");
+        List<String> nameComps = getPackageNameComps(Names.TRANSACTION_PACKAGE.value);
+        addImportPackageDeclaration(pos, null, Names.TRANSACTION_ORG.value, nameComps, Names.DEFAULT_VERSION.value,
+                Names.DOT.value + nameComps.get(nameComps.size() - 1));
     }
 
     public void addAbortStatement(DiagnosticPos pos, Set<Whitespace> ws) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -29,7 +29,6 @@ import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParser.StringTempl
 import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParserBaseListener;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachmentPoint;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.CompilerUtils;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.QuoteType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -54,13 +53,11 @@ public class BLangParserListener extends BallerinaParserBaseListener {
 
     private List<String> pkgNameComps;
     private String pkgVersion;
-    private boolean distributedTransactionEnabled;
 
     BLangParserListener(CompilerContext context, CompilationUnitNode compUnit,
                         BDiagnosticSource diagnosticSource) {
         this.pkgBuilder = new BLangPackageBuilder(context, compUnit);
         this.diagnosticSrc = diagnosticSource;
-        this.distributedTransactionEnabled = CompilerUtils.isDistributedTransactionsEnabled();
     }
 
     @Override
@@ -1608,7 +1605,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        this.pkgBuilder.endTransactionStmt(getCurrentPos(ctx), getWS(ctx), this.distributedTransactionEnabled);
+        this.pkgBuilder.endTransactionStmt(getCurrentPos(ctx), getWS(ctx));
     }
 
     /**

--- a/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/sql/SQLDatasourceUtils.java
+++ b/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/sql/SQLDatasourceUtils.java
@@ -44,7 +44,6 @@ import org.ballerinalang.util.transactions.BallerinaTransactionContext;
 import org.ballerinalang.util.transactions.LocalTransactionInfo;
 import org.ballerinalang.util.transactions.TransactionResourceManager;
 import org.ballerinalang.util.transactions.TransactionUtils;
-import org.wso2.ballerinalang.compiler.util.CompilerUtils;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -1070,10 +1069,6 @@ public class SQLDatasourceUtils {
         int transactionBlockId = localTransactionInfo.getCurrentTransactionBlockId();
 
         if (localTransactionInfo.isRetryPossible(context.getParentWorkerExecutionContext(), transactionBlockId)) {
-            return;
-        }
-
-        if (!CompilerUtils.isDistributedTransactionsEnabled()) {
             return;
         }
 


### PR DESCRIPTION
## Purpose
Support distributed transactions enable/disable through config
Here in addition to supporting dtx via config, setting it during the b7a compile time has been avoided. dtx enabling/disabling will happen at runtime

