### PR TITLE
Process annotations for the type definition

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1450,6 +1450,7 @@ public class BLangPackageBuilder {
         typeDefinition.addWS(ws);
         attachDocumentations(typeDefinition);
         attachDeprecatedNode(typeDefinition);
+        attachAnnotations(typeDefinition);
         this.compUnit.addTopLevelNode(typeDefinition);
     }
 


### PR DESCRIPTION
## Purpose
> Annotations are not processed for the type definition.
This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/8891