### PR TITLE
Fix issue #7705

### DIFF
--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/csv/Format.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/csv/Format.java
@@ -25,15 +25,15 @@ public enum Format {
     /**
      * The format would default, however empty lines will be allowed.
      */
-    DEFAULT(",", "\\r?\\n", ",", "\n", false),
+    DEFAULT(",", "\\r?\\n", ",", "\n", false, false),
     /**
      * CSV should conform with RFC4180 specification.
      */
-    CSV(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "\\r?\\n", ",", "\n", true),
+    CSV("\"|,(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "\\r?\\n", ",", "\n", true, true),
     /**
      * Tab delimited records.
      */
-    TDF("\\t", "\\r?\\n", "\t", "\n", true);
+    TDF("\\t", "\\r?\\n", "\t", "\n", true, false);
 
     /**
      * Defines the record separator for the format.
@@ -55,13 +55,18 @@ public enum Format {
      * Specifies whether white spaces should be ignored.
      */
     private boolean ignoreSpaces;
+    /**
+     * Specifies whether to ignore blanks.
+     */
+    private boolean ignoreBlanks;
 
-    Format(String rfs, String rrs, String wfs, String wrs, boolean ignoreSpaces) {
+    Format(String rfs, String rrs, String wfs, String wrs, boolean ignoreSpaces, boolean ignoreBlank) {
         this.readFieldSeparator = rfs;
         this.readRecSeparator = rrs;
         this.writeFieldSeparator = wfs;
         this.writeRecSeparator = wrs;
         this.ignoreSpaces = ignoreSpaces;
+        this.ignoreBlanks = ignoreBlank;
     }
 
     public String getReadRecSeparator() {
@@ -80,7 +85,11 @@ public enum Format {
         return writeFieldSeparator;
     }
 
-    public boolean isIgnoreSpaces() {
+    public boolean shouldIgnoreSpaces() {
         return ignoreSpaces;
+    }
+
+    public boolean shouldIgnoreBlanks() {
+        return ignoreBlanks;
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/CsvChannelTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/CsvChannelTest.java
@@ -227,6 +227,8 @@ public class CsvChannelTest {
         BValue[] returns = BRunUtil.invokeStateful(csvInputOutputProgramFile, "nextRecord");
         records = (BStringArray) returns[0];
         Assert.assertEquals(records.size(), expectedRecordLength);
+        Assert.assertEquals(records.stringValue(), "[\"User1,12\", \" WSO2\", \" 07xxxxxx\"]");
+
         returns = BRunUtil.invokeStateful(csvInputOutputProgramFile, "hasNextRecord");
         hasNextRecord = (BBoolean) returns[0];
         Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
@@ -304,6 +306,12 @@ public class CsvChannelTest {
         BValue[] args = {new BString(sourceToWrite), new BString("w"), new BString("UTF-8"),
                 new BString(",")};
         BRunUtil.invokeStateful(csvInputOutputProgramFile, "initCSVChannel", args);
+
+        args = new BValue[]{record};
+        BRunUtil.invokeStateful(csvInputOutputProgramFile, "writeRecord", args);
+
+        String[] data = {"Foo,12", "foo@ballerina.io", "332424242"};
+        record = new BStringArray(data);
 
         args = new BValue[]{record};
         BRunUtil.invokeStateful(csvInputOutputProgramFile, "writeRecord", args);


### PR DESCRIPTION
## Purpose
Fix issue describe in #7705

## Goals
- Fix the issue #7705
- Modify/Add relevant test cases

## Approach
When reading CSV files the enclosing quotes will be omitted by using the following regular expression,

```
"|,(?=([^"]*"[^"]*")*[^"]*$)
```

If any of the blank spaces/white spaces are left. They will be skipped. Hence a recursive skip function was introduced, instead of using java skip(..) directly to skip between all the fields. This was done to obtain advantage in terms of performance. 

## Release note
- Internally handles composite CSV fields by omitting the enclosing quotes 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8