### PR TITLE
Sync server field and setting the server header through setHeader()

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/http_headers.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_headers.bal
@@ -82,5 +82,10 @@ documentation {
 }
 @final public string PRAGMA = "pragma";
 
+documentation {
+    HTTP header key `server`. Specifies the details of the origin server.
+}
+@final public string SERVER = "server";
+
 documentation { HTTP header key `warning`. Specifies warnings generated when serving stale responses from HTTP caches. }
 @final public string WARNING = "warning";

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_response.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_response.bal
@@ -306,6 +306,11 @@ public function Response::getHeaders(string headerName) returns (string[]) {
 public function Response::setHeader(string headerName, string headerValue) {
     mime:Entity entity = self.getEntityWithoutBody();
     entity.setHeader(headerName, headerValue);
+
+    // TODO: see if this can be handled in a better manner
+    if (SERVER.equalsIgnoreCase(headerName)) {
+        self.server = headerValue;
+    }
 }
 
 public function Response::removeHeader(string key) {


### PR DESCRIPTION
## Purpose
> Syncs the `server` field in `Response` and the `setHeader()` function of `Response`. Now, the `server` header can be set in either of the following ways:
```ballerina
http:Response resp = new;
resp.setHeader(http:SERVER, "Ballerina");
// or
resp.server = "Ballerina";
```
> fix #2935