### PR TITLE
Add new configuration for recursive reference search

### DIFF
--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/recursivesearch/BallerinaRecursiveReferenceSearchConfigurable.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/recursivesearch/BallerinaRecursiveReferenceSearchConfigurable.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.plugins.idea.codeinsight.recursivesearch;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SearchableConfigurable;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+/**
+ * Adds enabling/disabling Ballerina recursive reference search in settings.
+ */
+public class BallerinaRecursiveReferenceSearchConfigurable implements SearchableConfigurable {
+
+    private JCheckBox myCbUseRecursiveReferenceSearch;
+
+    @NotNull
+    private final BallerinaRecursiveReferenceSearchSettings myRecursiveSearchSettings;
+    private final boolean myIsDialog;
+
+    public BallerinaRecursiveReferenceSearchConfigurable(@NotNull Project project, boolean dialogMode) {
+        myRecursiveSearchSettings = BallerinaRecursiveReferenceSearchSettings.getInstance();
+        myIsDialog = dialogMode;
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        FormBuilder builder = FormBuilder.createFormBuilder();
+        myCbUseRecursiveReferenceSearch = new JCheckBox("Use recursive reference search");
+        builder.addComponent(myCbUseRecursiveReferenceSearch);
+
+        JPanel result = new JPanel(new BorderLayout());
+        result.add(builder.getPanel(), BorderLayout.NORTH);
+        if (myIsDialog) {
+            result.setPreferredSize(new Dimension(300, -1));
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isModified() {
+        return myRecursiveSearchSettings.useRecursiveReferenceSearch() != myCbUseRecursiveReferenceSearch.isSelected();
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        myRecursiveSearchSettings.setUseRecursiveReferenceSearch(myCbUseRecursiveReferenceSearch.isSelected());
+    }
+
+    @Override
+    public void reset() {
+        myCbUseRecursiveReferenceSearch.setSelected(myRecursiveSearchSettings.useRecursiveReferenceSearch());
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "ballerina.recursive.reference.search";
+    }
+
+    @Nullable
+    @Override
+    public Runnable enableSearch(String option) {
+        return null;
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "Recursive Reference Search";
+    }
+
+    @Nullable
+    @Override
+    public String getHelpTopic() {
+        return null;
+    }
+
+    @Override
+    public void disposeUIResources() {
+        UIUtil.dispose(myCbUseRecursiveReferenceSearch);
+        myCbUseRecursiveReferenceSearch = null;
+    }
+}

--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/recursivesearch/BallerinaRecursiveReferenceSearchSettings.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/recursivesearch/BallerinaRecursiveReferenceSearchSettings.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.plugins.idea.codeinsight.recursivesearch;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.intellij.util.xmlb.annotations.Attribute;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Recursive reference search settings provider.
+ */
+@State(
+        name = "BallerinaRecursiveReferenceSearch",
+        storages = @Storage(file = "recursive.reference.search.xml")
+)
+public class BallerinaRecursiveReferenceSearchSettings implements
+        PersistentStateComponent<BallerinaRecursiveReferenceSearchSettings> {
+
+    @Attribute
+    private boolean myUseRecursiveReferenceSearch = false;
+
+    public static BallerinaRecursiveReferenceSearchSettings getInstance() {
+        return ServiceManager.getService(BallerinaRecursiveReferenceSearchSettings.class);
+    }
+
+    @Nullable
+    @Override
+    public BallerinaRecursiveReferenceSearchSettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(BallerinaRecursiveReferenceSearchSettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+
+    public boolean useRecursiveReferenceSearch() {
+        return myUseRecursiveReferenceSearch;
+    }
+
+    public void setUseRecursiveReferenceSearch(boolean useRecursiveReferenceSearch) {
+        myUseRecursiveReferenceSearch = useRecursiveReferenceSearch;
+    }
+}

--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/configuration/BallerinaConfigurableProvider.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/configuration/BallerinaConfigurableProvider.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.options.UnnamedConfigurable;
 import com.intellij.openapi.project.Project;
 import org.ballerinalang.plugins.idea.codeinsight.imports.BallerinaAutoImportConfigurable;
+import org.ballerinalang.plugins.idea.codeinsight.recursivesearch.BallerinaRecursiveReferenceSearchConfigurable;
 import org.ballerinalang.plugins.idea.codeinsight.semanticanalyzer.BallerinaSemanticAnalyzerConfigurable;
 import org.ballerinalang.plugins.idea.sdk.BallerinaSdkService;
 import org.jetbrains.annotations.Nls;
@@ -50,11 +51,15 @@ public class BallerinaConfigurableProvider extends ConfigurableProvider {
         Configurable sdkConfigurable = BallerinaSdkService.getInstance(myProject).createSdkConfigurable();
         Configurable autoImportConfigurable = new BallerinaAutoImportConfigurable(myProject, false);
         Configurable semanticAnalyzerConfigurable = new BallerinaSemanticAnalyzerConfigurable(myProject, false);
+        Configurable recursiveReferenceSearchConfigurable = new BallerinaRecursiveReferenceSearchConfigurable
+                (myProject, false);
 
         BallerinaCompositeConfigurable configurableWithSDK = new BallerinaCompositeConfigurable(sdkConfigurable,
-                librariesConfigurable, autoImportConfigurable, semanticAnalyzerConfigurable);
+                librariesConfigurable, autoImportConfigurable, semanticAnalyzerConfigurable,
+                recursiveReferenceSearchConfigurable);
         BallerinaCompositeConfigurable configurableWithoutSDK = new BallerinaCompositeConfigurable
-                (librariesConfigurable, autoImportConfigurable, semanticAnalyzerConfigurable);
+                (librariesConfigurable, autoImportConfigurable, semanticAnalyzerConfigurable,
+                        recursiveReferenceSearchConfigurable);
 
         return sdkConfigurable != null ? configurableWithSDK : configurableWithoutSDK;
     }

--- a/tool-plugins/intellij/src/main/resources/META-INF/plugin.xml
+++ b/tool-plugins/intellij/src/main/resources/META-INF/plugin.xml
@@ -194,6 +194,8 @@
 
         <applicationService
                 serviceImplementation="org.ballerinalang.plugins.idea.codeinsight.semanticanalyzer.BallerinaSemanticAnalyzerSettings"/>
+        <applicationService
+                serviceImplementation="org.ballerinalang.plugins.idea.codeinsight.recursivesearch.BallerinaRecursiveReferenceSearchSettings"/>
 
         <!--inspections-->
         <localInspection language="Ballerina" displayName="Unresolved reference inspection" groupPath="Ballerina"


### PR DESCRIPTION
## Purpose
This PR adds a new configuration to enable/disable recursive reference search. This is disabled by default because it can result in high CPU usage if the project structure is not defined properly.