### PR TITLE
Remove invalid test cases

### DIFF
--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLNativeFunctionTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLNativeFunctionTest.java
@@ -1355,22 +1355,6 @@ public class XMLNativeFunctionTest {
         Assert.assertEquals(returns[0].stringValue(), "<name xmlns:a=\"yyy\" a:text=\"hello\"/>");
     }
 
-    @Test(enabled = false)
-    public void testParseXMLElementWithXMLDeclrEntity() {
-        BValue[] returns = BRunUtil.invoke(result, "testParseXMLElementWithXMLDeclrEntity");
-        Assert.assertTrue(returns[0] instanceof BXML);
-        Assert.assertEquals(returns[0].stringValue(), "<root>hello world</root>");
-    }
-
-    @Test(enabled = false)
-    public void testParseXMLCommentWithXMLDeclrEntity() {
-        BValue[] returns = BRunUtil.invoke(result, "testParseXMLCommentWithXMLDeclrEntity");
-        Assert.assertEquals(returns[0], null);
-        Assert.assertTrue(returns[1].stringValue().startsWith("{message:\"failed to create xml: " +
-                "Unexpected EOF in prolog"));
-        Assert.assertTrue(returns[1].stringValue().endsWith("at [row,col {unknown-source}]: [1,74]\", cause:null}"));
-    }
-
     @Test
     public void testRemoveAttributeUsingStringName() {
         BValue[] returns = BRunUtil.invoke(result, "testRemoveAttributeUsingStringName");

--- a/tests/ballerina-test/src/test/resources/test-src/types/xml/xml-native-functions.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/xml/xml-native-functions.bal
@@ -814,16 +814,6 @@ function testUpdateAttributeWithDifferentUri() returns (xml) {
     return x1;
 }
 
-//function testParseXMLElementWithXMLDeclrEntity() returns (xml) {
-//    var x = xml `<?xml version='1.0' encoding='UTF-8' standalone='no'?><root>hello world</root>`;
-//    return x;
-//}
-
-//function testParseXMLCommentWithXMLDeclrEntity() returns (xml, error) {
-//    var (x, e) = <xml> "<?xml version='1.0' encoding='UTF-8' standalone='no'?><!-- comment node-->";
-//    return (x, e);
-//}
-
 function testRemoveAttributeUsingStringName() returns (xml) {
   xmlns "http://ballerina.com/aaa" as ns0;
   xml x = xml `<root xmlns:ns1="http://ballerina.com/bbb" foo1="bar1" ns0:foo1="bar2" ns1:foo1="bar3" ns0:foo2="bar4"> hello world!</root>`;


### PR DESCRIPTION
The intention of the original test case was to check conversion from string to xml, when there is a xml-declaration tag in the content.
However, since we have removed the string to xml conversion support, this test is no longer valid.