### PR TITLE
Provide API to get circuit breaker status

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/http/resiliency/http_circuit_breaker.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/resiliency/http_circuit_breaker.bal
@@ -327,6 +327,13 @@ public type CircuitBreakerClient object {
         until `resetTimeMillis` interval exceeds.
     }
     public function forceOpen();
+
+    documentation {
+        Provides `CircuitState` of the circuit breaker.
+
+        R{{}} The current `CircuitState` of circuit breaker
+    }
+    public function getCurrentState() returns CircuitState;
 };
 
 public function CircuitBreakerClient::post(string path, Request|string|xml|json|blob|io:ByteChannel|mime:Entity[]|()
@@ -578,6 +585,10 @@ public function CircuitBreakerClient::forceClose() {
 public function CircuitBreakerClient::forceOpen() {
     self.currentCircuitState = CB_OPEN_STATE;
     self.circuitHealth.lastForcedOpenTime = time:currentTime();
+}
+
+public function CircuitBreakerClient::getCurrentState() returns CircuitState {
+    return self.currentCircuitState;
 }
 
 documentation {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/CircuitBreakerTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/CircuitBreakerTest.java
@@ -20,13 +20,21 @@ package org.ballerinalang.test.net.http.resiliency;
 
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.util.StringUtils;
 import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.test.services.testutils.HTTPTestRequest;
+import org.ballerinalang.test.services.testutils.MessageUtils;
+import org.ballerinalang.test.services.testutils.Services;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 
 /**
  * Test cases for the Circuit Breaker.
@@ -34,6 +42,7 @@ import org.testng.annotations.Test;
 public class CircuitBreakerTest {
 
     private static final String CB_ERROR_MSG = "Upstream service unavailable.";
+    private static final String MOCK_ENDPOINT_NAME = "mockEP";
 
     // Following constants are defined to filter out Http Client errors from union responses.
     private static final int CB_CLIENT_FIRST_ERROR_INDEX = 3;
@@ -42,11 +51,13 @@ public class CircuitBreakerTest {
     private static final int CB_CLIENT_FAILURE_CASE_ERROR_INDEX = 5;
     private static final int CB_CLIENT_FORCE_OPEN_INDEX = 4;
 
-    private CompileResult compileResult;
+    private CompileResult compileResult, serviceResult;
 
     @BeforeClass
     public void setup() {
-        compileResult = BCompileUtil.compile("test-src/net/http/resiliency/circuit-breaker-test.bal");
+        String sourceFilePath = "test-src/net/http/resiliency/circuit-breaker-test.bal";
+        compileResult = BCompileUtil.compile(sourceFilePath);
+        serviceResult = BServiceUtil.setupProgramFile(this, sourceFilePath);
     }
 
     /**
@@ -181,6 +192,18 @@ public class CircuitBreakerTest {
             long statusCode = res.getIntField(0);
             Assert.assertEquals(statusCode, expectedStatusCodes[i], "Status code does not match.");
         }
+    }
+
+    @Test(description = "Test the getCurrentState function of circuit breaker")
+    public void testCBGetCurrentStatausScenario() {
+        String value = "Circuit Breaker is in CLOSED state";
+        String path = "/cb/getState";
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
+        HTTPCarbonMessage responseMsg = Services.invokeNew(serviceResult, MOCK_ENDPOINT_NAME, inRequestMsg);
+
+        Assert.assertNotNull(responseMsg, "Response message not found");
+        Assert.assertEquals(
+                StringUtils.getStringFromInputStream(new HttpMessageDataStreamer(responseMsg).getInputStream()), value);
     }
 
     private void validateCBResponses(BRefValueArray responses, BRefValueArray errors,


### PR DESCRIPTION
Fixes : https://github.com/ballerina-platform/ballerina-lang/issues/9131

## Purpose
Provide API to get circuit breaker status.

## Automation tests
 - Unit tests  - Yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```java
import ballerina/http;
import ballerina/io;
import ballerina/log;
import ballerina/runtime;

endpoint http:Client clientEP {
    url: "http://localhost:8080",
    circuitBreaker: {
        rollingWindow: {
            timeWindowMillis: 10000,
            bucketSizeMillis: 2000
        },
        failureThreshold: 0.3,
        resetTimeMillis: 1000,
        statusCodes: [500, 502, 503]
    },
    timeoutMillis: 2000
};

@http:ServiceConfig { basePath: "/cb" }
service<http:Service> circuitBreakerService bind {port: 9090} {

    @http:ResourceConfig {
        path: "/getState"
    }
    getState(endpoint caller, http:Request req) {
        http:CircuitBreakerClient cbClient = check <http:CircuitBreakerClient>clientEP.getCallerActions();
        http:CircuitState currentState = cbClient.getCurrentState();
        http:Response res = new;
        if (currentState == http:CB_CLOSED_STATE) {
            res.setPayload("Circuit Breaker is in CLOSED state");
            _ = caller->respond(res);
        }
    }
}
```
