### PR TITLE
Throw converter error for invalid b7a services

### DIFF
--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/SwaggerConverterException.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/SwaggerConverterException.java
@@ -1,0 +1,18 @@
+package org.ballerinalang.ballerina.swagger.convertor;
+
+/**
+ * Exception definition for Ballerina to OpenApi converter errors.
+ */
+public class SwaggerConverterException extends Exception {
+    public SwaggerConverterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SwaggerConverterException(String message) {
+        super(message);
+    }
+
+    public SwaggerConverterException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/test/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtilsTest.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/test/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtilsTest.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.ballerina.swagger.convertor.service;
 
+import org.ballerinalang.ballerina.swagger.convertor.SwaggerConverterException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -34,6 +35,20 @@ public class SwaggerConverterUtilsTest {
             "};\n" +
             "\n" +
             "service<http:Service> hello bind listener {\n" +
+            "    hi (endpoint caller, http:Request request) {\n" +
+            "        http:Response res;\n" +
+            "        res.setStringPayload(\"Hello World!\\n\");\n" +
+            "        _ = caller->respond(res);\n" +
+            "    }\n" +
+            "}";
+
+    private static String invalidEchoServiceBal = "import ballerina/http;\n" +
+            "\n" +
+            "endpoint http:Listener listener {\n" +
+            "    port:9090\n" +
+            "};\n" +
+            "\n" +
+            "service<http:Service> hello bind listener \n" +
             "    hi (endpoint caller, http:Request request) {\n" +
             "        http:Response res;\n" +
             "        res.setStringPayload(\"Hello World!\\n\");\n" +
@@ -236,7 +251,9 @@ public class SwaggerConverterUtilsTest {
                     serviceWithMultipleHTTPMethodsInResourceLevel, serviceName);
             Assert.assertNotNull(swaggerDefinition);
         } catch (IOException e) {
-            Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+            Assert.fail("Error while converting ballerina service to swagger definition");
+        } catch (SwaggerConverterException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
         }
     }
 
@@ -250,7 +267,9 @@ public class SwaggerConverterUtilsTest {
                     serviceWithNoHTTPMethodsAtResourceLevel, serviceName);
             Assert.assertNotNull(swaggerDefinition);
         } catch (IOException e) {
-            Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+            Assert.fail("Error while converting ballerina service to swagger definition");
+        } catch (SwaggerConverterException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
         }
     }
 
@@ -264,6 +283,8 @@ public class SwaggerConverterUtilsTest {
             Assert.assertNotNull(swaggerDefinition);
         } catch (IOException e) {
             Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+        } catch (SwaggerConverterException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
         }
     }
 
@@ -277,6 +298,8 @@ public class SwaggerConverterUtilsTest {
             Assert.assertNotNull(swaggerDefinition);
         } catch (IOException e) {
             Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+        } catch (SwaggerConverterException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
         }
     }
 
@@ -293,6 +316,8 @@ public class SwaggerConverterUtilsTest {
             Assert.assertNotNull(openAPIDefinition);
         } catch (IOException e) {
             Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+        } catch (SwaggerConverterException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
         }
     }
 
@@ -307,6 +332,20 @@ public class SwaggerConverterUtilsTest {
             Assert.assertNotNull(openAPIDefinition);
         } catch (IOException e) {
             Assert.fail("Error while converting ballerina echo service to swagger definition");
+        } catch (SwaggerConverterException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
+        }
+    }
+
+    @Test(description = "Test OAS definition generation when input ballerina service is invalid")
+    public void testServiceWithTypo() {
+        try {
+            String oasDef = SwaggerConverterUtils.generateOAS3Definitions(invalidEchoServiceBal, null);
+            Assert.fail("Error was not thrown for invalid ballerina service");
+        } catch (IOException e) {
+            Assert.fail("Error while converting ballerina echo service to swagger definition");
+        } catch (SwaggerConverterException e) {
+            Assert.assertEquals(e.getMessage(), "Please check if input source is valid and complete");
         }
     }
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
@@ -27,7 +27,6 @@ import org.ballerinalang.launcher.LauncherUtils;
 import org.ballerinalang.swagger.CodeGenerator;
 import org.ballerinalang.swagger.utils.GeneratorConstants.GenType;
 
-import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -158,7 +157,7 @@ public class SwaggerCmd implements BLauncherCmd {
 
         try {
             SwaggerConverterUtils.generateOAS3Definitions(servicePath, outPath, serviceName);
-        } catch (IOException e) {
+        } catch (Exception e) {
             String causeMessage = "";
             Throwable rootCause = ExceptionUtils.getRootCause(e);
 


### PR DESCRIPTION
## Purpose
If the b7a service provided for swagger export command is invalid or incomplete, there was a run time error logged.
This fix will show user an appropriate error.

## Goals
Fixes ballerina-platform/ballerina-lang#7337