### PR TITLE
Make response from server accessible by user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1540,7 +1540,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.172</transport.http.version>
+        <transport.http.version>6.0.178</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/ballerina/http/ws/websocket_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/ws/websocket_client.bal
@@ -29,6 +29,7 @@ public type WebSocketClient object {
         @readonly string negotiatedSubProtocol;
         @readonly boolean isSecure;
         @readonly boolean isOpen;
+        @readonly Response response;
         @readonly map attributes;
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -62,6 +62,7 @@ public class WebSocketConstants {
     public static final String CLIENT_CONNECTOR_CONFIGS = "clientEndpointConfigs";
     public static final String WEBSOCKET_UPGRADE_SERVICE_CONFIG = "upgradeService";
 
+    //The indexes of WebSocket endpoints
     public static final int LISTENER_ID_INDEX = 0;
     public static final int LISTENER_NEGOTIATED_SUBPROTOCOLS_INDEX = 1;
     public static final int LISTENER_IS_SECURE_INDEX = 0;
@@ -70,6 +71,8 @@ public class WebSocketConstants {
     public static final int LISTENER_CONNECTOR_INDEX = 1;
     public static final int LISTENER_CONFIG_INDEX = 2;
     public static final int LISTENER_HTTP_ENDPOINT_INDEX = 3;
+    public static final int CLIENT_RESPONSE_INDEX = 0;
+    public static final int CLIENT_CONNECTOR_INDEX = 2;
 
     public static final int CONNECTOR_IS_READY_INDEX = 0;
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -35,8 +35,8 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.services.ErrorHandlerUtils;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.websocket.HandshakeFuture;
-import org.wso2.transport.http.netty.contract.websocket.HandshakeListener;
+import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeFuture;
+import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
 
@@ -76,9 +76,9 @@ public abstract class WebSocketUtil {
         String[] subProtocols = wsService.getNegotiableSubProtocols();
         int idleTimeoutInSeconds = wsService.getIdleTimeoutInSeconds();
         int maxFrameSize = wsService.getMaxFrameSize();
-        HandshakeFuture future = initMessage.handshake(subProtocols, true, idleTimeoutInSeconds * 1000, headers,
-                                                       maxFrameSize);
-        future.setHandshakeListener(new HandshakeListener() {
+        ServerHandshakeFuture future = initMessage.handshake(subProtocols, true, idleTimeoutInSeconds * 1000, headers,
+                                                             maxFrameSize);
+        future.setHandshakeListener(new ServerHandshakeListener() {
             @Override
             public void onSuccess(WebSocketConnection webSocketConnection) {
                 // TODO: Need to create new struct

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -29,7 +29,6 @@ import org.ballerinalang.mime.util.EntityBodyHandler;
 import org.ballerinalang.mime.util.HeaderUtil;
 import org.ballerinalang.mime.util.MultipartDataSource;
 import org.ballerinalang.model.NativeCallableUnit;
-import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.net.http.AcceptEncodingConfig;
@@ -37,8 +36,6 @@ import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.runtime.message.MessageDataSource;
-import org.ballerinalang.util.codegen.PackageInfo;
-import org.ballerinalang.util.codegen.StructInfo;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.observability.ObservabilityConstants;
 import org.ballerinalang.util.observability.ObservabilityUtils;
@@ -63,8 +60,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 
-import static org.ballerinalang.mime.util.Constants.MEDIA_TYPE;
-import static org.ballerinalang.mime.util.Constants.PROTOCOL_PACKAGE_MIME;
 import static org.ballerinalang.mime.util.Constants.REQUEST_ENTITY_INDEX;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_STATUS_CODE;
@@ -105,7 +100,7 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         HttpUtil.enrichOutboundMessage(requestMsg, requestStruct);
         prepareOutboundRequest(context, bConnector, path, requestMsg);
         AcceptEncodingConfig acceptEncodingConfig = getAcceptEncodingConfig
-                                                        (getAcceptEncodingConfigFromEndpointConfig(bConnector));
+                (getAcceptEncodingConfigFromEndpointConfig(bConnector));
         handleAcceptEncodingHeader(requestMsg, acceptEncodingConfig);
         return requestMsg;
     }
@@ -133,7 +128,7 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
     }
 
     protected void handleAcceptEncodingHeader(HTTPCarbonMessage outboundRequest,
-            AcceptEncodingConfig acceptEncodingConfig) {
+                                              AcceptEncodingConfig acceptEncodingConfig) {
         if (acceptEncodingConfig == AcceptEncodingConfig.ALWAYS && (
                 outboundRequest.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString()) == null)) {
             outboundRequest
@@ -239,13 +234,7 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         }
     }
 
-    protected void executeNonBlockingAction(DataContext dataContext)
-            throws ClientConnectorException {
-        executeNonBlockingAction(dataContext, false);
-    }
-
-    protected void executeNonBlockingAction(DataContext dataContext,
-                                            boolean async) throws ClientConnectorException {
+    protected void executeNonBlockingAction(DataContext dataContext, boolean async) {
         HTTPCarbonMessage outboundRequestMsg = dataContext.getOutboundRequest();
         Object sourceHandler = outboundRequestMsg.getProperty(HttpConstants.SRC_HANDLER);
         if (sourceHandler == null) {
@@ -255,7 +244,7 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         Object poolableByteBufferFactory = outboundRequestMsg.getProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY);
         if (poolableByteBufferFactory == null) {
             outboundRequestMsg.setProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY,
-                    dataContext.context.getProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY));
+                                           dataContext.context.getProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY));
         }
         Object remoteAddress = outboundRequestMsg.getProperty(HttpConstants.REMOTE_ADDRESS);
         if (remoteAddress == null) {
@@ -285,13 +274,11 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
      * info through wire. If a boundary string exist at this point, serialize multipart entity body, else serialize
      * entity body which can either be a message data source or a byte channel.
      *
-     * @param dataContext               holds the ballerina context and callback
-     * @param outboundRequestMsg        Outbound request that needs to be sent across the wire
-     * @param async                     whether a handle should be return
-     * @return connector future for this particular request
-     * @throws Exception When an error occurs while sending the outbound request via client connector
+     * @param dataContext        holds the ballerina context and callback
+     * @param outboundRequestMsg Outbound request that needs to be sent across the wire
+     * @param async              whether a handle should be return
      */
-    private void send(DataContext dataContext, HTTPCarbonMessage outboundRequestMsg, boolean async) throws Exception {
+    private void send(DataContext dataContext, HTTPCarbonMessage outboundRequestMsg, boolean async) {
         BStruct bConnector = (BStruct) dataContext.context.getRefArgument(0);
         Struct httpClient = BLangConnectorSPIUtil.toStruct(bConnector);
         HttpClientConnector clientConnector = (HttpClientConnector)
@@ -430,13 +417,14 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         public void onMessage(HTTPCarbonMessage inboundResponseMessage) {
             this.outboundMsgDataStreamer.setIoException(new IOException("Response message already received"));
             this.dataContext.notifyInboundResponseStatus
-                    (createResponseStruct(this.dataContext.context, inboundResponseMessage), null);
+                    (HttpUtil.createResponseStruct(this.dataContext.context, inboundResponseMessage), null);
         }
 
         @Override
         public void onResponseHandle(ResponseHandle responseHandle) {
-            BStruct httpFuture = createStruct(this.dataContext.context, HttpConstants.HTTP_FUTURE,
-                                              HttpConstants.PROTOCOL_PACKAGE_HTTP);
+            BStruct httpFuture = BLangConnectorSPIUtil.createBStruct(this.dataContext.context,
+                                                                     HttpConstants.PROTOCOL_PACKAGE_HTTP,
+                                                                     HttpConstants.HTTP_FUTURE);
             httpFuture.addNativeData(HttpConstants.TRANSPORT_HANDLE, responseHandle);
             this.dataContext.notifyInboundResponseStatus(httpFuture, null);
         }
@@ -445,8 +433,9 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         public void onError(Throwable throwable) {
             BStruct httpConnectorError;
             if (throwable instanceof EndpointTimeOutException) {
-                httpConnectorError = createStruct(this.dataContext.context, HttpConstants.HTTP_TIMEOUT_ERROR,
-                        HttpConstants.PROTOCOL_PACKAGE_HTTP);
+                httpConnectorError = BLangConnectorSPIUtil.createBStruct(this.dataContext.context,
+                                                                         HttpConstants.PROTOCOL_PACKAGE_HTTP,
+                                                                         HttpConstants.HTTP_TIMEOUT_ERROR);
             } else if (throwable instanceof IOException) {
                 this.outboundMsgDataStreamer.setIoException((IOException) throwable);
                 httpConnectorError = HttpUtil.getError(this.dataContext.context, throwable);
@@ -491,41 +480,7 @@ public abstract class AbstractHTTPAction implements NativeCallableUnit {
         private void addHttpStatusCode(int statusCode) {
             Optional<ObserverContext> observerContext = ObservabilityUtils.getParentContext(context);
             observerContext.ifPresent(ctx -> ctx.addTag(ObservabilityConstants.TAG_KEY_HTTP_STATUS_CODE,
-                    String.valueOf(statusCode)));
+                                                        String.valueOf(statusCode)));
         }
-    }
-
-    /**
-     * Creates a ballerina struct.
-     *
-     * @param context         ballerina context
-     * @param structName      name of the struct
-     * @param protocolPackage package name
-     * @return the ballerina struct
-     */
-    protected BStruct createStruct(Context context, String structName, String protocolPackage) {
-        PackageInfo httpPackageInfo = context.getProgramFile()
-                .getPackageInfo(protocolPackage);
-        StructInfo structInfo = httpPackageInfo.getStructInfo(structName);
-        BStructType structType = structInfo.getType();
-        return new BStruct(structType);
-    }
-
-    /**
-     * Creates InResponse using the native {@code HTTPCarbonMessage}.
-     *
-     * @param context           ballerina context
-     * @param httpCarbonMessage the HTTPCarbonMessage
-     * @return the Response struct
-     */
-    BStruct createResponseStruct(Context context, HTTPCarbonMessage httpCarbonMessage) {
-        BStruct responseStruct = createStruct(context, HttpConstants.RESPONSE,
-                                              HttpConstants.PROTOCOL_PACKAGE_HTTP);
-        BStruct entity = createStruct(context, HttpConstants.ENTITY, PROTOCOL_PACKAGE_MIME);
-        BStruct mediaType = createStruct(context, MEDIA_TYPE, PROTOCOL_PACKAGE_MIME);
-
-        HttpUtil.populateInboundResponse(responseStruct, entity, mediaType, context.getProgramFile(),
-                                         httpCarbonMessage);
-        return responseStruct;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Delete.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Delete.java
@@ -25,9 +25,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 /**
@@ -55,14 +52,8 @@ public class Delete extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'delete' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), dataContext.context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Execute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Execute.java
@@ -28,8 +28,6 @@ import org.ballerinalang.net.http.AcceptEncodingConfig;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.util.Locale;
@@ -60,14 +58,8 @@ public class Execute extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'execute' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     @Override

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Forward.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Forward.java
@@ -31,7 +31,6 @@ import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.util.Locale;
@@ -62,14 +61,8 @@ public class Forward extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'forward' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     @Override

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Get.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Get.java
@@ -25,9 +25,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 
@@ -56,14 +53,7 @@ public class Get extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            // This is should be a JavaError. Need to handle this properly.
-            BallerinaException exception = new BallerinaException("Failed to invoke 'get' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
@@ -18,6 +18,7 @@ package org.ballerinalang.net.http.actions.httpclient;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
@@ -41,16 +42,16 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
         orgName = "ballerina", packageName = "http",
         functionName = "getNextPromise",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = HttpConstants.CALLER_ACTIONS,
-                structPackage = "ballerina.http"),
+                             structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "client", type = TypeKind.STRUCT),
                 @Argument(name = "httpFuture", type = TypeKind.STRUCT, structType = "HttpFuture",
-                        structPackage = "ballerina.http")
+                          structPackage = "ballerina.http")
         },
         returnType = {
                 @ReturnType(type = TypeKind.STRUCT, structType = "PushPromise", structPackage = "ballerina.http"),
                 @ReturnType(type = TypeKind.STRUCT, structType = "HttpConnectorError",
-                        structPackage = "ballerina.http"),
+                            structPackage = "ballerina.http"),
         }
 )
 public class GetNextPromise extends AbstractHTTPAction {
@@ -71,7 +72,7 @@ public class GetNextPromise extends AbstractHTTPAction {
                 setPushPromiseListener(new PromiseListener(dataContext));
     }
 
-    private class PromiseListener implements HttpClientConnectorListener {
+    private static class PromiseListener implements HttpClientConnectorListener {
 
         private DataContext dataContext;
 
@@ -82,7 +83,8 @@ public class GetNextPromise extends AbstractHTTPAction {
         @Override
         public void onPushPromise(Http2PushPromise pushPromise) {
             BStruct pushPromiseStruct =
-                    createStruct(dataContext.context, HttpConstants.PUSH_PROMISE, HttpConstants.PROTOCOL_PACKAGE_HTTP);
+                    BLangConnectorSPIUtil.createBStruct(dataContext.context, HttpConstants.PROTOCOL_PACKAGE_HTTP,
+                                                        HttpConstants.PUSH_PROMISE);
             HttpUtil.populatePushPromiseStruct(pushPromiseStruct, pushPromise);
             dataContext.notifyInboundResponseStatus(pushPromiseStruct, null);
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetPromisedResponse.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetPromisedResponse.java
@@ -71,7 +71,7 @@ public class GetPromisedResponse extends AbstractHTTPAction {
                 setPushResponseListener(new PushResponseListener(dataContext), http2PushPromise.getPromisedStreamId());
     }
 
-    private class PushResponseListener implements HttpClientConnectorListener {
+    private static class PushResponseListener implements HttpClientConnectorListener {
 
         private DataContext dataContext;
 
@@ -82,14 +82,12 @@ public class GetPromisedResponse extends AbstractHTTPAction {
         @Override
         public void onPushResponse(int promisedId, HTTPCarbonMessage httpCarbonMessage) {
             dataContext.notifyInboundResponseStatus(
-                    createResponseStruct(this.dataContext.context, httpCarbonMessage), null);
+                    HttpUtil.createResponseStruct(this.dataContext.context, httpCarbonMessage), null);
         }
 
         @Override
         public void onError(Throwable throwable) {
-            BStruct httpConnectorError = createStruct(
-                    dataContext.context, HttpConstants.STRUCT_GENERIC_ERROR, HttpConstants.PACKAGE_BALLERINA_BUILTIN);
-            httpConnectorError.setStringField(0, throwable.getMessage());
+            BStruct httpConnectorError =  HttpUtil.getError(dataContext.context, throwable);
             dataContext.notifyInboundResponseStatus(null, httpConnectorError);
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
@@ -26,6 +26,7 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
@@ -70,7 +71,7 @@ public class GetResponse extends AbstractHTTPAction {
                 setHttpConnectorListener(new ResponseListener(dataContext));
     }
 
-    private class ResponseListener implements HttpConnectorListener {
+    private static class ResponseListener implements HttpConnectorListener {
 
         private DataContext dataContext;
 
@@ -81,13 +82,11 @@ public class GetResponse extends AbstractHTTPAction {
         @Override
         public void onMessage(HTTPCarbonMessage httpCarbonMessage) {
             dataContext.notifyInboundResponseStatus(
-                    createResponseStruct(this.dataContext.context, httpCarbonMessage), null);
+                    HttpUtil.createResponseStruct(this.dataContext.context, httpCarbonMessage), null);
         }
 
         public void onError(Throwable throwable) {
-            BStruct httpConnectorError = createStruct(
-                    dataContext.context, HttpConstants.STRUCT_GENERIC_ERROR, HttpConstants.PACKAGE_BALLERINA_BUILTIN);
-            httpConnectorError.setStringField(0, throwable.getMessage());
+            BStruct httpConnectorError =  HttpUtil.getError(dataContext.context, throwable);
             dataContext.notifyInboundResponseStatus(null, httpConnectorError);
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Head.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Head.java
@@ -27,9 +27,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 
@@ -58,14 +55,8 @@ public class Head extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'head' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Options.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Options.java
@@ -27,9 +27,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 
@@ -58,13 +55,7 @@ public class Options extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'options' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Patch.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Patch.java
@@ -25,9 +25,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 
@@ -56,14 +53,8 @@ public class Patch extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'patch' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Post.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Post.java
@@ -25,9 +25,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 
@@ -56,14 +53,8 @@ public class Post extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'post' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Put.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Put.java
@@ -25,9 +25,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 
@@ -56,14 +53,8 @@ public class Put extends AbstractHTTPAction {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext);
-        } catch (ClientConnectorException clientConnectorException) {
-            BallerinaException exception = new BallerinaException("Failed to invoke 'put' action in " +
-                    HttpConstants.CALLER_ACTIONS + ". " + clientConnectorException.getMessage(), context);
-            dataContext.notifyInboundResponseStatus(null, HttpUtil.getError(context, exception));
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, false);
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
@@ -25,8 +25,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
-import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.contract.ClientConnectorException;
 
 /**
  * {@code Submit} action can be used to invoke a http call with any httpVerb in asynchronous manner.
@@ -54,12 +52,7 @@ public class Submit extends Execute {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         DataContext dataContext = new DataContext(context, callback, createOutboundRequestMsg(context));
-        try {
-            // Execute the operation
-            executeNonBlockingAction(dataContext, true);
-        } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'executeAsync' action in " + HttpConstants.CALLER_ACTIONS
-                    + ". " + clientConnectorException.getMessage(), context);
-        }
+        // Execute the operation
+        executeNonBlockingAction(dataContext, true);
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ConnectionAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ConnectionAction.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.net.http.nativeimpl.connection;
 
-import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
 import org.ballerinalang.mime.util.EntityBodyHandler;
 import org.ballerinalang.mime.util.HeaderUtil;
 import org.ballerinalang.mime.util.MultipartDataSource;
@@ -158,8 +157,7 @@ public abstract class ConnectionAction implements NativeCallableUnit {
 
         @Override
         public void onError(Throwable throwable) {
-            BStruct httpConnectorError = BLangConnectorSPIUtil.createBStruct(this.dataContext.context,
-                    HttpConstants.PACKAGE_BALLERINA_BUILTIN, HttpConstants.STRUCT_GENERIC_ERROR);
+            BStruct httpConnectorError =  HttpUtil.getError(dataContext.context, throwable);
             if (outboundMsgDataStreamer != null) {
                 if (throwable instanceof IOException) {
                     this.outboundMsgDataStreamer.setIoException((IOException) throwable);
@@ -167,7 +165,6 @@ public abstract class ConnectionAction implements NativeCallableUnit {
                     this.outboundMsgDataStreamer.setIoException(new IOException(throwable.getMessage()));
                 }
             }
-            httpConnectorError.setStringField(0, throwable.getMessage());
             this.dataContext.notifyOutboundResponseStatus(httpConnectorError);
         }
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/CancelWebSocketUpgradeTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/CancelWebSocketUpgradeTest.java
@@ -20,35 +20,23 @@ package org.ballerinalang.test.service.websocket;
 
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
-import org.ballerinalang.test.util.websocket.server.WebSocketRemoteServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.net.URISyntaxException;
 
 /**
- * This Class tests the cancelWebSocketUpgrade method of the http connector
+ * This Class tests the cancelWebSocketUpgrade method of the http connector.
  */
 public class CancelWebSocketUpgradeTest extends WebSocketIntegrationTest {
 
-    private WebSocketRemoteServer remoteServer;
-    private ServerInstance ballerinaServerInstance;
     private WebSocketTestClient client;
 
     @BeforeClass(description = "Initializes Ballerina with the cancel_websocket_upgrade.bal file")
-    public void setup() throws InterruptedException, BallerinaTestException {
-        remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
-        remoteServer.run();
-
-        String balPath = new File("src/test/resources/websocket/cancel_websocket_upgrade.bal")
-                .getAbsolutePath();
-        ballerinaServerInstance = ServerInstance.initBallerinaServer();
-        ballerinaServerInstance.startBallerinaServer(balPath);
-
+    public void setup() throws BallerinaTestException {
+        initBallerinaServer("cancel_websocket_upgrade.bal");
     }
 
     @Test(description = "Tests the cancelWebSocketUpgrade method",
@@ -71,8 +59,7 @@ public class CancelWebSocketUpgradeTest extends WebSocketIntegrationTest {
 
     @AfterClass(description = "Stops Ballerina")
     public void cleanup() throws BallerinaTestException {
-        ballerinaServerInstance.stopServer();
-        remoteServer.stop();
+        stopBallerinaServerInstance();
     }
 }
 

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderServerSupportTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderServerSupportTest.java
@@ -26,37 +26,44 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This Class tests auto ping pong support of WebSocket client server if there's no onPing resource.
+ * This Class tests receiving and sending of custom headers by Ballerina WebSocket server.
  */
-public class WebSocketAutoPingPongTest extends WebSocketIntegrationTest {
+public class CustomHeaderServerSupportTest extends WebSocketIntegrationTest {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9090/test/without/ping/resource";
-    private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+    private static final String URL = "ws://localhost:9090/simple/custom/header/server";
+    private static final String RECEIVED_TEXT = "some-header-value";
 
-    @BeforeClass(description = "Initializes Ballerina with the simple_server_without_ping_resource.bal file")
+    @BeforeClass(description = "Initializes the Ballerina server with the custom_header_server.bal file")
     public void setup() throws InterruptedException, BallerinaTestException, URISyntaxException {
-        initBallerinaServer("simple_server_without_ping_resource.bal");
-        client = new WebSocketTestClient(URL);
+        super.initBallerinaServer("custom_header_server.bal");
+        Map<String, String> map = new HashMap<>();
+        map.put("X-some-header", "some-header-value");
+        client = new WebSocketTestClient(URL, map);
         client.handshake();
     }
 
-    @Test(description = "Tests the auto ping pong support in Ballerina if there is no onPing resource")
-    public void testAutoPingPongSupport() throws InterruptedException {
-        CountDownLatch countDownLatch = new CountDownLatch(1);
-        client.setCountDownLatch(countDownLatch);
-        client.sendPing(SENDING_BYTE_BUFFER);
-        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
-        Assert.assertTrue(client.isPong());
-        Assert.assertEquals(client.getBufferReceived(), SENDING_BYTE_BUFFER);
+    @Test(description = "Tests custom header sent by the server")
+    public void testServerSentCustomHeader() {
+        Assert.assertEquals(client.getHeader("X-some-header"), RECEIVED_TEXT);
     }
 
-    @AfterClass(description = "Stops Ballerina")
+    @Test(description = "Tests reception of custom header by the server")
+    public void testServerRecievedCustomHeader() throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        client.sendText("custom-headers");
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        Assert.assertEquals(client.getTextReceived(), RECEIVED_TEXT);
+    }
+
+    @AfterClass(description = "Stops the Ballerina server")
     public void cleanup() throws BallerinaTestException, InterruptedException {
         client.shutDown();
         stopBallerinaServerInstance();

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
@@ -19,7 +19,6 @@
 package org.ballerinalang.test.service.websocket;
 
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 import org.ballerinalang.test.util.websocket.server.WebSocketRemoteServer;
 import org.testng.Assert;
@@ -27,8 +26,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -41,27 +38,22 @@ import java.util.concurrent.TimeUnit;
 public class PingPongSupportTestCase extends WebSocketIntegrationTest {
 
     private WebSocketRemoteServer remoteServer;
-    private ServerInstance ballerinaServerInstance;
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/pingpong/ws";
     private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
     private static final ByteBuffer RECEIVING_BYTE_BUFFER = ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8));
 
-    @BeforeClass(description = "Initializes the Ballerina server with the ping_pong_support.bal file")
+    @BeforeClass(description = "Initializes the Ballerina server with the ping_pong.bal file")
     public void setup() throws InterruptedException, BallerinaTestException, URISyntaxException {
         remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
         remoteServer.run();
-
-        String balPath = new File("src/test/resources/websocket/ping_pong_support.bal").getAbsolutePath();
-        ballerinaServerInstance = ServerInstance.initBallerinaServer();
-        ballerinaServerInstance.startBallerinaServer(balPath);
-
+        initBallerinaServer("ping_pong.bal");
         client = new WebSocketTestClient(URL);
         client.handshake();
     }
 
     @Test(description = "Tests ping to Ballerina WebSocket server")
-    public void testPingToBallerinaServer() throws IOException, InterruptedException {
+    public void testPingToBallerinaServer() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);
         client.sendPing(SENDING_BYTE_BUFFER);
@@ -101,7 +93,7 @@ public class PingPongSupportTestCase extends WebSocketIntegrationTest {
     @AfterClass(description = "Stops the Ballerina server")
     public void cleanup() throws BallerinaTestException, InterruptedException {
         client.shutDown();
-        ballerinaServerInstance.stopServer();
+        stopBallerinaServerInstance();
         remoteServer.stop();
     }
 }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketIntegrationTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketIntegrationTest.java
@@ -18,8 +18,11 @@
 
 package org.ballerinalang.test.service.websocket;
 
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 
+import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -27,10 +30,26 @@ import java.util.concurrent.TimeUnit;
  * Facilitate the common functionality of WebSocket integration tests.
  */
 public class WebSocketIntegrationTest {
-
+    private ServerInstance ballerinaServerInstance;
     protected static final int TIMEOUT_IN_SECS = 10;
     protected static final int REMOTE_SERVER_PORT = 15500;
 
+
+    /**
+     * Initializes Ballerina with the given bal file.
+     *
+     * @param fileName the filename to initialize the Ballerina server with
+     * @throws BallerinaTestException on Ballerina related issues
+     */
+    public void initBallerinaServer(String fileName) throws BallerinaTestException {
+        String balPath = new File("src/test/resources/websocket/" + fileName).getAbsolutePath();
+        ballerinaServerInstance = ServerInstance.initBallerinaServer();
+        ballerinaServerInstance.startBallerinaServer(balPath);
+    }
+
+    public void stopBallerinaServerInstance() throws BallerinaTestException {
+        ballerinaServerInstance.stopServer();
+    }
     /**
      * This method is only used when ack is needed from Ballerina WebSocket Proxy in order to sync ballerina
      * WebSocket Server and Client after the handshake in initiated from the {@link WebSocketTestClient}.

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketQueryAndPathParamSupportTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketQueryAndPathParamSupportTestCase.java
@@ -19,14 +19,12 @@
 package org.ballerinalang.test.service.websocket;
 
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.net.URISyntaxException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -36,14 +34,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class WebSocketQueryAndPathParamSupportTestCase extends WebSocketIntegrationTest {
 
-    private ServerInstance ballerinaServerInstance;
-
     @BeforeClass(description = "Initializes Ballerina")
     public void setup() throws BallerinaTestException {
-
-        String balPath = new File("src/test/resources/websocket/query_and_path_param_support.bal").getAbsolutePath();
-        ballerinaServerInstance = ServerInstance.initBallerinaServer();
-        ballerinaServerInstance.startBallerinaServer(balPath);
+        initBallerinaServer("query_and_path_param_support.bal");
     }
 
     @Test(description = "Tests path and query parameters support for WebSockets in Ballerina")
@@ -66,6 +59,6 @@ public class WebSocketQueryAndPathParamSupportTestCase extends WebSocketIntegrat
 
     @AfterClass(description = "Stops Ballerina")
     public void cleanup() throws BallerinaTestException {
-        ballerinaServerInstance.stopServer();
+        stopBallerinaServerInstance();
     }
 }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketServiceNotFoundTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketServiceNotFoundTest.java
@@ -20,14 +20,11 @@ package org.ballerinalang.test.service.websocket;
 
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
-import org.ballerinalang.test.util.websocket.server.WebSocketRemoteServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.net.URISyntaxException;
 
 /**
@@ -35,20 +32,11 @@ import java.net.URISyntaxException;
  */
 public class WebSocketServiceNotFoundTest extends WebSocketIntegrationTest {
 
-    private WebSocketRemoteServer remoteServer;
-    private ServerInstance ballerinaServerInstance;
     private WebSocketTestClient client;
 
     @BeforeClass(description = "Initializes Ballerina with the service_not_found.bal file")
-    public void setup() throws InterruptedException, BallerinaTestException {
-        remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
-        remoteServer.run();
-
-        String balPath = new File("src/test/resources/websocket/service_not_found.bal")
-                .getAbsolutePath();
-        ballerinaServerInstance = ServerInstance.initBallerinaServer();
-        ballerinaServerInstance.startBallerinaServer(balPath);
-
+    public void setup() throws BallerinaTestException {
+        initBallerinaServer("service_not_found.bal");
     }
 
     @Test(description = "Tests the service not found scenario",
@@ -60,7 +48,7 @@ public class WebSocketServiceNotFoundTest extends WebSocketIntegrationTest {
         client.shutDown();
     }
 
-    @Test(description = "Tests resource not found scenario",    
+    @Test(description = "Tests resource not found scenario",
           expectedExceptions = WebSocketHandshakeException.class,
           expectedExceptionsMessageRegExp = "Invalid handshake response getStatus: 404 Not Found")
     public void testResourceNotFound() throws InterruptedException, URISyntaxException {
@@ -71,8 +59,7 @@ public class WebSocketServiceNotFoundTest extends WebSocketIntegrationTest {
 
     @AfterClass(description = "Stops Ballerina")
     public void cleanup() throws BallerinaTestException {
-        ballerinaServerInstance.stopServer();
-        remoteServer.stop();
+       stopBallerinaServerInstance();
     }
 }
 

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClient.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClient.java
@@ -41,7 +41,6 @@ import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketCl
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -81,7 +80,6 @@ public class WebSocketTestClient {
 
     /**
      * Handshake with the remote server.
-     *
      */
     public void handshake() throws InterruptedException {
         group = new NioEventLoopGroup();
@@ -91,7 +89,7 @@ public class WebSocketTestClient {
             protected void initChannel(SocketChannel ch) {
                 ChannelPipeline pipeline = ch.pipeline();
                 pipeline.addLast(new HttpClientCodec(), new HttpObjectAggregator(8192),
-                          WebSocketClientCompressionHandler.INSTANCE, webSocketHandler);
+                                 WebSocketClientCompressionHandler.INSTANCE, webSocketHandler);
             }
         });
         channel = bootstrap.connect(uri.getHost(), uri.getPort()).sync().channel();
@@ -100,6 +98,7 @@ public class WebSocketTestClient {
 
     /**
      * Send text to the server.
+     *
      * @param text text need to be sent.
      */
     public void sendText(String text) throws InterruptedException {
@@ -112,9 +111,10 @@ public class WebSocketTestClient {
 
     /**
      * Send binary data to server.
+     *
      * @param buf buffer containing the data need to be sent.
      */
-    public void sendBinary(ByteBuffer buf) throws IOException, InterruptedException {
+    public void sendBinary(ByteBuffer buf) throws InterruptedException {
         if (channel == null) {
             logger.error("Channel is null. Cannot send text.");
             throw new IllegalArgumentException("Cannot find the channel to write");
@@ -124,9 +124,10 @@ public class WebSocketTestClient {
 
     /**
      * Send a ping message to the server.
+     *
      * @param buf content of the ping message to be sent.
      */
-    public void sendPing(ByteBuffer buf) throws IOException, InterruptedException {
+    public void sendPing(ByteBuffer buf) throws InterruptedException {
         if (channel == null) {
             logger.error("Channel is null. Cannot send text.");
             throw new IllegalArgumentException("Cannot find the channel to write");
@@ -173,6 +174,16 @@ public class WebSocketTestClient {
      */
     public boolean isPong() {
         return webSocketHandler.isPong();
+    }
+
+    /**
+     * Gets the header value from the response headers from the WebSocket handler.
+     *
+     * @param headerName the header name
+     * @return the header value from the response headers.
+     */
+    public String getHeader(String headerName) {
+        return webSocketHandler.getHeader(headerName);
     }
 
     /**

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClientHandler.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClientHandler.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
@@ -55,6 +56,7 @@ public class WebSocketTestClientHandler extends SimpleChannelInboundHandler<Obje
     private boolean isPing;
     private CountDownLatch countDownLatch = null;
     private ChannelHandlerContext ctx;
+    private HttpHeaders headers;
 
     public WebSocketTestClientHandler(WebSocketClientHandshaker handshaker) {
         this.handshaker = handshaker;
@@ -88,7 +90,9 @@ public class WebSocketTestClientHandler extends SimpleChannelInboundHandler<Obje
     public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
         Channel ch = ctx.channel();
         if (!handshaker.isHandshakeComplete()) {
-            handshaker.finishHandshake(ch, (FullHttpResponse) msg);
+            FullHttpResponse fullHttpResponse = (FullHttpResponse) msg;
+            headers = fullHttpResponse.headers();
+            handshaker.finishHandshake(ch, fullHttpResponse);
             logger.info("WebSocket Client connected!");
             handshakeFuture.setSuccess();
             return;
@@ -133,7 +137,6 @@ public class WebSocketTestClientHandler extends SimpleChannelInboundHandler<Obje
             }
         }
     }
-
 
 
     /**
@@ -195,4 +198,13 @@ public class WebSocketTestClientHandler extends SimpleChannelInboundHandler<Obje
         ctx.close();
     }
 
+    /**
+     * Gets the header value from the response headers.
+     *
+     * @param headerName the header name
+     * @return the header value from the response headers.
+     */
+    public String getHeader(String headerName) {
+        return headers.get(headerName);
+    }
 }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketHeadersHandler.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketHeadersHandler.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.util.websocket.server;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple Handler for testing the support for custom headers by WebSocket client and server.
+ * The class is a {@link ChannelDuplexHandler} and returns the request headers for the request and sets a new header
+ * to the response.
+ */
+public class WebSocketHeadersHandler extends ChannelDuplexHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketHeadersHandler.class);
+    private HttpHeaders requestHeaders;
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        log.debug("channel is active");
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        log.debug("channel is inactive");
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof FullHttpRequest) {
+            FullHttpRequest request = (FullHttpRequest) msg;
+            requestHeaders = request.headers();
+        }
+        super.channelRead(ctx, msg);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Exception Caught: " + cause.getMessage());
+        ctx.pipeline().remove(this);
+        ctx.fireExceptionCaught(cause);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse) msg;
+            response.headers().add("X-server-header", "server-header-value");
+            promise.addListener(future -> ctx.pipeline().remove(ctx.name()));
+        }
+        super.write(ctx, msg, promise);
+    }
+
+    /**
+     * Get http request requestHeaders.
+     *
+     * @return the http request requestHeaders
+     */
+    public HttpHeaders getRequestHeaders() {
+        return requestHeaders;
+    }
+}

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServerInitializer.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServerInitializer.java
@@ -34,13 +34,15 @@ public class WebSocketRemoteServerInitializer extends ChannelInitializer<SocketC
     private static final String WEBSOCKET_PATH = "/websocket";
 
     @Override
-    public void initChannel(SocketChannel ch) throws Exception {
+    public void initChannel(SocketChannel ch) {
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new HttpObjectAggregator(8192));
         pipeline.addLast(new WebSocketServerCompressionHandler());
+        WebSocketHeadersHandler headersHandler = new WebSocketHeadersHandler();
+        pipeline.addLast(headersHandler);
         pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
-        WebSocketRemoteServerFrameHandler frameHandler = new WebSocketRemoteServerFrameHandler();
+        WebSocketRemoteServerFrameHandler frameHandler = new WebSocketRemoteServerFrameHandler(headersHandler);
         pipeline.addLast(frameHandler);
     }
 }

--- a/tests/ballerina-test-integration/src/test/resources/websocket/custom_header_client.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/custom_header_client.bal
@@ -15,76 +15,63 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/io;
+import ballerina/log;
 
 @final string REMOTE_BACKEND_URL = "ws://localhost:15500/websocket";
 @final string ASSOCIATED_CONNECTION = "ASSOCIATED_CONNECTION";
 @final string data = "data";
 @final blob APPLICATION_DATA = data.toBlob("UTF-8");
 
-endpoint http:WebSocketListener ep {
-    port:9090
-};
-
 @http:WebSocketServiceConfig {
     path: "/pingpong/ws"
 }
-service <http:WebSocketService> PingPongTestService bind ep {
+service<http:WebSocketService> PingPongTestService bind { port: 9090 } {
 
     onOpen(endpoint wsEp) {
         endpoint http:WebSocketClient wsClientEp {
             url: REMOTE_BACKEND_URL,
-            callbackService: clientCallbackService
+            callbackService: clientCallbackService,
+            readyOnConnect: false,
+            customHeaders: { "X-some-header": "some-header-value" }
         };
         wsEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
         wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsEp;
+        wsClientEp->ready() but {
+            error e => log:printError(e.message, err = e)
+        };
     }
 
-    onText (endpoint wsEp, string text) {
+    onText(endpoint wsEp, string text) {
         endpoint http:WebSocketClient clientEp;
-
-        if(text == "ping-me") {
-            wsEp -> ping(APPLICATION_DATA) but {error e => io:println("error sending server ping")};
-        }
-
-        if(text == "ping-remote-server") {
+        if (text == "custom-headers") {
             clientEp = getAssociatedClientEndpoint(wsEp);
-            clientEp -> ping(APPLICATION_DATA) but {error e => io:println("error sending client ping")};
+            clientEp->pushText(text + ":X-some-header") but {
+                error e => log:printError("Error sending request headers", err = e)
+            };
         }
-
-        if(text == "tell-remote-server-to-ping") {
+        if (text == "server-headers") {
             clientEp = getAssociatedClientEndpoint(wsEp);
-            clientEp -> pushText("ping") but {error e => io:println("error sending client ping")};
+            clientEp->pushText(clientEp.response.getHeader("X-server-header")) but {
+                error e => log:printError("Error sending response headers", err = e)
+            };
         }
     }
-
-    onPing (endpoint wsEp, blob data) {
-        wsEp -> pong(data) but {error e => io:println("Error sending server pong")};
-    }
-
-    onPong (endpoint wsEp, blob data) {
-        wsEp -> pushText("pong-from-you") but {error e => io:println("server text error")};
-    }
-
 }
 
-service <http:WebSocketClientService> clientCallbackService {
+service<http:WebSocketClientService> clientCallbackService {
 
-    onPing (endpoint wsEp, blob data) {
+    onText(endpoint wsEp, string text) {
         endpoint http:WebSocketListener serverEp = getAssociatedListener(wsEp);
-        serverEp -> pushText("ping-from-remote-server-received") but {error e => io:println("error sending client text")};
-    }
-
-    onPong (endpoint wsEp, blob data) {
-        endpoint http:WebSocketListener serverEp = getAssociatedListener(wsEp);
-        serverEp -> pushText("pong-from-remote-server-received") but {error e => io:println("error sending client text")};
+        serverEp->pushText(text) but {
+            error e => log:printError("Error sending text to client", err = e)
+        };
     }
 }
 
 public function getAssociatedClientEndpoint(http:WebSocketListener wsServiceEp) returns (http:WebSocketClient) {
-    return check <http:WebSocketClient> wsServiceEp.attributes[ASSOCIATED_CONNECTION];
+    return check <http:WebSocketClient>wsServiceEp.attributes[ASSOCIATED_CONNECTION];
 }
 
 public function getAssociatedListener(http:WebSocketClient wsClientEp) returns (http:WebSocketListener) {
-    return check <http:WebSocketListener> wsClientEp.attributes[ASSOCIATED_CONNECTION];
+    return check <http:WebSocketListener>wsClientEp.attributes[ASSOCIATED_CONNECTION];
 }

--- a/tests/ballerina-test-integration/src/test/resources/websocket/ping_pong.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/ping_pong.bal
@@ -1,0 +1,125 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+import ballerina/log;
+
+@final string REMOTE_BACKEND_URL = "ws://localhost:15500/websocket";
+@final string ASSOCIATED_CONNECTION = "ASSOCIATED_CONNECTION";
+@final string data = "data";
+@final blob APPLICATION_DATA = data.toBlob("UTF-8");
+
+@http:WebSocketServiceConfig {
+    path: "/pingpong/ws"
+}
+service<http:WebSocketService> PingPongTestService bind { port: 9090 } {
+
+    onOpen(endpoint wsEp) {
+        endpoint http:WebSocketClient wsClientEp {
+            url: REMOTE_BACKEND_URL,
+            callbackService: clientCallbackService,
+            readyOnConnect: false
+        };
+        wsEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
+        wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsEp;
+        wsClientEp->ready() but {
+            error e => io:println(e.message)
+        };
+    }
+
+    onText(endpoint wsEp, string text) {
+        endpoint http:WebSocketClient clientEp;
+
+        if (text == "ping-me") {
+            wsEp->ping(APPLICATION_DATA) but {
+                error e => io:println("error sending server ping")
+            };
+        }
+
+        if (text == "ping-remote-server") {
+            clientEp = getAssociatedClientEndpoint(wsEp);
+            clientEp->ping(APPLICATION_DATA) but {
+                error e => io:println("error sending client ping")
+            };
+        }
+
+        if (text == "tell-remote-server-to-ping") {
+            clientEp = getAssociatedClientEndpoint(wsEp);
+            io:println(clientEp.response.getHeader("upgrade"));
+            clientEp->pushText("ping") but {
+                error e => io:println("error sending client ping")
+            };
+        }
+        if (text == "custom-headers") {
+            clientEp = getAssociatedClientEndpoint(wsEp);
+            clientEp->pushText(text + ":X-some-header") but {
+                error e => log:printError("Error sending request headers", err = e)
+            };
+        }
+        if (text == "server-headers") {
+            clientEp = getAssociatedClientEndpoint(wsEp);
+            clientEp->pushText(clientEp.response.getHeader("X-server-header")) but {
+                error e => log:printError("Error sending response headers", err = e)
+            };
+        }
+    }
+
+    onPing(endpoint wsEp, blob data) {
+        wsEp->pong(data) but {
+            error e => io:println("Error sending server pong")
+        };
+    }
+
+    onPong(endpoint wsEp, blob data) {
+        wsEp->pushText("pong-from-you") but {
+            error e => io:println("server text error")
+        };
+    }
+
+}
+
+service<http:WebSocketClientService> clientCallbackService {
+
+    onText(endpoint wsEp, string text) {
+        endpoint http:WebSocketListener serverEp = getAssociatedListener(wsEp);
+        serverEp->pushText(text) but {
+            error e => io:println("error sending client text")
+        };
+    }
+
+    onPing(endpoint wsEp, blob data) {
+        endpoint http:WebSocketListener serverEp = getAssociatedListener(wsEp);
+        serverEp->pushText("ping-from-remote-server-received") but {
+            error e => io:println("error sending client text")
+        };
+    }
+
+    onPong(endpoint wsEp, blob data) {
+        endpoint http:WebSocketListener serverEp = getAssociatedListener(wsEp);
+        serverEp->pushText("pong-from-remote-server-received") but {
+            error e => io:println("error sending client text")
+        };
+    }
+}
+
+public function getAssociatedClientEndpoint(http:WebSocketListener wsServiceEp) returns (http:WebSocketClient) {
+    return check <http:WebSocketClient>wsServiceEp.attributes[ASSOCIATED_CONNECTION];
+}
+
+public function getAssociatedListener(http:WebSocketClient wsClientEp) returns (http:WebSocketListener) {
+    return check <http:WebSocketListener>wsClientEp.attributes[ASSOCIATED_CONNECTION];
+}

--- a/tests/ballerina-test-integration/src/test/resources/websocket/query_and_path_param_support.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/query_and_path_param_support.bal
@@ -22,11 +22,7 @@ import ballerina/http;
 @final string QUERY1 = "QUERY1";
 @final string QUERY2 = "QUERY2";
 
-endpoint http:Listener ep {
-    port:9090
-};
-
-service <http:Service> simple bind ep {
+service<http:Service> simple bind { port: 9090 } {
 
     @http:ResourceConfig {
         webSocketUpgrade: {
@@ -34,9 +30,9 @@ service <http:Service> simple bind ep {
             upgradeService: simpleProxy
         }
     }
-    websocketProxy (endpoint httpEp, http:Request req, string path1, string path2) {
+    websocketProxy(endpoint httpEp, http:Request req, string path1, string path2) {
         endpoint http:WebSocketListener wsServiceEp;
-        wsServiceEp = httpEp -> acceptWebSocketUpgrade({"some-header":"some-header-value"});
+        wsServiceEp = httpEp->acceptWebSocketUpgrade({ "X-some-header": "some-header-value" });
         wsServiceEp.attributes[PATH1] = path1;
         wsServiceEp.attributes[PATH2] = path2;
         wsServiceEp.attributes[QUERY1] = req.getQueryParams()["q1"];
@@ -44,17 +40,19 @@ service <http:Service> simple bind ep {
     }
 }
 
-service <http:WebSocketService> simpleProxy {
+service<http:WebSocketService> simpleProxy {
 
     onText(endpoint wsEp, string text) {
         if (text == "send") {
-            string path1 = <string> wsEp.attributes[PATH1];
-            string path2 = <string> wsEp.attributes[PATH2];
-            string query1 = <string> wsEp.attributes[QUERY1];
-            string query2 = <string> wsEp.attributes[QUERY2];
+            string path1 = <string>wsEp.attributes[PATH1];
+            string path2 = <string>wsEp.attributes[PATH2];
+            string query1 = <string>wsEp.attributes[QUERY1];
+            string query2 = <string>wsEp.attributes[QUERY2];
 
             string msg = string `path-params: {{path1}}, {{path2}}; query-params: {{query1}}, {{query2}}`;
-            wsEp -> pushText(msg) but {error e => io:println("Error sending message. " + e.message)};
+            wsEp->pushText(msg) but {
+                error e => io:println("Error sending message. " + e.message)
+            };
         }
     }
 }

--- a/tests/ballerina-test-integration/src/test/resources/websocket/service_not_found.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/service_not_found.bal
@@ -17,14 +17,10 @@
 import ballerina/log;
 import ballerina/http;
 
-endpoint http:Listener ep {
-    port:9090
-};
-
 @http:ServiceConfig {
     basePath: "/proxy"
 }
-service<http:Service> simple bind ep {
+service<http:Service> simple bind { port: 9090 } {
 
     @http:ResourceConfig {
         webSocketUpgrade: {

--- a/tests/ballerina-test-integration/src/test/resources/websocket/simple_proxy_server.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/simple_proxy_server.bal
@@ -20,16 +20,12 @@ import ballerina/http;
 @final string REMOTE_BACKEND_URL = "ws://localhost:15500/websocket";
 @final string ASSOCIATED_CONNECTION = "ASSOCIATED_CONNECTION";
 
-endpoint http:WebSocketListener ep {
-    port:9090
-};
-
 @http:WebSocketServiceConfig {
     path: "/proxy/ws"
 }
-service <http:WebSocketService> simpleProxy bind ep {
+service<http:WebSocketService> simpleProxy bind { port: 9090 } {
 
-    onOpen (endpoint wsEp) {
+    onOpen(endpoint wsEp) {
         endpoint http:WebSocketClient wsClientEp {
             url: REMOTE_BACKEND_URL,
             callbackService: clientCallbackService,
@@ -37,47 +33,61 @@ service <http:WebSocketService> simpleProxy bind ep {
         };
         wsEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
         wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsEp;
-        wsClientEp -> ready() but { error e => io:println(e.message) };
+        wsClientEp->ready() but {
+            error e => io:println(e.message)
+        };
     }
 
-    onText (endpoint wsEp, string text) {
+    onText(endpoint wsEp, string text) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint(wsEp);
-        clientEp -> pushText(text) but {error e => io:println("server text error")};
+        clientEp->pushText(text) but {
+            error e => io:println("server text error")
+        };
     }
 
-    onBinary (endpoint wsEp, blob data) {
+    onBinary(endpoint wsEp, blob data) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint(wsEp);
-        clientEp -> pushBinary(data) but {error e => io:println("server binary error")};
+        clientEp->pushBinary(data) but {
+            error e => io:println("server binary error")
+        };
     }
 
-    onClose (endpoint wsEp, int statusCode, string reason) {
+    onClose(endpoint wsEp, int statusCode, string reason) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint(wsEp);
-        clientEp -> close(statusCode, reason) but {error e => io:println("server closing error")};
+        clientEp->close(statusCode, reason) but {
+            error e => io:println("server closing error")
+        };
     }
 
 }
 
-service <http:WebSocketClientService> clientCallbackService {
-    onText (endpoint wsEp, string text) {
+service<http:WebSocketClientService> clientCallbackService {
+    onText(endpoint wsEp, string text) {
         endpoint http:WebSocketListener serviceEp = getAssociatedListener(wsEp);
-        serviceEp -> pushText(text)  but {error e => io:println("client text error")};
+        serviceEp->pushText(text) but {
+            error e => io:println("client text error")
+        };
     }
 
-    onBinary (endpoint wsEp, blob data) {
+    onBinary(endpoint wsEp, blob data) {
         endpoint http:WebSocketListener serviceEp = getAssociatedListener(wsEp);
-        serviceEp -> pushBinary(data) but {error e => io:println("client binary error")};
+        serviceEp->pushBinary(data) but {
+            error e => io:println("client binary error")
+        };
     }
 
-    onClose (endpoint wsEp, int statusCode, string reason) {
+    onClose(endpoint wsEp, int statusCode, string reason) {
         endpoint http:WebSocketListener serviceEp = getAssociatedListener(wsEp);
-        serviceEp -> close(statusCode, reason) but {error e => io:println("client closing error")};
+        serviceEp->close(statusCode, reason) but {
+            error e => io:println("client closing error")
+        };
     }
 }
 
 public function getAssociatedClientEndpoint(http:WebSocketListener wsServiceEp) returns (http:WebSocketClient) {
-    return check <http:WebSocketClient> wsServiceEp.attributes[ASSOCIATED_CONNECTION];
+    return check <http:WebSocketClient>wsServiceEp.attributes[ASSOCIATED_CONNECTION];
 }
 
 public function getAssociatedListener(http:WebSocketClient wsClientEp) returns (http:WebSocketListener) {
-    return check <http:WebSocketListener> wsClientEp.attributes[ASSOCIATED_CONNECTION];
+    return check <http:WebSocketListener>wsClientEp.attributes[ASSOCIATED_CONNECTION];
 }


### PR DESCRIPTION
## Purpose
> User of a WebSocket client has to be able to access the response from the server. One reason for this would be to be able to access custom headers.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/8390

## Automation tests
 - Integration tests
   > Included test for client and server, sending and receiving custom headers.

## Security checks
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/transport-http/pull/166
