### PR TITLE
Use separate regex to split by new line

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
@@ -185,7 +185,7 @@ public class CommandExecutor {
         if (docAttachmentInfo != null) {
             String fileContent = context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY)
                     .getFileContent(Paths.get(URI.create(documentUri)));
-            String[] contentComponents = fileContent.split(System.lineSeparator());
+            String[] contentComponents = fileContent.split(CommonUtil.LINE_SEPARATOR_SPLIT);
             int replaceEndCol = contentComponents[line - 1].length();
             String replaceText = String.join(System.lineSeparator(),
                     Arrays.asList(Arrays.copyOfRange(contentComponents, 0, line)))
@@ -219,7 +219,7 @@ public class CommandExecutor {
 
         String fileContent = context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY)
                 .getFileContent(Paths.get(URI.create(documentUri)));
-        String[] contentComponents = fileContent.split(System.lineSeparator());
+        String[] contentComponents = fileContent.split(CommonUtil.LINE_SEPARATOR_SPLIT);
         List<TextEdit> textEdits = new ArrayList<>();
         bLangPackage.topLevelNodes.forEach(topLevelNode -> {
             CommandUtil.DocAttachmentInfo docAttachmentInfo = getDocumentEditForNode(topLevelNode);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -84,6 +84,8 @@ public class CommonUtil {
     
     public static final String LINE_SEPARATOR = System.lineSeparator();
 
+    public static final String LINE_SEPARATOR_SPLIT = "\\r?\\n";
+
     /**
      * Get the package URI to the given package name.
      *
@@ -290,7 +292,7 @@ public class CommonUtil {
         List<String> topLevelKeywords = Arrays.asList("function", "service", "resource", "endpoint", "type");
         LSDocument document = new LSDocument(identifier.getUri());
         String fileContent = docManager.getFileContent(getPath(document));
-        String[] splitedFileContent = fileContent.split(LINE_SEPARATOR);
+        String[] splitedFileContent = fileContent.split(LINE_SEPARATOR_SPLIT);
         if ((splitedFileContent.length - 1) >= startPosition.getLine()) {
             String lineContent = splitedFileContent[startPosition.getLine()];
             List<String> alphaNumericTokens = new ArrayList<>(Arrays.asList(lineContent.split("[^\\w']+")));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleMatchStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleMatchStatementContextResolver.java
@@ -50,7 +50,9 @@ import java.util.stream.Collectors;
  * Completion Item resolver for the match statement parser rule context.
  */
 public class ParserRuleMatchStatementContextResolver extends AbstractItemResolver {
-    private static final String LINE_SEPERATOR = System.lineSeparator();
+
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+
     @Override
     public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
@@ -123,16 +125,16 @@ public class ParserRuleMatchStatementContextResolver extends AbstractItemResolve
     private String getMatchFieldsSnippet(BUnionType bUnionType) {
         Set<BType> memberTypes = bUnionType.getMemberTypes();
         StringBuilder fieldsSnippet = new StringBuilder("{");
-        fieldsSnippet.append(LINE_SEPERATOR);
+        fieldsSnippet.append(LINE_SEPARATOR);
 
         memberTypes.forEach(bType -> {
             fieldsSnippet
                     .append("\t").append(bType.toString()).append(" => {")
-                    .append(LINE_SEPERATOR)
+                    .append(LINE_SEPARATOR)
                     .append("\t\t")
-                    .append(LINE_SEPERATOR)
+                    .append(LINE_SEPARATOR)
                     .append("\t").append("}")
-                    .append(LINE_SEPERATOR);
+                    .append(LINE_SEPARATOR);
         });
         fieldsSnippet.append("}");
         

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/CompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/CompletionUtil.java
@@ -107,7 +107,7 @@ public class CompletionUtil {
         String fileContent = documentManager.getFileContent(completionPath);
         lock.ifPresent(Lock::unlock);
 
-        String[] splitContent = fileContent.split(CommonUtil.LINE_SEPARATOR);
+        String[] splitContent = fileContent.split(CommonUtil.LINE_SEPARATOR_SPLIT);
         if (splitContent.length < line) {
             return "";
         } else {


### PR DESCRIPTION
## Purpose
> In order to avoid conflicting of both "\r\n" and "\n", instead of using the system based line separator use a regex to capture both.