### PR TITLE
[Data I/O] Add read/write String 

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/io/data_channel.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/io/data_channel.bal
@@ -45,28 +45,28 @@ public type DataChannel object {
     documentation {
         Reads a 16 bit integer.
 
-        R{{}} Value of the integer which is read or an error
+        R{{}} value of the integer which is read or an error
     }
     public native function readInt16() returns int|error;
 
     documentation {
         Reads a 32 bit integer.
 
-        R{{}} Value of the integer which is read or an error
+        R{{}} value of the integer which is read or an error
     }
     public native function readInt32() returns int|error;
 
     documentation {
         Reads a 64 bit integer.
 
-        R{{}} Value of the integer which is read or an error
+        R{{}} value of the integer which is read or an error
     }
     public native function readInt64() returns int|error;
 
     documentation {
         Writes 16 bit integer.
 
-        P{{value}}   Integer which will be written
+        P{{value}}   integer which will be written
         R{{}} nill if the content is written successfully or an error
     }
     public native function writeInt16(int value) returns error?;
@@ -74,7 +74,7 @@ public type DataChannel object {
     documentation {
         Writes 32 bit integer.
 
-        P{{value}}   Integer which will be written
+        P{{value}}   integer which will be written
         R{{}} nill if the content is written successfully or an error
     }
     public native function writeInt32(int value) returns error?;
@@ -82,7 +82,7 @@ public type DataChannel object {
     documentation {
         Writes 64 bit integer.
 
-        P{{value}}   Integer which will be written
+        P{{value}}   integer which will be written
         R{{}} nill if the content is written successfully or an error
     }
     public native function writeInt64(int value) returns error?;
@@ -90,30 +90,30 @@ public type DataChannel object {
     documentation {
         Reads 32 bit float.
 
-        R{{}} Value of the float which is read or an error
+        R{{}} value of the float which is read or an error
     }
     public native function readFloat32() returns float|error;
 
     documentation {
         Reads 64 bit float.
 
-        R{{}} Value of the float which is read or an error
+        R{{}} value of the float which is read or an error
     }
     public native function readFloat64() returns float|error;
 
     documentation {
         Writes 32 bit float.
 
-        P{{value}}   Float which will be written
-        R{{}} Value of the float which is read or an error
+        P{{value}}   float which will be written
+        R{{}} value of the float which is read or an error
     }
     public native function writeFloat32(float value) returns error?;
 
     documentation {
         Writes 64 bit float.
 
-        P{{value}}   Float which will be written
-        R{{}} Value of the float which is read or an error
+        P{{value}}   float which will be written
+        R{{}} value of the float which is read or an error
     }
     public native function writeFloat64(float value) returns error?;
 
@@ -131,4 +131,29 @@ public type DataChannel object {
         R{{}} nill if the content is written successfully or an error
     }
     public native function writeBool(boolean value) returns error?;
+
+    documentation {
+        Reads string value represented through the provided number of bytes.
+
+        P{{nBytes}} specifies the number of bytes which represents the string
+        P{{encoding}} specifies the char-set encoding of the string
+        R{{}} value of the string or an error
+    }
+    public native function readString(int nBytes, string encoding) returns string|error;
+
+    documentation {
+        Writes a given string value to the respective channel.
+
+        P{{value}} the value which should be written
+        P{{encoding}} the encoding which will represent the value string
+        R{{}} nill if the content is written successfully or an error
+    }
+    public native function writeString(string value, string encoding) returns error?;
+
+    documentation {
+        Closes the data channel.
+
+        R{{}} nill if the channel is closes successfully or an i/o error
+    }
+    public native function close() returns error?;
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/io/data_channel.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/io/data_channel.bal
@@ -105,7 +105,7 @@ public type DataChannel object {
         Writes 32 bit float.
 
         P{{value}}   float which will be written
-        R{{}} value of the float which is read or an error
+        R{{}} nill if the float is written successfully or an error
     }
     public native function writeFloat32(float value) returns error?;
 
@@ -113,7 +113,7 @@ public type DataChannel object {
         Writes 64 bit float.
 
         P{{value}}   float which will be written
-        R{{}} value of the float which is read or an error
+        R{{}} nill if the float is written successfully or an error
     }
     public native function writeFloat64(float value) returns error?;
 

--- a/stdlib/ballerina-builtin/src/main/ballerina/io/data_channel.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/io/data_channel.bal
@@ -153,7 +153,7 @@ public type DataChannel object {
     documentation {
         Closes the data channel.
 
-        R{{}} nill if the channel is closes successfully or an i/o error
+        R{{}} nill if the channel is closed successfully or an i/o error
     }
     public native function close() returns error?;
 };

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDataChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDataChannel.java
@@ -54,6 +54,12 @@ public class CloseDataChannel implements NativeCallableUnit {
      */
     private static final int DATA_CHANNEL_INDEX = 0;
 
+    /**
+     * Closes data channel.
+     *
+     * @param result the response received after the channel is closed.
+     * @return the result of the close response.
+     */
     private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDataChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDataChannel.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.nativeimpl.io;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
+import org.ballerinalang.nativeimpl.io.events.EventContext;
+import org.ballerinalang.nativeimpl.io.events.EventManager;
+import org.ballerinalang.nativeimpl.io.events.EventResult;
+import org.ballerinalang.nativeimpl.io.events.data.CloseDataChannelEvent;
+import org.ballerinalang.nativeimpl.io.utils.IOUtils;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Native function ballerina.io#DataChannel.close().
+ *
+ * @since 0.974.1
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "io",
+        functionName = "close",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "DataChannel", structPackage = "ballerina.io"),
+        returnType = {@ReturnType(type = TypeKind.RECORD, structType = "IOError", structPackage = "ballerina.io")},
+        isPublic = true
+)
+public class CloseDataChannel implements NativeCallableUnit {
+    /**
+     * The index of the DataChannel.
+     */
+    private static final int DATA_CHANNEL_INDEX = 0;
+
+    private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
+        EventContext eventContext = result.getContext();
+        Context context = eventContext.getContext();
+        CallableUnitCallback callback = eventContext.getCallback();
+        Throwable error = eventContext.getError();
+        if (null != error) {
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
+        }
+        callback.notifySuccess();
+        return result;
+    }
+
+    /**
+     * <p>
+     * Closes data channel.
+     * </p>
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct dataChannelStruct = (BStruct) context.getRefArgument(DATA_CHANNEL_INDEX);
+        DataChannel channel = (DataChannel) dataChannelStruct.getNativeData(IOConstants.DATA_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        CloseDataChannelEvent dataChannelCloseEvt = new CloseDataChannelEvent(channel, eventContext);
+        CompletableFuture<EventResult> publish = EventManager.getInstance().publish(dataChannelCloseEvt);
+        publish.thenApply(CloseDataChannel::closeResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
+    }
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDataChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDataChannel.java
@@ -55,7 +55,7 @@ public class CloseDataChannel implements NativeCallableUnit {
     private static final int DATA_CHANNEL_INDEX = 0;
 
     /**
-     * Closes data channel.
+     * Close data channel.
      *
      * @param result the response received after the channel is closed.
      * @return the result of the close response.
@@ -72,10 +72,9 @@ public class CloseDataChannel implements NativeCallableUnit {
         callback.notifySuccess();
         return result;
     }
-
     /**
      * <p>
-     * Closes data channel.
+     * Close data channel.
      * </p>
      * <p>
      * {@inheritDoc}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/IOConstants.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/IOConstants.java
@@ -69,7 +69,7 @@ public class IOConstants {
     public static final String IO_ERROR_STRUCT = "error";
 
     /**
-     * Represents the base number of protobuf
+     * Represents the base number of protobuf.
      */
     public static final int PROTO_BUF_BASE = 7;
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/IOConstants.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/IOConstants.java
@@ -67,4 +67,9 @@ public class IOConstants {
      * Struct which represents io error.
      */
     public static final String IO_ERROR_STRUCT = "error";
+
+    /**
+     * Represents the base number of protobuf
+     */
+    public static final int PROTO_BUF_BASE = 7;
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ReadString.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ReadString.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.nativeimpl.io;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
+import org.ballerinalang.nativeimpl.io.events.EventContext;
+import org.ballerinalang.nativeimpl.io.events.EventManager;
+import org.ballerinalang.nativeimpl.io.events.EventResult;
+import org.ballerinalang.nativeimpl.io.events.data.ReadStringEvent;
+import org.ballerinalang.nativeimpl.io.utils.IOUtils;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Native function ballerina.io#readString.
+ *
+ * @since 0.974.1
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "io",
+        functionName = "readString",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "DataChannel", structPackage = "ballerina.io"),
+        args = {@Argument(name = "nBytes", type = TypeKind.INT),
+                @Argument(name = "encoding", type = TypeKind.STRING)},
+        isPublic = true
+)
+public class ReadString implements NativeCallableUnit {
+    /**
+     * Represents data channel.
+     */
+    private static final int DATA_CHANNEL_INDEX = 0;
+    /**
+     * Represents the number of bytes.
+     */
+    private static final int NUMBER_OF_BYTES_INDEX = 0;
+    /**
+     * Represents the encoding index.
+     */
+    private static final int ENCODING_INDEX = 0;
+
+    /**
+     * Triggers upon receiving the response.
+     *
+     * @param result the response received after reading int.
+     * @return read int value.
+     */
+    private static EventResult readResponse(EventResult<String, EventContext> result) {
+        EventContext eventContext = result.getContext();
+        Context context = eventContext.getContext();
+        Throwable error = eventContext.getError();
+        CallableUnitCallback callback = eventContext.getCallback();
+        if (null != error) {
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
+        } else {
+            String readStr = result.getResponse();
+            context.setReturnValues(new BString(readStr));
+        }
+        callback.notifySuccess();
+        return result;
+    }
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct dataChannelStruct = (BStruct) context.getRefArgument(DATA_CHANNEL_INDEX);
+        long nBytes = context.getIntArgument(NUMBER_OF_BYTES_INDEX);
+        String encoding = context.getStringArgument(ENCODING_INDEX);
+        DataChannel channel = (DataChannel) dataChannelStruct.getNativeData(IOConstants.DATA_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        ReadStringEvent event = new ReadStringEvent(channel, eventContext, (int) nBytes, encoding);
+        CompletableFuture<EventResult> publish = EventManager.getInstance().publish(event);
+        publish.thenApply(ReadString::readResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
+    }
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteString.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteString.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.nativeimpl.io;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
+import org.ballerinalang.nativeimpl.io.events.EventContext;
+import org.ballerinalang.nativeimpl.io.events.EventManager;
+import org.ballerinalang.nativeimpl.io.events.EventResult;
+import org.ballerinalang.nativeimpl.io.events.data.WriteStringEvent;
+import org.ballerinalang.nativeimpl.io.utils.IOUtils;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Native function ballerina.io#writeString.
+ *
+ * @since 0.974.1
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "io",
+        functionName = "writeString",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "DataChannel", structPackage = "ballerina.io"),
+        args = {@Argument(name = "value", type = TypeKind.STRING),
+                @Argument(name = "encoding", type = TypeKind.STRING)},
+        isPublic = true
+)
+public class WriteString implements NativeCallableUnit {
+    /**
+     * Represents data channel.
+     */
+    private static final int DATA_CHANNEL_INDEX = 0;
+    /**
+     * Index which holds the value of the data to be written.
+     */
+    private static final int VALUE_INDEX = 0;
+    /**
+     * Index which will hold the string encoding.
+     */
+    private static final int ENCODING_INDEX = 1;
+
+    /**
+     * Triggers upon receiving the response.
+     *
+     * @param result the response received after writing string.
+     */
+    private static EventResult writeResponse(EventResult<Long, EventContext> result) {
+        EventContext eventContext = result.getContext();
+        Context context = eventContext.getContext();
+        Throwable error = eventContext.getError();
+        CallableUnitCallback callback = eventContext.getCallback();
+        if (null != error) {
+            BStruct errorStruct = IOUtils.createError(context, error.getMessage());
+            context.setReturnValues(errorStruct);
+        }
+        callback.notifySuccess();
+        return result;
+    }
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct dataChannelStruct = (BStruct) context.getRefArgument(DATA_CHANNEL_INDEX);
+        DataChannel channel = (DataChannel) dataChannelStruct.getNativeData(IOConstants.DATA_CHANNEL_NAME);
+        String value = context.getStringArgument(VALUE_INDEX);
+        String encoding = context.getStringArgument(ENCODING_INDEX);
+        EventContext eventContext = new EventContext(context, callback);
+        WriteStringEvent writeIntegerEvent = new WriteStringEvent(channel, value, encoding, eventContext);
+        CompletableFuture<EventResult> publish = EventManager.getInstance().publish(writeIntegerEvent);
+        publish.thenApply(WriteString::writeResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
+    }
+
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DataChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DataChannel.java
@@ -62,10 +62,7 @@ public class DataChannel {
      */
     private long decodeLong(Representation representation) throws IOException {
         ByteBuffer buffer;
-        long value = 0;
-        int totalNumberOfBits;
         int requiredNumberOfBytes;
-        int maxNumberOfBits = 0xFFFF;
         if (Representation.VARIABLE.equals(representation)) {
             throw new UnsupportedOperationException();
         } else {
@@ -75,7 +72,20 @@ public class DataChannel {
         }
         readFull(buffer);
         buffer.flip();
-        totalNumberOfBits = (buffer.limit() - 1) * Byte.SIZE;
+        return deriveLong(representation, buffer);
+    }
+
+    /**
+     * Iteratively identify the value for long.
+     *
+     * @param representation the capacity of the long value i.e whether it's 32bit, 64bit.
+     * @param buffer         holds the bytes which represents the long.
+     * @return the value of long.
+     */
+    private long deriveLong(Representation representation, ByteBuffer buffer) {
+        long value = 0;
+        int maxNumberOfBits = 0xFFFF;
+        int totalNumberOfBits = (buffer.limit() - 1) * representation.getBase();
         do {
             long shiftedValue = 0L;
             if (Representation.BIT_64.equals(representation)) {
@@ -90,7 +100,7 @@ public class DataChannel {
             }
             maxNumberOfBits = 0xFF;
             value = value + shiftedValue;
-            totalNumberOfBits = totalNumberOfBits - Byte.SIZE;
+            totalNumberOfBits = totalNumberOfBits - representation.getBase();
         } while (buffer.hasRemaining());
         return value;
     }
@@ -113,10 +123,10 @@ public class DataChannel {
             nBytes = representation.getNumberOfBytes();
             content = new byte[representation.getNumberOfBytes()];
         }
-        totalNumberOfBits = (nBytes * Byte.SIZE) - Byte.SIZE;
+        totalNumberOfBits = (nBytes * representation.getBase()) - representation.getBase();
         for (int count = 0; count < nBytes; count++) {
             content[count] = (byte) (value >> totalNumberOfBits);
-            totalNumberOfBits = totalNumberOfBits - Byte.SIZE;
+            totalNumberOfBits = totalNumberOfBits - representation.getBase();
         }
         return content;
     }
@@ -228,5 +238,14 @@ public class DataChannel {
     public String readString(int nBytes, String encoding) throws IOException {
         CharacterChannel ch = new CharacterChannel(this.channel, encoding);
         return ch.readAllChars(nBytes);
+    }
+
+    /**
+     * Closes the channel.
+     *
+     * @throws IOException during i/o error.
+     */
+    public void close() throws IOException {
+        this.channel.close();
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DataChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DataChannel.java
@@ -241,7 +241,7 @@ public class DataChannel {
     }
 
     /**
-     * Closes the channel.
+     * Close the channel.
      *
      * @throws IOException during i/o error.
      */

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DataChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DataChannel.java
@@ -76,7 +76,7 @@ public class DataChannel {
     }
 
     /**
-     * Iteratively identify the value for long.
+     * Merge bytes and encodes long.
      *
      * @param representation the capacity of the long value i.e whether it's 32bit, 64bit.
      * @param buffer         holds the bytes which represents the long.

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/Representation.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/Representation.java
@@ -19,6 +19,8 @@
 
 package org.ballerinalang.nativeimpl.io.channels.base;
 
+import org.ballerinalang.nativeimpl.io.IOConstants;
+
 /**
  * Defines how the bytes will be represented for different data types.
  */
@@ -38,7 +40,7 @@ public enum Representation {
     /**
      * Represents a variable value which does not have a size defined.
      */
-    VARIABLE(-1, 7);
+    VARIABLE(-1, IOConstants.PROTO_BUF_BASE);
 
     private int numberOfBytes;
 

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/Representation.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/Representation.java
@@ -26,46 +26,34 @@ public enum Representation {
     /**
      * Represents a 64 bit value.
      */
-    BIT_64(8),
+    BIT_64(8, Byte.SIZE),
     /**
      * Represents a 32 bit value.
      */
-    BIT_32(4),
+    BIT_32(4, Byte.SIZE),
     /**
      * Represents a 16 bit value.
      */
-    BIT_16(2),
+    BIT_16(2, Byte.SIZE),
     /**
      * Represents a variable value which does not have a size defined.
      */
-    VARIABLE(-1);
+    VARIABLE(-1, 7);
 
     private int numberOfBytes;
 
-    Representation(int numberOfBytes) {
+    private int base;
+
+    Representation(int numberOfBytes, int base) {
         this.numberOfBytes = numberOfBytes;
+        this.base = base;
     }
 
     public int getNumberOfBytes() {
         return numberOfBytes;
     }
 
-    /**
-     * finds a matching representation for the provided input string.
-     *
-     * @param representation the size representation string.
-     * @return the corresponding representation.
-     */
-    public static Representation find(String representation) {
-        switch (representation) {
-            case "64b":
-                return BIT_64;
-            case "32b":
-                return BIT_32;
-            case "16b":
-                return BIT_16;
-            default:
-                return BIT_64;
-        }
+    public int getBase() {
+        return base;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/CloseDataChannelEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/CloseDataChannelEvent.java
@@ -37,7 +37,6 @@ public class CloseDataChannelEvent implements Event {
      * Channel which will be closed.
      */
     private DataChannel channel;
-
     /**
      * Holds the context to the event.
      */

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/CloseDataChannelEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/CloseDataChannelEvent.java
@@ -20,60 +20,51 @@
 package org.ballerinalang.nativeimpl.io.events.data;
 
 import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
-import org.ballerinalang.nativeimpl.io.channels.base.Representation;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.result.DoubleResult;
+import org.ballerinalang.nativeimpl.io.events.result.BooleanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 /**
- * Represents the event to read float values.
+ * Represents the close event of data channel.
  */
-public class ReadFloatEvent implements Event {
+public class CloseDataChannelEvent implements Event {
     /**
-     * Will be used to read float.
+     * Channel which will be closed.
      */
     private DataChannel channel;
+
     /**
-     * Holds context to the event.
+     * Holds the context to the event.
      */
     private EventContext context;
-    /**
-     * Holds the representation.
-     */
-    private Representation representation;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadFloatEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(CloseDataChannelEvent.class);
 
-    public ReadFloatEvent(DataChannel channel, Representation representation, EventContext context) {
+    public CloseDataChannelEvent(DataChannel channel, EventContext context) {
         this.channel = channel;
         this.context = context;
-        this.representation = representation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EventResult get() {
-        DoubleResult result;
+        BooleanResult result;
         try {
-            double numericResult = channel.readDouble(representation);
-            result = new DoubleResult(numericResult, context);
+            channel.close();
+            result = new BooleanResult(true, context);
         } catch (IOException e) {
-            log.error("Error occurred while reading float", e);
+            log.error("Error occurred while closing data channel", e);
             context.setError(e);
-            result = new DoubleResult(context);
+            result = new BooleanResult(context);
         } catch (Throwable e) {
-            log.error("Unidentified error occurred while reading float", e);
+            log.error("Unidentified error occurred while closing data channel", e);
             context.setError(e);
-            result = new DoubleResult(context);
+            result = new BooleanResult(context);
         }
         return result;
     }
-
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadBoolEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadBoolEvent.java
@@ -23,7 +23,6 @@ import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.bytes.ReadBytesEvent;
 import org.ballerinalang.nativeimpl.io.events.result.BooleanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,7 @@ public class ReadBoolEvent implements Event {
      */
     private EventContext context;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadBytesEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(ReadBoolEvent.class);
 
     public ReadBoolEvent(DataChannel channel, EventContext context) {
         this.channel = channel;

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadIntegerEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadIntegerEvent.java
@@ -23,7 +23,6 @@ import org.ballerinalang.nativeimpl.io.channels.base.Representation;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.bytes.ReadBytesEvent;
 import org.ballerinalang.nativeimpl.io.events.result.LongResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +46,7 @@ public class ReadIntegerEvent implements Event {
      */
     private Representation representation;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadBytesEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(ReadIntegerEvent.class);
 
     public ReadIntegerEvent(DataChannel channel, Representation representation, EventContext context) {
         this.channel = channel;

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadStringEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadStringEvent.java
@@ -78,6 +78,5 @@ public class ReadStringEvent implements Event {
             result = new AlphaResult(context);
         }
         return result;
-
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadStringEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/ReadStringEvent.java
@@ -20,22 +20,21 @@
 package org.ballerinalang.nativeimpl.io.events.data;
 
 import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
-import org.ballerinalang.nativeimpl.io.channels.base.Representation;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.result.DoubleResult;
+import org.ballerinalang.nativeimpl.io.events.result.AlphaResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 /**
- * Represents the event to read float values.
+ * Represents the event to read string.
  */
-public class ReadFloatEvent implements Event {
+public class ReadStringEvent implements Event {
     /**
-     * Will be used to read float.
+     * Will be used to read string.
      */
     private DataChannel channel;
     /**
@@ -43,16 +42,21 @@ public class ReadFloatEvent implements Event {
      */
     private EventContext context;
     /**
-     * Holds the representation.
+     * Number of bytes which will represent the string.
      */
-    private Representation representation;
+    private int nBytes;
+    /**
+     * Represents the char-set encoding.
+     */
+    private String encoding;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadFloatEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(ReadStringEvent.class);
 
-    public ReadFloatEvent(DataChannel channel, Representation representation, EventContext context) {
+    public ReadStringEvent(DataChannel channel, EventContext context, int nBytes, String encoding) {
         this.channel = channel;
         this.context = context;
-        this.representation = representation;
+        this.nBytes = nBytes;
+        this.encoding = encoding;
     }
 
     /**
@@ -60,20 +64,20 @@ public class ReadFloatEvent implements Event {
      */
     @Override
     public EventResult get() {
-        DoubleResult result;
+        AlphaResult result;
         try {
-            double numericResult = channel.readDouble(representation);
-            result = new DoubleResult(numericResult, context);
+            String alphaResult = channel.readString(nBytes, encoding);
+            result = new AlphaResult(alphaResult, context);
         } catch (IOException e) {
-            log.error("Error occurred while reading float", e);
+            log.error("Error occurred while reading string", e);
             context.setError(e);
-            result = new DoubleResult(context);
+            result = new AlphaResult(context);
         } catch (Throwable e) {
-            log.error("Unidentified error occurred while reading float", e);
+            log.error("Unidentified error occurred while reading string", e);
             context.setError(e);
-            result = new DoubleResult(context);
+            result = new AlphaResult(context);
         }
         return result;
-    }
 
+    }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteBoolEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteBoolEvent.java
@@ -23,7 +23,6 @@ import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.bytes.ReadBytesEvent;
 import org.ballerinalang.nativeimpl.io.events.result.NumericResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +46,7 @@ public class WriteBoolEvent implements Event {
      */
     private boolean value;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadBytesEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(WriteBoolEvent.class);
 
     public WriteBoolEvent(DataChannel dataChannel, boolean value, EventContext context) {
         this.channel = dataChannel;

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteFloatEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteFloatEvent.java
@@ -24,7 +24,6 @@ import org.ballerinalang.nativeimpl.io.channels.base.Representation;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.bytes.ReadBytesEvent;
 import org.ballerinalang.nativeimpl.io.events.result.NumericResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +51,7 @@ public class WriteFloatEvent implements Event {
      */
     private Representation representation;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadBytesEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(WriteFloatEvent.class);
 
     public WriteFloatEvent(DataChannel dataChannel, double value, Representation representation, EventContext context) {
         this.channel = dataChannel;

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteIntegerEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteIntegerEvent.java
@@ -23,7 +23,6 @@ import org.ballerinalang.nativeimpl.io.channels.base.Representation;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.bytes.ReadBytesEvent;
 import org.ballerinalang.nativeimpl.io.events.result.NumericResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +50,7 @@ public class WriteIntegerEvent implements Event {
      */
     private Representation representation;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadBytesEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(WriteIntegerEvent.class);
 
     public WriteIntegerEvent(DataChannel dataChannel, long value, Representation representation, EventContext context) {
         this.channel = dataChannel;

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteStringEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteStringEvent.java
@@ -20,22 +20,21 @@
 package org.ballerinalang.nativeimpl.io.events.data;
 
 import org.ballerinalang.nativeimpl.io.channels.base.DataChannel;
-import org.ballerinalang.nativeimpl.io.channels.base.Representation;
 import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.result.DoubleResult;
+import org.ballerinalang.nativeimpl.io.events.result.NumericResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 /**
- * Represents the event to read float values.
+ * Represents the event to write string.
  */
-public class ReadFloatEvent implements Event {
+public class WriteStringEvent implements Event {
     /**
-     * Will be used to read float.
+     * Will be used to write string.
      */
     private DataChannel channel;
     /**
@@ -43,16 +42,21 @@ public class ReadFloatEvent implements Event {
      */
     private EventContext context;
     /**
-     * Holds the representation.
+     * Represents the value which will be written.
      */
-    private Representation representation;
+    private String value;
+    /**
+     * Represents the encoding of the string.
+     */
+    private String encoding;
 
-    private static final Logger log = LoggerFactory.getLogger(ReadFloatEvent.class);
+    private static final Logger log = LoggerFactory.getLogger(WriteStringEvent.class);
 
-    public ReadFloatEvent(DataChannel channel, Representation representation, EventContext context) {
-        this.channel = channel;
+    public WriteStringEvent(DataChannel dataChannel, String value, String encoding, EventContext context) {
+        this.channel = dataChannel;
         this.context = context;
-        this.representation = representation;
+        this.value = value;
+        this.encoding = encoding;
     }
 
     /**
@@ -60,20 +64,21 @@ public class ReadFloatEvent implements Event {
      */
     @Override
     public EventResult get() {
-        DoubleResult result;
+        NumericResult result;
         try {
-            double numericResult = channel.readDouble(representation);
-            result = new DoubleResult(numericResult, context);
+            channel.writeString(value, encoding);
+            result = new NumericResult(context);
         } catch (IOException e) {
-            log.error("Error occurred while reading float", e);
+            log.error("Error occurred while writing string", e);
             context.setError(e);
-            result = new DoubleResult(context);
+            result = new NumericResult(context);
         } catch (Throwable e) {
-            log.error("Unidentified error occurred while reading float", e);
+            log.error("Unidentified error occurred while writing string", e);
             context.setError(e);
-            result = new DoubleResult(context);
+            result = new NumericResult(context);
         }
         return result;
     }
+
 
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteStringEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/data/WriteStringEvent.java
@@ -79,6 +79,4 @@ public class WriteStringEvent implements Event {
         }
         return result;
     }
-
-
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
@@ -75,14 +75,26 @@ public class DataChannelTest {
     @Test(description = "read and write bool")
     public void processBool() {
         String sourceToWrite = currentDirectoryPath + "/boolean.bin";
-        //Will initialize the channel
-        boolean value = false;
-        BValue[] args = {new BBoolean(value), new BString(sourceToWrite)};
+        BValue[] args = {new BBoolean(false), new BString(sourceToWrite)};
         BRunUtil.invokeStateful(dataChannel, "testWriteBool", args);
 
         BValue[] args2 = {new BString(sourceToWrite)};
         BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadBool", args2);
 
-        Assert.assertEquals(value, ((BBoolean) result[0]).booleanValue());
+        Assert.assertEquals(false, ((BBoolean) result[0]).booleanValue());
+    }
+
+    @Test(description = "read and write string")
+    public void processString() {
+        String sourceToWrite = currentDirectoryPath + "/string.bin";
+        String content = "Ballerina";
+        String encoding = "UTF-8";
+        BValue[] args = {new BString(sourceToWrite), new BString(content), new BString(encoding)};
+        BRunUtil.invokeStateful(dataChannel, "testWriteString", args);
+
+        BValue[] args2 = {new BString(sourceToWrite), new BInteger(content.getBytes().length), new BString(encoding)};
+        BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadString", args2);
+
+        Assert.assertEquals(content, result[0].stringValue());
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataInputOutputTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataInputOutputTest.java
@@ -53,7 +53,7 @@ public class DataInputOutputTest {
         currentDirectoryPath = System.getProperty("user.dir") + "/target";
     }
 
-    @Test(description = "Test fixed long value ranges", dataProvider = "signedLongValues")
+    @Test(description = "Test fixed long value ranges", dataProvider = "SignedLongValues")
     public void testSignedFixedLong(long value, Representation representation) throws IOException, URISyntaxException {
         String filePath = currentDirectoryPath + "/sample.bin";
         ByteChannel byteChannel = TestUtil.openForReadingAndWriting(filePath);
@@ -109,6 +109,28 @@ public class DataInputOutputTest {
         Assert.assertEquals(readStr, content);
     }
 
+    @Test(description = "Test reading/writing mixed data input/output")
+    public void testMixedData() throws IOException {
+        int writtenInt = 13;
+        double writtenDouble = 48449.56f;
+        String filePath = currentDirectoryPath + "/sample.bin";
+        ByteChannel byteChannel = TestUtil.openForReadingAndWriting(filePath);
+        Channel channel = new MockByteChannel(byteChannel);
+        DataChannel dataChannel = new DataChannel(channel, ByteOrder.nativeOrder());
+        dataChannel.writeFixedLong(writtenInt, Representation.BIT_32);
+        dataChannel.writeDouble(writtenDouble, Representation.BIT_32);
+        dataChannel.writeBoolean(false);
+        byteChannel = TestUtil.openForReadingAndWriting(filePath);
+        channel = new MockByteChannel(byteChannel);
+        dataChannel = new DataChannel(channel, ByteOrder.nativeOrder());
+        long longValue = dataChannel.readFixedLong(Representation.BIT_32);
+        double doubleValue = dataChannel.readDouble(Representation.BIT_32);
+        boolean booleanValue = dataChannel.readBoolean();
+        Assert.assertEquals(writtenInt, longValue);
+        Assert.assertEquals(writtenDouble, doubleValue);
+        Assert.assertEquals(false, booleanValue);
+    }
+
     @DataProvider(name = "StringValues")
     public static Object[][] stringValues() {
         return new Object[][]{
@@ -117,7 +139,7 @@ public class DataInputOutputTest {
         };
     }
 
-    @DataProvider(name = "signedLongValues")
+    @DataProvider(name = "SignedLongValues")
     public static Object[][] signedLongValues() {
         return new Object[][]{
                 {0, BIT_16}, {0, BIT_32}, {0, BIT_64},

--- a/tests/ballerina-test/src/test/resources/test-src/io/data_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/data_io.bal
@@ -4,14 +4,14 @@ function testWriteFixedSignedInt(int value, string path) {
     io:ByteChannel ch = io:openFile(path, io:WRITE);
     io:DataChannel dataChannel = new(ch);
     var result = dataChannel.writeInt64(value);
-    var closeResult = ch.close();
+    var closeResult = dataChannel.close();
 }
 
 function testReadFixedSignedInt(string path) returns int|error {
     io:ByteChannel ch = io:openFile(path, io:READ);
     io:DataChannel dataChannel = new(ch);
     int result = check dataChannel.readInt64();
-    var closeResult = ch.close();
+    var closeResult = dataChannel.close();
     return result;
 }
 
@@ -19,14 +19,14 @@ function testWriteFixedFloat(float value, string path) {
     io:ByteChannel ch = io:openFile(path, io:WRITE);
     io:DataChannel dataChannel = new(ch);
     var result = dataChannel.writeFloat64(value);
-    var closeResult = ch.close();
+    var closeResult = dataChannel.close();
 }
 
 function testReadFixedFloat(string path) returns float|error {
     io:ByteChannel ch = io:openFile(path, io:READ);
     io:DataChannel dataChannel = new(ch);
     float result = check dataChannel.readFloat64();
-    var closeResult = ch.close();
+    var closeResult = dataChannel.close();
     return result;
 }
 
@@ -34,13 +34,28 @@ function testWriteBool(boolean value, string path) {
     io:ByteChannel ch = io:openFile(path, io:WRITE);
     io:DataChannel dataChannel = new(ch);
     var result = dataChannel.writeBool(value);
-    var closeResult = ch.close();
+    var closeResult = dataChannel.close();
 }
 
 function testReadBool(string path) returns boolean|error {
     io:ByteChannel ch = io:openFile(path, io:READ);
     io:DataChannel dataChannel = new(ch);
     boolean result = check dataChannel.readBool();
-    var closeResult = ch.close();
+    var closeResult = dataChannel.close();
+    return result;
+}
+
+function testWriteString(string path, string content, string encoding) {
+    io:ByteChannel ch = io:openFile(path, io:WRITE);
+    io:DataChannel dataChannel = new(ch);
+    var result = check dataChannel.writeString(content, encoding);
+    var closeResult = dataChannel.close();
+}
+
+function testReadString(string path, int nBytes, string encoding) returns string|error {
+    io:ByteChannel ch = io:openFile(path, io:READ);
+    io:DataChannel dataChannel = new(ch);
+    string result = check dataChannel.readString(nBytes, encoding);
+    var closeResult = dataChannel.close();
     return result;
 }


### PR DESCRIPTION
## Purpose
Add capability to perform read/write string values through data i/o channel.

## Goals
- Add capability to read/write string values
- Define the relevant test cases 

## Approach
Add ballerina functions which will allow a given user to read/write strings to a specified i/o channel.

The following is an example usage,

```
//Write string value
dataChannel.writeString(content, encoding);
//Read string value
dataChannel.readString(nBytes, encoding); 
```

## Release note
Adds the capability to read/write string values via data i/o channel

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8