### PR TITLE
Fix build failure due to removal of the composer-logging.properties

### DIFF
--- a/distribution/zip/ballerina-tools/src/assembly/bin.xml
+++ b/distribution/zip/ballerina-tools/src/assembly/bin.xml
@@ -106,12 +106,6 @@
             <fileMode>644</fileMode>
         </file>
         <file>
-            <source>${project.build.directory}/extracted-distributions/composer-server-distribution-jar/composer-logging.properties</source>
-            <outputDirectory>resources/composer/conf</outputDirectory>
-            <filtered>true</filtered>
-            <fileMode>644</fileMode>
-        </file>
-        <file>
             <source>conf/composer-config.yml</source>
             <outputDirectory>resources/composer/conf</outputDirectory>
             <filtered>true</filtered>


### PR DESCRIPTION
## Purpose
> Fix build failure due to removal of the composer-logging.properties. Resolves regression issue caused by https://github.com/ballerina-platform/ballerina-lang/pull/7828