### PR TITLE
Request body support for swagger codegen

### DIFF
--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
@@ -29,19 +29,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-models</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-models</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
         <dependency>

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaMediaType.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaMediaType.java
@@ -33,6 +33,7 @@ public class BallerinaMediaType implements BallerinaSwaggerObject<BallerinaMedia
     private Object example;
     private Map<String, Encoding> encoding;
     private Map<String, Object> extensions;
+    private String mediaType;
 
     @Override
     public BallerinaMediaType buildContext(MediaType mediaType) throws BallerinaOpenApiException {
@@ -73,5 +74,13 @@ public class BallerinaMediaType implements BallerinaSwaggerObject<BallerinaMedia
 
     public Map<String, Object> getExtensions() {
         return extensions;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
     }
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaMediaType.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaMediaType.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.model;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Encoding;
+import io.swagger.v3.oas.models.media.MediaType;
+import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
+
+import java.util.Map;
+
+/**
+ * Wraps {@link MediaType} to build a MediaType object model for ballerina templates.
+ */
+public class BallerinaMediaType implements BallerinaSwaggerObject<BallerinaMediaType, MediaType> {
+    private BallerinaSchema schema;
+    private Map<String, Example> examples;
+    private Object example;
+    private Map<String, Encoding> encoding;
+    private Map<String, Object> extensions;
+
+    @Override
+    public BallerinaMediaType buildContext(MediaType mediaType) throws BallerinaOpenApiException {
+        return buildContext(mediaType, null);
+    }
+
+    @Override
+    public BallerinaMediaType buildContext(MediaType mediaType, OpenAPI openAPI) throws BallerinaOpenApiException {
+        this.example = mediaType.getExample();
+        this.extensions = mediaType.getExtensions();
+        this.encoding = mediaType.getEncoding();
+        this.examples = mediaType.getExamples();
+        this.schema = new BallerinaSchema().buildContext(mediaType.getSchema(), openAPI);
+
+        return this;
+    }
+
+    @Override
+    public BallerinaMediaType getDefaultValue() {
+        return new BallerinaMediaType();
+    }
+
+    public BallerinaSchema getSchema() {
+        return schema;
+    }
+
+    public Map<String, Example> getExamples() {
+        return examples;
+    }
+
+    public Object getExample() {
+        return example;
+    }
+
+    public Map<String, Encoding> getEncoding() {
+        return encoding;
+    }
+
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOpenApi.java
@@ -130,10 +130,16 @@ public class BallerinaOpenApi implements BallerinaSwaggerObject<BallerinaOpenApi
         }
 
         schemaMap = openAPI.getComponents().getSchemas();
-        for (Map.Entry entry : schemaMap.entrySet()) {
+        for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
             try {
-                BallerinaSchema schema = new BallerinaSchema().buildContext((Schema) entry.getValue(), openAPI);
-                schemas.add(new AbstractMap.SimpleEntry<>((String) entry.getKey(), schema));
+                BallerinaSchema schema = new BallerinaSchema().buildContext(entry.getValue(), openAPI);
+
+                // If schema type has not been set, set the type with Schema name
+                if (StringUtils.isEmpty(schema.getType())) {
+                    schema.setType(entry.getKey());
+                }
+
+                schemas.add(new AbstractMap.SimpleEntry<>(entry.getKey(), schema));
             } catch (BallerinaOpenApiException e) {
                 // Ignore exception and try to build next schema. No need to break the flow for a failure of one schema.
             }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaOperation.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.parameters.Parameter;
-import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
@@ -47,7 +46,7 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
     private ExternalDocumentation externalDocs;
     private String operationId;
     private List<BallerinaParameter> parameters;
-    private RequestBody requestBody;
+    private BallerinaRequestBody requestBody;
     private Set<Map.Entry<String, ApiResponse>> responses;
     private Set<Map.Entry<String, Callback>> callbacks;
     private List<SecurityRequirement> security;
@@ -75,11 +74,11 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
         this.summary = operation.getSummary();
         this.description = operation.getDescription();
         this.externalDocs = operation.getExternalDocs();
-        this.requestBody = operation.getRequestBody();
         this.security = operation.getSecurity();
 
         this.parameters = new ArrayList<>();
         this.methods = null;
+        this.requestBody = new BallerinaRequestBody().buildContext(operation.getRequestBody(), openAPI);
 
         if (operation.getResponses() != null) {
             operation.getResponses()
@@ -178,7 +177,7 @@ public class BallerinaOperation implements BallerinaSwaggerObject<BallerinaOpera
         return parameters;
     }
 
-    public RequestBody getRequestBody() {
+    public BallerinaRequestBody getRequestBody() {
         return requestBody;
     }
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaRequestBody.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaRequestBody.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.model;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import org.apache.commons.lang3.StringUtils;
+import org.ballerinalang.swagger.exception.BallerinaOpenApiException;
+import org.ballerinalang.swagger.utils.GeneratorConstants;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wraps {@link RequestBody} to build a easily accessible RequestBody object model for templates.
+ */
+public class BallerinaRequestBody implements BallerinaSwaggerObject<BallerinaRequestBody, RequestBody> {
+    private String description;
+    private Set<Map.Entry<String, BallerinaMediaType>> content;
+    private Boolean required;
+    private Map<String, Object> extensions;
+    private String ref;
+    private BallerinaMediaType selectedMedia; // selected specific media type in multi content scenario
+
+    @Override
+    public BallerinaRequestBody buildContext(RequestBody body) throws BallerinaOpenApiException {
+        return buildContext(body, null);
+    }
+
+    @Override
+    public BallerinaRequestBody buildContext(RequestBody body, OpenAPI openAPI) throws BallerinaOpenApiException {
+        if (body == null || openAPI == null) {
+            return getDefaultValue();
+        }
+
+        // If reference type request body is provided extract the reference
+        if (!StringUtils.isEmpty(body.get$ref())) {
+            String refType = getReferenceType(body.get$ref());
+            body = openAPI.getComponents().getRequestBodies().get(refType);
+        }
+
+        this.description = body.getDescription();
+        this.required = body.getRequired();
+        this.extensions = body.getExtensions();
+        this.ref = body.get$ref();
+        this.content = new LinkedHashSet<>();
+
+        if (body.getContent() == null) {
+            throw new BallerinaOpenApiException("RequestBody content cannot be null");
+        }
+
+        int i = 0;
+        for (Map.Entry<String, MediaType> m : body.getContent().entrySet()) {
+            BallerinaMediaType bMedia = new BallerinaMediaType().buildContext(m.getValue(), openAPI);
+            AbstractMap.Entry<String, BallerinaMediaType> entry = new AbstractMap.SimpleEntry<>(m.getKey(), bMedia);
+
+            // keep first mediaType as selected media type
+            if (i == 0) {
+                this.selectedMedia = bMedia;
+            }
+            content.add(entry);
+            i++;
+        }
+
+        return this;
+    }
+
+    @Override
+    public BallerinaRequestBody getDefaultValue() {
+        return null;
+    }
+
+    private String getReferenceType(String refPath) {
+        // null check on refPath is not required since swagger parser always make sure this is not null
+        return refPath.substring(refPath.lastIndexOf(GeneratorConstants.OAS_PATH_SEPARATOR) + 1);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Set<Map.Entry<String, BallerinaMediaType>> getContent() {
+        return content;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public BallerinaMediaType getSelectedMedia() {
+        return selectedMedia;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
@@ -49,7 +49,6 @@ import java.util.Set;
  */
 public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, Schema> {
     private static final String LIST_SUFFIX = "List";
-    private static final String OAS_PATH_SEPARATOR = "/";
     private static final String UNSUPPORTED_PROPERTY_MSG = "// Unsupported Property Found.";
 
     private Schema oasSchema;
@@ -130,7 +129,7 @@ public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, 
 
     private String getReferenceType(String refPath) {
         // null check on refPath is not required since swagger parser always make sure this is not null
-        return refPath.substring(refPath.lastIndexOf(OAS_PATH_SEPARATOR) + 1);
+        return refPath.substring(refPath.lastIndexOf(GeneratorConstants.OAS_PATH_SEPARATOR) + 1);
     }
 
     private String getPropertyType(Schema prop) {

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
@@ -202,8 +202,13 @@ public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, 
     }
 
     /**
-     * Verify if {@code origName} is reserved ballerina keyword and prefix the {@code origName} with an '_'.
-     * Ex: toPropertyName("type") will return "_type".
+     * Change the provided property name to ballerina property name.
+     * <p>Following actions will be taken for the conversion</p>
+     * <ol>
+     * <li>Verify if {@code origName} is reserved ballerina keyword and prefix the {@code origName} with an '_'.
+     * Ex: toPropertyName("type") will return "_type".</li>
+     * <li>Escape invalid special characters</li>
+     * </ol>
      *
      * @param origName original property name
      * @return keyword escaped property name
@@ -215,6 +220,7 @@ public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, 
             escapedName = '_' + origName;
         }
 
+        escapedName = escapedName.replaceAll("[^a-zA-Z0-9_]+", "_");
         return escapedName;
     }
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/model/BallerinaSchema.java
@@ -198,7 +198,11 @@ public class BallerinaSchema implements BallerinaSwaggerObject<BallerinaSchema, 
             childSchemas.add(new BallerinaSchema().buildContext(schema, openAPI));
         }
 
-        childSchemas.forEach(schema -> this.properties.addAll(schema.getProperties()));
+        childSchemas.forEach(schema -> {
+            if (schema.getProperties() != null) {
+                this.properties.addAll(schema.getProperties());
+            }
+        });
     }
 
     /**

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/GeneratorConstants.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/GeneratorConstants.java
@@ -65,6 +65,7 @@ public class GeneratorConstants {
     public static final String GEN_SRC_DIR = "gen";
     public static final String DEFAULT_CLIENT_PKG = "client";
     public static final String DEFAULT_MOCK_PKG = "mock";
+    public static final String OAS_PATH_SEPARATOR = "/";
 
     public static final String UNTITLED_SERVICE = "UntitledAPI";
     public static final List<String> RESERVED_KEYWORDS = Collections.unmodifiableList(

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
@@ -46,7 +46,7 @@ public type {{cut info.title " "}}Client object {
         endpoint http:Client ep = self.clientEp.client;
         http:Request request = new;
 
-        //Create the required request as needed
+        // TODO: Update the request as needed
         return check ep->{{lower .}}("{{../../../key}}", request = request);
     }
     {{/methods}}{{else}}{{#allMethods}}
@@ -54,16 +54,19 @@ public type {{cut info.title " "}}Client object {
         endpoint http:Client ep = self.clientEp.client;
         http:Request request = new;
 
-        //Create the required request as needed
+        // TODO: Update the request as needed
         return check ep->{{lower .}}("{{../../../key}}", request = request);
     }
     {{/allMethods}}{{/if}}{{else}}
-    public function {{operationId}}({{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
-        endpoint http:Client ep = self.clientEp.client;
-        http:Request request = new;
+    public function {{operationId}}({{#requestBody}}{{>reqBody}}{{/requestBody}}{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response | error {
+        endpoint http:Client _{{operationId}}Ep = self.clientEp.client;
+        http:Request request = new;{{#requestBody}}{{#equals requestBody.selectedMedia.mediaType "application/json"}}
+        json _{{operationId}}JsonBody = check <json> _{{operationId}}Body;
+        request.setPayload(_{{operationId}}JsonBody);{{else}}
+        request.setPayload(_{{operationId}}Body);{{/equals}}{{/requestBody}}
 
-        //Create the required request as needed
-        return check ep->{{key}}("{{../../key}}", request = request);
+        // TODO: Update the request as needed
+        return check _{{operationId}}Ep->{{key}}("{{../../key}}", request = request);
     }
     {{/equals}}{{/value}}{{/operations}}{{/value}}{{/paths}}
 };

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
@@ -7,6 +7,7 @@ import ballerina/http;
 //=====================================
 public type {{cut info.title " "}}ClientConfig {
     string serviceUrl,
+    http:ClientEndpointConfig clientConfig,
 };
 
 //=======================================
@@ -20,7 +21,9 @@ public type {{cut info.title " "}}ClientEp object {
 
     public function init({{cut info.title " "}}ClientConfig config) {
         endpoint http:Client httpEp {
-            url: config.serviceUrl
+            url: config.serviceUrl,
+            auth: config.clientConfig.auth,
+            cache: config.clientConfig.cache
         };
 
         self.client = httpEp;

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/pathParams.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/pathParams.mustache
@@ -1,1 +1,1 @@
-{{#equals in "path"}}{{schema.type}} {{name}}{{#unless @last}}, {{/unless}}{{/equals}}
+{{#if requestBody}}, {{/if}}{{#equals in "path"}}{{schema.type}} {{name}}{{/equals}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/reqBody.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/reqBody.mustache
@@ -1,0 +1,1 @@
+{{requestBody.selectedMedia.schema.type}} _{{operationId}}Body

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/impl.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/impl.mustache
@@ -1,6 +1,6 @@
 import ballerina/http;
 {{#paths}}{{#value}}{{#operations}}{{#value}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) returns http:Response {
+public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}{{#requestBody}}{{>reqBody}}{{/requestBody}}) returns http:Response {
     //stub code - fill as necessary
     http:Response resp = new;
     string payload = "Sample {{operationId}} Response";

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/impl.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/impl.mustache
@@ -1,11 +1,10 @@
-import ballerina/http;
 {{#paths}}{{#value}}{{#operations}}{{#value}}
-public function {{operationId}} (http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}{{#requestBody}}{{>reqBody}}{{/requestBody}}) returns http:Response {
-    //stub code - fill as necessary
-    http:Response resp = new;
-    string payload = "Sample {{operationId}} Response";
-    resp.setTextPayload(payload);
+public function {{operationId}} (http:Request _{{operationId}}Req{{#parameters}}{{>pathParams}}{{/parameters}}{{#requestBody}}, {{requestBody.selectedMedia.schema.type}} _{{operationId}}Body{{/requestBody}}) returns http:Response {
+    // stub code - fill as necessary
+    http:Response _{{operationId}}Res = new;
+    string _{{operationId}}Payload = "Sample {{operationId}} Response";
+    _{{operationId}}Res.setTextPayload(_{{operationId}}Payload);
 
-	return resp;
+	return _{{operationId}}Res;
 }
 {{/value}}{{/operations}}{{/value}}{{/paths}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
@@ -1,5 +1,6 @@
-import ballerina/log;
 import ballerina/http;
+import ballerina/log;
+import ballerina/mime;
 import ballerina/swagger;
 
 {{#servers}}endpoint http:Listener ep{{@index}} { {{#host}}
@@ -46,13 +47,15 @@ service {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unless @last}}, {
     @http:ResourceConfig { {{#equals key "multi"}}{{#if methods}}
         methods:[{{#methods}}"{{.}}"{{#unless @last}}, {{/unless}}{{/methods}}],{{/if}}{{else}}
         methods:["{{upper key}}"],{{/equals}}
-        path:"{{../../key}}"{{#requestBody}},
-        body:"body"{{/requestBody}}
+        path:"{{../../key}}"{{#requestBody}}{{#equals "multipart/form-data" requestBody.selectedMedia.mediaType}}{{else}},
+        body:"_{{operationId}}Body"{{/equals}}{{/requestBody}}
     }{{#deprecated}}
     deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}{{#requestBody}}{{>reqBody}}{{/requestBody}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}}{{#requestBody}}, body{{/requestBody}});
-        outboundEp->respond(res) but { error e => log:printError("Error while responding", err = e) };
+    {{operationId}} (endpoint outboundEp, http:Request _{{operationId}}Req{{#parameters}}{{>pathParams}}{{/parameters}}{{#requestBody}}{{>reqBody}}{{/requestBody}}) { {{#equals requestBody.selectedMedia.mediaType "multipart/form-data"}}
+        mime:Entity[] _{{operationId}}Body = check _{{operationId}}Req.getBodyParts();
+    {{/equals}}
+        http:Response _{{operationId}}Res = {{operationId}}(_{{operationId}}Req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}}{{#requestBody}}, _{{operationId}}Body{{/requestBody}});
+        outboundEp->respond(_{{operationId}}Res) but { error e => log:printError("Error while responding", err = e) };
     }
 {{/value}}{{/operations}}{{/value}}{{/paths}}
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/mock.mustache
@@ -46,11 +46,12 @@ service {{cut info.title " "}} bind {{#servers}}ep{{@index}}{{#unless @last}}, {
     @http:ResourceConfig { {{#equals key "multi"}}{{#if methods}}
         methods:[{{#methods}}"{{.}}"{{#unless @last}}, {{/unless}}{{/methods}}],{{/if}}{{else}}
         methods:["{{upper key}}"],{{/equals}}
-        path:"{{../../key}}"
+        path:"{{../../key}}"{{#requestBody}},
+        body:"body"{{/requestBody}}
     }{{#deprecated}}
     deprecated {}{{/deprecated}}
-    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}});
+    {{operationId}} (endpoint outboundEp, http:Request req{{#parameters}}{{>pathParams}}{{/parameters}}{{#requestBody}}{{>reqBody}}{{/requestBody}}) {
+        http:Response res = {{operationId}}(req{{#parameters}}{{#equals in "path"}}, {{name}}{{/equals}}{{/parameters}}{{#requestBody}}, body{{/requestBody}});
         outboundEp->respond(res) but { error e => log:printError("Error while responding", err = e) };
     }
 {{/value}}{{/operations}}{{/value}}{{/paths}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/reqBody.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/reqBody.mustache
@@ -1,1 +1,1 @@
-, {{#if requestBody.isMultiContent}}var{{/if}}{{^if}}{{#if requestBody.selectedMedia.schema.isComposed}}var{{/if}}{{^if}}{{requestBody.selectedMedia.schema.type}}{{/if}}{{/if}} body
+{{#equals requestBody.selectedMedia.mediaType "multipart/form-data"}}{{else}}, {{requestBody.selectedMedia.schema.type}} _{{operationId}}Body{{/equals}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/reqBody.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/mock/reqBody.mustache
@@ -1,0 +1,1 @@
+, {{#if requestBody.isMultiContent}}var{{/if}}{{^if}}{{#if requestBody.selectedMedia.schema.isComposed}}var{{/if}}{{^if}}{{requestBody.selectedMedia.schema.type}}{{/if}}{{/if}} body

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/model/schemas.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/model/schemas.mustache
@@ -1,5 +1,5 @@
 {{#schemas}}{{#value}}
 {{#isArraySchema}}public type {{key}} {};{{/isArraySchema}}{{^isArraySchema}}
 public type {{key}} { {{#properties}}
-    {{#value}}{{type}}{{/value}} {{key}},{{/properties}}
+    {{#value}}{{#equals ../../key type}}{{type}}?{{else}}{{type}}{{/equals}}{{/value}} {{key}},{{/properties}}
 };{{/isArraySchema}}{{/value}}{{/schemas}}

--- a/pom.xml
+++ b/pom.xml
@@ -627,34 +627,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-jaxrs</artifactId>
-                <version>${io.swagger.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>jsr311-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.dataformat</groupId>
-                        <artifactId>jackson-dataformat-xml</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.yaml</groupId>
-                        <artifactId>snakeyaml</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-joda</artifactId>
-                <version>${com.fasterxml.jackson.datatype.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${com.fasterxml.jackson.dataformat.yaml.version}</version>
@@ -1550,8 +1522,8 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <commons.lang3.version>3.5</commons.lang3.version>
         <javax.websocket.version>1.1</javax.websocket.version>
-        <jackson.version>2.8.6</jackson.version>
-        <com.fasterxml.jackson.dataformat.yaml.version>2.8.8</com.fasterxml.jackson.dataformat.yaml.version>
+        <jackson.version>2.9.1</jackson.version>
+        <com.fasterxml.jackson.dataformat.yaml.version>2.9.1</com.fasterxml.jackson.dataformat.yaml.version>
         <tapestry.json.orbit.version>5.4.1.wso2v1</tapestry.json.orbit.version>
         <orbit.version.axiom>1.2.20</orbit.version.axiom>
         <saxon.wso2.version>9.7.0.wso2v1</saxon.wso2.version>
@@ -1578,21 +1550,21 @@
         <airline.version>0.7</airline.version>
         <guice.version>4.1.0</guice.version>
         <commons-cli.version>1.3.1</commons-cli.version>
-        <io.swagger.version>1.5.8</io.swagger.version>
+        <io.swagger.version>1.5.18</io.swagger.version>
         <com.fasterxml.jackson.datatype.version>2.4.1</com.fasterxml.jackson.datatype.version>
         <swagger.parser.version>1.0.34</swagger.parser.version>
-        <swagger.models.version>1.5.16</swagger.models.version>
+        <swagger.models.version>1.5.18</swagger.models.version>
         <swagger.v3.parser.version>2.0.0-rc3</swagger.v3.parser.version>
-        <swagger.v3.models.version>2.0.0</swagger.v3.models.version>
+        <swagger.v3.models.version>2.0.0-rc4</swagger.v3.models.version>
         <swagger.parser.v2.converter.version>2.0.0-rc3</swagger.parser.v2.converter.version>
-        <com.fasterxml.jackson.core.annotations.version>2.8.0</com.fasterxml.jackson.core.annotations.version>
+        <com.fasterxml.jackson.core.annotations.version>2.9.1</com.fasterxml.jackson.core.annotations.version>
         <rs-api.version>2.0</rs-api.version>
         <msf4j.version>2.4.2</msf4j.version>
         <servlet-api-version>2.5</servlet-api-version>
         <javax-transaction-version>1.2</javax-transaction-version>
         <quartz.version>2.3.0</quartz.version>
         <commons-net.version>3.6</commons-net.version>
-        <jackson-core.version>2.8.6</jackson-core.version>
+        <jackson-core.version>2.9.1</jackson-core.version>
         <apache.mina.core>2.0.16</apache.mina.core>
         <mimepull.version>1.9.7</mimepull.version>
         <broker.version>0.970.0</broker.version>


### PR DESCRIPTION
## Purpose
This PR introduces several improvements to swagger -> B7a code generator. 
With this PR users will be able to generate the code for resources containing request body parameters. Json type body params will be automatically matched with respective ballerina type definition. Users will have to provided data in matching types for other Media types.

Ex: 
1. For a resource containing `application/json` type request body, users will be able to use generated ballerina type for that parameter schema. **Note**: Inline parameter schema definitions will not be honored.
2. For a resource containing `application/xml` type request body, users will have to provided `xml` type data model. Generated ballerina data model will not be mapped automatically as ballerina doesn't support it at the moment.

## Goals

- Add requestBody support for swagger client
- Improve requestBody support for mock service
- Add support for cyclic type definitions
- Fix issue in composed schema generation
- Add special character validation to property names
- Update swagger dependencies
- Set schema name as schema type
- Introduce requestBody support in mock service
- Add support for recursive reference schemas

