### PR TITLE
Prevent non-existent error popup during file rename

### DIFF
--- a/composer/modules/web/src/core/view/tree-view/TreeNode.jsx
+++ b/composer/modules/web/src/core/view/tree-view/TreeNode.jsx
@@ -217,12 +217,11 @@ class TreeNode extends React.Component {
                             const { editor, command: { dispatch } } = this.context;
                             if (editor.isFileOpenedInEditor(node.id)) {
                                 const targetEditor = editor.getEditorByID(node.id);
-                                const wasActive = editor.getActiveEditor().id === targetEditor.id;
+                                editor.closeEditor(targetEditor);
                                 dispatch(WORKSPACE_CMDS.OPEN_FILE, {
                                     filePath: newFullPath,
-                                    activate: wasActive,
+                                    activate: true,
                                 });
-                                editor.closeEditor(targetEditor, wasActive ? editor.getActiveEditor() : undefined);
                             }
                             this.props.onNodeRefresh(this.props.parentNode);
                         }


### PR DESCRIPTION
When an already opened file in editor is renamed from
file explorer, it will move the file in fs and open
a new editor tab for the file. Then it will close existing
editor. However, a new validation added to composer for
verifing file's existency in fs has caused a regression
issue with this approach. This PR fixes the regression.

Issue: https://github.com/ballerina-platform/ballerina-lang/issues/8550
