### PR TITLE
Fix white space for AnyIdentifierName

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -1562,7 +1562,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        if (!(ctx.children.get(0) instanceof BallerinaParser.ReservedWordContext)) {
+        if (ctx.reservedWord() == null) {
             this.pkgBuilder.startInvocationNode(getWS(ctx));
         }
     }


### PR DESCRIPTION
## Purpose
> Fix white space collection for anyIdentifierName by checking whether identifier is a reserve word or not and collect the white space if the reserve word is null as reserve word has a separate listener. 