### PR TITLE
Separate blob tests from other datatype tests and fix postgres related issues

### DIFF
--- a/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
+++ b/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
@@ -203,7 +203,6 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             BRefValueArray structTypes) {
         Connection conn = null;
         CallableStatement stmt = null;
-        ResultSet rs = null;
         List<ResultSet> resultSets = null;
         boolean isInTransaction = context.isInTransaction();
         try {
@@ -600,7 +599,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             String sqlDataType = sqlType.toUpperCase(Locale.getDefault());
             switch (sqlDataType) {
             case Constants.SQLDataTypes.SMALLINT:
-                SQLDatasourceUtils.setIntValue(stmt, value, index, direction, Types.SMALLINT);
+                SQLDatasourceUtils.setSmallIntValue(stmt, value, index, direction, Types.SMALLINT);
                 break;
             case Constants.SQLDataTypes.VARCHAR:
                 SQLDatasourceUtils.setStringValue(stmt, value, index, direction, Types.VARCHAR);

--- a/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
+++ b/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
@@ -131,7 +131,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             context.setReturnValues(
                     constructTable(rm, context, rs, structType, loadSQLTableToMemory, columnDefinitions));
         } catch (Throwable e) {
-            SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
+            SQLDatasourceUtils.cleanupResources(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute query failed: " + e.getMessage(), e);
         }
     }
@@ -145,13 +145,13 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             conn = SQLDatasourceUtils.getDatabaseConnection(context, datasource, isInTransaction);
             String processedQuery = createProcessedQueryString(query, generatedParams);
             stmt = conn.prepareStatement(processedQuery);
-            createProcessedStatement(conn, stmt, generatedParams);
+            createProcessedStatement(conn, stmt, generatedParams, datasource.getDatabaseProductName());
             int count = stmt.executeUpdate();
             context.setReturnValues(new BInteger(count));
         } catch (SQLException e) {
             throw new BallerinaException("execute update failed: " + e.getMessage(), e);
         } finally {
-            SQLDatasourceUtils.cleanupConnection(null, stmt, conn, isInTransaction);
+            SQLDatasourceUtils.cleanupResources(stmt, conn, isInTransaction);
         }
     }
 
@@ -195,7 +195,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         } catch (SQLException e) {
             throw new BallerinaException("execute update with generated keys failed: " + e.getMessage(), e);
         } finally {
-            SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
+            SQLDatasourceUtils.cleanupResources(rs, stmt, conn, isInTransaction);
         }
     }
 
@@ -204,7 +204,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         Connection conn = null;
         CallableStatement stmt = null;
         ResultSet rs = null;
-        List<ResultSet> resultSets;
+        List<ResultSet> resultSets = null;
         boolean isInTransaction = context.isInTransaction();
         try {
             BRefValueArray generatedParams = constructParameters(context, parameters);
@@ -215,23 +215,25 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             boolean refCursorOutParamsPresent = generatedParams != null && isRefCursorOutParamPresent(generatedParams);
             boolean resultSetsReturned = !resultSets.isEmpty();
             TableResourceManager rm = null;
-            if (resultSetsReturned || refCursorOutParamsPresent) {
+            boolean requiredToReturnTables = structTypes != null && structTypes.size() > 0;
+            if ((resultSetsReturned && requiredToReturnTables) || refCursorOutParamsPresent) {
                 rm = new TableResourceManager(conn, stmt);
             }
             setOutParameters(context, stmt, parameters, rm);
-            if (resultSetsReturned) {
+            if (resultSetsReturned && requiredToReturnTables) {
                 rm.addAllResultSets(resultSets);
-                // If a result set has been returned from the stored procedure it needs to be pushed in to return values
+                // If a result set has been returned from the stored procedure it needs to be pushed in to return
+                // values
                 context.setReturnValues(constructTablesForResultSets(resultSets, rm, context, structTypes));
             } else if (!refCursorOutParamsPresent) {
                 // Even if there aren't any result sets returned from the procedure there could be ref cursors
                 // returned as OUT params. If there are present we cannot clean up the connection. If there is no
                 // returned result set or ref cursor OUT params we should cleanup the connection.
-                SQLDatasourceUtils.cleanupConnection(null, stmt, conn, isInTransaction);
+                SQLDatasourceUtils.cleanupResources(resultSets, stmt, conn, isInTransaction);
                 context.setReturnValues();
             }
         } catch (Throwable e) {
-            SQLDatasourceUtils.cleanupConnection(null, stmt, conn, isInTransaction);
+            SQLDatasourceUtils.cleanupResources(resultSets, stmt, conn, isInTransaction);
             throw new BallerinaException("execute stored procedure failed: " + e.getMessage(), e);
         }
     }
@@ -283,7 +285,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             conn.rollback();
             throw new BallerinaException("execute batch update failed: " + e.getMessage(), e);
         } finally {
-            SQLDatasourceUtils.cleanupConnection(null, stmt, conn, false);
+            SQLDatasourceUtils.cleanupResources(stmt, conn, false);
         }
         //After a command in a batch update fails to execute properly and a BatchUpdateException is thrown, the driver
         // may or may not continue to process the remaining commands in the batch. If the driver does not continue
@@ -570,7 +572,8 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                         currentOrdinal++;
                     }
                 } else {
-                    if (Constants.SQLDataTypes.REFCURSOR.equals(sqlType)) {
+                    if (Constants.SQLDataTypes.REFCURSOR.equals(sqlType) || Constants.SQLDataTypes.ARRAY
+                            .equals(sqlType)) {
                         setParameter(conn, stmt, sqlType, value, direction, currentOrdinal, databaseProductName);
                     } else {
                         setParameter(conn, stmt, sqlType, value, direction, currentOrdinal);
@@ -674,7 +677,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                 SQLDatasourceUtils.setNClobValue(stmt, value, index, direction, Types.NCLOB);
                 break;
             case Constants.SQLDataTypes.ARRAY:
-                SQLDatasourceUtils.setArrayValue(conn, stmt, value, index, direction, Types.ARRAY);
+                SQLDatasourceUtils.setArrayValue(conn, stmt, value, index, direction, Types.ARRAY, databaseProductName);
                 break;
             case Constants.SQLDataTypes.STRUCT:
                 SQLDatasourceUtils.setUserDefinedValue(conn, stmt, value, index, direction, Types.STRUCT);

--- a/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/table/BMirrorTable.java
+++ b/stdlib/ballerina-database/src/main/java/org/ballerinalang/database/table/BMirrorTable.java
@@ -89,7 +89,7 @@ public class BMirrorTable extends BTable {
         } catch (SQLException e) {
             throw new BallerinaException("execute add failed: " + e.getMessage(), e);
         } finally {
-            SQLDatasourceUtils.cleanupConnection(null, null, conn, isInTransaction);
+            SQLDatasourceUtils.cleanupResources(conn, isInTransaction);
         }
     }
 
@@ -120,7 +120,7 @@ public class BMirrorTable extends BTable {
             context.setReturnValues(TableUtils.createTableOperationError(context, e));
             SQLDatasourceUtils.handleErrorOnTransaction(context);
         } finally {
-            SQLDatasourceUtils.cleanupConnection(null, null, connection, isInTransaction);
+            SQLDatasourceUtils.cleanupResources(connection, isInTransaction);
         }
     }
 
@@ -156,7 +156,7 @@ public class BMirrorTable extends BTable {
             this.iterator = new SQLDataIterator(utcCalendar, constraintType, timeStructInfo, timeZoneStructInfo, rm, rs,
                     columnDefs);
         } catch (SQLException e) {
-            SQLDatasourceUtils.cleanupConnection(rs, preparedStmt, conn, false);
+            SQLDatasourceUtils.cleanupResources(rs, preparedStmt, conn, false);
             throw new BallerinaException("error in populating iterator for table : " + e.getMessage());
         }
     }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
@@ -175,13 +175,7 @@ public class SQLActionsTest {
         BString retValue = (BString) returns[0];
         final String expected = "James";
         Assert.assertEquals(retValue.stringValue(), expected);
-        if (dbType == POSTGRES) {
-            // In postgres, there are no procedures but functions. When we call a function internally a select
-            // happens eg: select InsertPersonData(100, 'J'); which returns a table containing an empty string
-            Assert.assertEquals(returns[1].stringValue(), "table");
-        } else {
-            Assert.assertEquals(returns[1].stringValue(), "nil");
-        }
+        Assert.assertEquals(returns[1].stringValue(), "nil");
     }
 
     @Test(groups = {"ConnectorTest", "MySQLNotSupported", "PostgresNotSupported"})
@@ -227,8 +221,7 @@ public class SQLActionsTest {
     public void testCallProcedureWithMultipleResultSetsAndNilConstraintCount() {
         BValue[] returns = BRunUtil
                 .invoke(resultNegative, "testCallProcedureWithMultipleResultSetsAndNilConstraintCount", connectionArgs);
-        Assert.assertTrue(returns[0].stringValue().contains("message:\"execute stored procedure failed: Mismatching "
-                + "record type count: 0 and returned result set count: 2 from the stored procedure\""));
+        Assert.assertEquals(returns[0].stringValue(), "nil");
     }
 
     @Test(groups = {"ConnectorTest", "PostgresNotSupported"})

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
@@ -192,7 +192,7 @@ public class SQLActionsTest {
         Assert.assertEquals(retValue.stringValue(), expected);
     }
 
-    @Test(groups = {"ConnectorTest", "MySQLNotSupported", "HSQLDBNotSupported"}, enabled = false)
+    @Test(groups = {"ConnectorTest", "MySQLNotSupported", "HSQLDBNotSupported"})
     public void testCallFunctionWithRefCursor() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testCallFunctionWithReturningRefcursor", connectionArgs);
         BString retValue = (BString) returns[0];
@@ -295,7 +295,7 @@ public class SQLActionsTest {
     @Test(groups = "ConnectorTest")
     public void testOutParameters() {
         BValue[] returns = BRunUtil.invoke(result, "testOutParameters", connectionArgs);
-        Assert.assertEquals(returns.length, 14);
+        Assert.assertEquals(returns.length, 13);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 9223372036854774807L);
         Assert.assertEquals(((BFloat) returns[2]).floatValue(), 123.34D, DELTA);
@@ -308,14 +308,21 @@ public class SQLActionsTest {
         Assert.assertEquals(((BInteger) returns[9]).intValue(), 1);
         Assert.assertEquals(((BInteger) returns[10]).intValue(), 5555);
         Assert.assertEquals(returns[11].stringValue(), "very long text");
-        Assert.assertEquals(returns[12].stringValue(), "d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==");
-        Assert.assertEquals(returns[13].stringValue(), "wso2 ballerina binary test.");
+        Assert.assertEquals(returns[12].stringValue(), "wso2 ballerina binary test.");
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testBlobOutInOutParameters() {
+        BValue[] returns = BRunUtil.invoke(result, "testBlobOutInOutParameters", connectionArgs);
+        Assert.assertEquals(returns.length, 2);
+        Assert.assertEquals(returns[0].stringValue(), "d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==");
+        Assert.assertEquals(returns[1].stringValue(), "YmxvYiBkYXRh");
     }
 
     @Test(groups = {"ConnectorTest"})
     public void testNullOutParameters() {
         BValue[] returns = BRunUtil.invoke(result, "testNullOutParameters", connectionArgs);
-        Assert.assertEquals(returns.length, 14);
+        Assert.assertEquals(returns.length, 13);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 0);
         Assert.assertEquals(((BFloat) returns[2]).floatValue(), 0.0D);
@@ -329,12 +336,18 @@ public class SQLActionsTest {
         Assert.assertEquals(((BInteger) returns[10]).intValue(), 0);
         Assert.assertEquals(returns[11].stringValue(), null);
         Assert.assertEquals(returns[12].stringValue(), null);
-        Assert.assertEquals(returns[13].stringValue(), null);
     }
 
     @Test(groups = "ConnectorTest")
     public void testINParameters() {
         BValue[] returns = BRunUtil.invoke(result, "testINParameters", connectionArgs);
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testBlobInParameter() {
+        BValue[] returns = BRunUtil.invoke(result, "testBlobInParameter", connectionArgs);
         BInteger retValue = (BInteger) returns[0];
         Assert.assertEquals(retValue.intValue(), 1);
     }
@@ -350,7 +363,12 @@ public class SQLActionsTest {
         Assert.assertEquals(((BFloat) returns[6]).floatValue(), 1234.567D);
         Assert.assertEquals(((BFloat) returns[7]).floatValue(), 1234.567D);
         Assert.assertEquals(((BFloat) returns[8]).floatValue(), 1234.567D, DELTA);
-        Assert.assertTrue(returns[9].stringValue().equals(returns[10].stringValue()));
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testINParametersWithDirectBlobValues() {
+        BValue[] returns = BRunUtil.invoke(result, "testINParametersWithDirectBlobValues", connectionArgs);
+        Assert.assertTrue(returns[0].stringValue().equals(returns[1].stringValue()));
     }
 
     @Test(groups = "ConnectorTest")
@@ -364,7 +382,6 @@ public class SQLActionsTest {
         Assert.assertEquals(((BFloat) returns[6]).floatValue(), 1234.567D);
         Assert.assertEquals(((BFloat) returns[7]).floatValue(), 1234.567D);
         Assert.assertEquals(((BFloat) returns[8]).floatValue(), 1234.567D, DELTA);
-        Assert.assertTrue(returns[9].stringValue().equals(returns[10].stringValue()));
     }
 
     @Test(groups = "ConnectorTest")
@@ -375,9 +392,16 @@ public class SQLActionsTest {
     }
 
     @Test(groups = "ConnectorTest")
+    public void testNullINParameterBlobValue() {
+        BValue[] returns = BRunUtil.invoke(result, "testNullINParameterBlobValue", connectionArgs);
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
+    @Test(groups = "ConnectorTest")
     public void testINOutParameters() {
         BValue[] returns = BRunUtil.invoke(result, "testINOutParameters", connectionArgs);
-        Assert.assertEquals(returns.length, 14);
+        Assert.assertEquals(returns.length, 13);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 9223372036854774807L);
         Assert.assertEquals(((BFloat) returns[2]).floatValue(), 123.34D, DELTA);
@@ -390,14 +414,13 @@ public class SQLActionsTest {
         Assert.assertEquals(((BInteger) returns[9]).intValue(), 1);
         Assert.assertEquals(((BInteger) returns[10]).intValue(), 5555);
         Assert.assertEquals(returns[11].stringValue(), "very long text");
-        Assert.assertEquals(returns[12].stringValue(), "YmxvYiBkYXRh");
-        Assert.assertEquals(returns[13].stringValue(), "wso2 ballerina binary test.");
+        Assert.assertEquals(returns[12].stringValue(), "wso2 ballerina binary test.");
     }
 
     @Test(groups = "ConnectorTest")
     public void testNullINOutParameters() {
         BValue[] returns = BRunUtil.invoke(result, "testNullINOutParameters", connectionArgs);
-        Assert.assertEquals(returns.length, 14);
+        Assert.assertEquals(returns.length, 13);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 0);
         Assert.assertEquals(((BFloat) returns[2]).floatValue(), 0.0D);
@@ -411,7 +434,13 @@ public class SQLActionsTest {
         Assert.assertEquals(((BInteger) returns[10]).intValue(), 0);
         Assert.assertEquals(returns[11].stringValue(), null);
         Assert.assertEquals(returns[12].stringValue(), null);
-        Assert.assertEquals(returns[13].stringValue(), null);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testNullOutInOutBlobParameters() {
+        BValue[] returns = BRunUtil.invoke(result, "testNullOutInOutBlobParameters", connectionArgs);
+        Assert.assertEquals(returns[0].stringValue(), null);
+        Assert.assertEquals(returns[1].stringValue(), null);
     }
 
     @Test(groups = "ConnectorTest")
@@ -636,45 +665,24 @@ public class SQLActionsTest {
         BValue[] returns = BRunUtil.invoke(result, "testComplexTypeRetrieval", connectionArgs);
         String expected0, expected1, expected2, expected3;
         if (dbType == MYSQL) {
-            expected0 = "<results><result><row_id>1</row_id><int_type>10</int_type><long_type>9223372036854774807"
-                    + "</long_type><float_type>123.34</float_type><double_type>2.139095039E9</double_type>"
-                    + "<boolean_type>true</boolean_type><string_type>Hello</string_type>"
-                    + "<numeric_type>1234.567</numeric_type><decimal_type>1234.567</decimal_type>"
-                    + "<real_type>1234.567</real_type><tinyint_type>1</tinyint_type>"
-                    + "<smallint_type>5555</smallint_type><clob_type>very long text</clob_type>"
+            expected0 = "<results><result><row_id>1</row_id>"
                     + "<blob_type>d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==</blob_type>"
-                    + "<binary_type>d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu</binary_type></result></results>";
+                    + "</result></results>";
             expected1 = "<results><result><row_id>1</row_id>"
                     + "<date_type>2017-02-03</date_type><time_type>11:35:45</time_type>"
                     + "<datetime_type>2017-02-03 11:53:00.0</datetime_type>"
                     + "<timestamp_type>2017-02-03 11:53:00.0</timestamp_type></result></results>";
-            expected2 = "[{\"row_id\":1,\"int_type\":10,\"long_type\":9223372036854774807,\"float_type\":123.34,"
-                    + "\"double_type\":2.139095039E9,\"boolean_type\":true,\"string_type\":\"Hello\","
-                    + "\"numeric_type\":1234.567,\"decimal_type\":1234.567,\"real_type\":1234.567,\"tinyint_type\":1,"
-                    + "\"smallint_type\":5555,\"clob_type\":\"very long text\","
-                    + "\"blob_type\":\"d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==\","
-                    + "\"binary_type\":\"d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu\"}]";
+            expected2 = "[{\"row_id\":1,\"blob_type\":\"d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==\"}]";
             expected3 = "[{\"row_id\":1,\"date_type\":\"2017-02-03\",\"time_type\":\"11:35:45\","
                     + "\"datetime_type\":\"2017-02-03 11:53:00.0\",\"timestamp_type\":\"2017-02-03 11:53:00.0\"}]";
         } else {
-            expected0 = "<results><result><ROW_ID>1</ROW_ID><INT_TYPE>10</INT_TYPE>"
-                    + "<LONG_TYPE>9223372036854774807</LONG_TYPE><FLOAT_TYPE>123.34</FLOAT_TYPE>"
-                    + "<DOUBLE_TYPE>2.139095039E9</DOUBLE_TYPE><BOOLEAN_TYPE>true</BOOLEAN_TYPE>"
-                    + "<STRING_TYPE>Hello</STRING_TYPE><NUMERIC_TYPE>1234.567</NUMERIC_TYPE>"
-                    + "<DECIMAL_TYPE>1234.567</DECIMAL_TYPE><REAL_TYPE>1234.567</REAL_TYPE><TINYINT_TYPE>1"
-                    + "</TINYINT_TYPE><SMALLINT_TYPE>5555</SMALLINT_TYPE><CLOB_TYPE>very long text</CLOB_TYPE>"
-                    + "<BLOB_TYPE>d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==</BLOB_TYPE>"
-                    + "<BINARY_TYPE>d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu</BINARY_TYPE></result></results>";
+            expected0 = "<results><result><ROW_ID>1</ROW_ID><BLOB_TYPE>d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==</BLOB_TYPE>"
+                    + "</result></results>";
             expected1 = "<results><result><ROW_ID>1</ROW_ID>"
                     + "<DATE_TYPE>2017-02-03</DATE_TYPE><TIME_TYPE>11:35:45</TIME_TYPE>"
                     + "<DATETIME_TYPE>2017-02-03 11:53:00.000000</DATETIME_TYPE>"
                     + "<TIMESTAMP_TYPE>2017-02-03 11:53:00.000000</TIMESTAMP_TYPE></result></results>";
-            expected2 = "[{\"ROW_ID\":1,\"INT_TYPE\":10,"
-                    + "\"LONG_TYPE\":9223372036854774807,\"FLOAT_TYPE\":123.34,\"DOUBLE_TYPE\":2.139095039E9,"
-                    + "\"BOOLEAN_TYPE\":true,\"STRING_TYPE\":\"Hello\",\"NUMERIC_TYPE\":1234.567,"
-                    + "\"DECIMAL_TYPE\":1234.567,\"REAL_TYPE\":1234.567,\"TINYINT_TYPE\":1,\"SMALLINT_TYPE\":5555,"
-                    + "\"CLOB_TYPE\":\"very long text\",\"BLOB_TYPE\":\"d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==\","
-                    + "\"BINARY_TYPE\":\"d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu\"}]";
+            expected2 = "[{\"ROW_ID\":1,\"BLOB_TYPE\":\"d3NvMiBiYWxsZXJpbmEgYmxvYiB0ZXN0Lg==\"}]";
             expected3 = "[{\"ROW_ID\":1,\"DATE_TYPE\":\"2017-02-03\","
                     + "\"TIME_TYPE\":\"11:35:45\",\"DATETIME_TYPE\":\"2017-02-03 11:53:00.000000\","
                     + "\"TIMESTAMP_TYPE\":\"2017-02-03 11:53:00.000000\"}]";

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
@@ -43,9 +43,6 @@ CREATE TABLE IF NOT EXISTS DateTimeTypes(
 insert into DateTimeTypes (row_id, date_type, time_type, datetime_type, timestamp_type) values
   (1, '2017-02-03', '11:35:45', '2017-02-03 11:53:00', '2017-02-03 11:53:00');
 /
-insert into BlobTable (row_id, blob_type) values
-  (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E');
-/
 insert into DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
   numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type) values
   (1, 10, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello',1234.567, 1234.567, 1234.567, 1, 5555,
@@ -54,6 +51,9 @@ insert into DataTypeTable (row_id, int_type, long_type, float_type, double_type,
 insert into DataTypeTable (row_id) values (2);
 /
 insert into BlobTable (row_id) values (2);
+/
+insert into BlobTable (row_id, blob_type) values
+  (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E');
 /
 insert into Customers (firstName,lastName,registrationID,creditLimit,country)
   values ('Peter', 'Stuart', 1, 5000.75, 'USA');

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
@@ -22,8 +22,13 @@ CREATE TABLE IF NOT EXISTS DataTypeTable(
   tinyint_type TINYINT,
   smallint_type SMALLINT,
   clob_type    CLOB,
-  blob_type    BLOB,
   binary_type  BINARY(27),
+  PRIMARY KEY (row_id)
+);
+/
+CREATE TABLE IF NOT EXISTS BlobTable(
+  row_id       INTEGER,
+  blob_type    BLOB,
   PRIMARY KEY (row_id)
 );
 /
@@ -38,13 +43,17 @@ CREATE TABLE IF NOT EXISTS DateTimeTypes(
 insert into DateTimeTypes (row_id, date_type, time_type, datetime_type, timestamp_type) values
   (1, '2017-02-03', '11:35:45', '2017-02-03 11:53:00', '2017-02-03 11:53:00');
 /
+insert into BlobTable (row_id, blob_type) values
+  (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E');
+/
 insert into DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
-  numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, blob_type, binary_type) values
+  numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type) values
   (1, 10, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello',1234.567, 1234.567, 1234.567, 1, 5555,
-  CONVERT('very long text', CLOB), X'77736F322062616C6C6572696E6120626C6F6220746573742E',
-  X'77736F322062616C6C6572696E612062696E61727920746573742E');
+  CONVERT('very long text', CLOB), X'77736F322062616C6C6572696E612062696E61727920746573742E');
 /
 insert into DataTypeTable (row_id) values (2);
+/
+insert into BlobTable (row_id) values (2);
 /
 insert into Customers (firstName,lastName,registrationID,creditLimit,country)
   values ('Peter', 'Stuart', 1, 5000.75, 'USA');
@@ -79,7 +88,7 @@ CREATE PROCEDURE SelectPersonDataMultiple()
 CREATE PROCEDURE TestOutParams (IN id INT, OUT paramInt INT, OUT paramBigInt BIGINT, OUT paramFloat FLOAT,
   OUT paramDouble DOUBLE, OUT paramBool BOOLEAN, OUT paramString VARCHAR(50),OUT paramNumeric NUMERIC(10,3),
   OUT paramDecimal DECIMAL(10,3), OUT paramReal REAL, OUT paramTinyInt TINYINT,
-  OUT paramSmallInt SMALLINT, OUT paramClob CLOB, OUT paramBlob BLOB, OUT paramBinary BINARY(27))
+  OUT paramSmallInt SMALLINT, OUT paramClob CLOB, OUT paramBinary BINARY(27))
   READS SQL DATA
   BEGIN ATOMIC
   SELECT int_type INTO paramInt FROM DataTypeTable where row_id = id;
@@ -94,20 +103,19 @@ CREATE PROCEDURE TestOutParams (IN id INT, OUT paramInt INT, OUT paramBigInt BIG
   SELECT tinyint_type INTO paramTinyInt FROM DataTypeTable where row_id = id;
   SELECT smallint_type INTO paramSmallInt FROM DataTypeTable where row_id = id;
   SELECT clob_type INTO paramClob FROM DataTypeTable where row_id = id;
-  SELECT blob_type INTO paramBlob FROM DataTypeTable where row_id = id;
   SELECT binary_type INTO paramBinary FROM DataTypeTable where row_id = id;
   END
 /
 CREATE PROCEDURE TestINOUTParams (IN id INT, INOUT paramInt INT, INOUT paramBigInt BIGINT, INOUT paramFloat FLOAT,
   INOUT paramDouble DOUBLE, INOUT paramBool BOOLEAN, INOUT paramString VARCHAR(50),
   INOUT paramNumeric NUMERIC(10,3), INOUT paramDecimal DECIMAL(10,3), INOUT paramReal REAL, INOUT paramTinyInt TINYINT,
-  INOUT paramSmallInt SMALLINT, INOUT paramClob CLOB, INOUT paramBlob BLOB, INOUT paramBinary BINARY(27))
+  INOUT paramSmallInt SMALLINT, INOUT paramClob CLOB, INOUT paramBinary BINARY(27))
   MODIFIES SQL DATA
   BEGIN ATOMIC
   INSERT INTO DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
-     numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, blob_type, binary_type)
+     numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type)
      VALUES (id, paramInt, paramBigInt, paramFloat, paramDouble, paramBool, paramString, paramNumeric, paramDecimal,
-     paramReal, paramTinyInt, paramSmallInt, paramClob, paramBlob, paramBinary);
+     paramReal, paramTinyInt, paramSmallInt, paramClob, paramBinary);
 
   SELECT int_type INTO paramInt FROM DataTypeTable where row_id = id;
   SELECT long_type INTO paramBigInt FROM DataTypeTable where row_id = id;
@@ -121,8 +129,16 @@ CREATE PROCEDURE TestINOUTParams (IN id INT, INOUT paramInt INT, INOUT paramBigI
   SELECT tinyint_type INTO paramTinyInt FROM DataTypeTable where row_id = id;
   SELECT smallint_type INTO paramSmallInt FROM DataTypeTable where row_id = id;
   SELECT clob_type INTO paramClob FROM DataTypeTable where row_id = id;
-  SELECT blob_type INTO paramBlob FROM DataTypeTable where row_id = id;
   SELECT binary_type INTO paramBinary FROM DataTypeTable where row_id = id;
+  END
+/
+CREATE PROCEDURE TestOUTINOUTParamsBlob (IN idOut INT, IN idInOut INT, OUT paramBlobOut BLOB, INOUT paramBlobInOut BLOB)
+  MODIFIES SQL DATA
+  BEGIN ATOMIC
+  INSERT INTO BlobTable (row_id, blob_type) values (idInOut, paramBlobInOut);
+  SELECT blob_type INTO paramBlobInOut FROM BlobTable where row_id = idInOut;
+
+  SELECT blob_type INTO paramBlobOut FROM BlobTable where row_id = idOut;
   END
 /
 CREATE TABLE IF NOT EXISTS ArrayTypes(

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorMYSQLDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorMYSQLDataFile.sql
@@ -48,11 +48,11 @@ insert into DataTypeTable (row_id, int_type, long_type, float_type, double_type,
   (1, 10, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello',1234.567, 1234.567, 1234.567, 1, 5555,
  'very long text', X'77736F322062616C6C6572696E612062696E61727920746573742E');
 /
-insert into BlobTable values (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E');
-/
 insert into DataTypeTable (row_id) values (2);
 /
 insert into BlobTable (row_id) values (2);
+/
+insert into BlobTable values (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E');
 /
 insert into Customers (firstName,lastName,registrationID,creditLimit,country)
   values ('Peter', 'Stuart', 1, 5000.75, 'USA');

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorMYSQLDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorMYSQLDataFile.sql
@@ -22,8 +22,13 @@ CREATE TABLE IF NOT EXISTS DataTypeTable(
   tinyint_type TINYINT,
   smallint_type SMALLINT,
   clob_type    TEXT,
-  blob_type    BLOB,
   binary_type  BINARY(27),
+  PRIMARY KEY (row_id)
+);
+/
+CREATE TABLE IF NOT EXISTS BlobTable(
+  row_id       INT,
+  blob_type    BLOB,
   PRIMARY KEY (row_id)
 );
 /
@@ -39,12 +44,15 @@ insert into DateTimeTypes (row_id, date_type, time_type, datetime_type, timestam
   (1, '2017-02-03', '11:35:45', '2017-02-03 11:53:00', '2017-02-03 11:53:00');
 /
 insert into DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
-  numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, blob_type, binary_type) values
+  numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type) values
   (1, 10, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello',1234.567, 1234.567, 1234.567, 1, 5555,
- 'very long text', X'77736F322062616C6C6572696E6120626C6F6220746573742E',
-  X'77736F322062616C6C6572696E612062696E61727920746573742E');
+ 'very long text', X'77736F322062616C6C6572696E612062696E61727920746573742E');
+/
+insert into BlobTable values (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E');
 /
 insert into DataTypeTable (row_id) values (2);
+/
+insert into BlobTable (row_id) values (2);
 /
 insert into Customers (firstName,lastName,registrationID,creditLimit,country)
   values ('Peter', 'Stuart', 1, 5000.75, 'USA');
@@ -75,7 +83,7 @@ CREATE PROCEDURE SelectPersonDataMultiple()
 CREATE PROCEDURE TestOutParams (IN id INT, OUT paramInt INT, OUT paramBigInt BIGINT, OUT paramFloat FLOAT,
   OUT paramDouble DOUBLE, OUT paramBool BOOLEAN, OUT paramString VARCHAR(50),OUT paramNumeric NUMERIC(10,3),
   OUT paramDecimal DECIMAL(10,3), OUT paramReal REAL, OUT paramTinyInt TINYINT,
-  OUT paramSmallInt SMALLINT, OUT paramClob TEXT, OUT paramBlob BLOB, OUT paramBinary BINARY(27))
+  OUT paramSmallInt SMALLINT, OUT paramClob TEXT, OUT paramBinary BINARY(27))
   READS SQL DATA
   BEGIN
   SELECT int_type INTO paramInt FROM DataTypeTable where row_id = id;
@@ -90,20 +98,19 @@ CREATE PROCEDURE TestOutParams (IN id INT, OUT paramInt INT, OUT paramBigInt BIG
   SELECT tinyint_type INTO paramTinyInt FROM DataTypeTable where row_id = id;
   SELECT smallint_type INTO paramSmallInt FROM DataTypeTable where row_id = id;
   SELECT clob_type INTO paramClob FROM DataTypeTable where row_id = id;
-  SELECT blob_type INTO paramBlob FROM DataTypeTable where row_id = id;
   SELECT binary_type INTO paramBinary FROM DataTypeTable where row_id = id;
   END
 /
 CREATE PROCEDURE TestINOUTParams (IN id INT, INOUT paramInt INT, INOUT paramBigInt BIGINT, INOUT paramFloat FLOAT,
   INOUT paramDouble DOUBLE, INOUT paramBool BOOLEAN, INOUT paramString VARCHAR(50),
   INOUT paramNumeric NUMERIC(10,3), INOUT paramDecimal DECIMAL(10,3), INOUT paramReal REAL, INOUT paramTinyInt TINYINT,
-  INOUT paramSmallInt SMALLINT, INOUT paramClob TEXT, INOUT paramBlob BLOB, INOUT paramBinary BINARY(27))
+  INOUT paramSmallInt SMALLINT, INOUT paramClob TEXT, INOUT paramBinary BINARY(27))
   MODIFIES SQL DATA
   BEGIN
   INSERT INTO DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
-     numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, blob_type, binary_type)
+     numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type)
      VALUES (id, paramInt, paramBigInt, paramFloat, paramDouble, paramBool, paramString, paramNumeric, paramDecimal,
-     paramReal, paramTinyInt, paramSmallInt, paramClob, paramBlob, paramBinary);
+     paramReal, paramTinyInt, paramSmallInt, paramClob, paramBinary);
 
   SELECT int_type INTO paramInt FROM DataTypeTable where row_id = id;
   SELECT long_type INTO paramBigInt FROM DataTypeTable where row_id = id;
@@ -117,8 +124,16 @@ CREATE PROCEDURE TestINOUTParams (IN id INT, INOUT paramInt INT, INOUT paramBigI
   SELECT tinyint_type INTO paramTinyInt FROM DataTypeTable where row_id = id;
   SELECT smallint_type INTO paramSmallInt FROM DataTypeTable where row_id = id;
   SELECT clob_type INTO paramClob FROM DataTypeTable where row_id = id;
-  SELECT blob_type INTO paramBlob FROM DataTypeTable where row_id = id;
   SELECT binary_type INTO paramBinary FROM DataTypeTable where row_id = id;
+  END
+/
+CREATE PROCEDURE TestOutInOutParamsBlob (IN idOut INT, IN idInOut INT, OUT paramBlobOut BLOB, INOUT paramBlobInOut BLOB)
+  READS SQL DATA
+  BEGIN
+  SELECT blob_type INTO paramBlobOut FROM BlobTable where row_id = idOut;
+
+  INSERT INTO BlobTable (row_id, blob_type) VALUES (idInOut, paramBlobInOut);
+  SELECT blob_type INTO paramBlobInOut FROM BlobTable where row_id = idInOut;
   END
 /
 CREATE PROCEDURE TestDateTimeOutParams (IN id INT, IN dateVal DATE, IN timeVal TIME, IN datetimeVal DATETIME,

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorPostgresDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorPostgresDataFile.sql
@@ -22,7 +22,6 @@ CREATE TABLE IF NOT EXISTS DataTypeTable(
   TINYINT_TYPE SMALLINT,
   SMALLINT_TYPE SMALLINT,
   CLOB_TYPE    TEXT,
-  BLOB_TYPE    BYTEA, --TODO: this should have been OID type..
   BINARY_TYPE  BYTEA,
   PRIMARY KEY (row_id)
 );
@@ -39,10 +38,9 @@ insert into DateTimeTypes (row_id, date_type, time_type, datetime_type, timestam
   (1, '2017-02-03', '11:35:45', '2017-02-03 11:53:00', '2017-02-03 11:53:00');
 /
 insert into DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
-  numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, blob_type, binary_type) values
+  numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type) values
   (1, 10, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello',1234.567, 1234.567, 1234.567, 1, 5555,
-  'very long text', E'\\x77736F322062616C6C6572696E6120626C6F6220746573742E',
-  E'\\x77736F322062616C6C6572696E612062696E61727920746573742E');
+  'very long text', E'\\x77736F322062616C6C6572696E612062696E61727920746573742E');
 /
 insert into DataTypeTable (row_id) values (2);
 /
@@ -70,7 +68,7 @@ CREATE FUNCTION SelectPersonData() RETURNS refcursor AS '
 CREATE FUNCTION TestOutParams (IN id BIGINT, OUT paramInt INTEGER, OUT paramBigInt BIGINT, OUT paramFloat FLOAT(4),
   OUT paramDouble DOUBLE PRECISION, OUT paramBool BOOLEAN, OUT paramString VARCHAR(50),OUT paramNumeric NUMERIC(10,3),
   OUT paramDecimal DECIMAL(10,3), OUT paramReal REAL, OUT paramTinyInt SMALLINT,
-  OUT paramSmallInt SMALLINT, OUT paramClob TEXT, OUT paramBlob BYTEA, OUT paramBinary BYTEA) AS '
+  OUT paramSmallInt SMALLINT, OUT paramClob TEXT, OUT paramBinary BYTEA) AS '
   BEGIN
   SELECT int_type INTO paramInt FROM DataTypeTable where row_id = id;
   SELECT long_type INTO paramBigInt FROM DataTypeTable where row_id = id;
@@ -84,20 +82,19 @@ CREATE FUNCTION TestOutParams (IN id BIGINT, OUT paramInt INTEGER, OUT paramBigI
   SELECT tinyint_type INTO paramTinyInt FROM DataTypeTable where row_id = id;
   SELECT smallint_type INTO paramSmallInt FROM DataTypeTable where row_id = id;
   SELECT clob_type INTO paramClob FROM DataTypeTable where row_id = id;
-  SELECT blob_type INTO paramBlob FROM DataTypeTable where row_id = id;
   SELECT binary_type INTO paramBinary FROM DataTypeTable where row_id = id;
   END
 ' LANGUAGE plpgsql;
 /
-CREATE FUNCTION TestINOUTParams (IN id BIGINT, INOUT paramInt INTEGER, INOUT paramBigInt BIGINT, INOUT paramFloat
+CREATE FUNCTION TestINOUTParams (IN id INTEGER, INOUT paramInt INTEGER, INOUT paramBigInt BIGINT, INOUT paramFloat
   FLOAT(2), INOUT paramDouble DOUBLE PRECISION, INOUT paramBool BOOLEAN, INOUT paramString VARCHAR(50),
   INOUT paramNumeric NUMERIC(10,3), INOUT paramDecimal DECIMAL(10,3), INOUT paramReal REAL, INOUT paramTinyInt
-  SMALLINT, INOUT paramSmallInt SMALLINT, INOUT paramClob TEXT, INOUT paramBlob BYTEA, INOUT paramBinary BYTEA) AS '
+  SMALLINT, INOUT paramSmallInt SMALLINT, INOUT paramClob TEXT, INOUT paramBinary BYTEA) AS '
   BEGIN
   INSERT INTO DataTypeTable (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type,
-     numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, blob_type, binary_type)
+     numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type, binary_type)
      VALUES (id, paramInt, paramBigInt, paramFloat, paramDouble, paramBool, paramString, paramNumeric, paramDecimal,
-     paramReal, paramTinyInt, paramSmallInt, paramClob, paramBlob, paramBinary);
+     paramReal, paramTinyInt, paramSmallInt, paramClob, paramBinary);
 
   SELECT int_type INTO paramInt FROM DataTypeTable where row_id = id;
   SELECT long_type INTO paramBigInt FROM DataTypeTable where row_id = id;
@@ -111,7 +108,6 @@ CREATE FUNCTION TestINOUTParams (IN id BIGINT, INOUT paramInt INTEGER, INOUT par
   SELECT tinyint_type INTO paramTinyInt FROM DataTypeTable where row_id = id;
   SELECT smallint_type INTO paramSmallInt FROM DataTypeTable where row_id = id;
   SELECT clob_type INTO paramClob FROM DataTypeTable where row_id = id;
-  SELECT blob_type INTO paramBlob FROM DataTypeTable where row_id = id;
   SELECT binary_type INTO paramBinary FROM DataTypeTable where row_id = id;
   END
 ' LANGUAGE plpgsql;

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_negative_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_negative_test.bal
@@ -206,11 +206,13 @@ function testCallProcedureWithMultipleResultSetsAndLowerConstraintCount(string j
                 ResultCustomers rs = check <ResultCustomers>dts[1].getNext();
                 firstName2 = rs.FIRSTNAME;
             }
-
             testDB.stop();
             return (firstName1, firstName2);
         }
-        () => return ("", "");
+        () => {
+            testDB.stop();
+            return ("", "");
+        }
         error e => {
             testDB.stop();
             return e;
@@ -247,7 +249,10 @@ function testCallProcedureWithMultipleResultSetsAndHigherConstraintCount(string 
             testDB.stop();
             return (firstName1, firstName2);
         }
-        () => return ("", "");
+        () => {
+            testDB.stop();
+            return ("", "");
+        }
         error e => {
             testDB.stop();
             return e;
@@ -256,7 +261,7 @@ function testCallProcedureWithMultipleResultSetsAndHigherConstraintCount(string 
 }
 
 function testCallProcedureWithMultipleResultSetsAndNilConstraintCount(string jdbcUrl, string userName, string password)
-             returns ((string, string)|error) {
+             returns (string|(string, string)|error) {
     endpoint jdbc:Client testDB {
         url: jdbcUrl,
         username: userName,
@@ -280,10 +285,13 @@ function testCallProcedureWithMultipleResultSetsAndNilConstraintCount(string jdb
                 ResultCustomers rs = check <ResultCustomers>dts[1].getNext();
                 firstName2 = rs.FIRSTNAME;
             }
-
+            testDB.stop();
             return (firstName1, firstName2);
         }
-        () => return ("", "");
+        () => {
+            testDB.stop();
+            return "nil";
+        }
         error e => {
             testDB.stop();
             return e;

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_test.bal
@@ -551,6 +551,18 @@ function testOutParameters(string jdbcUrl, string userName, string password) ret
     sql:Parameter paraClob = { sqlType: sql:TYPE_CLOB, direction: sql:DIRECTION_OUT };
     sql:Parameter paraBinary = { sqlType: sql:TYPE_BINARY, direction: sql:DIRECTION_OUT };
 
+    if (jdbcUrl.contains("postgres")) {
+        // There is no CLOB type in postgres. Therefore have to use TEXT type instead.
+        paraClob = { sqlType: sql:TYPE_VARCHAR, direction: sql:DIRECTION_OUT };
+        // In postgres FLOAT with no precision represents DOUBLE
+        // float(1) to float(24) means REAL
+        // float(25) to float(53) means double precision
+        // Therefore to get the OUT param right, it is required to use "REAL" type
+        paraFloat = { sqlType: sql:TYPE_REAL, direction: sql:DIRECTION_OUT };
+        // There is no TINYINT in postgres, hence using SMALLINT instead
+        paraTinyInt = { sqlType: sql:TYPE_SMALLINT, direction: sql:DIRECTION_OUT };
+    }
+
     _ = testDB->call("{call TestOutParams(?,?,?,?,?,?,?,?,?,?,?,?,?,?)}", (),
         paraID, paraInt, paraLong, paraFloat, paraDouble, paraBool, paraString, paraNumeric,
         paraDecimal, paraReal, paraTinyInt, paraSmallInt, paraClob, paraBinary);
@@ -609,6 +621,18 @@ function testNullOutParameters(string jdbcUrl, string userName, string password)
     sql:Parameter paraClob = { sqlType: sql:TYPE_CLOB, direction: sql:DIRECTION_OUT };
     sql:Parameter paraBinary = { sqlType: sql:TYPE_BINARY, direction: sql:DIRECTION_OUT };
 
+    if (jdbcUrl.contains("postgres")) {
+        // There is no CLOB type in postgres. Therefore have to use TEXT type instead.
+        paraClob = { sqlType: sql:TYPE_VARCHAR, direction: sql:DIRECTION_OUT };
+        // In postgres FLOAT with no precision represents DOUBLE
+        // float(1) to float(24) means REAL
+        // float(25) to float(53) means testCallProceduredouble precision
+        // Therefore to get the OUT param right, it is required to use "REAL" type
+        paraFloat = { sqlType: sql:TYPE_REAL, direction: sql:DIRECTION_OUT };
+        // There is no TINYINT in postgres, hence using SMALLINT instead
+        paraTinyInt = { sqlType: sql:TYPE_SMALLINT, direction: sql:DIRECTION_OUT };
+    }
+
     _ = testDB->call("{call TestOutParams(?,?,?,?,?,?,?,?,?,?,?,?,?,?)}", (),
         paraID, paraInt, paraLong, paraFloat, paraDouble, paraBool, paraString, paraNumeric,
         paraDecimal, paraReal, paraTinyInt, paraSmallInt, paraClob, paraBinary);
@@ -661,6 +685,11 @@ function testINParameters(string jdbcUrl, string userName, string password) retu
     sql:Parameter paraSmallInt = { sqlType: sql:TYPE_SMALLINT, value: 5555 };
     sql:Parameter paraClob = { sqlType: sql:TYPE_CLOB, value: "very long text" };
     sql:Parameter paraBinary = { sqlType: sql:TYPE_BINARY, value: "d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu" };
+
+    if (jdbcUrl.contains("postgres")) {
+        // In postgres there is no Clob type. TEXT type can be used instead.
+        paraClob = { sqlType: sql:TYPE_VARCHAR, value: "very long text" };
+    }
 
     int insertCount = check testDB->update("INSERT INTO DataTypeTable (row_id,int_type, long_type,
             float_type, double_type, boolean_type, string_type, numeric_type, decimal_type, real_type, tinyint_type,
@@ -871,7 +900,7 @@ function testINOutParameters(string jdbcUrl, string userName, string password) r
     sql:Parameter paraID = { sqlType: sql:TYPE_INTEGER, value: 5 };
     sql:Parameter paraInt = { sqlType: sql:TYPE_INTEGER, value: 10, direction: sql:DIRECTION_INOUT };
     sql:Parameter paraLong = { sqlType: sql:TYPE_BIGINT, value: "9223372036854774807", direction: sql:DIRECTION_INOUT };
-    sql:Parameter paraFloat = { sqlType: sql:TYPE_FLOAT, value: 123.34, direction: sql:DIRECTION_INOUT };
+    sql:Parameter paraFloat = { sqlType: sql:TYPE_REAL, value: 123.34, direction: sql:DIRECTION_INOUT };
     sql:Parameter paraDouble = { sqlType: sql:TYPE_DOUBLE, value: 2139095039, direction: sql:DIRECTION_INOUT };
     sql:Parameter paraBool = { sqlType: sql:TYPE_BOOLEAN, value: true, direction: sql:DIRECTION_INOUT };
     sql:Parameter paraString = { sqlType: sql:TYPE_VARCHAR, value: "Hello", direction: sql:DIRECTION_INOUT };
@@ -886,8 +915,14 @@ function testINOutParameters(string jdbcUrl, string userName, string password) r
     DIRECTION_INOUT };
 
     if (jdbcUrl.contains("postgres")) {
-        paraTinyInt = { sqlType: sql:TYPE_SMALLINT, value: 1 };
         paraClob = { sqlType: sql:TYPE_VARCHAR, value: "very long text", direction: sql:DIRECTION_INOUT };
+        // In postgres FLOAT with no precision represents DOUBLE
+        // float(1) to float(24) means REAL
+        // float(25) to float(53) means double precision
+        // Therefore to get the OUT param right, it is required to use "REAL" type
+        paraFloat = { sqlType: sql:TYPE_REAL, value: 123.34, direction: sql:DIRECTION_INOUT };
+        // There is no TINYINT in postgres, hence using SMALLINT instead
+        paraTinyInt = { sqlType: sql:TYPE_SMALLINT, value: 1, direction: sql:DIRECTION_INOUT };
     }
 
     _ = testDB->call("{call TestINOUTParams(?,?,?,?,?,?,?,?,?,?,?,?,?,?)}", (),
@@ -922,6 +957,17 @@ function testNullINOutParameters(string jdbcUrl, string userName, string passwor
     sql:Parameter paraSmallInt = { sqlType: sql:TYPE_SMALLINT, direction: sql:DIRECTION_INOUT };
     sql:Parameter paraClob = { sqlType: sql:TYPE_CLOB, direction: sql:DIRECTION_INOUT };
     sql:Parameter paraBinary = { sqlType: sql:TYPE_BINARY, direction: sql:DIRECTION_INOUT };
+
+    if (jdbcUrl.contains("postgres")) {
+        paraClob = { sqlType: sql:TYPE_VARCHAR, direction: sql:DIRECTION_INOUT };
+        // In postgres FLOAT with no precision represents DOUBLE
+        // float(1) to float(24) means REAL
+        // float(25) to float(53) means double precision
+        // Therefore to get the OUT param right, it is required to use "REAL" type
+        paraFloat = { sqlType: sql:TYPE_REAL, direction: sql:DIRECTION_INOUT };
+        // There is no TINYINT in postgres, hence using SMALLINT instead
+        paraTinyInt = { sqlType: sql:TYPE_SMALLINT, direction: sql:DIRECTION_INOUT };
+    }
 
     _ = testDB->call("{call TestINOUTParams(?,?,?,?,?,?,?,?,?,?,?,?,?,?)}", (),
         paraID, paraInt, paraLong, paraFloat, paraDouble, paraBool, paraString, paraNumeric,
@@ -976,17 +1022,24 @@ function testArrayInOutParameters(string jdbcUrl, string userName, string passwo
         poolOptions: { maximumPoolSize: 1 }
     };
 
+    int[] intArray1 = [10,20,30];
+    int[] intArray2 = [10000000, 20000000, 30000000];
+    float[] floatArray1 = [2454.23, 55594.49, 87964.123];
+    float[] floatArray2 = [2454.23, 55594.49, 87964.123];
+    boolean[] booleanArray = [false, false, true];
+    string[] stringArray = ["Hello","Ballerina","Lang"];
+
     sql:Parameter para1 = { sqlType: sql:TYPE_INTEGER, value: 3 };
     sql:Parameter para2 = { sqlType: sql:TYPE_INTEGER, direction: sql:DIRECTION_OUT };
-    sql:Parameter para3 = { sqlType: sql:TYPE_ARRAY, value: "10,20,30", direction: sql:DIRECTION_INOUT };
-    sql:Parameter para4 = { sqlType: sql:TYPE_ARRAY, value: "10000000, 20000000, 30000000", direction: sql:
+    sql:Parameter para3 = { sqlType: sql:TYPE_ARRAY, value: intArray1, direction: sql:DIRECTION_INOUT };
+    sql:Parameter para4 = { sqlType: sql:TYPE_ARRAY, value: intArray2, direction: sql:
     DIRECTION_INOUT };
-    sql:Parameter para5 = { sqlType: sql:TYPE_ARRAY, value: "2454.23, 55594.49, 87964.123", direction: sql:
+    sql:Parameter para5 = { sqlType: sql:TYPE_ARRAY, value: floatArray1, direction: sql:
     DIRECTION_INOUT };
-    sql:Parameter para6 = { sqlType: sql:TYPE_ARRAY, value: "2454.23, 55594.49, 87964.123", direction: sql:
+    sql:Parameter para6 = { sqlType: sql:TYPE_ARRAY, value: floatArray2, direction: sql:
     DIRECTION_INOUT };
-    sql:Parameter para7 = { sqlType: sql:TYPE_ARRAY, value: "FALSE, FALSE, TRUE", direction: sql:DIRECTION_INOUT };
-    sql:Parameter para8 = { sqlType: sql:TYPE_ARRAY, value: "Hello,Ballerina,Lang", direction: sql:DIRECTION_INOUT };
+    sql:Parameter para7 = { sqlType: sql:TYPE_ARRAY, value: booleanArray, direction: sql:DIRECTION_INOUT };
+    sql:Parameter para8 = { sqlType: sql:TYPE_ARRAY, value: stringArray, direction: sql:DIRECTION_INOUT };
 
     _ = testDB->call("{call TestArrayInOutParams(?,?,?,?,?,?,?,?)}", (),
         para1, para2, para3, para4, para5, para6, para7, para8);

--- a/tests/ballerina-test/src/test/resources/testng.xml
+++ b/tests/ballerina-test/src/test/resources/testng.xml
@@ -26,8 +26,14 @@ under the License.
         <!--<listener class-name="org.ballerinalang.test.utils.TestNGListener"/>-->
     </listeners>
 
+
     <!-- Ballerina language Test Cases. -->
     <test name="ballerina-lang-test-suite" preserve-order="true" parallel="false">
+        <groups>
+            <run>
+                <exclude name="HSQLDBNotSupported"/>
+            </run>
+        </groups>
         <packages>
             <package name="org.ballerinalang.test.vm.*"/>
             <package name="org.ballerinalang.test.annotations.*"/>


### PR DESCRIPTION
## Purpose
1. Separate blob tests from other datatype tests. This is due to the varying behavior of blob data type in different databases which may require differences in tests

Resolves https://github.com/ballerina-platform/ballerina-lang/issues/8801

2. Fix several postgresql related issues.

Resolves https://github.com/ballerina-platform/ballerina-lang/issues/8701 
Resolves https://github.com/ballerina-platform/ballerina-lang/issues/8800 
Resolves https://github.com/ballerina-platform/ballerina-lang/issues/8924


