### PR TITLE
Update testerina error messages

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/test/assert.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/test/assert.bal
@@ -50,7 +50,7 @@ public function assertEquals(any actual, any expected, string msg = "Assertion F
     if (!reflect:equals(actual,expected)) {
         string expectedStr = <string> expected;
         string actualStr = <string> actual;
-        string errorMsg = string `{{msg}}: expected {{expectedStr}} but found {{actualStr}}`;
+        string errorMsg = string `{{msg}}: expected '{{expectedStr}}' but found '{{actualStr}}'`;
         throw createBallerinaError(errorMsg, assertFailureErrorCategory);
     }
 }
@@ -63,7 +63,7 @@ public function assertNotEquals(any actual, any expected, string msg = "Assertio
     if (reflect:equals(actual,expected)) {
         string expectedStr = <string> expected;
         string actualStr = <string> actual;
-        string errorMsg = string `{{msg}}: expected the actual value not to be {{expectedStr}}`;
+        string errorMsg = string `{{msg}}: expected the actual value not to be '{{expectedStr}}'`;
         throw createBallerinaError(errorMsg, assertFailureErrorCategory);
     }
 }

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/AssertTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/AssertTest.java
@@ -54,7 +54,7 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
-            ".*expected 8 but found 6.*")
+            ".*expected '8' but found '6'.*")
     public void testAssertIntEqualsFail() {
         BValue[] args = {new BInteger(3), new BInteger(3)};
         BTestUtils.invoke(compileResult, "testAssertIntEquals", args);
@@ -67,7 +67,7 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
-            ".*expected 30.05 but found 21.05.*")
+            ".*expected '30.05' but found '21.05'.*")
     public void testAssertFloatEqualsFail() {
         BValue[] args = {new BFloat(1), new BFloat(20.050)};
         BTestUtils.invoke(compileResult, "testAssertFloatEquals", args);
@@ -80,7 +80,7 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
-            ".*expected JohnDoe but found DoeJohn.*")
+            ".*expected 'JohnDoe' but found 'DoeJohn'.*")
     public void testAssertStringEqualsFail() {
         BValue[] args = {new BString("Doe"), new BString("John")};
         BTestUtils.invoke(compileResult, "testAssertStringEquals", args);
@@ -119,7 +119,7 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
-            ".*expected false but found true.*")
+            ".*expected 'false' but found 'true'.*")
     public void testAssertBooleanEqualsFail() {
         BValue[] args = {new BBoolean(true), new BBoolean(false)};
         BTestUtils.invoke(compileResult, "testAssertBooleanEquals", args);
@@ -145,23 +145,23 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*expected \\[\"A\", \"B\", \"C\"\\] but found \\[\"A\", \"B\"," +
-                  " \"C\", \"D\"\\].*")
+          expectedExceptionsMessageRegExp = ".*expected '\\[\"A\", \"B\", \"C\"\\]' but found '\\[\"A\", \"B\"," +
+                  " \"C\", \"D\"\\]'.*")
     public void testAssertStringArrayEquals1() {
         BValue[] args = {new BInteger(1)};
         BTestUtils.invoke(compileResult, "testAssertStringArrayEquals", args);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*expected \\[\"A\", \"b\", \"C\"\\] but found \\[\"A\", \"B\"," +
-                  " \"C\"\\].*")
+          expectedExceptionsMessageRegExp = ".*expected '\\[\"A\", \"b\", \"C\"\\]' but found '\\[\"A\", \"B\"," +
+                  " \"C\"\\]'.*")
     public void testAssertStringArrayEquals2() {
         BValue[] args = {new BInteger(2)};
         BTestUtils.invoke(compileResult, "testAssertStringArrayEquals", args);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp = ".*expected " +
-            "\\[\"A\", \"b\", \"C\"\\] but found \\[\"A\", \"B\", \"C\"\\].*")
+            "'\\[\"A\", \"b\", \"C\"\\]' but found '\\[\"A\", \"B\", \"C\"\\]'.*")
     public void testAssertStringArrayEquals3() {
         BValue[] args = {new BInteger(3)};
         BTestUtils.invoke(compileResult, "testAssertStringArrayEquals", args);
@@ -174,14 +174,14 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*expected \\[1, 2, 3\\] but found \\[1, 2, 3, 4\\].*")
+          expectedExceptionsMessageRegExp = ".*expected '\\[1, 2, 3\\]' but found '\\[1, 2, 3, 4\\]'.*")
     public void testAssertIntArrayEquals1() {
         BValue[] args = {new BInteger(1)};
         BTestUtils.invoke(compileResult, "testAssertIntArrayEquals", args);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*expected \\[1, 5, 3\\] but found \\[1, 2, 3\\].*")
+          expectedExceptionsMessageRegExp = ".*expected '\\[1, 5, 3\\]' but found '\\[1, 2, 3\\]'.*")
     public void testAssertIntArrayEquals2() {
         BValue[] args = {new BInteger(2)};
         BTestUtils.invoke(compileResult, "testAssertIntArrayEquals", args);
@@ -194,22 +194,22 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*expected \\[1.1, 2.2, 3.3\\] but found \\[1.1, 2.2, 3.3, " +
-                  "4.4\\].*")
+          expectedExceptionsMessageRegExp = ".*expected '\\[1.1, 2.2, 3.3\\]' but found '\\[1.1, 2.2, 3.3, " +
+                  "4.4\\]'.*")
     public void testAssertFloatArrayEquals1() {
         BValue[] args = {new BInteger(1)};
         BTestUtils.invoke(compileResult, "testAssertFloatArrayEquals", args);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = ".*expected \\{\\} but found \\{\"a\":\"b\"\\}.*")
+            expectedExceptionsMessageRegExp = ".*expected '\\{\\}' but found '\\{\"a\":\"b\"\\}'.*")
     public void testAssertJsonEquals1() {
         BValue[] args = {new BJSON("{\"a\":\"b\"}"), new BJSON("{}")};
         BTestUtils.invoke(compileResult, "testAssertJsonEquals", args);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*expected \\[1.1, 2.22, 3.3\\] but found \\[1.1, 2.2, 3.3\\].*")
+          expectedExceptionsMessageRegExp = ".*expected '\\[1.1, 2.22, 3.3\\]' but found '\\[1.1, 2.2, 3.3\\]'.*")
     public void testAssertFloatArrayEquals2() {
         BValue[] args = {new BInteger(2)};
         BTestUtils.invoke(compileResult, "testAssertFloatArrayEquals", args);
@@ -225,7 +225,7 @@ public class AssertTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = ".*expected the actual value not to be \\{\"a\":\"b\"\\}.*")
+            expectedExceptionsMessageRegExp = ".*expected the actual value not to be '\\{\"a\":\"b\"\\}'.*")
     public void testAssertNotEqualsNegative() {
         BValue[] args = {};
         BTestUtils.invoke(compileResult, "testAssertNotEquals2", args);


### PR DESCRIPTION
## Purpose
This PR updates testerina error messages so that the expected and actual results are enclosed within quotes to increase readability.

Eg-
### Current output

```
caused by error, message: assertion Failed!: expected error log but found error log with cause
	at ballerina/test:assertEquals(assert.bal:54)
```
### Modified output
```
caused by error, message: assertion Failed!: expected 'error log' but found 'error log with cause'
	at ballerina/test:assertEquals(assert.bal:54)
```