### PR TITLE
[WebSub] Switch to HTTP redirection functionality

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -153,7 +153,7 @@ documentation {
     Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.
 
     F{{enabled}} Enable/disable redirection
-    F{{maxCount}} Maximun number of redirects to follow
+    F{{maxCount}} Maximum number of redirects to follow
 }
 public type FollowRedirects {
     boolean enabled = false,

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/annotation.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/annotation.bal
@@ -34,6 +34,8 @@ documentation {
     F{{callback}} The callback to use when registering, if unspecified host:port/path will be used
     F{{auth}} The auth configuration to use when subscribing at the hub
     F{{secureSocket}} The secure socket configuration to use when subscribing at the hub
+    F{{followRedirects}} The HTTP redirect related configuration specifying if subscription requests should be sent
+                            to redirected hubs/topics
 }
 public type SubscriberServiceConfiguration {
     Listener[] endpoints,
@@ -47,6 +49,7 @@ public type SubscriberServiceConfiguration {
     string callback,
     http:AuthConfig? auth,
     http:SecureSocket? secureSocket,
+    http:FollowRedirects? followRedirects,
 };
 
 documentation {

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/hub_client_endpoint.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/hub_client_endpoint.bal
@@ -43,7 +43,10 @@ public type Client object {
     }
     public function init(HubClientEndpointConfig config) {
         endpoint http:Client httpClientEndpoint {
-            url:config.url, secureSocket:config.secureSocket, auth:config.auth
+            url:config.url,
+            secureSocket:config.secureSocket,
+            auth:config.auth,
+            followRedirects:config.followRedirects
         };
 
         self.httpClientEndpoint = httpClientEndpoint;
@@ -57,7 +60,7 @@ public type Client object {
     }
     public function getCallerActions() returns (CallerActions) {
         //TODO: create a single object - move to init
-        CallerActions webSubHubClientConn = new CallerActions(config.url, httpClientEndpoint);
+        CallerActions webSubHubClientConn = new CallerActions(config.url, httpClientEndpoint, config.followRedirects);
         return webSubHubClientConn;
     }
 
@@ -69,9 +72,11 @@ documentation {
     F{{url}} The URL of the target Hub
     F{{secureSocket}} SSL/TLS related options for the underlying HTTP Client
     F{{auth}} Authentication mechanism for the underlying HTTP Client
+    F{{followRedirects}} HTTP redirect related configuration
 }
 public type HubClientEndpointConfig {
     string url,
     http:SecureSocket? secureSocket,
     http:AuthConfig? auth,
+    http:FollowRedirects? followRedirects,
 };

--- a/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
+++ b/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
@@ -41,6 +41,7 @@ public class WebSubSubscriberConstants {
     public static final String ANN_WEBSUB_ATTR_CALLBACK = "callback";
     public static final String ANN_WEBSUB_ATTR_AUTH_CONFIG = "auth";
     public static final String ANN_WEBSUB_ATTR_SECURE_SOCKET_CONFIG = "secureSocket";
+    public static final String ANN_WEBSUB_ATTR_FOLLOW_REDIRECTS_CONFIG = "followRedirects";
 
     public static final String TOPIC_ID_HEADER = "TOPIC_ID_HEADER";
     public static final String TOPIC_ID_PAYLOAD_KEY = "TOPIC_ID_PAYLOAD_KEY";

--- a/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RetrieveSubscriptionParameters.java
+++ b/stdlib/ballerina-websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RetrieveSubscriptionParameters.java
@@ -97,6 +97,14 @@ public class RetrieveSubscriptionParameters extends AbstractHttpNativeFunction {
             subscriptionDetails.put(WebSubSubscriberConstants.ANN_WEBSUB_ATTR_SECURE_SOCKET_CONFIG, null);
         }
 
+        if (annotationStruct.getRefField(WebSubSubscriberConstants.ANN_WEBSUB_ATTR_FOLLOW_REDIRECTS_CONFIG) != null) {
+            BStruct secureSocket = (BStruct) annotationStruct.getRefField(
+                    WebSubSubscriberConstants.ANN_WEBSUB_ATTR_FOLLOW_REDIRECTS_CONFIG).getVMValue();
+            subscriptionDetails.put(WebSubSubscriberConstants.ANN_WEBSUB_ATTR_FOLLOW_REDIRECTS_CONFIG, secureSocket);
+        } else {
+            subscriptionDetails.put(WebSubSubscriberConstants.ANN_WEBSUB_ATTR_FOLLOW_REDIRECTS_CONFIG, null);
+        }
+
         String callback = annotationStruct.getStringField(WebSubSubscriberConstants.ANN_WEBSUB_ATTR_CALLBACK);
 
         if (callback.isEmpty()) {


### PR DESCRIPTION
## Purpose
This PR switches to the ballerina/http redirection functionality, instead of custom redirection for discovery, since https://github.com/ballerina-platform/ballerina-lang/issues/7339 is now fixed.

We are still using custom redirection for POST requests (subscription) since redirection is not supported for POST requests.