### PR TITLE
Fix #6297 replacing the 'Open File Explorer' icon with file open icon

### DIFF
--- a/composer/modules/web/src/core/workspace/plugin.js
+++ b/composer/modules/web/src/core/workspace/plugin.js
@@ -373,7 +373,7 @@ class WorkspacePlugin extends Plugin {
                     region: REGIONS.LEFT_PANEL,
                     // region specific options for left-panel views
                     regionOptions: {
-                        activityBarIcon: 'file-browse',
+                        activityBarIcon: 'folder-open',
                         panelTitle: 'Explorer',
                         panelActions: [
                             {


### PR DESCRIPTION
## Purpose
> This commit fixes the issue of misleading Open File Explorer icon with file open icon.

Resolves #6297 

![image](https://user-images.githubusercontent.com/10986966/41220503-3ed0fd26-6d7f-11e8-9b72-9bb9651e983e.png)
