### PR TITLE
Remove TransferEncoding from EP configs

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -74,7 +74,6 @@ documentation {
     F{{circuitBreaker}} Configurations associated with Circuit Breaker behaviour
     F{{timeoutMillis}} The maximum time to wait (in milliseconds) for a response before closing the connection
     F{{keepAlive}} Specifies whether to reuse a connection for multiple requests
-    F{{transferEncoding}} The types of encoding applied to the request
     F{{chunking}} The chunking behaviour of the request
     F{{httpVersion}} The HTTP version understood by the client
     F{{forwarded}} The choice of setting `forwarded`/`x-forwarded` header
@@ -92,7 +91,6 @@ public type ClientEndpointConfig {
     CircuitBreakerConfig? circuitBreaker,
     int timeoutMillis = 60000,
     KeepAlive keepAlive = KEEPALIVE_AUTO,
-    TransferEncoding transferEncoding = "CHUNKING",
     Chunking chunking = "AUTO",
     string httpVersion = "1.1",
     string forwarded = "disable",

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
@@ -58,7 +58,6 @@ documentation {
     F{{httpVersion}} The HTTP version supported by the endpoint
     F{{forwarded}} The choice of setting `forwarded`/`x-forwarded` header
     F{{keepAlive}} Specifies whether to reuse a connection for multiple requests
-    F{{transferEncoding}} The types of encoding applied to the request
     F{{chunking}} The chunking behaviour of the request
     F{{followRedirects}} Redirect related options
     F{{retryConfig}} Retry related options
@@ -77,7 +76,6 @@ public type FailoverClientEndpointConfiguration {
     string httpVersion = "1.1",
     string forwarded = "disable",
     KeepAlive keepAlive = KEEPALIVE_AUTO,
-    TransferEncoding transferEncoding = "CHUNKING",
     Chunking chunking = "AUTO",
     FollowRedirects? followRedirects,
     RetryConfig? retryConfig,
@@ -98,7 +96,6 @@ public function FailoverClient::init(FailoverClientEndpointConfiguration failove
     self.httpEP.config.httpVersion = failoverClientConfig.httpVersion;
     self.httpEP.config.forwarded = failoverClientConfig.forwarded;
     self.httpEP.config.keepAlive = failoverClientConfig.keepAlive;
-    self.httpEP.config.transferEncoding = failoverClientConfig.transferEncoding;
     self.httpEP.config.chunking = failoverClientConfig.chunking;
     self.httpEP.config.followRedirects = failoverClientConfig.followRedirects;
     self.httpEP.config.retryConfig = failoverClientConfig.retryConfig;
@@ -113,7 +110,6 @@ function createClientEPConfigFromFailoverEPConfig(FailoverClientEndpointConfigur
         circuitBreaker:foConfig.circuitBreaker,
         timeoutMillis:foConfig.timeoutMillis,
         keepAlive:foConfig.keepAlive,
-        transferEncoding:foConfig.transferEncoding,
         chunking:foConfig.chunking,
         httpVersion:foConfig.httpVersion,
         forwarded:foConfig.forwarded,

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_commons.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_commons.bal
@@ -55,17 +55,6 @@ documentation {Never set accept-encoding header in outbound request/response.}
 @final public Compression COMPRESSION_NEVER = "NEVER";
 
 documentation {
-    Represent transfer encoding options.
-
-    `CHUNKING`: Payload is divided into chunks of data if payload is larger than 8KB
-}
-public type TransferEncoding "CHUNKING";
-
-
-documentation {Payload is divided into chunks of data if payload is larger than 8KB.}
-@final public TransferEncoding TRANSFERENCODE_CHUNKING = "CHUNKING";
-
-documentation {
     A record for providing trust store related configurations.
 
     F{{path}} Path to the trust store file

--- a/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
@@ -54,7 +54,6 @@ documentation {
     F{{httpVersion}} The HTTP version to be used to communicate with the endpoint
     F{{forwarded}} The choice of setting forwarded/x-forwarded header
     F{{keepAlive}} Specifies whether to keep the connection alive (or not) for multiple request/response pairs
-    F{{transferEncoding}} The types of encoding applied to the request
     F{{chunking}} The chunking behaviour of the request
     F{{followRedirects}} Redirect related options
     F{{retryConfig}} Retry related options
@@ -73,7 +72,6 @@ public type LoadBalanceClientEndpointConfiguration {
     string httpVersion = "1.1",
     string forwarded = "disable",
     KeepAlive keepAlive = KEEPALIVE_AUTO,
-    TransferEncoding transferEncoding = "CHUNKING",
     Chunking chunking = "AUTO",
     FollowRedirects? followRedirects,
     RetryConfig? retryConfig,
@@ -94,7 +92,6 @@ public function LoadBalanceClient::init(LoadBalanceClientEndpointConfiguration l
     self.httpEP.config.httpVersion = loadBalanceClientConfig.httpVersion;
     self.httpEP.config.forwarded = loadBalanceClientConfig.forwarded;
     self.httpEP.config.keepAlive = loadBalanceClientConfig.keepAlive;
-    self.httpEP.config.transferEncoding = loadBalanceClientConfig.transferEncoding;
     self.httpEP.config.chunking = loadBalanceClientConfig.chunking;
     self.httpEP.config.followRedirects = loadBalanceClientConfig.followRedirects;
     self.httpEP.config.retryConfig = loadBalanceClientConfig.retryConfig;
@@ -109,7 +106,6 @@ function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientEndpointCo
         circuitBreaker:lbConfig.circuitBreaker,
         timeoutMillis:lbConfig.timeoutMillis,
         keepAlive:lbConfig.keepAlive,
-        transferEncoding:lbConfig.transferEncoding,
         chunking:lbConfig.chunking,
         httpVersion:lbConfig.httpVersion,
         forwarded:lbConfig.forwarded,

--- a/stdlib/ballerina-http/src/main/ballerina/http/secure_listener.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/secure_listener.bal
@@ -76,7 +76,6 @@ documentation {
     F{{host}} Host of the endpoint
     F{{port}} Port of the endpoint
     F{{keepAlive}} The keepAlive behaviour of the endpoint
-    F{{transferEncoding}} The types of encoding applied to the response
     F{{secureSocket}} The SSL configurations for the `endpoint`
     F{{httpVersion}} Highest HTTP version supported
     F{{requestLimits}} Request validation limits configuration
@@ -87,7 +86,6 @@ public type SecureEndpointConfiguration {
     string host,
     int port = 9090,
     KeepAlive keepAlive = KEEPALIVE_AUTO,
-    TransferEncoding transferEncoding = TRANSFERENCODE_CHUNKING,
     ServiceSecureSocket? secureSocket,
     string httpVersion = "1.1",
     RequestLimits? requestLimits,

--- a/stdlib/ballerina-http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/service_endpoint.bal
@@ -119,7 +119,6 @@ documentation {
     F{{port}} The port to which the endpoint should bind to
     F{{keepAlive}} Can be set to either `KEEPALIVE_AUTO`, which respects the `connection` header, or `KEEPALIVE_ALWAYS`,
                    which always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection
-    F{{transferEncoding}} The types of encoding applied to the response
     F{{secureSocket}} The SSL configurations for the service endpoint. This needs to be configured in order to
                       communicate through HTTPS.
     F{{httpVersion}} Highest HTTP version supported by the endpoint
@@ -131,7 +130,6 @@ public type ServiceEndpointConfiguration {
     string host,
     int port,
     KeepAlive keepAlive = KEEPALIVE_AUTO,
-    TransferEncoding transferEncoding = TRANSFERENCODE_CHUNKING,
     ServiceSecureSocket? secureSocket,
     string httpVersion = "1.1",
     RequestLimits? requestLimits,

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -105,7 +105,6 @@ public class HttpConstants {
     public static final String ANN_CONFIG_ATTR_CACHE_SIZE = "cacheSize";
     public static final String ANN_CONFIG_ATTR_CACHE_VALIDITY_PERIOD = "cacheValidityPeriod";
     public static final String ANN_CONFIG_ATTR_WEBSOCKET = "webSocket";
-    public static final String ANN_CONFIG_ATTR_TRANSFER_ENCODING = "transferEncoding";
     public static final String ANN_CONFIG_ATTR_MAXIMUM_URL_LENGTH = "maxUriLength";
     public static final String ANN_CONFIG_ATTR_MAXIMUM_HEADER_SIZE = "maxHeaderSize";
     public static final String ANN_CONFIG_ATTR_MAXIMUM_ENTITY_BODY_SIZE = "maxEntityBodySize";
@@ -276,7 +275,6 @@ public class HttpConstants {
 
     //Service Endpoint Config
     public static final String ENDPOINT_CONFIG_HOST = "host";
-    public static final String ENDPOINT_CONFIG_TRANSFER_ENCODING = "transferEncoding";
     public static final String ENDPOINT_CONFIG_PORT = "port";
     public static final String ENDPOINT_CONFIG_KEEP_ALIVE = "keepAlive";
     public static final String ENDPOINT_CONFIG_CHUNKING = "chunking";
@@ -314,7 +312,6 @@ public class HttpConstants {
 
     //Client Endpoint Config
     public static final String URI = "uri";
-    public static final String CLIENT_EP_TRNASFER_ENCODING = "transferEncoding";
     public static final String CLIENT_EP_CHUNKING = "chunking";
     public static final String CLIENT_EP_ENDPOINT_TIMEOUT = "timeoutMillis";
     public static final String CLIENT_EP_IS_KEEP_ALIVE = "keepAlive";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
@@ -246,15 +246,6 @@ public class CreateHttpClient extends BlockingNativeCallableUnit {
         senderConfiguration.setFollowRedirect(followRedirect);
         senderConfiguration.setMaxRedirectCount(maxRedirectCount);
 
-        // For the moment we don't have to pass it down to transport as we only support
-        // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-        String transferEncoding =
-                clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_TRNASFER_ENCODING).getStringValue();
-        if (transferEncoding != null && !HttpConstants.ANN_CONFIG_ATTR_CHUNKING.equalsIgnoreCase(transferEncoding)) {
-            throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
-                    + transferEncoding);
-        }
-
         String chunking = clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_CHUNKING).getStringValue();
         senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -242,15 +242,6 @@ public class CreateSimpleHttpClient extends BlockingNativeCallableUnit {
         senderConfiguration.setFollowRedirect(followRedirect);
         senderConfiguration.setMaxRedirectCount(maxRedirectCount);
 
-        // For the moment we don't have to pass it down to transport as we only support
-        // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-        String transferEncoding =
-                clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_TRNASFER_ENCODING).getStringValue();
-        if (transferEncoding != null && !HttpConstants.ANN_CONFIG_ATTR_CHUNKING.equalsIgnoreCase(transferEncoding)) {
-            throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
-                    + transferEncoding);
-        }
-
         String chunking = clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_CHUNKING).getStringValue();
         senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/InitEndpoint.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/InitEndpoint.java
@@ -112,8 +112,6 @@ public class InitEndpoint extends BlockingNativeCallableUnit {
         String host = endpointConfig.getStringField(HttpConstants.ENDPOINT_CONFIG_HOST);
         long port = endpointConfig.getIntField(HttpConstants.ENDPOINT_CONFIG_PORT);
         String keepAlive = endpointConfig.getRefField(HttpConstants.ENDPOINT_CONFIG_KEEP_ALIVE).getStringValue();
-        String transferEncoding =
-                endpointConfig.getRefField(HttpConstants.ENDPOINT_CONFIG_TRANSFER_ENCODING).getStringValue();
         Struct sslConfig = endpointConfig.getStructField(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
         String httpVersion = endpointConfig.getStringField(HttpConstants.ENDPOINT_CONFIG_VERSION);
         Struct requestLimits = endpointConfig.getStructField(HttpConstants.ENDPOINT_REQUEST_LIMITS);
@@ -133,14 +131,6 @@ public class InitEndpoint extends BlockingNativeCallableUnit {
         listenerConfiguration.setPort(Math.toIntExact(port));
 
         listenerConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAlive));
-
-        // For the moment we don't have to pass it down to transport as we only support
-        // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-        if ((!transferEncoding.isEmpty()) && !HttpConstants.ANN_CONFIG_ATTR_CHUNKING
-                .equalsIgnoreCase(transferEncoding)) {
-            throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
-                                                          + transferEncoding);
-        }
 
         // Set Request validation limits.
         if (requestLimits != null) {


### PR DESCRIPTION
## Purpose
To remove TransferEncoding configurations from Service and Client EP configurations.