### PR TITLE
Return correct client from FO,LB endpoints

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover_client_endpoint.bal
@@ -41,12 +41,12 @@ public type FailoverClient object {
     public function init(FailoverClientEndpointConfiguration failoverClientConfig);
 
     documentation {
-        Returns the HTTP actions associated with the endpoint.
+        Returns the HTTP failover actions associated with the endpoint.
 
-        R{{}} The HTTP caller actions provider of the endpoint
+        R{{}} The HTTP failover actions associated with the endpoint
     }
-    public function getCallerActions() returns CallerActions {
-        return httpEP.httpClient;
+    public function getCallerActions() returns FailoverActions {
+        return check <FailoverActions>httpEP.httpClient;
     }
 };
 
@@ -137,7 +137,7 @@ function createFailOverClient(FailoverClientEndpointConfiguration failoverClient
         failoverCodesIndex:failoverCodes,
         failoverInterval:failoverClientConfig.intervalMillis
     };
-    return new Failover(config.url, config, failoverInferredConfig);
+    return new FailoverActions(config.url, config, failoverInferredConfig);
 }
 
 function createFailoverHttpClientArray(FailoverClientEndpointConfiguration failoverClientConfig) returns CallerActions[] {

--- a/stdlib/ballerina-http/src/main/ballerina/http/failover_connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/failover_connector.bal
@@ -61,13 +61,13 @@ public type FailoverInferredConfig {
 };
 
 documentation {
-    Failover caller actions which provides failover capabilities to an HTTP client endpoint.
+    Failover caller actions which provides failover capabilities to the failover client endpoint.
 
     F{{serviceUri}} The URL of the remote HTTP endpoint
     F{{config}} The configurations of the client endpoint associated with this `Failover` instance
     F{{failoverInferredConfig}} Configurations derived from `FailoverConfig`
 }
-public type Failover object {
+public type FailoverActions object {
 
     public {
         string serviceUri;
@@ -218,74 +218,74 @@ public type Failover object {
     public function rejectPromise(PushPromise promise);
 };
 
-public function Failover::post(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::post(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_POST, self.failoverInferredConfig);
 }
 
-public function Failover::head(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::head(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_HEAD, self.failoverInferredConfig);
 }
 
-public function Failover::patch(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::patch(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_PATCH, self.failoverInferredConfig);
 }
 
-public function Failover::put(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::put(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_PUT, self.failoverInferredConfig);
 }
 
-public function Failover::options(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::options(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_OPTIONS, self.failoverInferredConfig);
 }
 
-public function Failover::forward(string path, Request request) returns Response|error {
+public function FailoverActions::forward(string path, Request request) returns Response|error {
     return performFailoverAction(path, request, HTTP_FORWARD, self.failoverInferredConfig);
 }
 
-public function Failover::execute(string httpVerb, string path, Request request) returns Response|error {
+public function FailoverActions::execute(string httpVerb, string path, Request request) returns Response|error {
     return performExecuteAction(path, request, httpVerb, self.failoverInferredConfig);
 }
 
-public function Failover::delete(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::delete(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_DELETE, self.failoverInferredConfig);
 }
 
-public function Failover::get(string path, Request? request = ()) returns Response|error {
+public function FailoverActions::get(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performFailoverAction(path, req, HTTP_GET, self.failoverInferredConfig);
 }
 
-public function Failover::submit(string httpVerb, string path, Request request) returns HttpFuture|error {
+public function FailoverActions::submit(string httpVerb, string path, Request request) returns HttpFuture|error {
     error err = {message:"Unsupported action for Failover client."};
     return err;
 }
 
-public function Failover::getResponse(HttpFuture httpFuture) returns (error) {
+public function FailoverActions::getResponse(HttpFuture httpFuture) returns (error) {
     error err = {message:"Unsupported action for Failover client."};
     return err;
 }
 
-public function Failover::hasPromise(HttpFuture httpFuture) returns (boolean) {
+public function FailoverActions::hasPromise(HttpFuture httpFuture) returns (boolean) {
     return false;
 }
 
-public function Failover::getNextPromise(HttpFuture httpFuture) returns PushPromise|error {
+public function FailoverActions::getNextPromise(HttpFuture httpFuture) returns PushPromise|error {
     error err = {message:"Unsupported action for Failover client."};
     return err;
 }
 
-public function Failover::getPromisedResponse(PushPromise promise) returns Response|error {
+public function FailoverActions::getPromisedResponse(PushPromise promise) returns Response|error {
     error err = {message:"Unsupported action for Failover client."};
     return err;
 }
 
-public function Failover::rejectPromise(PushPromise promise) {
+public function FailoverActions::rejectPromise(PushPromise promise) {
 }
 
 // Performs execute action of the Failover connector. extract the corresponding http integer value representation

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_load_balancer.bal
@@ -19,7 +19,8 @@ documentation {Load balancing algorithm - Round Robin}
 @final public string ROUND_ROBIN = "round-robin";
 
 documentation {
-    Load Balancer adds an additional layer to the HTTP client to make network interactions more resilient.
+    LoadBalancer caller actions which provides load balancing and failover capabilities to the
+    load balance client endpoint.
 
     F{{serviceUri}} The URL of the remote HTTP endpoint
     F{{config}} The configurations of the client endpoint associated with this `LoadBalancer` instance
@@ -28,7 +29,7 @@ documentation {
     F{{nextIndex}} Index of the next load balancing client
     F{{failover}} Whether to fail over in case of a failure
 }
-public type LoadBalancer object {
+public type LoadBalancerActions object {
    public {
        string serviceUri;
        ClientEndpointConfig config;
@@ -199,80 +200,80 @@ public type LoadBalanceActionError {
     error[] httpActionErr,
 };
 
-public function LoadBalancer::post(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::post(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_POST);
 }
 
-public function LoadBalancer::head(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::head(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_HEAD);
 }
 
-public function LoadBalancer::patch(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::patch(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_PATCH);
 }
 
-public function LoadBalancer::put(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::put(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_PUT);
 }
 
-public function LoadBalancer::options(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::options(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_OPTIONS);
 }
 
-public function LoadBalancer::forward(string path, Request request) returns Response|error {
+public function LoadBalancerActions::forward(string path, Request request) returns Response|error {
     return performLoadBalanceAction(self, path, request, HTTP_FORWARD);
 }
 
-public function LoadBalancer::execute(string httpVerb, string path, Request request) returns Response|error {
+public function LoadBalancerActions::execute(string httpVerb, string path, Request request) returns Response|error {
     return performLoadBalanceExecuteAction(self, path, request, httpVerb);
 }
 
-public function LoadBalancer::delete(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::delete(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_DELETE);
 }
 
-public function LoadBalancer::get(string path, Request? request = ()) returns Response|error {
+public function LoadBalancerActions::get(string path, Request? request = ()) returns Response|error {
     Request req = request ?: new;
     return performLoadBalanceAction(self, path, req, HTTP_GET);
 }
 
-public function LoadBalancer::submit(string httpVerb, string path, Request request) returns HttpFuture|error {
+public function LoadBalancerActions::submit(string httpVerb, string path, Request request) returns HttpFuture|error {
     error err = {message:"Unsupported action for LoadBalancer client."};
     return err;
 }
 
-public function LoadBalancer::getResponse(HttpFuture httpFuture) returns Response|error {
+public function LoadBalancerActions::getResponse(HttpFuture httpFuture) returns Response|error {
     error err = {message:"Unsupported action for LoadBalancer client."};
     return err;
 }
 
-public function LoadBalancer::hasPromise(HttpFuture httpFuture) returns (boolean) {
+public function LoadBalancerActions::hasPromise(HttpFuture httpFuture) returns (boolean) {
     return false;
 }
 
-public function LoadBalancer::getNextPromise(HttpFuture httpFuture) returns PushPromise|error {
+public function LoadBalancerActions::getNextPromise(HttpFuture httpFuture) returns PushPromise|error {
     error err = {message:"Unsupported action for LoadBalancer client."};
     return err;
 }
 
-public function LoadBalancer::getPromisedResponse(PushPromise promise) returns Response|error {
+public function LoadBalancerActions::getPromisedResponse(PushPromise promise) returns Response|error {
     error err = {message:"Unsupported action for LoadBalancer client."};
     return err;
 }
 
-public function LoadBalancer::rejectPromise(PushPromise promise) {
+public function LoadBalancerActions::rejectPromise(PushPromise promise) {
 }
 
 // Performs execute action of the Load Balance connector. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
-function performLoadBalanceExecuteAction(LoadBalancer lb, string path, Request request,
-                                          string httpVerb) returns Response|error {
+function performLoadBalanceExecuteAction(LoadBalancerActions lb, string path, Request request,
+                                         string httpVerb) returns Response|error {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     if (connectorAction != HTTP_NONE) {
         return performLoadBalanceAction(lb, path, request, connectorAction);
@@ -283,7 +284,7 @@ function performLoadBalanceExecuteAction(LoadBalancer lb, string path, Request r
 }
 
 // Handles all the actions exposed through the Load Balance connector.
-function performLoadBalanceAction(LoadBalancer lb, string path, Request request, HttpOperation requestAction)
+function performLoadBalanceAction(LoadBalancerActions lb, string path, Request request, HttpOperation requestAction)
                                     returns Response|error {
     int loadBalanceTermination = 0; // Tracks at which point failover within the load balancing should be terminated.
     //TODO: workaround to initialize a type inside a function. Change this once fix is aailable.
@@ -330,7 +331,7 @@ documentation {
     P{{loadBalanceConfigArray}} Array of HTTP Clients that needs to be load balanced
     R{{}} HttpClient elected from the algorithm
 }
-public function roundRobin(LoadBalancer lb, CallerActions[] loadBalanceConfigArray) returns CallerActions {
+public function roundRobin(LoadBalancerActions lb, CallerActions[] loadBalanceConfigArray) returns CallerActions {
     CallerActions httpClient = new;
 
     lock {

--- a/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/load_balance_client_endpoint.bal
@@ -39,10 +39,12 @@ public type LoadBalanceClient object {
     public function init(LoadBalanceClientEndpointConfiguration loadBalanceClientConfig);
 
     documentation {
-        Returns the backing HTTP client used by the load balance client endpoint.
+        Returns the HTTP LoadBalancer actions associated with the endpoint.
+
+        R{{}} The HTTP LoadBalancer actions associated with the endpoint
     }
-    public function getCallerActions() returns CallerActions {
-        return httpEP.httpClient;
+    public function getCallerActions() returns LoadBalancerActions {
+        return check <LoadBalancerActions> httpEP.httpClient;
     }
 };
 
@@ -126,7 +128,7 @@ function createLoadBalancerClient(LoadBalanceClientEndpointConfiguration loadBal
     ClientEndpointConfig config = createClientEPConfigFromLoalBalanceEPConfig(loadBalanceClientConfig,
                                                                             loadBalanceClientConfig.targets[0]);
     CallerActions[] lbClients = createLoadBalanceHttpClientArray(loadBalanceClientConfig);
-    return new LoadBalancer(loadBalanceClientConfig.targets[0].url, config, lbClients,
+    return new LoadBalancerActions(loadBalanceClientConfig.targets[0].url, config, lbClients,
                                             loadBalanceClientConfig.algorithm, 0, loadBalanceClientConfig.failover);
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
@@ -30,7 +30,7 @@ function testSuccessScenario () returns (http:Response | error) {
     };
 
     http:Response clientResponse = new;
-    http:Failover foClient = check <http:Failover>backendClientEP.getCallerActions();
+    http:FailoverActions foClient =  backendClientEP.getCallerActions();
     MockClient mockClient1 = new;
     MockClient mockClient2 = new;
     http:CallerActions[] httpClients = [<http:CallerActions> mockClient1, <http:CallerActions> mockClient2];
@@ -60,7 +60,7 @@ function testFailureScenario () returns (http:Response | error) {
     };
 
     error err = {};
-    http:Failover foClient = check <http:Failover>backendClientEP.getCallerActions();
+    http:FailoverActions foClient = backendClientEP.getCallerActions();
     MockClient mockClient1 = new;
     MockClient mockClient2 = new;
     http:CallerActions[] httpClients = [<http:CallerActions> mockClient1, <http:CallerActions> mockClient2];


### PR DESCRIPTION
At the moment FO and LB endpoints always return a CallerAction object from the getCallerActions(..) method. This is to return correct client object from getCallerActions(..) method. Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/8468

## Purpose
To return appropriate client from the FO, LB endpoints.

## Goals
Fix issues in API docs generation.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes