### PR TITLE
[WebSocket] OnError Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1647,7 +1647,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.186</transport.http.version>
+        <transport.http.version>6.0.187</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1647,7 +1647,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.186-SNAPSHOT</transport.http.version>
+        <transport.http.version>6.0.186</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1647,7 +1647,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.184</transport.http.version>
+        <transport.http.version>6.0.186-SNAPSHOT</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/ballerina/http/Package.md
+++ b/stdlib/ballerina-http/src/main/ballerina/http/Package.md
@@ -63,9 +63,9 @@ Here `upgradeService` is a `WebSocketService`.
 
 **onIdleTimeout**: This resource is dispatched when idle timeout is reached. idleTimeout has to be configured by the user.
 
-**onClose**: This resource is dispatched when a close message is recieved.
+**onClose**: This resource is dispatched when a close message is received.
 
-
+**onError**: This resource is dispatched when an error occurred in a particular WebSocket connection. This will always be followed by a connection closure.
 
 See [WebSocket Basic Example](https://ballerina.io/learn/by-example/websocket-basic-sample.html), 
 [HTTP to WebSocket Upgrade Example](https://ballerina.io/learn/by-example/http-to-websocket-upgrade.html),

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketClientConnectorListener.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketClientConnectorListener.java
@@ -21,6 +21,7 @@ package org.ballerinalang.net.http;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketCloseMessage;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnectorListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketControlMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
@@ -65,8 +66,8 @@ public class WebSocketClientConnectorListener implements WebSocketConnectorListe
     }
 
     @Override
-    public void onError(Throwable throwable) {
-        throw new BallerinaConnectorException("Unexpected error occurred in WebSocket transport", throwable);
+    public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
+        WebSocketDispatcher.dispatchError(connectionInfo, throwable);
     }
 
     @Override

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -46,6 +46,7 @@ public class WebSocketConstants {
     public static final String RESOURCE_NAME_ON_PONG = "onPong";
     public static final String RESOURCE_NAME_ON_CLOSE = "onClose";
     public static final String RESOURCE_NAME_ON_IDLE_TIMEOUT = "onIdleTimeout";
+    public static final String RESOURCE_NAME_ON_ERROR = "onError";
 
     public static final String WEBSOCKET_MESSAGE = "WEBSOCKET_MESSAGE";
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -17,7 +17,9 @@
  */
 package org.ballerinalang.net.http;
 
+import io.netty.handler.codec.CorruptedFrameException;
 import org.ballerinalang.bre.bvm.BLangVMErrors;
+import org.ballerinalang.bre.bvm.BLangVMStructs;
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.Executor;
@@ -30,6 +32,11 @@ import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.services.ErrorHandlerUtils;
+import org.ballerinalang.util.codegen.PackageInfo;
+import org.ballerinalang.util.codegen.ProgramFile;
+import org.ballerinalang.util.codegen.StructureTypeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketCloseMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
@@ -50,6 +57,8 @@ import java.util.Map;
  * @since 0.94
  */
 public class WebSocketDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketDispatcher.class);
 
     /**
      * This will find the best matching service for given web socket request.
@@ -203,6 +212,45 @@ public class WebSocketDispatcher {
             }
         };
         Executor.submit(onCloseResource, onCloseCallback, null, null, bValues);
+    }
+
+    public static void dispatchError(WebSocketOpenConnectionInfo connectionInfo, Throwable throwable) {
+        WebSocketService webSocketService = connectionInfo.getService();
+        Resource onErrorResource = webSocketService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_ERROR);
+        if (isUnexpectedError(throwable)) {
+            log.error("Unexpected error", throwable);
+            return;
+        }
+        if (onErrorResource == null) {
+            ErrorHandlerUtils.printError(throwable);
+            return;
+        }
+        BValue[] bValues = new BValue[onErrorResource.getParamDetails().size()];
+        bValues[0] = connectionInfo.getWebSocketEndpoint();
+        bValues[1] = getError(webSocketService, throwable);
+        CallableUnitCallback onErrorCallback = new CallableUnitCallback() {
+            @Override
+            public void notifySuccess() {
+                // Do nothing.
+            }
+
+            @Override
+            public void notifyFailure(BStruct error) {
+                ErrorHandlerUtils.printError("error: " + BLangVMErrors.getPrintableStackTrace(error));
+            }
+        };
+        Executor.submit(onErrorResource, onErrorCallback, null, null, bValues);
+    }
+
+    private static boolean isUnexpectedError(Throwable throwable) {
+        return !(throwable instanceof CorruptedFrameException);
+    }
+
+    private static BStruct getError(WebSocketService webSocketService, Throwable throwable) {
+        ProgramFile programFile = webSocketService.getServiceInfo().getPackageInfo().getProgramFile();
+        PackageInfo errorPackageInfo = programFile.getPackageInfo(BLangVMErrors.PACKAGE_BUILTIN);
+        StructureTypeInfo errorStructInfo = errorPackageInfo.getStructInfo(BLangVMErrors.STRUCT_GENERIC_ERROR);
+        return BLangVMStructs.createBStruct(errorStructInfo, throwable.getMessage());
     }
 
     public static void dispatchIdleTimeout(WebSocketOpenConnectionInfo connectionInfo,

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketServerConnectorListener.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketServerConnectorListener.java
@@ -179,8 +179,9 @@ public class WebSocketServerConnectorListener implements WebSocketConnectorListe
     }
 
     @Override
-    public void onError(Throwable throwable) {
-        log.error("Unexpected error occurred in WebSocket transport", throwable);
+    public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
+        WebSocketDispatcher.dispatchError(
+                connectionManager.removeConnectionInfo(webSocketConnection.getId()), throwable);
     }
 
     @Override

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -39,7 +39,6 @@ import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeFuture;
 import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
-import org.wso2.transport.http.netty.contract.websocket.WebSocketMessage;
 
 import java.util.List;
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -39,6 +39,7 @@ import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeFuture;
 import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketMessage;
 
 import java.util.List;
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
@@ -150,10 +150,9 @@ public class WebSocketResourceValidator {
         validateParamDetailsSize(paramDetails, 2, serviceName, resource, dlog);
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
         if (paramDetails.size() < 2 || !"error".equals(paramDetails.get(1).type.toString())) {
-            dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                    "Invalid resource signature for " + resource.getName().getValue() +
-                            " resource in service " +
-                            serviceName + ": The second parameter should be an error");
+            dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, String.format("Invalid resource signature for " +
+                            "%s resource in service %s: The second parameter should be an error",
+                    resource.getName().getValue(),serviceName ));
         }
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
@@ -55,8 +55,8 @@ public class WebSocketResourceValidator {
                 break;
             default:
                 dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                                   "Invalid resource name " + resource.getName().getValue() + " in service " +
-                                           serviceName);
+                        "Invalid resource name " + resource.getName().getValue() + " in service " +
+                                serviceName);
         }
 
     }
@@ -69,8 +69,8 @@ public class WebSocketResourceValidator {
             validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
         } else {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "onOpen resource is not supported for " + WebSocketConstants.WEBSOCKET_CLIENT_SERVICE +
-                                       " " + serviceName);
+                    "onOpen resource is not supported for " + WebSocketConstants.WEBSOCKET_CLIENT_SERVICE +
+                            " " + serviceName);
         }
     }
 
@@ -81,15 +81,15 @@ public class WebSocketResourceValidator {
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
         if (paramDetails.size() < 2 || !"string".equals(paramDetails.get(1).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The second parameter should be a string");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The second parameter should be a string");
         }
         if (paramDetails.size() == 3 && !"boolean".equals(paramDetails.get(2).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The third parameter should be a boolean");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The third parameter should be a boolean");
         }
     }
 
@@ -100,15 +100,15 @@ public class WebSocketResourceValidator {
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
         if (paramDetails.size() < 2 || !"blob".equals(paramDetails.get(1).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The second parameter should be a blob");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The second parameter should be a blob");
         }
         if (paramDetails.size() == 3 && !"boolean".equals(paramDetails.get(2).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The third parameter should be a boolean");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The third parameter should be a boolean");
         }
     }
 
@@ -119,9 +119,9 @@ public class WebSocketResourceValidator {
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
         if (paramDetails.size() < 2 || !"blob".equals(paramDetails.get(1).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The second parameter should be a blob");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The second parameter should be a blob");
         }
     }
 
@@ -132,15 +132,15 @@ public class WebSocketResourceValidator {
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
         if (paramDetails.size() < 2 || !"int".equals(paramDetails.get(1).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The second parameter should be an int");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The second parameter should be an int");
         }
         if (paramDetails.size() < 3 || !"string".equals(paramDetails.get(2).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The third parameter should be a string");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The third parameter should be a string");
         }
     }
 
@@ -152,7 +152,7 @@ public class WebSocketResourceValidator {
         if (paramDetails.size() < 2 || !"error".equals(paramDetails.get(1).type.toString())) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, String.format("Invalid resource signature for " +
                             "%s resource in service %s: The second parameter should be an error",
-                    resource.getName().getValue(),serviceName ));
+                    resource.getName().getValue(), serviceName));
         }
     }
 
@@ -160,9 +160,9 @@ public class WebSocketResourceValidator {
                                                  BLangResource resource, DiagnosticLog dlog) {
         if (paramDetails == null || paramDetails.size() != expectedSize) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": Expected parameter count = " + expectedSize);
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": Expected parameter count = " + expectedSize);
         }
     }
 
@@ -170,9 +170,9 @@ public class WebSocketResourceValidator {
                                                  BLangResource resource, DiagnosticLog dlog) {
         if (paramDetails == null || paramDetails.size() < min || paramDetails.size() > max) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": Unexpected parameter count");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": Unexpected parameter count");
         }
     }
 
@@ -184,9 +184,9 @@ public class WebSocketResourceValidator {
                 (isClient && !WebSocketConstants.WEBSOCKET_CLIENT_ENDPOINT_NAME.equals(
                         paramDetails.get(0).type.toString()))) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
-                               "Invalid resource signature for " + resource.getName().getValue() +
-                                       " resource in service " +
-                                       serviceName + ": The first parameter should be an endpoint");
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The first parameter should be an endpoint");
         }
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
@@ -48,7 +48,10 @@ public class WebSocketResourceValidator {
                 validateOnPingPongResource(serviceName, resource, dlog, isClient);
                 break;
             case WebSocketConstants.RESOURCE_NAME_ON_CLOSE:
-                validateCloseResource(serviceName, resource, dlog, isClient);
+                validateOnCloseResource(serviceName, resource, dlog, isClient);
+                break;
+            case WebSocketConstants.RESOURCE_NAME_ON_ERROR:
+                validateOnErrorResource(serviceName, resource, dlog, isClient);
                 break;
             default:
                 dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
@@ -122,8 +125,8 @@ public class WebSocketResourceValidator {
         }
     }
 
-    private static void validateCloseResource(String serviceName, BLangResource resource, DiagnosticLog dlog,
-                                              boolean isClient) {
+    private static void validateOnCloseResource(String serviceName, BLangResource resource, DiagnosticLog dlog,
+                                                boolean isClient) {
         List<BLangVariable> paramDetails = resource.getParameters();
         validateParamDetailsSize(paramDetails, 3, serviceName, resource, dlog);
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
@@ -138,6 +141,19 @@ public class WebSocketResourceValidator {
                                "Invalid resource signature for " + resource.getName().getValue() +
                                        " resource in service " +
                                        serviceName + ": The third parameter should be a string");
+        }
+    }
+
+    private static void validateOnErrorResource(String serviceName, BLangResource resource, DiagnosticLog dlog,
+                                                boolean isClient) {
+        List<BLangVariable> paramDetails = resource.getParameters();
+        validateParamDetailsSize(paramDetails, 2, serviceName, resource, dlog);
+        validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
+        if (paramDetails.size() < 2 || !"error".equals(paramDetails.get(1).type.toString())) {
+            dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos,
+                    "Invalid resource signature for " + resource.getName().getValue() +
+                            " resource in service " +
+                            serviceName + ": The second parameter should be an error");
         }
     }
 

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
@@ -1,0 +1,52 @@
+package org.ballerinalang.test.service.websocket;
+
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class OnErrorWebSocketTest extends WebSocketIntegrationTest {
+
+    private WebSocketTestClient client;
+    private static final String URL = "ws://localhost:9090/error/ws";
+    private LogLeecher logLeecher;
+
+    @BeforeClass(description = "Initializes the Ballerina server with the error_log_service.bal file")
+    public void setup() throws InterruptedException, BallerinaTestException, URISyntaxException {
+        String expectingErrorLog = "error occurred: received continuation data frame outside fragmented message";
+        logLeecher = new LogLeecher(expectingErrorLog);
+        initBallerinaServer("error_log_service.bal", logLeecher);
+
+        client = new WebSocketTestClient(URL);
+        client.handshake();
+    }
+
+    @Test
+    public void testOnError() throws InterruptedException, BallerinaTestException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        client.sendCorruptedFrame();
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        logLeecher.waitForText(TIMEOUT_IN_SECS * 1000);
+        CloseWebSocketFrame closeWebSocketFrame = client.getReceiveCloseFrame();
+
+        Assert.assertNotNull(closeWebSocketFrame);
+        Assert.assertEquals(closeWebSocketFrame.statusCode(), 1002);
+
+        closeWebSocketFrame.release();
+    }
+
+    @AfterClass(description = "Stops the Ballerina server")
+    public void cleanup() throws BallerinaTestException, InterruptedException {
+        client.shutDown();
+        stopBallerinaServerInstance();
+    }
+}

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.ballerinalang.test.service.websocket;
 
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
@@ -13,6 +31,9 @@ import java.net.URISyntaxException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Test whether the errors are received correctly to the onError resource in WebSocket server.
+ */
 public class OnErrorWebSocketTest extends WebSocketIntegrationTest {
 
     private WebSocketTestClient client;

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketIntegrationTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketIntegrationTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * Facilitate the common functionality of WebSocket integration tests.
  */
 public class WebSocketIntegrationTest {
-    protected ServerInstance ballerinaServerInstance;
+    private ServerInstance ballerinaServerInstance;
     protected static final int TIMEOUT_IN_SECS = 10;
     protected static final int REMOTE_SERVER_PORT = 15500;
 

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketIntegrationTest.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/WebSocketIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.service.websocket;
 
 import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 
@@ -30,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * Facilitate the common functionality of WebSocket integration tests.
  */
 public class WebSocketIntegrationTest {
-    private ServerInstance ballerinaServerInstance;
+    protected ServerInstance ballerinaServerInstance;
     protected static final int TIMEOUT_IN_SECS = 10;
     protected static final int REMOTE_SERVER_PORT = 15500;
 
@@ -38,8 +39,22 @@ public class WebSocketIntegrationTest {
     /**
      * Initializes Ballerina with the given bal file.
      *
-     * @param fileName the filename to initialize the Ballerina server with
-     * @throws BallerinaTestException on Ballerina related issues
+     * @param fileName the filename to initialize the Ballerina server with.
+     * @param logLeecher Log leecher match the logs in the bal file.
+     * @throws BallerinaTestException on Ballerina related issues.
+     */
+    public void initBallerinaServer(String fileName, LogLeecher logLeecher) throws BallerinaTestException {
+        String balPath = new File("src/test/resources/websocket/" + fileName).getAbsolutePath();
+        ballerinaServerInstance = ServerInstance.initBallerinaServer();
+        ballerinaServerInstance.addLogLeecher(logLeecher);
+        ballerinaServerInstance.startBallerinaServer(balPath);
+    }
+
+    /**
+     * Initializes Ballerina with the given bal file.
+     *
+     * @param fileName the filename to initialize the Ballerina server with.
+     * @throws BallerinaTestException on Ballerina related issues.
      */
     public void initBallerinaServer(String fileName) throws BallerinaTestException {
         String balPath = new File("src/test/resources/websocket/" + fileName).getAbsolutePath();

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClient.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClient.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
@@ -100,6 +101,7 @@ public class WebSocketTestClient {
      * Send text to the server.
      *
      * @param text text need to be sent.
+     * @throws InterruptedException if connection is interrupted while sending the message.
      */
     public void sendText(String text) throws InterruptedException {
         if (channel == null) {
@@ -113,6 +115,7 @@ public class WebSocketTestClient {
      * Send binary data to server.
      *
      * @param buf buffer containing the data need to be sent.
+     * @throws InterruptedException if connection is interrupted while sending the message.
      */
     public void sendBinary(ByteBuffer buf) throws InterruptedException {
         if (channel == null) {
@@ -126,6 +129,7 @@ public class WebSocketTestClient {
      * Send a ping message to the server.
      *
      * @param buf content of the ping message to be sent.
+     * @throws InterruptedException if connection is interrupted while sending the message.
      */
     public void sendPing(ByteBuffer buf) throws InterruptedException {
         if (channel == null) {
@@ -133,6 +137,19 @@ public class WebSocketTestClient {
             throw new IllegalArgumentException("Cannot find the channel to write");
         }
         channel.writeAndFlush(new PingWebSocketFrame(Unpooled.wrappedBuffer(buf))).sync();
+    }
+
+    /**
+     * Send corrupted frame to the server.
+     *
+     * @throws InterruptedException if connection is interrupted while sending the message.
+     */
+    public void sendCorruptedFrame() throws InterruptedException {
+        if (channel == null) {
+            logger.error("Channel is null. Cannot send text.");
+            throw new IllegalArgumentException("Cannot find the channel to write");
+        }
+        channel.writeAndFlush(new ContinuationWebSocketFrame(Unpooled.wrappedBuffer(new byte[]{1, 2, 3, 4}))).sync();
     }
 
     /**
@@ -184,6 +201,16 @@ public class WebSocketTestClient {
      */
     public String getHeader(String headerName) {
         return webSocketHandler.getHeader(headerName);
+    }
+
+    /**
+     * Retrieve the received close frame to the client.
+     * <b>Note: Release the close frame after using it using CloseWebSocketFrame.release()</b>
+     *
+     * @return the close frame received to the client.
+     */
+    public CloseWebSocketFrame getReceiveCloseFrame() {
+        return webSocketHandler.getReceiveCloseFrame();
     }
 
     /**

--- a/tests/ballerina-test-integration/src/test/resources/websocket/error_log_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/error_log_service.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/io;
 import ballerina/http;
 

--- a/tests/ballerina-test-integration/src/test/resources/websocket/error_log_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/error_log_service.bal
@@ -1,0 +1,27 @@
+import ballerina/io;
+import ballerina/http;
+
+
+@http:WebSocketServiceConfig {
+    path: "/error/ws"
+}
+service<http:WebSocketService> errorService bind {port: 9090} {
+    onOpen(endpoint ep) {
+        io:println("connection open");
+    }
+
+    onText(endpoint ep, string text) {
+        io:println(string `text received: {{text}}`);
+        ep->pushText(text) but {
+            error => io:println("error sending message")
+        };
+    }
+
+    onError(endpoint ep, error err) {
+        io:println(string `error occurred: {{err.message}}`);
+    }
+
+    onClose(endpoint ep, int statusCode, string reason) {
+        io:println(string `Connection closed with {{statusCode}}, {{reason}}`);
+    }
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
@@ -147,7 +147,6 @@ public class WebSocketCompilationTest {
                 "The second parameter should be an error");
     }
 
-
     @Test(description = "Invalid resource in WebSocketService")
     public void testInValidResource() {
         CompileResult compileResult = BCompileUtil.compile(

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
@@ -135,6 +135,19 @@ public class WebSocketCompilationTest {
                                     "string");
     }
 
+    @Test(description = "Invalid signature for onError resources")
+    public void testFailOnError() {
+        CompileResult compileResult = BCompileUtil.compile(
+                "test-src/net/websocket/compilation/fail_onError.bal");
+        Diagnostic[] diag = compileResult.getDiagnostics();
+        Assert.assertEquals(diag.length, 2);
+        Assert.assertEquals(diag[0].getMessage(), "Invalid resource signature for onError resource in service echo: " +
+                "Expected parameter count = 2");
+        Assert.assertEquals(diag[1].getMessage(), "Invalid resource signature for onError resource in service echo: " +
+                "The second parameter should be an error");
+    }
+
+
     @Test(description = "Invalid resource in WebSocketService")
     public void testInValidResource() {
         CompileResult compileResult = BCompileUtil.compile(

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
@@ -18,9 +18,9 @@
 
 package org.ballerinalang.test.net.websocket.compilation;
 
+import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,6 +32,7 @@ public class WebSocketCompilationTest {
     public void testSuccess() {
         CompileResult compileResult = BCompileUtil.compileAndSetup(
                 "test-src/net/websocket/compilation/success.bal");
+
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }
 
@@ -39,6 +40,7 @@ public class WebSocketCompilationTest {
     public void testSuccessClient() {
         CompileResult compileResult = BCompileUtil.compileAndSetup(
                 "test-src/net/websocket/compilation/success_client.bal");
+
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }
 
@@ -46,141 +48,121 @@ public class WebSocketCompilationTest {
     public void testSuccessWebSocketUpgrade() {
         CompileResult compileResult = BCompileUtil.compileAndSetup(
                 "test-src/net/websocket/compilation/success_websocket_upgrade.bal");
+
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }
 
     @Test(description = "Invalid signature for onOpen and onIdle resources")
     public void testFailOnOpenOnIdle() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onOpen_onIdle.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 3);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "Invalid resource signature for onOpen resource in service echo: The first parameter " +
-                                    "should be an " +
-                                    "endpoint");
-        Assert.assertEquals(diag[1].getMessage(),
-                            "Invalid resource signature for onIdleTimeout resource in service echo: Expected " +
-                                    "parameter count =" +
-                                    " 1");
-        Assert.assertEquals(diag[2].getMessage(),
-                            "Invalid resource signature for onIdleTimeout resource in service echo: The first " +
-                                    "parameter should" +
-                                    " be an endpoint");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onOpen_onIdle.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 3);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onOpen resource in service " +
+                "echo: The first parameter should be an endpoint", 29, 5);
+        BAssertUtil.validateError(compileResult, 1, "Invalid resource signature for onIdleTimeout resource in " +
+                "service echo: Expected parameter count = 1", 32, 5);
+        BAssertUtil.validateError(compileResult, 2, "Invalid resource signature for onIdleTimeout resource in " +
+                "service echo: The first parameter should be an endpoint", 32 , 5);
     }
 
     @Test(description = "Invalid parameter count for onText resource")
     public void testFailOnTextParamCount() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/net/websocket/compilation/fail_onText_param_count.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "Invalid resource signature for onText resource in service echo: Unexpected parameter " +
-                                    "count");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onText resource in service " +
+                "echo: Unexpected parameter count", 30, 5);
     }
 
     @Test(description = "Invalid signature for onText resource")
     public void testFailOnText() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onText.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "Invalid resource signature for onText resource in service echo: The second parameter " +
-                                    "should be a " +
-                                    "string");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onText.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onText resource in service " +
+                "echo: The second parameter should be a string", 30, 5);
     }
 
     @Test(description = "Invalid signature for onBinary resource")
     public void testFailOnBinary() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onBinary.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "Invalid resource signature for onBinary resource in service echo: The second parameter " +
-                                    "should be " +
-                                    "a blob");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onBinary.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onBinary resource in service " +
+                "echo: The second parameter should be a blob", 30, 5);
     }
 
     @Test(description = "Invalid signature for onPing and onPong resources")
     public void testFailOnPingOnPong() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onPing_onPong.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 3);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "Invalid resource signature for onPing resource in service echo: The second parameter " +
-                                    "should be a " +
-                                    "blob");
-        Assert.assertEquals(diag[1].getMessage(),
-                            "Invalid resource signature for onPong resource in service echo: Expected parameter count" +
-                                    " = 2");
-        Assert.assertEquals(diag[2].getMessage(),
-                            "Invalid resource signature for onPong resource in service echo: The second parameter " +
-                                    "should be a " +
-                                    "blob");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onPing_onPong.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 3);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onPing resource in service " +
+                "echo: The second parameter should be a blob", 30, 5);
+        BAssertUtil.validateError(compileResult, 1, "Invalid resource signature for onPong resource in service " +
+                "echo: Expected parameter count = 2", 33, 5);
+        BAssertUtil.validateError(compileResult, 2, "Invalid resource signature for onPong resource in service " +
+                "echo: The second parameter should be a blob", 33, 5);
     }
 
     @Test(description = "Invalid signature for onClose resource")
     public void testFailOnClose() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onClose.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "Invalid resource signature for onClose resource in service echo: The third parameter " +
-                                    "should be a " +
-                                    "string");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onClose.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onClose resource in service " +
+                "echo: The third parameter should be a string", 30, 5);
     }
 
     @Test(description = "Invalid signature for onError resources")
     public void testFailOnError() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onError.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 2);
-        Assert.assertEquals(diag[0].getMessage(), "Invalid resource signature for onError resource in service echo: " +
-                "Expected parameter count = 2");
-        Assert.assertEquals(diag[1].getMessage(), "Invalid resource signature for onError resource in service echo: " +
-                "The second parameter should be an error");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onError.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 2);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onError resource in service " +
+                "echo: Expected parameter count = 2", 30, 5);
+        BAssertUtil.validateError(compileResult, 1, "Invalid resource signature for onError resource in service " +
+                "echo: The second parameter should be an error", 30, 5);
     }
 
     @Test(description = "Invalid resource in WebSocketService")
     public void testInValidResource() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/invalid_resource.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(), "Invalid resource name onFind in service echo");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/invalid_resource.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "Invalid resource name onFind in service echo", 30, 5);
     }
 
     @Test(description = "Invalid resource onOpen in WebSocketClientService")
     public void testFailOnOpenClient() {
-        CompileResult compileResult = BCompileUtil.compile(
-                "test-src/net/websocket/compilation/fail_onOpen_client.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(), "onOpen resource is not supported for WebSocketClientService echo");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onOpen_client.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "onOpen resource is not supported for WebSocketClientService echo",
+                26, 5);
     }
 
     @Test(description = "WebSocketClientService is bound to an endpoint")
     public void testFailClientBoundToEndpoint() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/net/websocket/compilation/fail_client_bound_to_endpoint.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(), "WebSocketClientService cannot be bound to an endpoint");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0, "WebSocketClientService cannot be bound to an endpoint", 25, 1);
     }
 
     @Test(description = "WebSocket upgrade resource config has a no upgradeService")
     public void testFailWebSocketUpgradeNoService() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/net/websocket/compilation/fail_websocket_upgrade_no_service.bal");
-        Diagnostic[] diag = compileResult.getDiagnostics();
-        Assert.assertEquals(diag.length, 1);
-        Assert.assertEquals(diag[0].getMessage(),
-                            "An upgradeService need to be specified for the WebSocket upgrade resource");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0,
+                "An upgradeService need to be specified for the WebSocket upgrade resource", 28, 5);
+    }
+
+    private void assertExpectedDiagnosticsLength(CompileResult compileResult, int expectedLength) {
+        Assert.assertEquals(compileResult.getDiagnostics().length, expectedLength);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_client_bound_to_endpoint.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_client_bound_to_endpoint.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onBinary.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onBinary.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onClose.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onClose.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onError.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onError.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onError.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onError.bal
@@ -1,0 +1,16 @@
+import ballerina/http;
+import ballerina/io;
+
+endpoint http:WebSocketListener echoEP {
+    host:"0.0.0.0",
+    port:9090
+};
+
+@http:WebSocketServiceConfig {
+    path:"/echo"
+}
+service<http:WebSocketService> echo bind echoEP {
+
+    onError(endpoint caller, string err, string reason) {
+    }
+}

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onOpen_client.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onOpen_client.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onOpen_onIdle.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onOpen_onIdle.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onPing_onPong.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onPing_onPong.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText_param_count.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_onText_param_count.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_websocket_upgrade_no_service.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/fail_websocket_upgrade_no_service.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/io;
 import ballerina/http;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/invalid_resource.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/invalid_resource.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success.bal
@@ -10,27 +10,27 @@ endpoint http:WebSocketListener echoEP {
     path:"/echo"
 }
 service<http:WebSocketService> echo bind echoEP {
-    onOpen(endpoint conn) {
+    onOpen(endpoint caller) {
     }
 
-    onText(endpoint conn, string text) {
+    onText(endpoint caller, string text) {
     }
 
-    onBinary(endpoint conn, blob text, boolean final) {
-
+    onBinary(endpoint caller, blob text, boolean final) {
     }
 
-    onClose(endpoint conn, int val, string text) {
-
+    onClose(endpoint caller, int val, string text) {
     }
 
-    onIdleTimeout(endpoint conn) {
-
+    onIdleTimeout(endpoint caller) {
     }
-    onPing(endpoint conn, blob so) {
 
+    onPing(endpoint caller, blob so) {
     }
-    onPong(endpoint conn, blob yes) {
 
+    onPong(endpoint caller, blob yes) {
+    }
+
+    onError(endpoint caller, error err) {
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success_client.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success_client.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/io;
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success_websocket_upgrade.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/websocket/compilation/success_websocket_upgrade.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/io;
 import ballerina/http;
 


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/7624
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/8901
> Note: Please review and merge https://github.com/wso2/transport-http/pull/188 before merging this PR since this PR depends on it.

## Goals
> Add onError support to WebSocket service to acknowledge the protocol errors happening in WebSocket connection.

## Approach
> Add onError resource to WebSocket service

## Automation tests
 - Unit tests 
   > Yes
 - Integration tests
   > yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
 ```ballerina
import ballerina/io;
import ballerina/http;

@http:WebSocketServiceConfig {
    path: "/error/ws"
}
service<http:WebSocketService> errorService bind {port: 9090} {
    onError(endpoint ep, error err) {
        io:println(string `error occurred: {{err.message}}`);
    }
}
```