### PR TITLE
Let BLauncher to find SwaggerCmd help

### DIFF
--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
@@ -44,6 +44,7 @@ public class SwaggerCmd implements BLauncherCmd {
     private static final String client = "CLIENT";
     private static final String mock = "MOCK";
     private static final String export = "EXPORT";
+    private static final String CMD_NAME = "swagger";
 
     private static final PrintStream outStream = System.err;
 
@@ -73,7 +74,7 @@ public class SwaggerCmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (helpFlag) {
-            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo("swagger");
+            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(CMD_NAME);
             outStream.println(commandUsageInfo);
             return;
         }
@@ -108,7 +109,7 @@ public class SwaggerCmd implements BLauncherCmd {
 
     @Override
     public String getName() {
-        return "swagger";
+        return CMD_NAME;
     }
 
     @Override

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
@@ -46,7 +46,6 @@ public class SwaggerCmd implements BLauncherCmd {
     private static final String export = "EXPORT";
 
     private static final PrintStream outStream = System.err;
-    private JCommander parentCmdParser;
 
     @Parameter(arity = 1, description = "<action> <swagger spec| ballerina file>. action : mock|client|export")
     private List<String> argList;
@@ -74,7 +73,7 @@ public class SwaggerCmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (helpFlag) {
-            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(parentCmdParser, "swagger");
+            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo("swagger");
             outStream.println(commandUsageInfo);
             return;
         }
@@ -114,22 +113,10 @@ public class SwaggerCmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder out) {
-        out.append("Generates ballerina mock service, client for a given swagger definition ");
-        out.append(System.lineSeparator());
-        out.append("or exports swagger definition of a ballerina service");
-        out.append(System.lineSeparator());
-        out.append(System.lineSeparator());
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
-        stringBuilder.append("  ballerina swagger <mock | client> <swagger file> -p<package name> "
-                + "-o[<output directory name>]\n");
-        stringBuilder.append("  ballerina swagger export <ballerina service file> -o[<output directory name>] "
-                + "-s<service name>\n");
-        stringBuilder.append("\tmock      : generates a ballerina mock service\n");
-        stringBuilder.append("\tclient    : generates a ballerina client\n");
-        stringBuilder.append("\texport    : exports swagger definition of a ballerina service\n");
     }
 
     private void generateFromSwagger(String targetLanguage) {
@@ -172,7 +159,6 @@ public class SwaggerCmd implements BLauncherCmd {
 
     @Override
     public void setParentCmdParser(JCommander parentCmdParser) {
-        this.parentCmdParser = parentCmdParser;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
'man page' type help content is now processed by parent command launcher. Each command doesn't need to provide help content separately.