### PR TITLE
Fix bug in boolean type handling in Ballerina Streaming

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BStream.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BStream.java
@@ -221,7 +221,8 @@ public class BStream implements BRefType<Object> {
                         event[index] = data.getFloatField(++floatValueIndex);
                         break;
                     case TypeTags.BOOLEAN_TAG:
-                        event[index] = data.getBooleanField(++boolValueIndex);
+                        int boolValue = data.getBooleanField(++boolValueIndex);
+                        event[index] = (boolValue == 1);
                         break;
                     case TypeTags.STRING_TAG:
                         event[index] = data.getStringField(++stringValueIndex);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/streaming/BooleanTypeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/streaming/BooleanTypeTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.streaming;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This contains methods to test boolean type conversion of Ballerina Streaming.
+ *
+ * @since 0.965.0
+ */
+public class BooleanTypeTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/streaming/boolean-type-test.bal");
+    }
+
+    @Test(description = "Test Boolean types in streaming query")
+    public void testFilterQuery() {
+        BValue[] outputRequestCountObjs = BRunUtil.invoke(result, "startStreamingQuery");
+        Assert.assertNotNull(outputRequestCountObjs);
+
+        Assert.assertEquals(outputRequestCountObjs.length, 1, "Expected events are not received");
+
+        BStruct requestCount = (BStruct) outputRequestCountObjs[0];
+
+        Assert.assertEquals(requestCount.getIntField(0), 7);
+        Assert.assertEquals(requestCount.getBooleanField(0), 1);
+    }
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/streaming/BooleanTypeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/streaming/BooleanTypeTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 /**
  * This contains methods to test boolean type conversion of Ballerina Streaming.
  *
- * @since 0.965.0
+ * @since 0.970.1
  */
 public class BooleanTypeTest {
 

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/boolean-type-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/boolean-type-test.bal
@@ -1,0 +1,100 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/runtime;
+import ballerina/io;
+
+type ClientRequest {
+    string host;
+};
+
+type RequestCount {
+    string host;
+    int count;
+    boolean test;
+};
+
+stream<ClientRequest> requestStream;
+RequestCount[] globalRequestsArray = [];
+int requestCount = 0;
+
+function initRealtimeRequestCounter() {
+
+    stream<RequestCount> requestCountStream;
+    stream<RequestCount> requestCountStream2;
+
+    // Whenever the `requestCountStream` stream receives an event from the streaming rules defined in the `forever` block,
+    // the `printRequestCount` function is invoked.
+    requestCountStream.subscribe(printRequestCount);
+    requestCountStream2.subscribe(printRequestCount2);
+
+    // Gather all the events coming in to the `requestStream` for five seconds, group them by the host, count the number
+    // of requests per host, and check if the count is more than six. If yes, publish the output (host and the count) to
+    // the `requestCountStream` stream as an alert. This `forever` block is executed once, when initializing the service.
+    // The processing happens asynchronously each time the `requestStream` receives an event.
+    forever {
+        from requestStream
+        window timeBatch(5000)
+        select host, count(host) as count, (host == "local") as test
+        group by host
+        having count > 6
+        => (RequestCount[] counts) {
+        // `counts` is the output of the streaming rules and is published to the `requestCountStream`.
+        // The `select` clause should match the structure of the `RequestCount` struct.
+            requestCountStream.publish(counts);
+        }
+
+        from requestCountStream
+        select host, count, test
+        => (RequestCount[] counts) {
+            requestCountStream2.publish(counts);
+        }
+    }
+}
+
+function startStreamingQuery() returns (RequestCount[]) {
+
+    int i = 0;
+    int count = 0;
+    initRealtimeRequestCounter();
+    ClientRequest t1 = {host:"local"};
+
+    while ( i < 7) {
+        requestStream.publish(t1);
+        runtime:sleep(100);
+        i = i + 1;
+    }
+
+    while(true) {
+        runtime:sleep(500);
+        count++;
+        if((lengthof globalRequestsArray) > 0 || count == 10) {
+            break;
+        }
+    }
+    return globalRequestsArray;
+}
+
+// Define the `printRequestCount` function.
+function printRequestCount(RequestCount reqCount) {
+    io:println("ALERT!! : Received more than 6 requests from the " +
+            "host within 5 seconds : " + reqCount.host);
+}
+
+function printRequestCount2(RequestCount reqCount) {
+    globalRequestsArray[requestCount] = reqCount;
+    requestCount = requestCount + 1;
+}


### PR DESCRIPTION
Ballerina represents boolean values with integer 0 and 1. This needs to be converted to proper boolean values for ballerina streams to work properly. In BStream object, The conversion is properly handled with this PR