### PR TITLE
Use monaco's inbuilt Undo/Redo stack for composer

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/operations/undoable-bal-editor-operation.js
+++ b/composer/modules/web/src/plugins/ballerina/operations/undoable-bal-editor-operation.js
@@ -46,6 +46,7 @@ class UndoableBalEditorOperation extends UndoableOperation {
     }
 
     undo() {
+        this.originEvt.data.sourceEditor.undo(this.getTitle());
         this.getFile().setContent(this.getOldContent(), {
             type: EVENTS.UNDO_EVENT,
             originEvt: this.originEvt,
@@ -57,6 +58,7 @@ class UndoableBalEditorOperation extends UndoableOperation {
     }
 
     redo() {
+        this.originEvt.data.sourceEditor.redo(this.getTitle());
         this.getFile().setContent(this.getNewContent(), {
             type: EVENTS.REDO_EVENT,
             originEvt: this.originEvt,

--- a/composer/modules/web/src/plugins/ballerina/utils/monaco-based-undo-manager.js
+++ b/composer/modules/web/src/plugins/ballerina/utils/monaco-based-undo-manager.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import _ from 'lodash';
+import EventChannel from 'event_channel';
+
+/**
+ * Class to represent undo/redo manager
+ * @class UndoManager
+ * @augments EventChannel
+ */
+class MonacoBasedUndoManager extends EventChannel {
+
+    /**
+     * @inheritdoc
+     */
+    constructor(sourceEditor) {
+        super();
+        this.sourceEditor = sourceEditor;
+    }
+
+    /**
+     * Push a new undoable op to stack
+     * @param {UndoableOperation} undoableOperation Op Instance
+     */
+    push(undoableOperation) {
+    }
+
+    /**
+     * @returns {boolean} true if has undoable operations
+     */
+    hasUndo() {
+        return this.sourceEditor.getCurrentModel()._commandManager.past.length > 0
+                || this.sourceEditor.getCurrentModel()._commandManager.currentStackElement !== undefined;
+    }
+
+    /**
+     * Undo most recent operation
+     */
+    undo() {
+        this.sourceEditor.undo();
+    }
+
+    /**
+     * @returns {boolean} true if has redoable operations
+     */
+    hasRedo() {
+        return this.sourceEditor.getCurrentModel()._commandManager.future.length > 0;
+    }
+
+    /**
+     * Redo most recent undone operation
+     */
+    redo() {
+        this.sourceEditor.redo();
+    }
+}
+
+export default MonacoBasedUndoManager;

--- a/composer/modules/web/src/plugins/ballerina/views/source-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/source-editor.jsx
@@ -131,6 +131,10 @@ class SourceEditor extends React.Component {
         }
     }
 
+    shouldIgnoreChangeEvt() {
+        return this.ignoreChangeEvt;
+    }
+
     setContent(newContent, ignoreChangeEvt = false) {
         this.preventChangeEvt = ignoreChangeEvt;
         this.getCurrentModel()
@@ -169,7 +173,7 @@ class SourceEditor extends React.Component {
             modelForFile = monaco.editor.createModel(this.props.file.content, BAL_LANGUAGE, uri);
         }
         modelForFile.onDidChangeContent(({ changes, isRedoing, isUndoing }) => {
-            if (isRedoing || isUndoing || this.preventChangeEvt) {
+            if (this.shouldIgnoreChangeEvt()) {
                 return;
             }
             const changeEvent = {


### PR DESCRIPTION
## Purpose
Currently we were using our own implementation for undo/redo. It had several limitations including the inabilitly to put cursor back on the place where it was previously, upon undo/redo. 
With this change, we are directly using monaco editor API for handling undo/redo and this comes with those missing features.