### PR TITLE
Sync XML unit tests with actual runtime behaviour

### DIFF
--- a/tests/ballerina-test/pom.xml
+++ b/tests/ballerina-test/pom.xml
@@ -223,6 +223,8 @@
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
                         <classpathDependencyExcludes>org.slf4j:slf4j-log4j12</classpathDependencyExcludes>
+                        <classpathDependencyExcludes>org.codehaus.woodstox:woodstox-core-asl</classpathDependencyExcludes>
+                        <classpathDependencyExcludes>org.codehaus.woodstox:stax2-api</classpathDependencyExcludes>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/DataBindingTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/DataBindingTest.java
@@ -189,7 +189,7 @@ public class DataBindingTest {
 
     @Test(expectedExceptions = BallerinaConnectorException.class,
             expectedExceptionsMessageRegExp = ".*data binding failed: Error in reading payload : " +
-                    "Unexpected character.*")
+                    "ParseError at .*")
     public void testDataBindingIncompatibleXMLPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body4", "POST", "name':'WSO2', 'team':'ballerina");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -127,7 +127,7 @@ public class ArrayTest {
 
         BXMLItem[] xmlArray = { new BXMLItem("<foo/>"), new BXMLItem("<bar>hello</bar>") };
         BRefValueArray bXmlArray = new BRefValueArray(xmlArray, BTypes.typeXML);
-        Assert.assertEquals(bXmlArray.stringValue(), "[<foo/>, <bar>hello</bar>]");
+        Assert.assertEquals(bXmlArray.stringValue(), "[<foo></foo>, <bar>hello</bar>]");
     }
 
     @Test(description = "Test arrays with errors")

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
@@ -297,7 +297,7 @@ public class JSONTest {
         Assert.assertTrue(returns[0] instanceof BXML);
 
         OMNode returnElement = ((BXMLItem) returns[0]).value();
-        Assert.assertEquals(returnElement.toString(), "<foo key=\"value\"/>");
+        Assert.assertEquals(returnElement.toString(), "<foo key=\"value\"></foo>");
     }
 
     @Test(description = "Convert json object with attribute and value")
@@ -345,7 +345,7 @@ public class JSONTest {
 
         String textValue = returns[0].stringValue();
         Assert.assertEquals(textValue, "<name>John</name><age>30</age>"
-                + "<car xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>");
+                + "<car xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"></car>");
     }
 
     @Test(description = "Convert a json object with null object elements")
@@ -357,7 +357,7 @@ public class JSONTest {
 
         OMNode returnElement = ((BXMLItem) returns[0]).value();
         Assert.assertEquals(returnElement.toString(), "<Person><name>John</name><age>30</age>"
-                + "<car xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/></Person>");
+                + "<car xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"></car></Person>");
     }
 
     @Test(description = "Convert a json object with empty elements")
@@ -368,7 +368,8 @@ public class JSONTest {
         Assert.assertTrue(returns[0] instanceof BString);
 
         String textValue = returns[0].stringValue();
-        Assert.assertEquals(textValue, "<address/><homeAddresses/><phoneNumbers/>");
+        Assert.assertEquals(textValue, "<address></address><homeAddresses></homeAddresses>" +
+                "<phoneNumbers></phoneNumbers>");
     }
 
     @Test(description = "Convert a json object with empty elements and non emepty elements")
@@ -378,8 +379,8 @@ public class JSONTest {
 
         Assert.assertTrue(returns[0] instanceof BXML);
         OMNode returnElement = ((BXMLItem) returns[0]).value();
-        Assert.assertEquals(returnElement.toString(), "<info><address/><homeAddresses><item>a</item><item>b</item>"
-                + "</homeAddresses><phoneNumbers/></info>");
+        Assert.assertEquals(returnElement.toString(), "<info><address></address><homeAddresses><item>a</item>"
+                + "<item>b</item></homeAddresses><phoneNumbers></phoneNumbers></info>");
     }
 
     @Test(description = "Convert a simple json object with attributes")

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralTest.java
@@ -188,9 +188,10 @@ public class TableLiteralTest {
         BValue[] returns = BRunUtil.invoke(result, "testTableWithAllDataToXml");
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<results><result><id>1</id><jsonData>{\"name\":\"apple\","
-                + "\"color\":\"red\",\"price\":30.3}</jsonData><xmlData>&lt;book>The Lost World&lt;"
-                + "/book></xmlData></result><result><id>2</id><jsonData>{\"name\":\"apple\",\"color\":\"red\","
-                + "\"price\":30.3}</jsonData><xmlData>&lt;book>The Lost World&lt;/book></xmlData></result></results>");
+                + "\"color\":\"red\",\"price\":30.3}</jsonData><xmlData>&lt;book&gt;The Lost World&lt;"
+                + "/book&gt;</xmlData></result><result><id>2</id><jsonData>{\"name\":\"apple\",\"color\":\"red\","
+                + "\"price\":30.3}</jsonData><xmlData>&lt;book&gt;The Lost World&lt;/book&gt;</xmlData></result>"
+                + "</results>");
     }
 
     @Test(priority = 1)

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -481,13 +481,13 @@ public class TableTest {
         if (dbType == POSTGRES) {
             expected = "<results><result><int_type>0</int_type><long_type>0</long_type><float_type>0.0</float_type>"
                     + "<double_type>0.0</double_type><boolean_type>false</boolean_type>"
-                    + "<string_type xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "</result></results>";
+                    + "<string_type xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\">"
+                    + "</string_type></result></results>";
         } else {
             expected = "<results><result><INT_TYPE>0</INT_TYPE><LONG_TYPE>0</LONG_TYPE><FLOAT_TYPE>0.0</FLOAT_TYPE>"
                     + "<DOUBLE_TYPE>0.0</DOUBLE_TYPE><BOOLEAN_TYPE>false</BOOLEAN_TYPE>"
-                    + "<STRING_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "</result></results>";
+                    + "<STRING_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\">"
+                    + "</STRING_TYPE></result></results>";
         }
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
@@ -735,10 +735,10 @@ public class TableTest {
                     + "<BLOB_TYPE>U2FtcGxlIFRleHQ=</BLOB_TYPE><CLOB_TYPE>Sample Text</CLOB_TYPE>"
                     + "<BINARY_TYPE>U2FtcGxlIFRleHQ=</BINARY_TYPE></result>"
                     + "<result><ROW_ID>200</ROW_ID>"
-                    + "<BLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "<CLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "<BINARY_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "</result></results>";
+                    + "<BLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"></BLOB_TYPE>"
+                    + "<CLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"></CLOB_TYPE>"
+                    + "<BINARY_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\">"
+                    + "</BINARY_TYPE></result></results>";
         } else {
             expectedJson = "[{\"ROW_ID\":100,\"BLOB_TYPE\":\"U2FtcGxlIFRleHQ=\",\"CLOB_TYPE\":\"Sample Text\","
                     + "\"BINARY_TYPE\":\"U2FtcGxlIFRleHQAAAAAAAAAAAAAAAAAAAAA\"},{\"ROW_ID\":200,\"BLOB_TYPE\":null,"
@@ -747,10 +747,10 @@ public class TableTest {
                     + "<BLOB_TYPE>U2FtcGxlIFRleHQ=</BLOB_TYPE><CLOB_TYPE>Sample Text</CLOB_TYPE>"
                     + "<BINARY_TYPE>U2FtcGxlIFRleHQAAAAAAAAAAAAAAAAAAAAA</BINARY_TYPE></result>"
                     + "<result><ROW_ID>200</ROW_ID>"
-                    + "<BLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "<CLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "<BINARY_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>"
-                    + "</result></results>";
+                    + "<BLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"></BLOB_TYPE>"
+                    + "<CLOB_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"></CLOB_TYPE>"
+                    + "<BINARY_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\">"
+                    + "</BINARY_TYPE></result></results>";
         }
         Assert.assertEquals((returns[2]).stringValue(), expectedJson);
         Assert.assertEquals((returns[3]).stringValue(), expectedXML);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributesTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributesTest.java
@@ -52,7 +52,8 @@ public class XMLAttributesTest {
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns4=\"http://sample.com/wso2/f\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns3=\"http://sample.com/wso2/d1\" " +
-                "xmlns:ns0Kf5j=\"http://sample.com/wso2/e\" foo1=\"bar1\" ns0Kf5j:foo2=\"bar2\" ns4:foo3=\"bar3\"/>");
+                "xmlns:ns0Kf5j=\"http://sample.com/wso2/e\" foo1=\"bar1\" ns0Kf5j:foo2=\"bar2\" " +
+                "ns4:foo3=\"bar3\"></root>");
     }
     
     @Test(expectedExceptions = {BLangRuntimeException.class}, 
@@ -67,7 +68,7 @@ public class XMLAttributesTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(),
                 "<root xmlns=\"http://sample.com/wso2/c1\" xmlns:ns3=\"http://sample.com/wso2/f\" " +
-                "xmlns:ns0=\"http://sample.com/wso2/a1\" xmlns:ns1=\"http://sample.com/wso2/b1\" foo1=\"bar\"/>");
+                "xmlns:ns0=\"http://sample.com/wso2/a1\" xmlns:ns1=\"http://sample.com/wso2/b1\" foo1=\"bar\"></root>");
     }
     
     @Test
@@ -76,12 +77,12 @@ public class XMLAttributesTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns4=\"http://wso2.com\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns4=\"http://wso2.com\"></root>");
         
         Assert.assertTrue(returns[1] instanceof BXML);
         Assert.assertEquals(returns[1].stringValue(), "<root xmlns=\"http://ballerinalang.org/\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns4=\"http://wso2.com\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns4=\"http://wso2.com\"></root>");
     }
     
     @Test
@@ -90,7 +91,7 @@ public class XMLAttributesTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns0:foo1=\"bar1\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns0:foo1=\"bar1\"></root>");
     }
 
     @Test
@@ -101,7 +102,7 @@ public class XMLAttributesTest {
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns4=\"http://sample.com/wso2/f/\" " +
                 "xmlns:ns5=\"http://sample.com/wso2/f/\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:pre=\"http://sample.com/wso2/f\" " +
-                "ns4:diff=\"yes\" pre:foo1=\"bar1\"/>");
+                "ns4:diff=\"yes\" pre:foo1=\"bar1\"></root>");
     }
 
     @Test
@@ -111,7 +112,7 @@ public class XMLAttributesTest {
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns4=\"http://sample.com/wso2/f/\" " +
                 "xmlns:ns5=\"http://sample.com/wso2/f/\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns4:diff=\"yes\" ns5:foo1=\"bar1\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns4:diff=\"yes\" ns5:foo1=\"bar1\"></root>");
     }
 
     @Test
@@ -121,7 +122,7 @@ public class XMLAttributesTest {
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns4=\"http://sample.com/wso2/f/\" " + 
                 "xmlns:ns5=\"http://sample.com/wso2/f/\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns4:diff=\"yes\" ns4:foo1=\"bar1\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns4:diff=\"yes\" ns4:foo1=\"bar1\"></root>");
     }
 
     @Test(expectedExceptions = { BLangRuntimeException.class }, 
@@ -133,7 +134,7 @@ public class XMLAttributesTest {
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns5=\"http://sample.com/wso2/f/\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns4=\"http://sample.com/wso2/f/\" " +
-                "xmlns:ns3=\"http://sample.com/wso2/f\" ns4:diff=\"yes\"/>");
+                "xmlns:ns3=\"http://sample.com/wso2/f\" ns4:diff=\"yes\"></root>");
     }
 
     @Test
@@ -144,7 +145,7 @@ public class XMLAttributesTest {
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns4=\"http://sample.com/wso2/f/\" " +
                 "xmlns:ns5=\"http://sample.com/wso2/f/\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:foo1=\"bar1\" " +
-                "ns4:diff=\"yes\" foo2=\"bar2\" foo3=\"bar3\"/>");
+                "ns4:diff=\"yes\" foo2=\"bar2\" foo3=\"bar3\"></root>");
     }
 
 
@@ -156,7 +157,7 @@ public class XMLAttributesTest {
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://defaultNs/\" " +
                 "xmlns:ns0=\"http://sample.com/wso2/e\" xmlns:ns1=\"http://sample.com/wso2/b1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/d1\" xmlns:foo1=\"bar1\" xmlns:foo3=\"bar3\" " +
-                "ns0:foo2=\"newbar2\" foo1=\"newbar1\" foo3=\"newbar3\"/>");
+                "ns0:foo2=\"newbar2\" foo1=\"newbar1\" foo3=\"newbar3\"></root>");
     }
 
     @Test
@@ -168,7 +169,7 @@ public class XMLAttributesTest {
                 "xmlns:ns0=\"http://sample.com/wso2/a1\" xmlns:ns1=\"http://sample.com/wso2/b1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/d1\" xmlns:foo1=\"bar1\" " +
                 "xmlns:nsbrlwf=\"http://sample.com/wso2/f/t\" ns0Kf5j:foo2=\"bar2\" ns4:foo3=\"bar3\" " +
-                "nsbrlwf:foo3=\"newbar3\"/>");
+                "nsbrlwf:foo3=\"newbar3\"></root>");
     }
     
     @Test
@@ -177,12 +178,12 @@ public class XMLAttributesTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://wso2.com\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\"></root>");
         
         Assert.assertTrue(returns[1] instanceof BXML);
         Assert.assertEquals(returns[1].stringValue(), "<root xmlns=\"http://ballerinalang.org/\" " +
                 "xmlns:ns3=\"http://wso2.com\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\"></root>");
     }
     
     @Test
@@ -191,7 +192,7 @@ public class XMLAttributesTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
-                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns0:foo1=\"newbar1\" ns3:foo2=\"newbar2\"/>");
+                "xmlns:ns1=\"http://sample.com/wso2/b1\" ns0:foo1=\"newbar1\" ns3:foo2=\"newbar2\"></root>");
     }
 
     @Test
@@ -201,7 +202,7 @@ public class XMLAttributesTest {
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/f\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns5=\"http://sample.com/wso2/a1\" xmlns:ns1=\"http://sample.com/wso2/b1\" " +
-                "ns0:foo1=\"newaddedbar1\" ns3:foo2=\"bar2\"/>");
+                "ns0:foo1=\"newaddedbar1\" ns3:foo2=\"bar2\"></root>");
     }
     
     @Test
@@ -311,7 +312,7 @@ public class XMLAttributesTest {
                 "xmlns:ns0=\"http://sample.com/wso2/a1\" xmlns:ns1=\"http://sample.com/wso2/b1\" " +
                 "xmlns:ns3=\"http://sample.com/wso2/d1\" xmlns:ns403=\"http://sample.com/wso2/e3\" " +
                 "xmlns:nsn7xFP=\"http://sample.com/wso2/f3\" ns401:foo1=\"bar1\" ns1:foo2=\"bar2\" " +
-                "ns403:foo3=\"bar3\" nsn7xFP:foo4=\"bar4\"/>");
+                "ns403:foo3=\"bar3\" nsn7xFP:foo4=\"bar4\"></root>");
     }
     
     @Test
@@ -322,7 +323,7 @@ public class XMLAttributesTest {
                 "xmlns:p1=\"http://wso2.com\" xmlns:p2=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns401=\"http://sample.com/wso2/a1\" xmlns:ns0=\"http://sample.com/wso2/a1\" " +
                 "xmlns:ns1=\"http://sample.com/wso2/b1\" xmlns:ns3=\"http://sample.com/wso2/d1\" " +
-                "ns401:foo1=\"bar1\" p1:foo2=\"bar2\"/>");
+                "ns401:foo1=\"bar1\" p1:foo2=\"bar2\"></root>");
     }
 
     @Test
@@ -331,7 +332,7 @@ public class XMLAttributesTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<root xmlns=\"http://sample.com/wso2/c1\" " +
                 "xmlns:nsRJUck=\"http://wso2.com\" xmlns:nsn7xDi=\"http://sample.com/wso2/a1\" " +
-                "foo1=\"bar1\" nsRJUck:foo2=\"bar2\" nsn7xDi:foo3=\"bar3\"/>");
+                "foo1=\"bar1\" nsRJUck:foo2=\"bar2\" nsn7xDi:foo3=\"bar3\"></root>");
     }
 
     @Test

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -198,20 +198,20 @@ public class XMLLiteralTest {
     public void testExpressionAsAttributeValue() {
         BValue[] returns = BRunUtil.invoke(result, "testExpressionAsAttributeValue");
         Assert.assertTrue(returns[0] instanceof BXML);
-        Assert.assertEquals(returns[0].stringValue(), "<foo bar=\"&quot;zzz&quot;\"/>");
+        Assert.assertEquals(returns[0].stringValue(), "<foo bar=\"&quot;zzz&quot;\"></foo>");
 
         Assert.assertTrue(returns[1] instanceof BXML);
-        Assert.assertEquals(returns[1].stringValue(), "<foo bar=\"aaazzzbb'b33>22ccc?\"/>");
+        Assert.assertEquals(returns[1].stringValue(), "<foo bar=\"aaazzzbb'b33&gt;22ccc?\"></foo>");
 
         Assert.assertTrue(returns[2] instanceof BXML);
-        Assert.assertEquals(returns[2].stringValue(), "<foo bar=\"}aaazzzbbb33>22ccc{d{}e}{f{\"/>");
+        Assert.assertEquals(returns[2].stringValue(), "<foo bar=\"}aaazzzbbb33&gt;22ccc{d{}e}{f{\"></foo>");
 
         Assert.assertTrue(returns[3] instanceof BXML);
-        Assert.assertEquals(returns[3].stringValue(), "<foo bar1=\"aaa{zzz}b{{b&quot;b33>22c}}cc{d{}e}{f{\" "
-                + "bar2=\"aaa{zzz}b{{b&quot;b33>22c}}cc{d{}e}{f{\"/>");
+        Assert.assertEquals(returns[3].stringValue(), "<foo bar1=\"aaa{zzz}b{{b&quot;b33&gt;22c}}cc{d{}e}{f{\" "
+                + "bar2=\"aaa{zzz}b{{b&quot;b33&gt;22c}}cc{d{}e}{f{\"></foo>");
 
         Assert.assertTrue(returns[4] instanceof BXML);
-        Assert.assertEquals(returns[4].stringValue(), "<foo bar=\"\"/>");
+        Assert.assertEquals(returns[4].stringValue(), "<foo bar=\"\"></foo>");
     }
 
     @Test
@@ -219,12 +219,12 @@ public class XMLLiteralTest {
         BValue[] returns = BRunUtil.invoke(result, "testElementLiteralWithTemplateChildren");
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<root>hello aaa&lt;bbb good morning <fname>John</fname> "
-                + "<lname>Doe</lname>. Have a nice day!<foo>123</foo><bar/></root>");
+                + "<lname>Doe</lname>. Have a nice day!<foo>123</foo><bar></bar></root>");
 
         Assert.assertTrue(returns[1] instanceof BXML);
         BXMLSequence seq = (BXMLSequence) returns[1];
         Assert.assertEquals(seq.stringValue(), "hello aaa<bbb good morning <fname>John</fname> <lname>Doe</lname>. "
-                + "Have a nice day!<foo>123</foo><bar/>");
+                + "Have a nice day!<foo>123</foo><bar></bar>");
 
         BRefValueArray items = seq.value();
         Assert.assertEquals(items.size(), 7);
@@ -238,7 +238,7 @@ public class XMLLiteralTest {
         Assert.assertEquals(returns[0].stringValue(),
                 "<root xmlns=\"http://ballerina.com/\" xmlns:ns0=\"http://ballerina.com/a\" "
                         + "xmlns:ns1=\"http://ballerina.com/c\" ns0:id=\"456\"><foo>123</foo>"
-                        + "<bar ns1:status=\"complete\"/></root>");
+                        + "<bar ns1:status=\"complete\"></bar></root>");
 
         Assert.assertTrue(returns[1] instanceof BXML);
         BXMLSequence seq = (BXMLSequence) returns[1];
@@ -246,7 +246,7 @@ public class XMLLiteralTest {
                 "<foo xmlns=\"http://ballerina.com/\" "
                         + "xmlns:ns0=\"http://ballerina.com/a\" xmlns:ns1=\"http://ballerina.com/c\">123</foo>"
                         + "<bar xmlns=\"http://ballerina.com/\" xmlns:ns0=\"http://ballerina.com/a\" "
-                        + "xmlns:ns1=\"http://ballerina.com/c\" ns1:status=\"complete\"/>");
+                        + "xmlns:ns1=\"http://ballerina.com/c\" ns1:status=\"complete\"></bar>");
 
         BRefValueArray items = seq.value();
         Assert.assertEquals(items.size(), 2);
@@ -331,7 +331,7 @@ public class XMLLiteralTest {
         BValue[] returns = BRunUtil.invoke(result, "testFunctionCallInXMLTemplate");
         Assert.assertTrue(returns[0] instanceof BXMLItem);
 
-        Assert.assertEquals(returns[0].stringValue(), "<foo>&lt;-->returned from a function</foo>");
+        Assert.assertEquals(returns[0].stringValue(), "<foo>&lt;--&gt;returned from a function</foo>");
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Currently, the XML type related test cases are not testing the actual runtime behavior of Ballerina XML parser. This is because the transitive dependency "org.codehaus.woodstox" of "axiom" is included in the test execution, whereas it is not included in the actual Ballerina distribution.

## Approach
Excluding the "woodstox" dependency during test execution and change the unit tests to reflect the actual behavior of the XML parser.

Resolves #5087