### PR TITLE
Bump transport-http version to 6.0.195

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1666,7 +1666,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.194</transport.http.version>
+        <transport.http.version>6.0.195</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -199,7 +199,7 @@ public class WebSocketDispatcher {
         BValue[] bValues = new BValue[paramDetails.size()];
         bValues[0] = connectionInfo.getWebSocketEndpoint();
         bValues[1] = new BInteger(closeCode);
-        bValues[2] = new BString(closeReason);
+        bValues[2] = new BString(closeReason == null ? "" : closeReason);
         CallableUnitCallback onCloseCallback = new CallableUnitCallback() {
             @Override
             public void notifySuccess() {


### PR DESCRIPTION
This PR bumps the transport-http version to 6.0.195

_Please review and merge https://github.com/wso2/transport-http/pull/201 before merging this PR._