### PR TITLE
Revert "Add doc annotation for endpoint"

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/file/service_endpoint.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/file/service_endpoint.bal
@@ -21,7 +21,6 @@
 documentation {
     Represents directory listener endpoint where used to listen to a directory in the local file system.
 
-    E{{}}
     F{{config}} Represents necessary configurations that need to configure
 }
 public type Listener object {


### PR DESCRIPTION
Reverts ballerina-platform/ballerina-lang#8031. Due to test failures. 