### PR TITLE
Stop HSQL server

### DIFF
--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
@@ -44,6 +44,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class MetricsTestCase {
 
     private ServerInstance serverInstance;
+    private SQLDBUtils.SqlServer sqlServer;
     private static final String RESOURCE_LOCATION = "src" + File.separator + "test" + File.separator +
             "resources" + File.separator + "observability" + File.separator + "metrics" + File.separator;
     private static final String DB_NAME = "TEST_DB";
@@ -56,7 +57,7 @@ public class MetricsTestCase {
                 File.separator + "bre" + File.separator + "lib" + File.separator + "hsqldb.jar").toPath(),
                 REPLACE_EXISTING);
         SQLDBUtils.deleteFiles(new File(SQLDBUtils.DB_DIRECTORY), DB_NAME);
-        SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "observability" +
+        sqlServer = SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "observability" +
                 File.separator + "metrics" + File.separator + "data.sql");
         String balFile = new File(RESOURCE_LOCATION + "metrics-test.bal").getAbsolutePath();
         serverInstance.setArguments(new String[]{balFile, "--observe"});
@@ -98,6 +99,7 @@ public class MetricsTestCase {
     @AfterClass
     private void cleanup() throws Exception {
         serverInstance.stopServer();
+        sqlServer.stop();
     }
 
     private void addMetrics() {

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/transaction/MicroTransactionTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/transaction/MicroTransactionTestCase.java
@@ -44,6 +44,7 @@ public class MicroTransactionTestCase {
     private ServerInstance initiator;
     private ServerInstance participant1;
     private ServerInstance participant2;
+    private SQLDBUtils.SqlServer sqlServer;
     private static final String DB_NAME = "TEST_SQL_CONNECTOR";
     private static final String[] ARGS = {"-e", "http.coordinator.host=127.0.0.1"};
 
@@ -64,7 +65,7 @@ public class MicroTransactionTestCase {
                 new File(participant2.getServerHome() + File.separator + "bre" + File.separator + "lib" +
                         File.separator + "hsqldb.jar"));
         SQLDBUtils.deleteFiles(new File(SQLDBUtils.DB_DIRECTORY), DB_NAME);
-        SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "transaction/data.sql");
+        sqlServer = SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "transaction/data.sql");
         participant2.
                 startBallerinaServer(new File("src" + File.separator + "test" + File.separator + "resources"
                         + File.separator + "transaction" + File.separator + "participant2.bal").getAbsolutePath(),
@@ -299,6 +300,7 @@ public class MicroTransactionTestCase {
         initiator.stopServer();
         participant1.stopServer();
         participant2.stopServer();
+        sqlServer.stop();
     }
 
     private static void copyFile(File source, File dest) throws IOException {

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/SQLDBUtils.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/SQLDBUtils.java
@@ -23,6 +23,7 @@ import org.hsqldb.persist.HsqlProperties;
 import org.hsqldb.server.ServerAcl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,7 +51,7 @@ public class SQLDBUtils {
      * @param dbName      Name of the DB instance.
      * @param sqlFile     SQL statements for initialization.
      */
-    public static void initDatabase(String dbDirectory, String dbName, String sqlFile) {
+    public static SqlServer initDatabase(String dbDirectory, String dbName, String sqlFile) {
         Connection connection = null;
         Statement st = null;
         try {
@@ -75,13 +76,29 @@ public class SQLDBUtils {
             Server server = new Server();
             server.setProperties(p);
             server.start();
+            return new SqlServer(server);
         } catch (ClassNotFoundException | SQLException | ServerAcl.AclFormatException | IOException e) {
             LOG.error("Error ", e);
+            return new SqlServer(null);
         } finally {
             releaseResources(connection, st);
         }
     }
 
+    public static class SqlServer {
+
+        final Server server;
+
+        private SqlServer(Server server) {
+            this.server = server;
+        }
+
+        public void stop() {
+            if (server != null) {
+                server.stop();
+            }
+        }
+    }
 
     /**
      * Delete the given directory along with all files and sub directories.


### PR DESCRIPTION
## Purpose
We need to stop HSQL server in each test to make sure that HSQL server can be started from any test case.

## Goals
Introduce an object with stop method when initializing database.

## Automation tests
 - Integration tests
MetricsTestCase and MicroTransactionTestCase was passed

## Test environment
Java 1.8.0_162 on Ubuntu 17.10