### PR TITLE
Remove unnecessary logging of error

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -747,7 +747,6 @@ public class CPU {
             } catch (HandleErrorException e) {
                 throw e;
             } catch (Throwable e) {
-                BLangVMUtils.log("fatal error: " + e.getMessage());
                 ctx.setError(BLangVMErrors.createError(ctx, e.getMessage()));
                 handleError(ctx);
             }


### PR DESCRIPTION
## Purpose
> At this location in CPU.java errors are logged unnecessarily because when the error propagates upwards the error gets logged eventually if it is not properly handled in Ballerina code.