### PR TITLE
Fix error popping out when opening non existent files kept in web storage

### DIFF
--- a/composer/modules/web/src/core/editor/constants.js
+++ b/composer/modules/web/src/core/editor/constants.js
@@ -41,6 +41,7 @@ export const VIEWS = {
 export const DIALOGS = {
     DIRTY_CLOSE_CONFIRM: 'composer.dialog.editor.dirty-file-close-confirm',
     OPENED_FILE_DELETE_CONFIRM: 'composer.dialog.editor.opened-file-delete-confirm',
+    NON_EXISTENT_FILE_OPEN_CONFIRM: 'composer.dialog.editor.non-existent-file-open-confirm',
 };
 
 export const MENUS = {

--- a/composer/modules/web/src/core/editor/dialogs/NonExistentFileOpenConfirmDialog.jsx
+++ b/composer/modules/web/src/core/editor/dialogs/NonExistentFileOpenConfirmDialog.jsx
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'semantic-ui-react';
+import Dialog from './../../view/Dialog';
+
+/**
+ * Confirm Dialog when opening non existent files
+ * @extends React.Component
+ */
+class NonExistentFileOpenConfirmDialog extends React.Component {
+
+    /**
+     * @inheritdoc
+     */
+    constructor(props) {
+        super(props);
+        this.state = {
+            error: '',
+            showDialog: true,
+        };
+        this.onDialogHide = this.onDialogHide.bind(this);
+    }
+
+    /**
+     * Called when user hides the dialog
+     */
+    onDialogHide() {
+        this.setState({
+            error: '',
+            showDialog: false,
+        });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    render() {
+        return (
+            <Dialog
+                show={this.state.showDialog}
+                title='File Not Found'
+                titleIcon='warning circle'
+                actions={[
+                    <Button
+                        key='non-existent-file-open-confirm-dialog-save'
+                        primary
+                        onClick={(evt) => {
+                            this.onDialogHide();
+                            this.props.onSave();
+                            evt.stopPropagation();
+                            evt.preventDefault();
+                        }}
+                    >
+                        Save
+                    </Button>,
+                    <Button
+                        key='non-existent-file-open-confirm-dialog-close-n-delete'
+                        secondary
+                        onClick={(evt) => {
+                            this.onDialogHide();
+                            this.props.onConfirm();
+                            evt.stopPropagation();
+                            evt.preventDefault();
+                        }}
+                    >
+                        Remove
+                    </Button>,
+                ]}
+                closeAction
+                onHide={this.onDialogHide}
+                onAfterHide={this.props.onAfterHide}
+                error={this.state.error}
+            >
+                <h4>
+                    Opened file cannot be found in the disk. Do you want to save the changes you made to
+                    {' "' + this.props.file.name + '.' + this.props.file.extension + '" '}?
+                </h4>
+                <p>
+                    Your changes will be lost if you don&#39;t save them.
+                </p>
+
+            </Dialog>
+        );
+    }
+}
+
+NonExistentFileOpenConfirmDialog.propTypes = {
+    file: PropTypes.objectOf(Object).isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    onAfterHide: PropTypes.func,
+    onSave: PropTypes.func.isRequired,
+};
+
+NonExistentFileOpenConfirmDialog.defaultProps = {
+    onAfterHide: () => { },
+};
+
+export default NonExistentFileOpenConfirmDialog;

--- a/composer/modules/web/src/core/editor/plugin.js
+++ b/composer/modules/web/src/core/editor/plugin.js
@@ -25,6 +25,7 @@ import { REGIONS, COMMANDS as LAYOUT_COMMANDS } from './../layout/constants';
 import { getCommandDefinitions } from './commands';
 import { getHandlerDefinitions } from './handlers';
 import { getMenuDefinitions } from './menus';
+import { exists } from './../workspace/fs-util';
 import { PLUGIN_ID, VIEWS as VIEW_IDS, HISTORY, COMMANDS as COMMMAND_IDS,
     EVENTS, TOOLS as TOOL_IDS, DIALOGS as DIALOG_IDS } from './constants';
 import { EVENTS as WORKSPACE_EVENTS, COMMANDS as WORKSPACE_COMMANDS } from './../workspace/constants';
@@ -35,6 +36,7 @@ import Editor from './model/Editor';
 
 import DirtyFileCloseConfirmDialog from './dialogs/DirtyFileCloseConfirmDialog';
 import OpenedFileDeleteConfirmDialog from './dialogs/OpenedFileDeleteConfirmDialog';
+import NonExistentFileOpenConfirmDialog from './dialogs/NonExistentFileOpenConfirmDialog';
 
 /**
  * Editor Plugin is responsible for providing editors to opening files.
@@ -183,6 +185,15 @@ class EditorPlugin extends Plugin {
      * @param {EditorTab} editor
      */
     setActiveEditor(editor) {
+        if (editor instanceof Editor && !editor.file.fullPath.endsWith("untitled.bal")) {
+            exists(editor.file.fullPath).then((response) => {
+                if (response.exists === false) {
+                    this.showNonExistentFileOpenDialog(editor);
+                }
+            }).catch(() => {
+                this.showNonExistentFileOpenDialog(editor);
+            });
+        }
         this.activeEditor = editor;
         this.activeEditorID = editor ? editor.id : undefined;
         const { pref: { history }, workspace, command: { dispatch } } = this.appContext;
@@ -195,6 +206,31 @@ class EditorPlugin extends Plugin {
             }, 100);
         }
         dispatch(EVENTS.ACTIVE_TAB_CHANGE, { editor });
+    }
+
+    /**
+     * Shows non-existent file open dialog box.
+     * @param {Editor} editor Editor instance
+     */
+    showNonExistentFileOpenDialog(editor) {
+        const {command: {dispatch}} = this.appContext;
+        dispatch(LAYOUT_COMMANDS.POPUP_DIALOG, {
+            id: DIALOG_IDS.NON_EXISTENT_FILE_OPEN_CONFIRM,
+            additionalProps: {
+                file: editor.file,
+                onConfirm: () => {
+                    this.closeTab(editor);
+                },
+                onSave: () => {
+                    dispatch(WORKSPACE_COMMANDS.SAVE_FILE, {
+                        file: editor.file,
+                        onSaveSuccess: () => {
+                            this.closeTab(editor);
+                        },
+                    });
+                },
+            },
+        });
     }
 
     /**
@@ -399,6 +435,15 @@ class EditorPlugin extends Plugin {
                 {
                     id: DIALOG_IDS.OPENED_FILE_DELETE_CONFIRM,
                     component: OpenedFileDeleteConfirmDialog,
+                    propsProvider: () => {
+                        return {
+                            editorPlugin: this,
+                        };
+                    },
+                },
+                {
+                    id: DIALOG_IDS.NON_EXISTENT_FILE_OPEN_CONFIRM,
+                    component: NonExistentFileOpenConfirmDialog,
                     propsProvider: () => {
                         return {
                             editorPlugin: this,


### PR DESCRIPTION
## Purpose
> This fix includes showing confirmation dialog box when opening non-existent files kept in web storage.