### PR TITLE
Disable text document formatting temporary.

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -82,7 +82,7 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
         res.getCapabilities().setReferencesProvider(true);
         res.getCapabilities().setCodeActionProvider(true);
         res.getCapabilities().setExecuteCommandProvider(executeCommandOptions);
-        res.getCapabilities().setDocumentFormattingProvider(true);
+        res.getCapabilities().setDocumentFormattingProvider(false);
         res.getCapabilities().setRenameProvider(true);
 
         return CompletableFuture.supplyAsync(() -> res);


### PR DESCRIPTION
## Purpose
> Disable text document formatting temporary.
>
> Getting NPE when formatting.
> 
> java.util.concurrent.CompletionException: java.lang.NullPointerException
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1592)
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1582)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: java.lang.NullPointerException
	at org.ballerinalang.langserver.SourceGen.getSourceOf(SourceGen.java:598)
	at org.ballerinalang.langserver.SourceGen.join(SourceGen.java:1086)
	at org.ballerinalang.langserver.SourceGen.getSourceOf(SourceGen.java:72)
	at org.ballerinalang.langserver.BallerinaTextDocumentService.lambda$formatting$174(BallerinaTextDocumentService.java:376)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
	... 5 more