### PR TITLE
Disable semantic analyzer by default

### DIFF
--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/semanticanalyzer/BallerinaSemanticAnalyzerSettings.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/semanticanalyzer/BallerinaSemanticAnalyzerSettings.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
 public class BallerinaSemanticAnalyzerSettings implements PersistentStateComponent<BallerinaSemanticAnalyzerSettings> {
 
     @Attribute
-    private boolean myUseSemanticAnalyzer = true;
+    private boolean myUseSemanticAnalyzer = false;
 
     public static BallerinaSemanticAnalyzerSettings getInstance() {
         return ServiceManager.getService(BallerinaSemanticAnalyzerSettings.class);


### PR DESCRIPTION
## Purpose
This PR disables the semantic analyzer which is enabled by default. This is done to avoid performance issues.

Now the user will have to go to **Settings -> Languages and Frameworks -> Ballerina -> Semantic Analyzer** and enable it manually if required.