### PR TITLE
Fix white spaces ignored when compiling

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1052,6 +1052,7 @@ public class BLangPackageBuilder {
         BLangNameReference nameReference = nameReferenceStack.pop();
         invocationNode.name = (BLangIdentifier) nameReference.name;
         invocationNode.addWS(this.invocationWsStack.pop());
+        invocationNode.addWS(nameReference.ws);
         invocationNode.pkgAlias = (BLangIdentifier) nameReference.pkgAlias;
         addExpressionNode(invocationNode);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -487,7 +487,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
             compilationPath = LSCompiler.createAndGetTempFile(tempFileId);
         }
         balFile = LSCompiler.compileContent(content, compilationPath, CompilerPhase.TAINT_ANALYZE, documentManager,
-                                            false);
+                true);
         if (balFile.getDiagnostics() != null) {
             balDiagnostics = balFile.getDiagnostics();
         }
@@ -569,9 +569,9 @@ class BallerinaTextDocumentService implements TextDocumentService {
     @Override
     public void didSave(DidSaveTextDocumentParams params) {
     }
-    
+
     // Private methods
-    
+
     private void fillNewPackages(BLangPackage bLangPackage) {
         if (bLangPackage == null) {
             return;


### PR DESCRIPTION
## Purpose
> This fixes the issue where whitespaces are ignored while compiling a .bal file in composer for drawing the diagram. This causes codes to get their white spaces removed and and some case made them invalid.