### PR TITLE
Mandate java version 1.8 for ballerina runtime

### DIFF
--- a/distribution/zip/ballerina/bin/ballerina
+++ b/distribution/zip/ballerina/bin/ballerina
@@ -146,6 +146,12 @@ if [ "$CMD" = "--java.debug" ]; then
   echo "Please start the remote debugging client to continue..."
 fi
 
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8|9]"`
+if [ "$jdk_18" = "" ]; then
+   echo "Error: Ballerina is supported only on JDK 1.8 and above"
+   exit 1
+fi
+
 BALLERINA_XBOOTCLASSPATH=""
 for f in "$BALLERINA_HOME"/bre/lib/bootstrap/xboot/*.jar
 do

--- a/distribution/zip/ballerina/bin/ballerina.bat
+++ b/distribution/zip/ballerina/bin/ballerina.bat
@@ -96,6 +96,21 @@ goto end
 :doneStart
 if "%OS%"=="Windows_NT" @setlocal
 if "%OS%"=="WINNT" @setlocal
+rem find the version of the jdk
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk18
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8|9]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk18
+
+:unknownJdk
+echo Ballerina is supported only on JDK 1.8 and above
+goto end
+
+:jdk18
 goto runServer
 
 


### PR DESCRIPTION
## Purpose
This will mandate java version 1.8 for ballerina runtime. Resolves #3017