### PR TITLE
Changes for transport-http version bump to 6.0.192

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1666,7 +1666,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.187</transport.http.version>
+        <transport.http.version>6.0.192</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/Register.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/Register.java
@@ -85,9 +85,8 @@ public class Register extends AbstractHttpNativeFunction {
         serverConnectorFuture.setHttpConnectorListener(
                 new BallerinaHTTPConnectorListener(httpServicesRegistry, serviceEndpoint
                         .getStructField(HttpConstants.SERVICE_ENDPOINT_CONFIG)));
-        serverConnectorFuture
-                .setWSConnectorListener(new WebSocketServerConnectorListener(webSocketServicesRegistry, serviceEndpoint
-                        .getStructField(HttpConstants.SERVICE_ENDPOINT_CONFIG)));
+        serverConnectorFuture.setWebSocketConnectorListener(new WebSocketServerConnectorListener(
+                webSocketServicesRegistry, serviceEndpoint.getStructField(HttpConstants.SERVICE_ENDPOINT_CONFIG)));
 
         serverConnectorFuture.setPortBindingEventListener(new HttpConnectorPortBindingListener());
         try {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/Start.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/Start.java
@@ -81,11 +81,11 @@ public class Start extends BlockingNativeCallableUnit {
         }
         WebSocketService wsService = (WebSocketService) serviceConfig;
         boolean readyOnConnect = clientEndpointConfig.getBooleanField(WebSocketConstants.CLIENT_READY_ON_CONNECT);
-        ClientHandshakeFuture handshakeFuture = clientConnector.connect(clientConnectorListener);
+        ClientHandshakeFuture handshakeFuture = clientConnector.connect();
+        handshakeFuture.setWebSocketConnectorListener(clientConnectorListener);
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        handshakeFuture.setClientHandshakeListener(
-                new WebSocketClientHandshakeListener(context, wsService, clientConnectorListener, readyOnConnect,
-                                                     countDownLatch));
+        handshakeFuture.setClientHandshakeListener(new WebSocketClientHandshakeListener(context, wsService,
+                clientConnectorListener, readyOnConnect, countDownLatch));
         try {
             if (!countDownLatch.await(60, TimeUnit.SECONDS)) {
                 throw new BallerinaConnectorException("Waiting for WebSocket handshake in not successful");


### PR DESCRIPTION
This PR include the changes required to bump the transport-http version to 6.0.192.

_Please review and merge https://github.com/wso2/transport-http/pull/196 before merging this PR._