### PR TITLE
Show a warning to the user if the ballerina version does not match the plugin's

### DIFF
--- a/tool-plugins/vscode/plugin/extension.js
+++ b/tool-plugins/vscode/plugin/extension.js
@@ -17,8 +17,9 @@
  *
  */
 
-const { workspace, commands, window, ExtensionContext, debug } = require('vscode');
+const { workspace, commands, window, ExtensionContext, debug, extensions } = require('vscode');
 const { LanguageClient, LanguageClientOptions, ServerOptions } = require('vscode-languageclient');
+const { exec } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const { getLSService } = require('./serverStarter');
@@ -88,6 +89,22 @@ function checkHome(homePath) {
 	return false;
 }
 
+function checkVersion(homePath) {
+	if (!fs.existsSync(path.join(homePath, 'bin', 'ballerina'))) {
+		return;
+	}
+
+	exec(`${path.join(homePath, 'bin', 'ballerina')} version`, (err, stdout, stderr) => {
+		const platformVersion = stderr.toString().trim();
+		const extensionVersion = 'Ballerina ' + extensions.getExtension('ballerina.ballerina').packageJSON.version
+
+		if (platformVersion != extensionVersion) {
+			console.log(`Version mismatch. Platform version: ${platformVersion} Extension version: ${extensionVersion}`);
+			window.showWarningMessage(msgs.VERSION_MISMATCH);
+		}
+	});
+}
+
 exports.activate = function(context) {
 	// Options to control the language client
 	const clientOptions = {
@@ -105,6 +122,8 @@ exports.activate = function(context) {
 		showHomeNotSetWarning();
 		return;
 	}
+
+	checkVersion(config.home);
 
 	if (!checkHome(config.home)) {
 		rendererErrored(context);

--- a/tool-plugins/vscode/plugin/messages.js
+++ b/tool-plugins/vscode/plugin/messages.js
@@ -5,4 +5,5 @@ module.exports = {
     HOME_INCORRECT: 'The configured \"ballerina.home\" seems incorrect.',
     HOME_CHANGED: '\"ballerina.home\" configuration changed. Please restart vscode for changes to take effect.',
     SHOW_LSERRORS_CHANGED: 'Configuration for displaying output from language server changed. Please restart vscode for changes to take effect.',
+    VERSION_MISMATCH: 'Version of ballerina found inside the configured "ballerina.home" does not match with this plugin\'s version. Some features may not work properly.',
 }

--- a/tool-plugins/vscode/plugin/package.json
+++ b/tool-plugins/vscode/plugin/package.json
@@ -2,7 +2,7 @@
     "name": "ballerina",
     "displayName": "Ballerina",
     "description": "Intellisense, Diagram View, Debugging, code formatting and refactoring for Ballerina",
-    "version": "0.970.0-beta4-SNAPSHOT",
+    "version": "0.970.0-beta14-SNAPSHOT",
     "publisher": "ballerina",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Purpose
To avoid confusing the user due to possible mismatching versions between the sdk and the plugin, a warning is shown when the plugin starts up

![image](https://user-images.githubusercontent.com/3872221/39174804-4c3ba7e2-47c6-11e8-8a4e-4a108229f29f.png)

