### PR TITLE
Use native folder open wizard for create project dialog on electron

### DIFF
--- a/composer/modules/web/src/core/workspace/dialogs/CreateProjectDialog.jsx
+++ b/composer/modules/web/src/core/workspace/dialogs/CreateProjectDialog.jsx
@@ -26,6 +26,7 @@ import ScrollBarsWithContextAPI from './../../view/scroll-bars/ScrollBarsWithCon
 import Dialog from './../../view/Dialog';
 import FileTree from './../../view/tree-view/FileTree';
 import { create, exists as checkFileExists, createProject } from './../fs-util';
+import { isOnElectron } from './../../utils/client-info';
 
 const HISTORY_LAST_ACTIVE_PATH = 'composer.history.workspace.create-project-dialog.last-active-path';
 
@@ -223,31 +224,52 @@ class CreateProjectDialog extends React.Component {
                                         dirPath: evt.target.value,
                                     });
                                 }}
+                                action={isOnElectron() &&
+                                    <Button
+                                        icon='folder open'
+                                        content='Select'
+                                        onClick={(evt) => {
+                                            const { ipcRenderer } = require('electron');
+                                            ipcRenderer.send('show-folder-open-dialog');
+                                            ipcRenderer.once('folder-open-wizard-closed', (e, dirPath) => {
+                                                if (dirPath) {
+                                                    this.updateState({
+                                                        error: '',
+                                                        dirPath,
+                                                    });
+                                                }
+                                            });
+                                            evt.preventDefault();
+                                        }}
+                                    />
+                                }
                             />
                         </Form.Group>
 
                     </Form>
-                    <ScrollBarsWithContextAPI
-                        style={{
-                            height: 300,
-                        }}
-                        autoHide
-                    >
-                        <FileTree
-                            activeKey={this.state.dirPath}
-                            onSelect={
-                                (node) => {
-                                    const dirPath = node.id;
-                                    const projectName = node.fileName;
-                                    this.updateState({
-                                        error: '',
-                                        dirPath,
-                                        projectName,
-                                    });
+                    {!isOnElectron() &&
+                        <ScrollBarsWithContextAPI
+                            style={{
+                                height: 300,
+                            }}
+                            autoHide
+                        >
+                            <FileTree
+                                activeKey={this.state.dirPath}
+                                onSelect={
+                                    (node) => {
+                                        const dirPath = node.id;
+                                        const projectName = node.fileName;
+                                        this.updateState({
+                                            error: '',
+                                            dirPath,
+                                            projectName,
+                                        });
+                                    }
                                 }
-                            }
-                        />
-                    </ScrollBarsWithContextAPI>
+                            />
+                        </ScrollBarsWithContextAPI>
+                    }
                 </Dialog>
             </div>
         );


### PR DESCRIPTION
This will add a select folder btn to bring up native folder open dialog for selecting the destination folder in create-project-wizard. Also it will fall back to embedded file tree representation on browsers.

<img width="622" alt="screen shot 2018-06-04 at 5 27 40 pm" src="https://user-images.githubusercontent.com/1505855/40916290-d05e969e-681c-11e8-9b88-cf31010a7377.png">

Below is how it will look in browsers

<img width="631" alt="screen shot 2018-06-04 at 5 33 02 pm" src="https://user-images.githubusercontent.com/1505855/40916460-6f7b8426-681d-11e8-8e30-4fafd460e1d4.png">
