### PR TITLE
Add documentation support for endpoints and type nodes

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -330,14 +330,17 @@ class BallerinaTextDocumentService implements TextDocumentService {
                                                                  params.getTextDocument().getUri(),
                                                                  params.getRange().getStart().getLine()));
                 commands.add(CommandUtil.getAllDocGenerationCommand(params.getTextDocument().getUri()));
-            } else if (!params.getContext().getDiagnostics().isEmpty()) {
+            }
+            if (!params.getContext().getDiagnostics().isEmpty()) {
                 LSContextManager lsContextManager = LSContextManager.getInstance();
                 String sourceRoot = LSCompiler.getSourceRoot(Paths.get(params.getTextDocument().getUri()));
                 CompilerContext compilerContext = lsContextManager.getCompilerContext(sourceRoot);
                 LSPackageCache lsPackageCache = LSPackageCache.getInstance(compilerContext);
                 params.getContext().getDiagnostics().forEach(diagnostic -> {
-                    commands.addAll(CommandUtil
-                                            .getCommandsByDiagnostic(diagnostic, params, lsPackageCache));
+                    if (params.getRange().getStart().getLine() == diagnostic.getRange().getStart().getLine()) {
+                        commands.addAll(CommandUtil
+                                .getCommandsByDiagnostic(diagnostic, params, lsPackageCache));
+                    }
                 });
             }
             return commands;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
@@ -25,6 +25,7 @@ import org.ballerinalang.langserver.compiler.LSCompiler;
 import org.ballerinalang.langserver.compiler.LSServiceOperationContext;
 import org.ballerinalang.langserver.compiler.common.LSCustomErrorStrategy;
 import org.ballerinalang.model.tree.Node;
+import org.ballerinalang.model.tree.TopLevelNode;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.Position;
@@ -35,7 +36,7 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
-import org.wso2.ballerinalang.compiler.tree.BLangEnum;
+import org.wso2.ballerinalang.compiler.tree.BLangEndpoint;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -43,7 +44,6 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangStruct;
-import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.net.URI;
@@ -272,17 +272,17 @@ public class CommandExecutor {
             case UtilSymbolKeys.STRUCT_KEYWORD_KEY:
                 docAttachmentInfo = CommandUtil.getStructDocumentationByPosition(bLangPackage, line);
                 break;
-            case UtilSymbolKeys.ENUM_KEYWORD_KEY:
-                docAttachmentInfo = CommandUtil.getEnumDocumentationByPosition(bLangPackage, line);
-                break;
-            case UtilSymbolKeys.TRANSFORMER_KEYWORD_KEY:
-                docAttachmentInfo = CommandUtil.getTransformerDocumentationByPosition(bLangPackage, line);
+            case UtilSymbolKeys.ENDPOINT_KEYWORD_KEY:
+                docAttachmentInfo = CommandUtil.getEndpointDocumentationByPosition(bLangPackage, line);
                 break;
             case UtilSymbolKeys.RESOURCE_KEYWORD_KEY:
                 docAttachmentInfo = CommandUtil.getResourceDocumentationByPosition(bLangPackage, line);
                 break;
             case UtilSymbolKeys.SERVICE_KEYWORD_KEY:
                 docAttachmentInfo = CommandUtil.getServiceDocumentationByPosition(bLangPackage, line);
+                break;
+            case UtilSymbolKeys.TYPE_KEYWORD_KEY:
+                docAttachmentInfo = CommandUtil.getTypeNodeDocumentationByPosition(bLangPackage, line);
                 break;
             default:
                 break;
@@ -312,19 +312,15 @@ public class CommandExecutor {
                     docAttachmentInfo = CommandUtil.getStructNodeDocumentation((BLangStruct) node, replaceFrom);
                 }
                 break;
-            case ENUM:
-                if (((BLangEnum) node).docAttachments.isEmpty()) {
-                    replaceFrom = CommonUtil.toZeroBasedPosition(((BLangEnum) node).getPosition()).getStartLine();
-                    docAttachmentInfo = CommandUtil.getEnumNodeDocumentation((BLangEnum) node, replaceFrom);
-                }
+            case ENDPOINT:
+                // TODO: Here we need to check for the doc attachments of the endpoint.
+                replaceFrom = CommonUtil.toZeroBasedPosition(((BLangEndpoint) node).getPosition()).getStartLine();
+                docAttachmentInfo = CommandUtil.getEndpointNodeDocumentation((BLangEndpoint) node, replaceFrom);
                 break;
-            case TRANSFORMER:
-                if (((BLangTransformer) node).docAttachments.isEmpty()) {
-                    replaceFrom =
-                            CommonUtil.toZeroBasedPosition(((BLangTransformer) node).getPosition()).getStartLine();
-                    docAttachmentInfo = CommandUtil.getTransformerNodeDocumentation((BLangTransformer) node,
-                            replaceFrom);
-                }
+            case OBJECT:
+            case RECORD:
+                replaceFrom = CommonUtil.toZeroBasedPosition((DiagnosticPos) node.getPosition()).getStartLine();
+                docAttachmentInfo = CommandUtil.getTypeNodeDocumentation((TopLevelNode) node, replaceFrom);
                 break;
             case RESOURCE:
                 if (((BLangResource) node).docAttachments.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/UtilSymbolKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/UtilSymbolKeys.java
@@ -49,8 +49,6 @@ public class UtilSymbolKeys {
     
     public static final String ANON_STRUCT_CHECKER = "$anon";
 
-    public static final String CREATE_KEYWORD_KEY = "create";
-
     public static final String ENDPOINT_KEYWORD_KEY = "endpoint";
 
     public static final String FUNCTION_KEYWORD_KEY = "function";
@@ -59,15 +57,9 @@ public class UtilSymbolKeys {
 
     public static final String SERVICE_KEYWORD_KEY = "service";
 
-    public static final String CONNECTOR_KEYWORD_KEY = "connector";
-
-    public static final String ACTION_KEYWORD_KEY = "action";
-
-    public static final String ENUM_KEYWORD_KEY = "enum";
-
-    public static final String TRANSFORMER_KEYWORD_KEY = "transformer";
-
     public static final String STRUCT_KEYWORD_KEY = "struct";
+
+    public static final String TYPE_KEYWORD_KEY = "type";
 
     public static final String MATCH_KEYWORD_KEY = "match";
     

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -284,11 +284,10 @@ public class CommonUtil {
     public static String topLevelNodeTypeInLine(TextDocumentIdentifier identifier, Position startPosition,
                                                 WorkspaceDocumentManager docManager) {
         // TODO: Need to support service and resources as well.
-        List<String> topLevelKeywords = Arrays.asList("function", "service", "resource", "struct", "enum",
-                                                      "transformer", "object");
+        List<String> topLevelKeywords = Arrays.asList("function", "service", "resource", "endpoint", "type");
         LSDocument document = new LSDocument(identifier.getUri());
         String fileContent = docManager.getFileContent(getPath(document));
-        String[] splitedFileContent = fileContent.split("\\n|\\r\\n|\\r");
+        String[] splitedFileContent = fileContent.split(LINE_SEPARATOR);
         if ((splitedFileContent.length - 1) >= startPosition.getLine()) {
             String lineContent = splitedFileContent[startPosition.getLine()];
             List<String> alphaNumericTokens = new ArrayList<>(Arrays.asList(lineContent.split("[^\\w']+")));


### PR DESCRIPTION
## Purpose
> Add documentation support for endpoint nodes and type nodes. Type nodes include both records and objects. Documentation parameters for the object only populate the public fields
