### PR TITLE
Fix suggestions not appearing issue in windows

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
@@ -75,7 +75,7 @@ public class LSCompiler {
     private static Path untitledProjectPath;
 
     private static final Pattern untitledFilePattern =
-            Pattern.compile("^(?:file:\\/\\/)?\\/temp\\/(.*)\\/untitled.bal");
+            Pattern.compile(".*[/\\\\]temp[/\\\\](.*)[/\\\\]untitled.bal");
 
     static {
         // Here we will create a tmp directory as the untitled project repo.
@@ -107,9 +107,9 @@ public class LSCompiler {
     /**
      * Returns a BallerinaFile compiling in-memory content.
      *
-     * @param content
-     * @param phase
-     * @return
+     * @param content       Content to be compiled
+     * @param phase         Compiler Phase
+     * @return {@link BallerinaFile}    BallerinaFile containing the compiled package
      */
     public BallerinaFile compileContent(String content, CompilerPhase phase, boolean preserveWhitespace) {
         java.nio.file.Path filePath = createAndGetTempFile(UNTITLED_BAL);


### PR DESCRIPTION
## Purpose
> Completions are not working for the untitled files in composer in a windows environment. With this fix, introduce a new File pattern matching regex to avoid the issue.
The issue was due to the Lang server not being able to identify the untitled file request since the pattern had not addressed the proper windows file pattern.