### PR TITLE
Enable native folder-select wizard in export diagram dialog

### DIFF
--- a/composer/modules/distribution/src/workspace.js
+++ b/composer/modules/distribution/src/workspace.js
@@ -34,44 +34,49 @@ const extensions = [
 ];
 
 function setupNativeWizards(mainWindow) {
-    ipcMain.on('show-file-open-dialog', function (event) {
+    ipcMain.on('show-file-open-dialog', function (event, title, message, exts, props) {
         dialog.showOpenDialog(
           mainWindow,
             {
-                title: 'Open Ballerina File',
-                message: 'choose ballerina file to open',
-                filters: extensions,
-                properties: ['openFile', 'promptToCreate']
+                title,
+                message,
+                filters: exts ? exts : extensions,
+                properties: props ? props : ['openFile', 'promptToCreate']
             }, function (file) {
                 event.sender.send('file-open-wizard-closed', file)
             }
         );
     });
 
-    ipcMain.on('show-file-save-dialog', function (event) {
+    ipcMain.on('show-file-save-dialog', function (event, title, message, exts, props) {
         dialog.showSaveDialog(
           mainWindow,
             {
-                title: 'Save Ballerina File',
-                message: 'select where to save the ballerina file',
-                filters: extensions
+                title,
+                message,
+                filters: exts ? exts : extensions,
+                properties: props ? props : []
             }, function (file) {
                 event.sender.send('file-save-wizard-closed', file);
             }
         );
     });
 
-    ipcMain.on('show-folder-open-dialog', function (event) {
+    ipcMain.on('show-folder-open-dialog', function (event, title, message, props) {
         dialog.showOpenDialog(
           mainWindow,
             {
-                title: 'Open Ballerina Folder',
-                message: 'select a ballerina project folder',
-                properties: ['openDirectory', 'createDirectory']
+                title,
+                message,
+                properties: props ? props : ['openDirectory', 'createDirectory']
             }, function (folders) {
                 event.sender.send('folder-open-wizard-closed', folders ? folders[0] : undefined);
             }
         );
+    });
+
+    ipcMain.on('show-error-dialog', function (event, title, message) {
+        dialog.showErrorBox(title, message);
     });
 }
 

--- a/composer/modules/web/src/core/workspace/dialogs/CreateProjectDialog.jsx
+++ b/composer/modules/web/src/core/workspace/dialogs/CreateProjectDialog.jsx
@@ -230,7 +230,8 @@ class CreateProjectDialog extends React.Component {
                                         content='Select'
                                         onClick={(evt) => {
                                             const { ipcRenderer } = require('electron');
-                                            ipcRenderer.send('show-folder-open-dialog');
+                                            ipcRenderer.send('show-folder-open-dialog', 'Select Project Path',
+                                                'select parent folder for the project');
                                             ipcRenderer.once('folder-open-wizard-closed', (e, dirPath) => {
                                                 if (dirPath) {
                                                     this.updateState({

--- a/composer/modules/web/src/core/workspace/handlers.js
+++ b/composer/modules/web/src/core/workspace/handlers.js
@@ -99,7 +99,7 @@ export function getHandlerDefinitions(workspaceManager) {
                 if (!targetFile.isPersisted) {
                     if (isOnElectron()) {
                         const { ipcRenderer } = require('electron');
-                        ipcRenderer.send('show-file-save-dialog');
+                        ipcRenderer.send('show-file-save-dialog', 'Save File', 'select where to save the file');
                         ipcRenderer.once('file-save-wizard-closed', (e, filePath) => {
                             if (!filePath) {
                                 return;
@@ -146,7 +146,7 @@ export function getHandlerDefinitions(workspaceManager) {
                 if (activeEditor && activeEditor.file) {
                     if (isOnElectron()) {
                         const { ipcRenderer } = require('electron');
-                        ipcRenderer.send('show-file-save-dialog');
+                        ipcRenderer.send('show-file-save-dialog', 'Save File', 'select where to save the file');
                         ipcRenderer.once('file-save-wizard-closed', (e, filePath) => {
                             saveFile(activeEditor.file, filePath, workspaceManager.appContext);
                         });
@@ -168,7 +168,7 @@ export function getHandlerDefinitions(workspaceManager) {
                 const { command: { dispatch } } = workspaceManager.appContext;
                 if (isOnElectron()) {
                     const { ipcRenderer } = require('electron');
-                    ipcRenderer.send('show-file-open-dialog');
+                    ipcRenderer.send('show-file-open-dialog', 'Open File in Composer', 'select a file to open');
                     ipcRenderer.once('file-open-wizard-closed', (e, file) => {
                         if (file) {
                             dispatch(COMMANDS.OPEN_FILE, {
@@ -188,7 +188,7 @@ export function getHandlerDefinitions(workspaceManager) {
                 const { command: { dispatch } } = workspaceManager.appContext;
                 if (isOnElectron()) {
                     const { ipcRenderer } = require('electron');
-                    ipcRenderer.send('show-folder-open-dialog');
+                    ipcRenderer.send('show-folder-open-dialog', 'Open Folder in Composer', 'select a folder to open');
                     ipcRenderer.once('folder-open-wizard-closed', (e, folder) => {
                         if (folder) {
                             dispatch(COMMANDS.OPEN_FOLDER, { folderPath: folder });

--- a/composer/modules/web/src/plugins/export-diagram/dialogs/export-diagram-dialog.jsx
+++ b/composer/modules/web/src/plugins/export-diagram/dialogs/export-diagram-dialog.jsx
@@ -28,6 +28,7 @@ import { createOrUpdate, exists as checkFileExists } from 'core/workspace/fs-uti
 import { DIALOGS } from 'core/workspace/constants';
 import { COMMANDS as LAYOUT_COMMANDS } from 'core/layout/constants';
 import ScrollBarsWithContextAPI from 'core/view/scroll-bars/ScrollBarsWithContextAPI';
+import { isOnElectron } from 'core/utils/client-info';
 
 
 const FILE_TYPE = 'file';
@@ -425,7 +426,7 @@ class ExportDiagramDialog extends React.Component {
                             <Form.Input
                                 fluid
                                 className='inverted'
-                                label='File Path'
+                                label='Directory'
                                 placeholder='eg: /home/user/diagrams'
                                 value={this.state.filePath}
                                 onChange={(evt) => {
@@ -434,6 +435,25 @@ class ExportDiagramDialog extends React.Component {
                                         filePath: evt.target.value,
                                     });
                                 }}
+                                action={isOnElectron() &&
+                                    <Button
+                                        icon='folder open'
+                                        content='Select'
+                                        onClick={(evt) => {
+                                            const { ipcRenderer } = require('electron');
+                                            ipcRenderer.send('show-folder-open-dialog');
+                                            ipcRenderer.once('folder-open-wizard-closed', (e, filePath) => {
+                                                if (filePath) {
+                                                    this.setState({
+                                                        error: '',
+                                                        filePath,
+                                                    });
+                                                }
+                                            });
+                                            evt.preventDefault();
+                                        }}
+                                    />
+                                }
                             />
                         </Form.Group>
                         <Form.Group controlId='fileName' inline className='inverted'>
@@ -467,33 +487,35 @@ class ExportDiagramDialog extends React.Component {
 
                         </Form.Group>
                     </Form>
-                    <ScrollBarsWithContextAPI
-                        style={{
-                            height: 300,
-                        }}
-                        autoHide
-                    >
-                        <FileTree
-                            activeKey={this.state.filePath}
-                            onSelect={
-                                (node) => {
-                                    let filePath = node.id;
-                                    let fileName = this.state.fileName;
-                                    if (node.type === FILE_TYPE) {
-                                        filePath = node.filePath;
-                                        fileName = node.fileName + '.' + node.extension;
+                    {!isOnElectron() &&
+                        <ScrollBarsWithContextAPI
+                            style={{
+                                height: 300,
+                            }}
+                            autoHide
+                        >
+                            <FileTree
+                                activeKey={this.state.filePath}
+                                onSelect={
+                                    (node) => {
+                                        let filePath = node.id;
+                                        let fileName = this.state.fileName;
+                                        if (node.type === FILE_TYPE) {
+                                            filePath = node.filePath;
+                                            fileName = node.fileName + '.' + node.extension;
+                                        }
+                                        const { history } = this.props.appContext.pref;
+                                        history.put(HISTORY_LAST_ACTIVE_PATH, filePath);
+                                        this.setState({
+                                            error: '',
+                                            filePath,
+                                            fileName,
+                                        });
                                     }
-                                    const { history } = this.props.appContext.pref;
-                                    history.put(HISTORY_LAST_ACTIVE_PATH, filePath);
-                                    this.setState({
-                                        error: '',
-                                        filePath,
-                                        fileName,
-                                    });
                                 }
-                            }
-                        />
-                    </ScrollBarsWithContextAPI>
+                            />
+                        </ScrollBarsWithContextAPI>
+                    }
                 </Dialog>
             </div>
         );

--- a/composer/modules/web/src/plugins/export-diagram/dialogs/export-diagram-dialog.jsx
+++ b/composer/modules/web/src/plugins/export-diagram/dialogs/export-diagram-dialog.jsx
@@ -441,7 +441,8 @@ class ExportDiagramDialog extends React.Component {
                                         content='Select'
                                         onClick={(evt) => {
                                             const { ipcRenderer } = require('electron');
-                                            ipcRenderer.send('show-folder-open-dialog');
+                                            ipcRenderer.send('show-folder-open-dialog', 'Select Directory to Export',
+                                                'select directory to export the image');
                                             ipcRenderer.once('folder-open-wizard-closed', (e, filePath) => {
                                                 if (filePath) {
                                                     this.setState({


### PR DESCRIPTION
## Purpose
Enable native folder-select wizard on export diagram dialog in electron based distribution. Fallback to embededd file tree on browsers.

<img width="585" alt="screen shot 2018-06-05 at 9 26 05 am" src="https://user-images.githubusercontent.com/1505855/40954641-15e2701a-68a3-11e8-9f51-a28e01821c5b.png">

<img width="592" alt="screen shot 2018-06-05 at 9 27 34 am" src="https://user-images.githubusercontent.com/1505855/40954645-1d97e754-68a3-11e8-9373-060bc8316e80.png">

## Update

Also contains the changes for refactoring wizard titles accordingly and enabling native file open wizard for importing swagger.