### PR TITLE
Handle argument analysis when arg diag-pos is null

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -1868,7 +1868,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
             if (taintRecord == null) {
                 // This is when current parameter is "sensitive". Therefore, providing a tainted
                 // value to a sensitive parameter is invalid and should return a compiler error.
-                addTaintError(argExpr.pos, paramSymbol.name.value,
+                DiagnosticPos argPos = argExpr.pos != null ? argExpr.pos : invocationExpr.pos;
+                addTaintError(argPos, paramSymbol.name.value,
                         DiagnosticCode.TAINTED_VALUE_PASSED_TO_SENSITIVE_PARAMETER);
             } else if (taintRecord.taintError != null && taintRecord.taintError.size() > 0) {
                 // This is when current parameter is derived to be sensitive. The error already generated
@@ -1877,7 +1878,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                         invocationExpr.symbol.pkgID.name.getValue().equals(mainPkgId.name.getValue())) {
                     addTaintError(taintRecord.taintError);
                 } else {
-                    addTaintError(argExpr.pos, paramSymbol.name.value,
+                    DiagnosticPos argPos = argExpr.pos != null ? argExpr.pos : invocationExpr.pos;
+                    addTaintError(argPos, paramSymbol.name.value,
                             DiagnosticCode.TAINTED_VALUE_PASSED_TO_SENSITIVE_PARAMETER);
                 }
             } else {


### PR DESCRIPTION
## Purpose
When compiling [1], the diag-position of "path" argument is null in the object available in "invocationExpr.requiredArgs", whereas it is not null in the object present in "invocationExpr.argExprs". This change make sure taint checking mechanism works regardless of the arg diag-position being available.

[1] https://github.com/ayomawdb/ballerina/blob/64906d998cdfa02bdfb43722a93903b89e659242/stdlib/ballerina-http/src/main/ballerina/http/http_retry_client.bal#L205