### PR TITLE
Copy edit on CLI help files

### DIFF
--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-build.help
@@ -10,8 +10,8 @@ DESCRIPTION
      Compiles Ballerina sources and writes the output to a file. 
 
      By default, output filename for a package is the package name 
-     suffixed with ‘.balx’. The default output for a source will have 
-     The ‘.bal’ suffix replaced with ‘.balx’. 
+     suffixed with ‘.balx’. The default output for a source will  
+     replace the ‘.bal’ suffix with ‘.balx’. 
 
      If the output file is specified with the -o flag, the output 
      will be written to the given output file name. 
@@ -25,12 +25,12 @@ OPTIONS
           Builds a compiled package. 
 
      --offline
-          Builds offline without downloading dependencies 
+          Builds offline without downloading dependencies. 
 
-     -r   Recursive  mode.  Operates  as fast as lightning at the
+     -r   Recursive mode. Operates as fast as lightning at the
           expense of a megabyte of virtual memory.
 
-DEFAULT BEHAVIOUR
+DEFAULT BEHAVIOR
      Generates a compiled binary file for the source or package given 
      with ‘.balx’ file extension. 
 

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-default.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-default.help
@@ -6,21 +6,18 @@ SYNOPSIS
         <command> [<args>]
 
 DESCRIPTION
-     Ballerina is a general purpose, concurrent and strongly typed
+     Ballerina is a general purpose, concurrent, and strongly typed
      programming language with both textual and graphical syntaxes. 
      It is optimized for programming integration solutions.
 
-     To learn more on how to run commands with Ballerina, use
+     To learn how to run commands with Ballerina, use
          ballerina help [command]
      You can find the list of commands in the BALLERINA COMMANDS 
-     Section of this help page. 
+     section of this help page. 
 
-     You can follow https://ballerina.io/learn/quick-tour/ to get  
-     started. 
-     To lean more, you can follow the resources provided in
-     https://ballerina.io/learn/quick-tour/ 
-
-     To find out the latest on Ballerina, visit https://ballerina.io. 
+     To get started, visit https://ballerina.io/learn/quick-tour/ 
+     
+     To find out the latest on Ballerina, visit https://ballerina.io
 
 OPTIONS
      -v
@@ -38,7 +35,7 @@ OPTIONS
           port number for the remote connection. 
 
 BALLERINA COMMANDS
-     The list of available commands are:
+     Available commands are:
          run        Run Ballerina program
          build      Compile Ballerina program
          install    Install packages to home repository
@@ -50,8 +47,8 @@ BALLERINA COMMANDS
          doc        Generate Ballerina API documentation
          grpc       Generate connector/service using protobuf   
                     definition
-         swagger    Generate client/service using swagger definition
-                    or export swagger file for a Ballerina service
+         swagger    Generate client/service using Swagger definition
+                    or export Swagger file for a Ballerina service
          test       Test Ballerina program
          version    Print Ballerina version
          encrypt    Encrypt sensitive data
@@ -60,7 +57,7 @@ EXAMPLES
      Check the current version of Ballerina in use on your system
      $ ballerina -v
 
-     Look for help on how to use ballerina command 
+     Get help on how to use the ballerina command 
      $ ballerina help 
 
      Run your hello Ballerina program  

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-doc.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-doc.help
@@ -9,10 +9,10 @@ SYNOPSIS
         [<balfile>|<packagename]
 
 DESCRIPTION
-     Ballerina doc command generates API documentation for given 
+     Ballerina doc command generates API documentation for a given 
      program or package. 
 
-     By default if no source or package name given, it will generate 
+     By default if no source or package name is given, it will generate 
      API documentation for all the packages in the current project
      folder. 
 
@@ -26,7 +26,7 @@ OPTIONS
          to format the generated API documentation.
   
      --sourceroot <path>     
-         Path to the directory containing source files and packages
+         Path to the directory containing source files and packages.
 
      -o <path>
      --output <path>
@@ -35,11 +35,11 @@ OPTIONS
     
      -n
      --native
-         Reads the source as native ballerina code. 
+         Reads the source as native Ballerina code. 
 
      -e <package, ...>
      --exclude <package, ...>
-         Comma separated list of package names to be excluded from 
+         Comma-separated list of package names to be excluded from 
          generated documentation. 
 
      -c <path>
@@ -48,9 +48,9 @@ OPTIONS
 
      -v
      --verbose
-         Prints debug level logs while generating documentation
+         Prints debug level logs while generating documentation.
      -e
-         Ballerina environment parameters
+         Ballerina environment parameters.
 
 EXAMPLES
      Generate API documentation for current project 

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-encrypt.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-encrypt.help
@@ -8,27 +8,27 @@ DESCRIPTION
      Encrypt command performs symmetric encryption of sensitive 
      configuration values using AES, CBC mode with PKCS#5 padding. 
 
-     Configuration values containing sensitive information, such as 
+     Configuration values containing sensitive information such as 
      passwords and secrets should be encrypted to maintain 
      confidentiality. 
 
      Once executed, the encrypt command will prompt for the value to 
-     be encrypted and a secret which is used as the AES encryption /     
+     be encrypted and a secret that is used as the AES encryption /     
      decryption key.
 
      The encrypted configuration value can then be used as a 
-     configuration value, by placing the encrypt command output in a 
+     configuration value by placing the encrypt command output in a 
      configuration file or by passing it as a runtime argument.
 
      The Ballerina Config API will automatically decrypt the
-     configuration values on-demand.
+     configuration values on demand.
 
 OPTIONS
-     Ballerina encrypt command takes no options
+     Ballerina encrypt command takes no options.
 
 DEFAULT BEHAVIOUR
      AES, CBC mode with PKCS#5 padding will be used to encrypt the 
-     provided value, by using the provided encryption key.
+     provided value by using the provided encryption key.
 
 EXAMPLES
      Encrypt sensitive data

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-grpc.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-grpc.help
@@ -5,7 +5,7 @@ SYNOPSIS
     ballerina grpc --input <proto-file-path> [--output <path>]
         
 DESCRIPTION
-     Generates ballerina gRPC client stub for gRPC service for a given gRPC protoc definition.
+     Generates the Ballerina gRPC client stub for gRPC service for a given gRPC protoc definition.
 
 OPTIONS
      --input <proto-file-path>

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-help.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-help.help
@@ -12,8 +12,8 @@ DESCRIPTION
      If a command is given, the help page for the given command 
      is printed. 
 
-     Note that ballerina ?, ballerina –h and ballerina --help are  
-     identical to ballerina help  Those formats are internally 
+     Note that ballerina ?, ballerina –h, and ballerina --help are  
+     identical to ballerina help. Those formats are internally 
      converted into ballerina help.
 
      ballerina command synopsis: 
@@ -41,8 +41,8 @@ OPTIONS
      Ballerina help takes no command line options 
 
 EXAMPLES
-     Look for help on how to use ballerina command 
+     Look for help on how to use the ballerina command 
      $ ballerina help 
 
-     Learn how to run ballerina run command  
+     Learn how to use the Ballerina run command  
      $ ballerina help run

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-init.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-init.help
@@ -8,31 +8,31 @@ DESCRIPTION
      Ballerina init creates an initial project structure for you to 
      get started with a Ballerina project. 
 
-    The created set of artifacts includes a Ballerina.toml and a 
-    sample ballerina source file.You can use Ballerina.toml to manage
-    the organization setting and version for the project.
+     The created set of artifacts includes a Ballerina.toml and a 
+     sample Ballerina source file. You can use Ballerina.toml to manage
+     the organization setting and version for the project.
      
-     The generated set of artifacts also include a service skeleton 
-     and a test skeleton that you can use to kick start the project
-     with. 
+     The generated set of artifacts also includes a service skeleton 
+     and a test skeleton that you can use to kick start the project. 
 
-     You may create a new folder, cd to that folder and then run init 
-     command to generate artifacts into that folder to initiate a 
-     project with a clean start. 
+     To initiate a project with a clean start, you can create a new 
+     folder, cd to that folder, and then run the init command to generate 
+     artifacts into that folder. 
 
 OPTIONS
      -i
      --interactive
           Creates a new Ballerina project in interactive mode. 
-          You will be guided through a set of question on what 
-          configuration files to generate, sources files to generate, 
-          what version to use, what organization name to use and 
-          if it is a main program or a service. 
+          You will be guided through a set of questions on what 
+          configuration files to generate, source files to generate, 
+          version to use, organization name to use, and whether it 
+          is a main program or a service. 
 
 EXAMPLES
      Initialize a project 
      $ ballerina init
-     If you want to get a clean start, you may optionally 
+     
+     Optionally, if you want to get a clean start 
      $ mkdir myproj
      $ cd myproj
      $ ballerina init

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-install.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-install.help
@@ -6,16 +6,15 @@ SYNOPSIS
 
 DESCRIPTION
      Installs the given package from project repository to home 
-     repository. 
-     Project repository resides within the project home. 
-     Home repository reside within the home folders ‘.ballerina’ 
-     folder by default. 
+     repository. Project repository resides within the project home. 
+     Home repository reside within the home folder (‘.ballerina’ 
+     folder by default). 
 
 OPTIONS
-     Ballerina install command takes no options   
+     Ballerina install command takes no options.
 
-DEFAULT BEHAVIOUR
-     Install package from project repository to home repository 
+DEFAULT BEHAVIOR
+     Installs package from project repository to home repository. 
 
 EXAMPLES
      Install math package 
@@ -23,5 +22,5 @@ EXAMPLES
      This will place the current version of the package (assume 0.0.1)
      on a Mac or Linux machine in 
      ~/.ballerina/repo/user_name/math/0.0.1/math.zip 
-     On a Windows machine the package will be placed to 
+     On a Windows machine the package will be placed in 
      \User\user_name\.ballerina\repo\user_name\math\0.0.1\math.zip

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-list.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-list.help
@@ -9,7 +9,7 @@ DESCRIPTION
      packages for a given Ballerina source file or a package. 
 
 OPTIONS
-     Ballerina list command takes no options
+     Ballerina list command takes no options.
 
 EXAMPLES
      List dependencies for hello_service.bal 

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-pull.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-pull.help
@@ -5,14 +5,13 @@ SYNOPSIS
     ballerina pull <package-name>
 
 DESCRIPTION
-     Downloads the given package form Ballerina Central 
+     Downloads the given package from Ballerina Central 
      (https://central.ballerina.io/) repository and installs to home
-     repository. 
-     By default, package will be placed within the .ballerina home
-     repository of the user. 
+     repository. By default, package will be placed within the 
+     .ballerina home repository of the user. 
 
 OPTIONS
-     Ballerina pull command takes no options  
+     Ballerina pull command takes no options.
 
 EXAMPLES
      Download Gmail connector by WSO2 from Ballerina Central 

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-push.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-push.help
@@ -8,23 +8,21 @@ DESCRIPTION
      Uploads the given package to Ballerina Central 
      (https://central.ballerina.io/) repository. 
 
-     For push command to work, you need to copy and paste your 
-     Ballerina Central access token in Settings.toml in your home 
-     repository (<USER_HOME>/.ballerina/). 
-     Please register on Ballerina central and visit user dashboard at 
-     https://central.ballerina.io/dashboard to gain access to your 
-     user token.  
+     Before you can push, you must enter your Ballerina Central
+     access token in Settings.toml in your home repository 
+     (<USER_HOME>/.ballerina/). To get your token, register
+     on Ballerina Central and visit the user dashboard at 
+     https://central.ballerina.io/dashboard.  
 
-     When you push a package to Ballerina Central the runtime will 
-     validate organizations for user against the org-name defined in 
-     your package’s Ballerina.toml file. 
-     Therefore when you have more than one organization in 
-     Ballerina Central you need to make sure that you pick the 
+     When you push a package to Ballerina Central, the runtime will 
+     validate organizations for the user against the org-name defined in 
+     your package’s Ballerina.toml file. Therefore, when you have more 
+     than one organization in Ballerina Central, be sure to pick the 
      organization name that you intend to push the package into and 
      set that as org-name in the package Ballerina.toml file. 
 
 OPTIONS
-     Ballerina push command takes no options 
+     Ballerina push command takes no options.
 
 EXAMPLES
      Push math package to Ballerina Central 

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-run.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-run.help
@@ -1,6 +1,6 @@
 NAME
     Ballerina help run - Run Ballerina program source files, 
-    binaries or packages
+    binaries, or packages
 
 SYNOPSIS
      ballerina run [-s|--service] [-e] [--offline] [--observe] 
@@ -8,36 +8,32 @@ SYNOPSIS
          <balfile | packagename | balxfile> [args...]  
 
 DESCRIPTION
-     Run command executes the provided program or package. 
+     Run command executes the given program or package. 
 
      If a Ballerina source file (.bal file) or a source package is 
-     given, run command compiles and runs it. 
-     When the source is given, the compilation is done internally, 
-     and it does not generate a binary file. 
+     given, the run command compiles and runs it. The compilation 
+     is done internally and does not generate a binary file. 
  
-     You may use ballerina build command to compile a source and 
-     provide the generated binary file (.balx file) to run command. 
-
-     The difference of running a source file as opposed to a compiled
-     binary file is that, running binary file is much faster. This is 
-     because the source file run requires compilation phase and 
-     running does not require that. 
+     You may use the Ballerina build command to compile a source and 
+     provide the generated binary file (.balx file) to the run command. 
+     The binary runs much faster than a source file, because the source 
+     file run requires a compilation phase. 
 
      By default, ballerina run executes the main function. 
-     If the main function is not there, it executes services. 
+     If the main function is not present, run executes services. 
      When both a main function and a service are present, you can use 
-     [-s|--service] option to run service over main function. 
+     [-s|--service] option to run the service instead of the main function. 
      You must have either a main function or a service in order to run 
-     a program or a package
+     a program or a package.
 
 OPTIONS
      -s
      --service
          Runs services instead of main function (if available) in the 
-         given program or package. The default behaviour is to run 
-         the main function if there is one, else if there is only a
-         service defined, the service will be started. In case both a 
-         main function and a service is available in the program or
+         given program or package. The default behavior is to run 
+         the main function (if available), else if there is only a
+         service defined, the service will be started. If both a 
+         main function and a service are available in the program or
          package, this option allows you to start the service.  
 
      -e <key1=value1, key2=value2, …>
@@ -46,13 +42,13 @@ OPTIONS
      --offline
          In a package build, the dependencies are always checked from 
          the remote repository (Ballerina Central) to check for latest 
-         Artifacts. If --offline is given, this remote check is not 
-         done, rather the local artifacts will be used. 
+         artifacts. If --offline is given, this remote check is not 
+         done and the local artifacts will be used instead. 
 
      --observe
          Enables observability for the Ballerina program and lets
          users observe it through Jaeger (tracing) and Prometheus
-         (metrics) by default. If --observe is given,  it will display
+         (metrics) by default. If --observe is given, it will display
          a log mentioning push/pull endpoints that will be used for
          Jaeger and Prometheus. Moreover, default configurations of
          Jaeger and Prometheus can be overridden using environment
@@ -61,7 +57,7 @@ OPTIONS
      --sourceroot <path>
          Provides the path to be taken as the root of the source. 
          Source will be looked up relative to the given source root 
-         path
+         path.
 
      -c <config-file>
      --config <config-file>
@@ -70,17 +66,17 @@ OPTIONS
      -B <option1, option2, …>
          Provides a list of Ballerina VM options to be used by runtime 
          when executing a Ballerina program or package. This accepts a 
-         comma separated list of options
+         comma-separated list of options.
 
      args... 
          The list of command line arguments for the Ballerina program 
          being run. The semantics of these arguments are defined by 
          the program design. 
 
-DEFAULT BEHAVIOUR
-     Runs the main function in the program or the package given.
-     If no main function defined, then it will look for a service. 
-     If none of them are present, the run command will fail.   
+DEFAULT BEHAVIOR
+     Runs the main function in the given program or package.
+     If no main function is defined, it will look for a service. 
+     If no main function or service is present, the run command will fail.   
 
 EXAMPLES
      Run hello source program  
@@ -92,5 +88,5 @@ EXAMPLES
      Run hello package  
      $ ballerina run hello
 
-     Run math package with three program args: add, 10 and 5
+     Run math package with three program args: add, 10, and 5
      $ ballerina run math add 10 5

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-search.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-search.help
@@ -5,13 +5,13 @@ SYNOPSIS
     ballerina search <text>
 
 DESCRIPTION
-     Searches Ballerina Central for given text appearing in 
-     organization name, package name or package descriptions. 
+     Searches Ballerina Central for the given text appearing in 
+     organization name, package name, or package descriptions. 
 
-     Search text is treated crease insensitive when search is execute. 
+     Search text is treated as case-insensitive when search is executed. 
 
 OPTIONS
-     Ballerina search command takes no options
+     Ballerina search command takes no options.
 
 EXAMPLES
      Search for Foo organization

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-swagger.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-swagger.help
@@ -1,6 +1,6 @@
 NAME
     Ballerina swagger - Generates Ballerina code for a provided 
-    swagger definition or exports the swagger definition of a 
+    Swagger definition or exports the Swagger definition of a 
     Ballerina service.
 
 SYNOPSIS
@@ -13,71 +13,69 @@ SYNOPSIS
         [-s <servicename>|--service <servicename>]
 
 DESCRIPTION
-    Ballerina swagger command can generate Ballerina source using 
-    swagger definition. Either a mock service or a client stub can 
-    be generated with a given Swagger definition file. 
-    
-    It can also export a swagger definition of a Ballerina service.
+    Ballerina swagger command can generate a Ballerina source (either
+    a mock service or a client stub) from the given Swagger definition 
+    file. It can also export a Swagger definition from a Ballerina service.
     
     Generated Ballerina sources will be written into the gen folder 
     under the provided package name. 
 
 SUB COMMANDS
     mock <swaggerfile>
-        Generates a ballerina service for the swagger file. This 
+        Generates a Ballerina service from the Swagger file. This 
         generated service can be used as a mock version of the 
         actual service implementation. Generated sources will 
         contain service definition in gen/ and resource 
         implementation file in package root directory with suffix
-         _impl. _impl file is not overwritten by code regeneration.
+         _impl. The _impl file is not overwritten by code regeneration.
 
     client <swaggerfile>
-        Generates a ballerina client stub for the service defined 
-        in swagger file. This client can be used in client 
-        applications to call the service defined in swagger file.
+        Generates a Ballerina client stub for the service defined 
+        in the Swagger file. This client can be used in client 
+        applications to call the service defined in the Swagger file.
 
     export <balfile>
-        Export the ballerina service to a OpenApi Specification 3.0 
-        definition. For export to work properly input ballerina 
-        service must contain basic service and resource level http 
+        Export the Ballerina service to an OpenApi Specification 3.0 
+        definition. For export to work properly, the input ballerina 
+        service must contain basic service and resource level HTTP 
         annotations defining the service.
 
 OPTIONS
     -p <packagename>
     --package <packagename>
-        Name of a ballerina package which should contain the 
+        Name of a Ballerina package, which should contain the 
         generated source files. If provided package doesn’t exist 
         in output directory, it’ll be created automatically. If 
         package name is not provided while generating ballerina code, 
         generated sources will be written into main package (current 
-        directory)
+        directory).
 
     -o <path>
     --output<path>
         Generated/Exported sources will be written into this 
         directory. 
-        In the case of ballerina code generation output directory 
-        must be a ballerina project
+        In the case of Ballerina code generation, output directory 
+        must be a Ballerina project.
 
     -s <servicename>
     --service <servicename>
-        If input ballerina file contain multiple services, service 
+        If input Ballerina file contains multiple services, service 
         can be used to provide a specific service name to export. 
-        If not provided first service definition found in input 
-        ballerina file will be exported to a swagger definition
+        If not provided, the first service definition found in the input 
+        Ballerina file will be exported to a Swagger definition.
 
-DEFAULT BEHAVIOUR
+DEFAULT BEHAVIOR
     If output path is not provided, current directory will be 
-    selected as the output directory
+    selected as the output directory.
 
 EXAMPLES
-    Generate ballerina mock service with package name hellomock
-    and output written to service_project folder 
+    Generate a Ballerina mock service with package name hellomock
+    and write the output to the service_project folder 
     $ ballerina swagger mock hello.yaml -p hellomock -o service_project
 
-    Generate ballerina client  with package name helloclient
-    and output written to client_project folder
+    Generate a Ballerina client with package name helloclient
+    and write the output to the client_project folder
     $ ballerina swagger client hello.yaml -p helloclient -o client_project
 
-    Export swagger definition for hello_service.bal
+    Export a Swagger definition for hello_service.bal
     $ ballerina swagger export hello_service.bal -o project

--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-test.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-test.help
@@ -1,5 +1,5 @@
 NAME
-    Ballerina test - Run ballerina tests and display a summary of 
+    Ballerina test - Run Ballerina tests and display a summary of 
     test results.
 
 SYNOPSIS
@@ -10,18 +10,18 @@ SYNOPSIS
 
 
 DESCRIPTION
-    Ballerina test commands allows you to compile and run Ballerina 
+    Ballerina test command allows you to compile and run Ballerina 
     test sources and prints a summary of test results. You can 
-    execute tests in a single test file, a test package or in an 
-    entire ballerina project.
+    execute tests in a single test file, a test package, or an 
+    entire Ballerina project.
     
-    ballerina test without any parameters execute tests in the entire
-    project.
+    Use ballerina test without any parameters to execute tests for 
+    the entire project.
     
-    ballerina test <packagename> will execute tests within the 
+    Use ballerina test <packagename> to execute tests within the 
     specified package.
     
-    ballerina test <balfile> will execute the given Ballerina test 
+    Use ballerina test <balfile> to execute the given Ballerina test 
     file. Note that imports from other packages will not work for 
     file executions. File path can be a relative or absolute.
 
@@ -29,27 +29,27 @@ OPTIONS
 
      -lg
      --list-groups
-    Lists the test groups available in the test files. Groups are 
-    tags that are added to test functions. The groups are used to
-    control the execution of test functions by specifying a  
-    group or a set of groups that needs to be executed in a test 
-    run. A test function can be grouped with groups parameter 
-    within @test:config annotation.
+         Lists the test groups available in the test files. Groups are 
+         tags that are added to test functions. The groups are used to
+         control the execution of test functions by specifying a  
+         group or a set of groups that need to be executed in a test 
+         run. A test function can be grouped with the groups parameter 
+         within the @test:config annotation.
 
      --groups <test_group, ...>              
          Specify test groups to be executed. Groups are tags that are 
          added to test functions. The groups are used to control the 
          execution of test functions by specifying a group or a set of 
-         groups that needs to be executed in a test run. A test 
-         function can be grouped with groups parameter within 
+         groups that need to be executed in a test run. A test 
+         function can be grouped with the groups parameter within the
          @test:config annotation.
 
      --disable-groups <test_group, ...>      
          Specify test groups to be excluded. Groups are tags that are 
          added to test functions. The groups are used to control the 
          execution of test functions by specifying a group or a set of 
-         groups that needs to be executed in a test run. A test 
-         function can be grouped with groups parameter within 
+         groups that need to be executed in a test run. A test 
+         function can be grouped with the groups parameter within the
          @test:config annotation.
 
      --sourceroot <path>         
@@ -58,7 +58,7 @@ OPTIONS
          sourceroot. 
 
      -e                    
-         Ballerina environment parameters
+         Ballerina environment parameters.
 
      --debug <port>               
          Remote debug Ballerina tests over the port given.   
@@ -68,7 +68,7 @@ OPTIONS
          Path to the test configuration file.
 
      -B 
-         Ballerina VM options
+         Ballerina VM options.
 
 EXAMPLES
      Run all tests in the current project


### PR DESCRIPTION
## Purpose
> Copy editing pass

## Goals
> Ensure consistency and clarity in help text

## Approach
> Walked through each file and did a copy edit.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A