### PR TITLE
Mandate build when pushing a package to central if the package is not already built

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -97,7 +97,7 @@ public class PushUtils {
                                             ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, orgName,
                                             packageName, version, packageName + ".zip");
         if (Files.notExists(pkgPathFromPrjtDir)) {
-            throw new BLangCompilerException("Package doesn't exist. Did you run `ballerina build`?");
+            BuilderUtils.compileAndWrite(prjDirPath, packageName, packageName, false, false, false);
         }
 
         if (installToRepo == null) {


### PR DESCRIPTION
## Purpose
> This PR will mandate build when pushing a package to central if the package is not already built.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/8884
