### PR TITLE
Add x-MULTI extension support

### DIFF
--- a/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/resources/templates/client/client.mustache
+++ b/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/resources/templates/client/client.mustache
@@ -55,15 +55,7 @@ public function {{../../name}}Client::{{lower .}}{{../name}}({{#parameters}}{{ty
     //Create the required request as needed{{#contentType}}
     request.setHeader("Content-Type", "{{contentType}}");{{/contentType}}
     string path = string `{{path}}`;
-    var res = ep->{{lower .}}(path, request = request);
-
-    match res {
-        http:HttpConnectorError httpError => {
-            error err = {message: httpError.message};
-            return err;
-        }
-        http:Response resp => return resp;
-    }
+    return check ep->{{lower .}}(path, request = request);
 }
 {{/supportedMethods}}{{/isMultiMethod}}{{^isMultiMethod}}
 public function {{../name}}Client::{{name}}({{#parameters}}{{type}} {{name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error {
@@ -73,15 +65,7 @@ public function {{../name}}Client::{{name}}({{#parameters}}{{type}} {{name}}{{#u
     //Create the required request as needed{{#contentType}}
     request.setHeader("Content-Type", "{{contentType}}");{{/contentType}}
     string path = string `{{path}}`;
-    var res = ep->{{lower method}}(path, request = request);
-
-    match res {
-        http:HttpConnectorError httpError => {
-            error err = {message: httpError.message};
-            return err;
-        }
-        http:Response resp => return resp;
-    }
+    return check ep->{{lower method}}(path, request = request);
 }{{/isMultiMethod}}
 {{/resources}}
 {{#if endpoints}}//======================================================

--- a/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/resources/templates/client/client.mustache
+++ b/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/resources/templates/client/client.mustache
@@ -43,19 +43,19 @@ public type {{name}}Client object {
     }
 
     new (clientEp) {}
-    {{#resources}}
-    public function {{name}}({{#parameters}}{{type}} {{name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error;{{/resources}}
+    {{#resources}}{{#isMultiMethod}}{{#supportedMethods}}
+    public function {{lower .}}{{name}}({{#parameters}}{{type}} {{name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error;{{/supportedMethods}}{{/isMultiMethod}}{{^isMultiMethod}}
+    public function {{name}}({{#parameters}}{{type}} {{name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error;{{/isMultiMethod}}{{/resources}}
 };
-
-{{#resources}}
-public function {{../name}}Client::{{name}}({{#parameters}}{{type}} {{name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error {
+{{#resources}}{{#isMultiMethod}}{{#supportedMethods}}
+public function {{../../name}}Client::{{lower .}}{{../name}}({{#parameters}}{{type}} {{../name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error {
     endpoint http:Client ep = self.clientEp.client;
     http:Request request = new;
 
     //Create the required request as needed{{#contentType}}
     request.setHeader("Content-Type", "{{contentType}}");{{/contentType}}
     string path = string `{{path}}`;
-    var res = ep -> {{lower method}}(path, request = request);
+    var res = ep->{{lower .}}(path, request = request);
 
     match res {
         http:HttpConnectorError httpError => {
@@ -65,6 +65,24 @@ public function {{../name}}Client::{{name}}({{#parameters}}{{type}} {{name}}{{#u
         http:Response resp => return resp;
     }
 }
+{{/supportedMethods}}{{/isMultiMethod}}{{^isMultiMethod}}
+public function {{../name}}Client::{{name}}({{#parameters}}{{type}} {{name}}{{#unless @last}}, {{/unless}}{{/parameters}}) returns http:Response | error {
+    endpoint http:Client ep = self.clientEp.client;
+    http:Request request = new;
+
+    //Create the required request as needed{{#contentType}}
+    request.setHeader("Content-Type", "{{contentType}}");{{/contentType}}
+    string path = string `{{path}}`;
+    var res = ep->{{lower method}}(path, request = request);
+
+    match res {
+        http:HttpConnectorError httpError => {
+            error err = {message: httpError.message};
+            return err;
+        }
+        http:Response resp => return resp;
+    }
+}{{/isMultiMethod}}
 {{/resources}}
 {{#if endpoints}}//======================================================
 //============Invocation of Generated Client============
@@ -75,8 +93,9 @@ function main (string... args) { {{#endpoints}}
     };{{/endpoints}}
 
     {{#resources.0}}
-    // Sample invocation of the generated client connector
-    var res = ep0 -> {{name}}({{#parameters}}{{>arguments}}{{/parameters}});
+    // Sample invocation of the generated client connector{{#isMultiMethod}}{{#supportedMethods.0}}
+    var res = ep0->{{lower .}}{{name}}({{#parameters}}{{>arguments}}{{/parameters}});{{/supportedMethods.0}}{{/isMultiMethod}}{{^isMultiMethod}}
+    var res = ep0->{{name}}({{#parameters}}{{>arguments}}{{/parameters}});{{/isMultiMethod}}
     match (res) {
         error err => io:println(err.message);
             http:Response resp => {

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
@@ -173,8 +173,12 @@ public class CodeGenerator {
             if (param0 == null) {
                 throw new IllegalArgumentException("found 'null', expected 'string'");
             }
-            if (object != null && object.toString().equals(param0.toString())) {
-                result = options.fn(options.context);
+            if (object != null) {
+                if (object.toString().equals(param0.toString())) {
+                    result = options.fn(options.context);
+                } else {
+                    result = options.inverse();
+                }
             } else {
                 result = null;
             }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -164,7 +164,8 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
                 BallerinaServer balServer = new BallerinaServer().buildContext(server);
                 servers.add(balServer);
             } catch (BallerinaOpenApiException e) {
-                // Ignore the exception and move to other servers
+                // Ignore the exception, set default value for this server and move forward
+                servers.add(new BallerinaServer().getDefaultValue());
             }
         });
     }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -98,7 +98,7 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
      * @throws BallerinaOpenApiException when context building fails
      */
     private void setPaths(OpenAPI openAPI) throws BallerinaOpenApiException {
-        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+        if (openAPI.getPaths() == null) {
             return;
         }
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
@@ -28,6 +28,8 @@ import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +51,11 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
     private Set<Map.Entry<String, ApiResponse>> responses;
     private Set<Map.Entry<String, Callback>> callbacks;
     private List<SecurityRequirement> security;
+    private List<String> methods;
+
+    // Not static since handlebars can't see static variables
+    private final List<String> allMethods =
+            Arrays.asList("HEAD", "OPTIONS", "PATCH", "DELETE", "POST", "PUT", "GET");
 
     public BallerinaOperation() {
         this.responses = new LinkedHashSet<>();
@@ -68,6 +75,7 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
         this.security = operation.getSecurity();
         this.operationId = operation.getOperationId();
         this.parameters = new ArrayList<>();
+        this.methods = null;
 
         if (operation.getResponses() != null) {
             operation.getResponses()
@@ -89,6 +97,42 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
     @Override
     public BallerinaOperation buildContext(Operation operation) throws BallerinaOpenApiException {
         return buildContext(operation, null);
+    }
+
+    /**
+     * Build BallerinaOperation with user extension.
+     * Complete BallerinaOperation object will not be built. Only selected
+     * set of attributes are supported.
+     *
+     * @param xObj extension context object
+     * @return BallerinaOperation built with extension details
+     */
+    public BallerinaOperation buildXContext(Object xObj) {
+        LinkedHashMap extension = (LinkedHashMap) xObj;
+        Object operationId = extension.get("operationId");
+        Object tags = extension.get("tags");
+        Object summary = extension.get("summary");
+        Object description = extension.get("description");
+        Object xMethodsObj = extension.get("x-METHODS");
+        this.parameters = new ArrayList<>();
+
+        if (operationId != null) {
+            this.operationId = operationId.toString();
+        }
+        if (tags != null && tags instanceof ArrayList) {
+            this.tags = (ArrayList<String>) tags;
+        }
+        if (summary != null) {
+            this.summary = summary.toString();
+        }
+        if (description != null) {
+            this.description = description.toString();
+        }
+        if (xMethodsObj != null && (xMethodsObj instanceof ArrayList)) {
+            this.methods =  (ArrayList) xMethodsObj;
+        }
+
+        return this;
     }
 
     @Override
@@ -138,5 +182,13 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
 
     public void setOperationId(String operationId) {
         this.operationId = operationId;
+    }
+
+    public List<String> getMethods() {
+        return methods;
+    }
+
+    public List<String> getAllMethods() {
+        return allMethods;
     }
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaServer.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaServer.java
@@ -88,8 +88,8 @@ public class BallerinaServer implements BallerinaSwaggerObject<BallerinaServer, 
 
     @Override
     public BallerinaServer getDefaultValue() {
-        this.host = "localhost";
-        this.port = 80;
+        this.host = null; // host not required for default binding
+        this.port = 9090;
         this.basePath = "/";
 
         return this;

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
@@ -47,15 +47,7 @@ public type {{cut info.title " "}}Client object {
         http:Request request = new;
 
         //Create the required request as needed
-        var res = ep->{{lower .}}("{{../../../key}}", request = request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
+        return check ep->{{lower .}}("{{../../../key}}", request = request);
     }
     {{/methods}}{{else}}{{#allMethods}}
     public function {{lower .}}{{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
@@ -63,15 +55,7 @@ public type {{cut info.title " "}}Client object {
         http:Request request = new;
 
         //Create the required request as needed
-        var res = ep->{{lower .}}("{{../../../key}}", request = request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
+        return check ep->{{lower .}}("{{../../../key}}", request = request);
     }
     {{/allMethods}}{{/if}}{{else}}
     public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
@@ -79,15 +63,7 @@ public type {{cut info.title " "}}Client object {
         http:Request request = new;
 
         //Create the required request as needed
-        var res = ep->{{key}}("{{../../key}}", request = request);
-
-        match res {
-            http:HttpConnectorError httpError => {
-                error err = {message: httpError.message};
-                return err;
-            }
-            http:Response resp => return resp;
-        }
+        return check ep->{{key}}("{{../../key}}", request = request);
     }
     {{/equals}}{{/value}}{{/operations}}{{/value}}{{/paths}}
 };

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
@@ -41,13 +41,13 @@ public type {{cut info.title " "}}Client object {
     }
 
     new (clientEp) {}
-{{#paths}}{{#value}}{{#operations}}{{#value}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
+{{#paths}}{{#value}}{{#operations}}{{#value}}{{#equals key "multi"}}{{#if methods}}{{#methods}}
+    public function {{lower .}}{{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
         endpoint http:Client ep = self.clientEp.client;
         http:Request request = new;
 
         //Create the required request as needed
-        var res = ep -> {{key}}("{{../../key}}", request = request);
+        var res = ep->{{lower .}}("{{../../../key}}", request = request);
 
         match res {
             http:HttpConnectorError httpError => {
@@ -57,5 +57,37 @@ public type {{cut info.title " "}}Client object {
             http:Response resp => return resp;
         }
     }
-{{/value}}{{/operations}}{{/value}}{{/paths}}
+    {{/methods}}{{else}}{{#allMethods}}
+    public function {{lower .}}{{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
+        endpoint http:Client ep = self.clientEp.client;
+        http:Request request = new;
+
+        //Create the required request as needed
+        var res = ep->{{lower .}}("{{../../../key}}", request = request);
+
+        match res {
+            http:HttpConnectorError httpError => {
+                error err = {message: httpError.message};
+                return err;
+            }
+            http:Response resp => return resp;
+        }
+    }
+    {{/allMethods}}{{/if}}{{else}}
+    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
+        endpoint http:Client ep = self.clientEp.client;
+        http:Request request = new;
+
+        //Create the required request as needed
+        var res = ep->{{key}}("{{../../key}}", request = request);
+
+        match res {
+            http:HttpConnectorError httpError => {
+                error err = {message: httpError.message};
+                return err;
+            }
+            http:Response resp => return resp;
+        }
+    }
+    {{/equals}}{{/value}}{{/operations}}{{/value}}{{/paths}}
 };

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
@@ -1,3 +1,4 @@
+import ballerina/log;
 import ballerina/http;
 import ballerina/swagger;
 
@@ -42,14 +43,15 @@ service {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unless @last}}, {
             }{{#unless @last}},{{/unless}}{{/parameters}}
         ]
     }
-    @http:ResourceConfig {
-        methods:["{{upper key}}"],
+    @http:ResourceConfig { {{#equals key "multi"}}{{#if methods}}
+        methods:[{{#methods}}"{{.}}"{{#unless @last}}, {{/unless}}{{/methods}}],{{/if}}{{else}}
+        methods:["{{upper key}}"],{{/equals}}
         path:"{{../../key}}"
     }{{#deprecated}}
     deprecated {}{{/deprecated}}
     {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
         http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
-        _ = outboundEp -> respond(res);
+        outboundEp->respond(res) but { error e => log:printError("Error while responding", err = e) };
     }
 {{/value}}{{/operations}}{{/value}}{{/paths}}
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
@@ -1,8 +1,8 @@
 import ballerina/http;
 import ballerina/swagger;
 
-{{#servers}}endpoint http:Listener ep{{@index}} {
-    host: "{{host}}",
+{{#servers}}endpoint http:Listener ep{{@index}} { {{#host}}
+    host: "{{host}}",{{/host}}
     port: {{port}}
 };
 {{/servers}}
@@ -24,7 +24,7 @@ import ballerina/swagger;
 @http:ServiceConfig {
     basePath: "{{servers.0.basePath}}"{{!-- {{only one base path is allowed for all endpoints}} --}}
 }
-service<http:Service> {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unless @last}}, {{/unless}}{{/servers}} {
+service {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unless @last}}, {{/unless}}{{/servers}} {
 {{#paths}}{{#value}}{{#operations}}{{#value}}
     @swagger:ResourceInfo {
         tags: [{{#tags}}"{{.}}"{{#unless @last}},{{/unless}}{{/tags}}],

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
@@ -110,6 +110,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /action:
+    x-MULTI:
+      operationId: getAction
+      responses:
+        '200':
+          description: Successful
+          examples:
+            application/json: Ok
+      x-METHODS:
+        - HEAD
+        - OPTIONS
+        - PATCH
+        - DELETE
+        - POST
+        - PUT
+        - GET
 components:
   schemas:
     Pet:


### PR DESCRIPTION
## Purpose
Composer need support for x-MULTI extension. This PR provides swagger to ballerina support for this extension. This PR also include several minor fixes for bal-swagger code generator.

## Goals

- Add support for x-MULTI path extension
- Update default codegen server bindings
- Add inverse support for equals helper
- Update errors after HttpConnectorError changes 