### PR TITLE
Restructure tools distro directories

### DIFF
--- a/distribution/zip/ballerina-tools/bin/composer
+++ b/distribution/zip/ballerina-tools/bin/composer
@@ -175,7 +175,7 @@ status=$START_EXIT_STATUS
 
 # Setting Classpath
 
-COMPOSER_CLASSPATH="$BAL_COMPOSER_HOME/resources/composer/services/*"
+COMPOSER_CLASSPATH="$BAL_COMPOSER_HOME/lib/resources/composer/services/*"
 COMPOSER_CLASSPATH="$COMPOSER_CLASSPATH:$BAL_COMPOSER_HOME/bre/lib/*"
 
 #To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
@@ -186,20 +186,19 @@ COMPOSER_CLASSPATH="$COMPOSER_CLASSPATH:$BAL_COMPOSER_HOME/bre/lib/*"
     -Xms256m -Xmx1024m \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath="$BAL_COMPOSER_HOME/logs/heap-dump-tool.hprof" \
-    -Djava.util.logging.config.file="$BAL_COMPOSER_HOME/resources/composer/conf/composer-logging.properties" \
     $JAVA_OPTS \
     -classpath "$COMPOSER_CLASSPATH" \
     -Djava.command="$JAVACMD" \
     -Dballerina.home="$BAL_COMPOSER_HOME" \
-    -Dcomposer.config.path="$BAL_COMPOSER_HOME/resources/composer/conf/composer-config.yml" \
-    -Dcomposer.public.path="$BAL_COMPOSER_HOME/resources/composer/web/public" \
+    -Dcomposer.config.path="$BAL_COMPOSER_HOME/lib/resources/composer/conf/composer-config.yml" \
+    -Dcomposer.public.path="$BAL_COMPOSER_HOME/lib/resources/composer/web/public" \
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \
     -Dcomposer.port=9091 \
     -DenableCloud=$ENABLE_CLOUD \
     -Dworkspace.port=8289 \
     -Dopen.browser=true \
-    -Dtransports.netty.conf=./resources/composer/services/netty-transports.yml \
-    -Dmsf4j.conf=./resources/composer/services/deployment.yaml \
+    -Dtransports.netty.conf=./lib/resources/composer/services/netty-transports.yml \
+    -Dmsf4j.conf=./lib/resources/composer/services/deployment.yaml \
     org.ballerinalang.composer.server.launcher.ServerLauncher $@
 

--- a/distribution/zip/ballerina-tools/bin/composer.bat
+++ b/distribution/zip/ballerina-tools/bin/composer.bat
@@ -52,7 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem find BALLERINA_HOME if it does not exist due to either an invalid value passed
 rem by the user or the %0 problem on Windows 9x
-if not exist "%BALLERINA_HOME%\bin\version.txt" goto noServerHome
+if not exist "%BALLERINA_HOME%\lib\version.txt" goto noServerHome
 
 goto updateClasspath
 
@@ -137,7 +137,7 @@ rem ----------------- Execute The Requested Command ----------------------------
 :runServer
 cd %BALLERINA_HOME%
 
-FOR %%C in ("%BALLERINA_HOME%\resources\composer\services\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;".\resources\composer\services\%%~nC%%~xC"
+FOR %%C in ("%BALLERINA_HOME%\lib\resources\composer\services\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;".\lib\resources\composer\services\%%~nC%%~xC"
 set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\*"
 rem ---------- Add jars to classpath ----------------
 
@@ -145,7 +145,7 @@ rem set BALLERINA_CLASSPATH=.\bin\bootstrap;%BALLERINA_CLASSPATH%
 
 set JAVA_ENDORSED=".\bin\bootstrap\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%BALLERINA_HOME%\logs\heap-dump.hprof" -Djava.util.logging.config.file="%BALLERINA_HOME%\resources\composer\conf\composer-logging.properties" -Dcom.sun.management.jmxremote -classpath %BALLERINA_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED%  -Dballerina.home="%BALLERINA_HOME%" -Dcomposer.config.path="%BALLERINA_HOME%\resources\composer\conf\composer-config.yml" -Dcomposer.public.path="%BALLERINA_HOME%\resources\composer\web\public" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Dfile.encoding=UTF8 -Dcomposer.port=9091 -Dopen.browser=true -DenableCloud=false -Dworkspace.port=8289 -Dtransports.netty.conf=./resources/composer/services/netty-transports.yml -Dmsf4j.conf=./resources/composer/services/deployment.yaml
+set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%BALLERINA_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %BALLERINA_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED%  -Dballerina.home="%BALLERINA_HOME%" -Dcomposer.public.path="%BALLERINA_HOME%\lib\resources\composer\web\public" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Dfile.encoding=UTF8 -Dcomposer.port=9091 -Dopen.browser=true -DenableCloud=false -Dworkspace.port=8289 -Dtransports.netty.conf=./lib/resources/composer/services/netty-transports.yml -Dmsf4j.conf=./lib/resources/composer/services/deployment.yaml
 
 :runJava
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% org.ballerinalang.composer.server.launcher.ServerLauncher %CMD%

--- a/distribution/zip/ballerina-tools/src/assembly/bin.xml
+++ b/distribution/zip/ballerina-tools/src/assembly/bin.xml
@@ -34,7 +34,7 @@
             <directory>
                 ${project.build.directory}/extracted-distributions/ballerina-composer-web-zip/ballerina-composer-web-${project.version}
             </directory>
-            <outputDirectory>.</outputDirectory>
+            <outputDirectory>lib</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>
@@ -53,7 +53,7 @@
     <files>
         <file>
             <source>bin/version.txt</source>
-            <outputDirectory>bin/</outputDirectory>
+            <outputDirectory>lib/</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
         </file>
@@ -93,7 +93,7 @@
             <source>
                 ${project.build.directory}/extracted-distributions/composer-server-distribution-jar/netty-transports.yml
             </source>
-            <outputDirectory>resources/composer/services</outputDirectory>
+            <outputDirectory>lib/resources/composer/services</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
         </file>
@@ -101,13 +101,7 @@
             <source>
                 ${project.build.directory}/extracted-distributions/composer-server-distribution-jar/deployment.yaml
             </source>
-            <outputDirectory>resources/composer/services</outputDirectory>
-            <filtered>true</filtered>
-            <fileMode>644</fileMode>
-        </file>
-        <file>
-            <source>conf/composer-config.yml</source>
-            <outputDirectory>resources/composer/conf</outputDirectory>
+            <outputDirectory>lib/resources/composer/services</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
         </file>
@@ -133,7 +127,7 @@
 
         <!-- Composer specific artifacts -->
         <dependencySet>
-            <outputDirectory>resources/composer/services</outputDirectory>
+            <outputDirectory>lib/resources/composer/services</outputDirectory>
             <includes>
                 <include>org.ballerinalang:composer-server-distribution:jar</include>
             </includes>

--- a/tool-plugins/vscode/plugin/extension.js
+++ b/tool-plugins/vscode/plugin/extension.js
@@ -71,7 +71,7 @@ function showHomeNotSetWarning() {
 
 function checkHome(homePath) {
 	try {
-		if (fs.readdirSync(path.join(homePath, 'resources')).indexOf('composer') > -1) {
+		if (fs.readdirSync(path.join(homePath, 'lib', 'resources')).indexOf('composer') > -1) {
 			return true;
 		}
 	} catch(e) {
@@ -106,7 +106,7 @@ exports.activate = function(context) {
 		return;
 	}
 
-	if(!checkHome(config.home)) {
+	if (!checkHome(config.home)) {
 		rendererErrored(context);
 		return;
 	}

--- a/tool-plugins/vscode/plugin/serverStarter.js
+++ b/tool-plugins/vscode/plugin/serverStarter.js
@@ -25,7 +25,7 @@ const { workspace } = require('vscode');
 
 let serverProcess;
 const libPath = '/bre/lib/*'
-const composerlibPath = '/resources/composer/services/*';
+const composerlibPath = '/lib/resources/composer/services/*';
 const main = 'org.ballerinalang.vscode.server.Main';
 
 let LSService;
@@ -40,7 +40,7 @@ function getClassPath() {
     let classpath = path.join(sdkPath, composerlibPath) + sep + path.join(sdkPath, libPath) + sep + jarPath;
 
     if (customClassPath) {
-        classpath =  path.join(customClassPath, '/*') + sep + classpath;
+        classpath =  customClassPath + sep + classpath;
     }
     return classpath;
 }


### PR DESCRIPTION
## Purpose
- remove resources/composer/samples - Samples are now not shown in composer. Instead we're showing BBE on welcome page
- remove resources/composer/conf - The logging configs are not needed now. See #7796, We're removing logs from composer.
- move resources to inside a lib directory
- bin/version.txt to lib/version.txt
