### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8.9.0
   - nvm use 8.9.0
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!tool-plugins/vscode/server,!tool-plugins/vscode/plugin,!tool-plugins/vscode'
 
 script: mvn test -B
 


### PR DESCRIPTION
## Purpose
This PR updates Travis config to skip VSCode plugin related modules when building. This is done because Travis build otherwise fails due to an issue in a plugin which is used by Travis.