### PR TITLE
Migrate to electron@2.0.2

### DIFF
--- a/composer/modules/distribution/package-lock.json
+++ b/composer/modules/distribution/package-lock.json
@@ -902,9 +902,9 @@
       "dev": true
     },
     "electron": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.0.tgz",
-      "integrity": "sha512-FCcVzHgoBmNTPUEhKN7yUxjluCRNAQsHNOfdtFEWKL3DPYEdLdyQW8CpmJEMqIXha5qZ+qdKVAtwvvuJs+b/PQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
+      "integrity": "sha512-XmkGVoHLOqmjZ2nU/0zEzMl3TZEz452Q1fTJFKjylg4pLYaq7na7V2uxzydVQNQukZGbERoA7ayjxXzTsXbtdA==",
       "dev": true,
       "requires": {
         "@types/node": "8.10.14",

--- a/composer/modules/distribution/package.json
+++ b/composer/modules/distribution/package.json
@@ -86,7 +86,7 @@
   "devDependencies": {
     "cross-env": "^3.2.3",
     "decompress": "^4.0.0",
-    "electron": "^2.0.0",
+    "electron": "^2.0.2",
     "electron-builder": "^20.13.3",
     "electron-icon-generator": "^1.0.2",
     "glob": "^7.1.1"


### PR DESCRIPTION
## Purpose

Electron@2.0.0 has some issues in OSX where
composer would crash when users are going to change
the filters in file open/save wizards.
https://github.com/electron/electron/issues/12230
This update will fix it.
