### PR TITLE
Fix unwanted margin in about dialog

### DIFF
--- a/composer/modules/web/scss/modules/help-plugin.scss
+++ b/composer/modules/web/scss/modules/help-plugin.scss
@@ -1,7 +1,6 @@
 .modal-about {
 
     .ui.header {
-        margin-left: 15px;
         .version {
             font-size: 12px;
         }


### PR DESCRIPTION
<img width="226" alt="screen shot 2018-06-14 at 11 01 14 am" src="https://user-images.githubusercontent.com/1505855/41393644-69d2cb02-6fc4-11e8-9cc0-b966b1bf4938.png">
<img width="584" alt="screen shot 2018-06-14 at 11 01 19 am" src="https://user-images.githubusercontent.com/1505855/41393675-78af9330-6fc4-11e8-8765-0c17f35ac367.png">
