### PR TITLE
Check for constraint in stream assignability

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -217,7 +217,7 @@ public class Types {
         }
 
         if (target.tag == TypeTags.STREAM && source.tag == TypeTags.STREAM) {
-            return true;
+            return isAssignable(((BStreamType) source).constraint, ((BStreamType) target).constraint);
         }
 
         BSymbol symbol = symResolver.resolveImplicitConversionOp(source, target);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -16,6 +16,7 @@
  */
 package org.ballerinalang.test.types.stream;
 
+import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
@@ -37,10 +38,33 @@ import java.util.Objects;
 public class BStreamValueTest {
 
     private CompileResult result;
+    private CompileResult failureResult;
 
     @BeforeClass
     public void setup() {
         result = BCompileUtil.compile("test-src/types/stream/stream-value.bal");
+        failureResult = BCompileUtil.compile("test-src/types/stream/stream-negative.bal");
+    }
+
+    @Test(description = "Test streams for invalid scenarios")
+    public void testConstrainedStreamNegative() {
+        Assert.assertEquals(failureResult.getErrorCount(), 8);
+        BAssertUtil.validateError(failureResult, 0, "incompatible types: expected 'stream<int>',"
+                                  + " found 'stream'", 14, 12);
+        BAssertUtil.validateError(failureResult, 1, "incompatible types: expected 'stream<int>',"
+                                  + " found 'stream<string>'", 19, 12);
+        BAssertUtil.validateError(failureResult, 2, "incompatible types: expected"
+                                  + " 'stream<Person>', found 'stream<Employee>'", 24, 37);
+        BAssertUtil.validateError(failureResult, 3, "incompatible types: expected"
+                                  + " 'stream<Person>', found 'stream'", 30, 37);
+        BAssertUtil.validateError(failureResult, 4, "incompatible types: 'stream<Employee>'"
+                                  + " cannot be converted to 'stream<Person>'", 41, 24);
+        BAssertUtil.validateError(failureResult, 5, "incompatible types: 'Employee' cannot be"
+                                  + " converted to 'stream<int>'", 48, 17);
+        BAssertUtil.validateError(failureResult, 6, "incompatible types: 'stream<Person>' cannot"
+                                  + " be converted to 'stream<Employee>'", 55, 26);
+        BAssertUtil.validateError(failureResult, 7, "incompatible types: 'any' cannot be"
+                                  + " converted to 'stream<Employee>'", 63, 18);
     }
 
     @Test(description = "Test publishing objects of invalid type to a stream",

--- a/tests/ballerina-test/src/test/resources/test-src/types/stream/stream-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/stream/stream-negative.bal
@@ -1,0 +1,65 @@
+type Person {
+    string name;
+    int age;
+    string address;
+};
+
+type Employee {
+    string name;
+    int age;
+};
+
+function testInvalidStreamAssignment() returns stream<int> {
+    stream testStream;
+    return testStream;
+}
+
+function testInvalidConstrainedStreamAssignment() returns stream<int> {
+    stream<string> testStream;
+    return testStream;
+}
+
+function testStreamAsInvalidArgument() returns stream<Person> {
+    stream<Employee> testStream;
+    stream<Person> m = returnStream(testStream);
+    return m;
+}
+
+function testAnyStreamAsInvalidArgument() returns stream<Person> {
+    stream testStream;
+    stream<Person> m = returnStream(testStream);
+    return m;
+}
+
+function returnStream(stream<Person> m) returns stream<Person> {
+    return m;
+}
+
+function testInvalidObjectConstrainedStreamCast() returns stream<Person> {
+    stream<Employee> testEmployeeStream;
+    stream<Person> testPersonStream;
+    testPersonStream = <stream<Person>>testEmployeeStream;
+    return testPersonStream;
+}
+
+function testInvalidObjectToConstrainedStreamCast() returns stream<int> {
+    Employee s = {name:"Anne", age:25};
+    stream<int> intStream;
+    intStream = <stream<int>>s;
+    return intStream;
+}
+
+function testInvalidConstrainedStreamCast() returns stream<Employee> {
+    stream<Person> testPersonStream;
+    stream<Employee> testEmployeeStream;
+    testEmployeeStream = <stream<Employee>>testPersonStream;
+    return testEmployeeStream;
+}
+
+function testInvalidAnyToConstrainedStreamCast() returns stream<Employee> {
+    stream<Employee> testStream;
+    any anyValue = testStream;
+    stream<Employee> castStream;
+    castStream = <stream<Employee>>anyValue;
+    return castStream;
+}


### PR DESCRIPTION
## Purpose
This PR adds changes to consider the type by which the stream is constrained, when checking if a stream is assignable to another.