### PR TITLE
LS : Fix memory growing issue of the cached BLangPackages

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageCache.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageCache.java
@@ -59,19 +59,11 @@ public class LSPackageCache {
 
     /**
      * Find the package by Package ID.
-     * @param compilerContext       compiler context
      * @param pkgId                 Package Id to lookup
      * @return {@link BLangPackage} BLang Package resolved
      */
-    public BLangPackage findPackage(CompilerContext compilerContext, PackageID pkgId) {
-        BLangPackage bLangPackage = packageCache.get(pkgId);
-        if (bLangPackage != null) {
-            return bLangPackage;
-        } else {
-            bLangPackage = LSPackageLoader.getPackageById(compilerContext, pkgId);
-            this.put(bLangPackage.packageID, bLangPackage);
-            return bLangPackage;
-        }
+    public BLangPackage get(PackageID pkgId) {
+        return packageCache.get(pkgId);
     }
 
     /**

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageLoader.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageLoader.java
@@ -59,8 +59,17 @@ public class LSPackageLoader {
      * @return {@link BLangPackage} Resolved BLang Package
      */
     public static BLangPackage getPackageById(CompilerContext context, PackageID packageID) {
-        PackageLoader pkgLoader = PackageLoader.getInstance(context);
-        return pkgLoader.loadAndDefinePackage(packageID);
+        BLangPackage bLangPackage = LSPackageCache.getInstance(context).get(packageID);
+        if (bLangPackage == null) {
+            synchronized (LSPackageLoader.class) {
+                bLangPackage = LSPackageCache.getInstance(context).get(packageID);
+                if (bLangPackage == null) {
+                    PackageLoader pkgLoader = PackageLoader.getInstance(context);
+                    bLangPackage = pkgLoader.loadAndDefinePackage(packageID);
+                }
+            }
+        }
+        return bLangPackage;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -182,8 +182,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 String sourceRoot = LSCompiler.getSourceRoot(path);
                 CompilerContext compilerContext = lsContextManager.getCompilerContext(currentBLangPackage.packageID,
                                                                                       sourceRoot);
-                LSPackageCache lsPackageCache = LSPackageCache.getInstance(compilerContext);
-                hover = HoverUtil.getHoverContent(hoverContext, currentBLangPackage, lsPackageCache);
+                hover = HoverUtil.getHoverContent(hoverContext, currentBLangPackage);
             } catch (Exception | AssertionError e) {
                 hover = new Hover();
                 List<Either<String, MarkedString>> contents = new ArrayList<>();
@@ -247,8 +246,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 String sourceRoot = LSCompiler.getSourceRoot(path);
                 CompilerContext compilerContext = lsContextManager.getCompilerContext(currentBLangPackage.packageID,
                                                                                       sourceRoot);
-                LSPackageCache lsPackageCache = LSPackageCache.getInstance(compilerContext);
-                contents = DefinitionUtil.getDefinitionPosition(definitionContext, lsPackageCache);
+                contents = DefinitionUtil.getDefinitionPosition(definitionContext);
             } catch (Throwable e) {
                 contents = new ArrayList<>();
             } finally {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
@@ -20,7 +20,7 @@ import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
-import org.ballerinalang.langserver.compiler.LSPackageCache;
+import org.ballerinalang.langserver.compiler.LSPackageLoader;
 import org.ballerinalang.langserver.compiler.LSServiceOperationContext;
 import org.ballerinalang.langserver.compiler.common.LSDocument;
 import org.ballerinalang.langserver.definition.DefinitionTreeVisitor;
@@ -32,6 +32,7 @@ import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -46,11 +47,9 @@ public class DefinitionUtil {
      * Get definition position for the given definition context.
      *
      * @param definitionContext context of the definition.
-     * @param lSPackageCache    package context for language server.
      * @return {@link List} list of locations
      */
-    public static List<Location> getDefinitionPosition(LSServiceOperationContext definitionContext,
-                                                       LSPackageCache lSPackageCache) {
+    public static List<Location> getDefinitionPosition(LSServiceOperationContext definitionContext) {
         List<Location> contents = new ArrayList<>();
         if (definitionContext.get(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY) == null) {
             return contents;
@@ -58,7 +57,7 @@ public class DefinitionUtil {
         String nodeKind = definitionContext.get(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY);
 
         BLangPackage bLangPackage = getPackageOfTheOwner(definitionContext
-                .get(NodeContextKeys.NODE_OWNER_PACKAGE_KEY), definitionContext, lSPackageCache);
+                .get(NodeContextKeys.NODE_OWNER_PACKAGE_KEY), definitionContext);
         BLangNode bLangNode = null;
         switch (nodeKind) {
             case ContextConstants.FUNCTION:
@@ -181,11 +180,10 @@ public class DefinitionUtil {
      *
      * @param packageID         package id
      * @param definitionContext definition context
-     * @param lSPackageCache    ls package cache
      * @return {@link BLangPackage} package of the owner
      */
-    private static BLangPackage getPackageOfTheOwner(PackageID packageID, LSServiceOperationContext definitionContext,
-                                                     LSPackageCache lSPackageCache) {
-        return lSPackageCache.findPackage(definitionContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY), packageID);
+    private static BLangPackage getPackageOfTheOwner(PackageID packageID, LSServiceOperationContext definitionContext) {
+        CompilerContext compilerContext = definitionContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
+        return LSPackageLoader.getPackageById(compilerContext, packageID);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -19,7 +19,7 @@ import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.position.PositionTreeVisitor;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
-import org.ballerinalang.langserver.compiler.LSPackageCache;
+import org.ballerinalang.langserver.compiler.LSPackageLoader;
 import org.ballerinalang.langserver.compiler.LSServiceOperationContext;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkedString;
@@ -202,16 +202,15 @@ public class HoverUtil {
      * @param currentBLangPackage package which currently user working on.
      * @return {@link Hover} return Hover object.
      */
-    public static Hover getHoverContent(LSServiceOperationContext hoverContext, BLangPackage currentBLangPackage,
-                                        LSPackageCache packageContext) {
+    public static Hover getHoverContent(LSServiceOperationContext hoverContext, BLangPackage currentBLangPackage) {
         PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(hoverContext);
         currentBLangPackage.accept(positionTreeVisitor);
         Hover hover;
 
         // If the cursor is on a node of the current package go inside, else check builtin and native packages.
         if (hoverContext.get(NodeContextKeys.PACKAGE_OF_NODE_KEY) != null) {
-            hover = getHoverInformation(packageContext
-                    .findPackage(hoverContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY),
+            hover = getHoverInformation(LSPackageLoader.getPackageById(
+                    hoverContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY),
                             hoverContext.get(NodeContextKeys.PACKAGE_OF_NODE_KEY)), hoverContext);
         } else {
             hover = new Hover();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -17,7 +17,7 @@ package org.ballerinalang.langserver.signature;
 
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
-import org.ballerinalang.langserver.compiler.LSPackageCache;
+import org.ballerinalang.langserver.compiler.LSPackageLoader;
 import org.ballerinalang.langserver.compiler.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.model.elements.DocTag;
@@ -167,8 +167,7 @@ public class SignatureHelpUtil {
         List<ParameterInfoModel> paramModels = new ArrayList<>();
         String functionName = signatureContext.get(SignatureKeys.CALLABLE_ITEM_NAME);
         CompilerContext compilerContext = signatureContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
-        LSPackageCache lsPackageCache = LSPackageCache.getInstance(compilerContext);
-        BLangPackage bLangPackage = lsPackageCache.findPackage(compilerContext, bInvokableSymbol.pkgID);
+        BLangPackage bLangPackage = LSPackageLoader.getPackageById(compilerContext, bInvokableSymbol.pkgID);
         BLangFunction blangFunction = bLangPackage.getFunctions().stream()
                 .filter(bLangFunction -> bLangFunction.getName().getValue().equals(functionName))
                 .findFirst()


### PR DESCRIPTION
## Purpose
> Migrated all methods invoking LSPackageCache to load and define built-in packages. Each invocation of the PackageLoader.loadAndDefine() will re-populate the symbols such as functions..etc for that particular package. 
>
> Thus, moved the PackageLoader.loadAndDefine() as the back-off method of the LSPackageLoader.getPackageById(...) method. Always use LSPackageLoader to retrieve the packages. If it does not exists, LSPackageLoader will call PackageLoader.loadAndDefine() for you.