### PR TITLE
Fix literals true values are escaped in source gen

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/model/tree-builder.js
+++ b/composer/modules/web/src/plugins/ballerina/model/tree-builder.js
@@ -532,6 +532,12 @@ class TreeBuilder {
         }
 
         if (node.kind === 'Literal') {
+            if (node.symbolType && node.symbolType.length > 0 &&
+                (node.symbolType[0] === 'string' || node.symbolType[0] === 'float') &&
+                node.ws && node.ws.length < 2 && node.ws[0].text) {
+                node.value = node.ws[0].text;
+            }
+
             if ((node.value === 'nil' || node.value === 'null') && node.ws
                 && node.ws.length < 3 && node.ws[0].text === '(') {
                 node.emptyParantheses = true;


### PR DESCRIPTION
## Purpose
> This PR will fix that the user entered values are changed after source gen.

Example for the issue: if user enter 39.00 after source gen value changed to 39.0 ...  