### PR TITLE
[WebSocket] SSL Support for WebSocket Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1666,7 +1666,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.200-SNAPSHOT</transport.http.version>
+        <transport.http.version>6.0.200</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1666,7 +1666,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.199</transport.http.version>
+        <transport.http.version>6.0.200-SNAPSHOT</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1666,7 +1666,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.200</transport.http.version>
+        <transport.http.version>6.0.203</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
+++ b/stdlib/ballerina-grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
@@ -93,13 +93,13 @@ public class Init extends BlockingNativeCallableUnit {
             scheme = url.getProtocol();
             SenderConfiguration configuration = populateSenderConfigurationOptions(endpointConfig, scheme);
             ManagedChannel channel;
-            if (configuration.getSSLConfig() == null) {
+            if (configuration.generateSSLConfig() == null) {
                 channel = ManagedChannelBuilder.forAddress(url.getHost(), url.getPort())
                         .usePlaintext(true)
                         .build();
             } else {
                 try {
-                    SslContext sslContext = new SSLHandlerFactory(configuration.getSSLConfig())
+                    SslContext sslContext = new SSLHandlerFactory(configuration.generateSSLConfig())
                             .createHttp2TLSContextForClient();
                     channel = NettyChannelBuilder
                             .forAddress(generateSocketAddress(url.getHost(), url.getPort()))

--- a/stdlib/ballerina-http/src/main/ballerina/http/websocket/websocket_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/websocket/websocket_client.bal
@@ -86,6 +86,7 @@ documentation {
         F{{readyOnConnect}}
  true if the client is ready to recieve messages as soon as the connection is established. This is true by default. If changed to false the function ready() of the
 `WebSocketClient`needs to be called once to start receiving messages.
+        F{{secureSocket}} SSL/TLS related options
 }
 public type WebSocketClientEndpointConfig {
     string url,
@@ -93,5 +94,6 @@ public type WebSocketClientEndpointConfig {
     string[] subProtocols,
     map<string> customHeaders,
     int idleTimeoutInSeconds = -1,
-    boolean readyOnConnect = true;
+    boolean readyOnConnect = true,
+    SecureSocket? secureSocket,
 };

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -25,7 +25,7 @@ import org.wso2.transport.http.netty.config.TransportsConfiguration;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnector;
-import org.wso2.transport.http.netty.contract.websocket.WsClientConnectorConfig;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnectorConfig;
 import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 
@@ -149,7 +149,7 @@ public class HttpConnectionManager {
         return false;
     }
 
-    public WebSocketClientConnector getWebSocketClientConnector(WsClientConnectorConfig configuration) {
+    public WebSocketClientConnector getWebSocketClientConnector(WebSocketClientConnectorConfig configuration) {
         return  httpConnectorFactory.createWsClientConnector(configuration);
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -29,7 +29,6 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnector
 import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -171,9 +170,7 @@ public class HttpConnectionManager {
 
         SenderConfiguration httpsSender = new SenderConfiguration("https-sender");
         httpsSender.setScheme("https");
-        httpsSender.setTrustStoreFile(String.valueOf(
-                Paths.get(System.getProperty("ballerina.home"), "bre", "security", "ballerinaTruststore.p12")));
-        httpsSender.setTrustStorePass("ballerina");
+        HttpUtil.setDefaultTrustStore(httpsSender);
 
         TransportProperty latencyMetrics = new TransportProperty();
         latencyMetrics.setName("latency.metrics.enabled");

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -56,9 +56,9 @@ public class WebSocketConstants {
 
     public static final String CLIENT_URL_CONFIG = "url";
     public static final String CLIENT_SERVICE_CONFIG = "callbackService";
-    public static final String CLIENT_SUBPROTOCOLS_CONFIG = "subProtocols";
-    public static final String CLIENT_CUSTOMHEADERS_CONFIG = "customHeaders";
-    public static final String CLIENT_IDLETIMOUT_CONFIG = "idleTimeoutInSeconds";
+    public static final String CLIENT_SUB_PROTOCOLS_CONFIG = "subProtocols";
+    public static final String CLIENT_CUSTOM_HEADERS_CONFIG = "customHeaders";
+    public static final String CLIENT_IDLE_TIMOUT_CONFIG = "idleTimeoutInSeconds";
     public static final String CLIENT_READY_ON_CONNECT = "readyOnConnect";
     public static final String CLIENT_CONNECTOR_CONFIGS = "clientEndpointConfigs";
     public static final String WEBSOCKET_UPGRADE_SERVICE_CONFIG = "upgradeService";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -294,7 +294,7 @@ public class WebSocketDispatcher {
 
     private static void pingAutomatically(WebSocketControlMessage controlMessage) {
         WebSocketConnection webSocketConnection = controlMessage.getWebSocketConnection();
-        webSocketConnection.pong(controlMessage.getPayload()).addListener(future -> {
+        webSocketConnection.pong(controlMessage.getByteBuffer()).addListener(future -> {
             Throwable cause = future.cause();
             if (!future.isSuccess() && cause != null) {
                 ErrorHandlerUtils.printError(cause);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.net.http.clientendpoint;
 
-import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
@@ -34,7 +33,6 @@ import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
-import org.wso2.transport.http.netty.config.Parameter;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
@@ -43,11 +41,7 @@ import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.net.http.HttpConstants.CALLER_ACTIONS;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
@@ -129,90 +123,14 @@ public class CreateHttpClient extends BlockingNativeCallableUnit {
 
     private void populateSenderConfigurationOptions(SenderConfiguration senderConfiguration, Struct
             clientEndpointConfig) {
-        ProxyServerConfiguration proxyServerConfiguration = null;
-        Struct secureSocket = null;
+        ProxyServerConfiguration proxyServerConfiguration;
+        Struct secureSocket;
         Value[] targetServices = clientEndpointConfig.getArrayField(HttpConstants.TARGET_SERVICES);
 
         for (Value targetService : targetServices) {
             secureSocket = targetService.getStructValue().getStructField(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
-
             if (secureSocket != null) {
-                Struct trustStore = secureSocket.getStructField(HttpConstants.ENDPOINT_CONFIG_TRUST_STORE);
-                Struct keyStore = secureSocket.getStructField(HttpConstants.ENDPOINT_CONFIG_KEY_STORE);
-                Struct protocols = secureSocket.getStructField(HttpConstants.ENDPOINT_CONFIG_PROTOCOLS);
-                Struct validateCert = secureSocket.getStructField(HttpConstants.ENDPOINT_CONFIG_VALIDATE_CERT);
-                List<Parameter> clientParams = new ArrayList<>();
-                if (trustStore != null) {
-                    String trustStoreFile = trustStore.getStringField(HttpConstants.FILE_PATH);
-                    if (StringUtils.isNotBlank(trustStoreFile)) {
-                        senderConfiguration.setTrustStoreFile(trustStoreFile);
-                    }
-                    String trustStorePassword = trustStore.getStringField(HttpConstants.PASSWORD);
-                    if (StringUtils.isNotBlank(trustStorePassword)) {
-                        senderConfiguration.setTrustStorePass(trustStorePassword);
-                    }
-                }
-                if (keyStore != null) {
-                    String keyStoreFile = keyStore.getStringField(HttpConstants.FILE_PATH);
-                    if (StringUtils.isNotBlank(keyStoreFile)) {
-                        senderConfiguration.setKeyStoreFile(keyStoreFile);
-                    }
-                    String keyStorePassword = keyStore.getStringField(HttpConstants.PASSWORD);
-                    if (StringUtils.isNotBlank(keyStorePassword)) {
-                        senderConfiguration.setKeyStorePassword(keyStorePassword);
-                    }
-                }
-                if (protocols != null) {
-                    List<Value> sslEnabledProtocolsValueList = Arrays
-                            .asList(protocols.getArrayField(HttpConstants.ENABLED_PROTOCOLS));
-                    if (sslEnabledProtocolsValueList.size() > 0) {
-                        String sslEnabledProtocols = sslEnabledProtocolsValueList.stream().map(Value::getStringValue)
-                                .collect(Collectors.joining(",", "", ""));
-                        Parameter clientProtocols = new Parameter(HttpConstants.SSL_ENABLED_PROTOCOLS,
-                                sslEnabledProtocols);
-                        clientParams.add(clientProtocols);
-                    }
-                    String sslProtocol = protocols.getStringField(HttpConstants.PROTOCOL_VERSION);
-                    if (StringUtils.isNotBlank(sslProtocol)) {
-                        senderConfiguration.setSSLProtocol(sslProtocol);
-                    }
-                }
-
-                if (validateCert != null) {
-                    boolean validateCertEnabled = validateCert.getBooleanField(HttpConstants.ENABLE);
-                    int cacheSize = (int) validateCert.getIntField(HttpConstants.SSL_CONFIG_CACHE_SIZE);
-                    int cacheValidityPeriod = (int) validateCert
-                            .getIntField(HttpConstants.SSL_CONFIG_CACHE_VALIDITY_PERIOD);
-                    senderConfiguration.setValidateCertEnabled(validateCertEnabled);
-                    if (cacheValidityPeriod != 0) {
-                        senderConfiguration.setCacheValidityPeriod(cacheValidityPeriod);
-                    }
-                    if (cacheSize != 0) {
-                        senderConfiguration.setCacheSize(cacheSize);
-                    }
-                }
-                boolean hostNameVerificationEnabled = secureSocket
-                        .getBooleanField(HttpConstants.SSL_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
-                boolean ocspStaplingEnabled = secureSocket.getBooleanField(HttpConstants.ENDPOINT_CONFIG_OCSP_STAPLING);
-                senderConfiguration.setOcspStaplingEnabled(ocspStaplingEnabled);
-                senderConfiguration.setHostNameVerificationEnabled(hostNameVerificationEnabled);
-
-                List<Value> ciphersValueList = Arrays
-                        .asList(secureSocket.getArrayField(HttpConstants.SSL_CONFIG_CIPHERS));
-                if (ciphersValueList.size() > 0) {
-                    String ciphers = ciphersValueList.stream().map(Value::getStringValue)
-                            .collect(Collectors.joining(",", "", ""));
-                    Parameter clientCiphers = new Parameter(HttpConstants.CIPHERS, ciphers);
-                    clientParams.add(clientCiphers);
-                }
-                String enableSessionCreation = String.valueOf(secureSocket
-                        .getBooleanField(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION));
-                Parameter clientEnableSessionCreation = new Parameter(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION,
-                        enableSessionCreation);
-                clientParams.add(clientEnableSessionCreation);
-                if (!clientParams.isEmpty()) {
-                    senderConfiguration.setParameters(clientParams);
-                }
+                HttpUtil.populateSSLConfiguration(senderConfiguration, secureSocket);
             }
         }
         Struct proxy = clientEndpointConfig.getStructField(HttpConstants.PROXY_STRUCT_REFERENCE);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/InitEndpoint.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/InitEndpoint.java
@@ -115,20 +115,26 @@ public class InitEndpoint extends BlockingNativeCallableUnit {
                                                WebSocketClientConnectorConfig clientConnectorConfig) {
         clientConnectorConfig.setAutoRead(false); // Frames are read sequentially in ballerina.
         Value[] subProtocolValues = clientEndpointConfig
-                .getArrayField(WebSocketConstants.CLIENT_SUBPROTOCOLS_CONFIG);
+                .getArrayField(WebSocketConstants.CLIENT_SUB_PROTOCOLS_CONFIG);
         if (subProtocolValues != null) {
             clientConnectorConfig.setSubProtocols(Arrays.stream(subProtocolValues).map(Value::getStringValue)
                                                           .toArray(String[]::new));
         }
         Map<String, Value> headerValues = clientEndpointConfig.getMapField(
-                WebSocketConstants.CLIENT_CUSTOMHEADERS_CONFIG);
+                WebSocketConstants.CLIENT_CUSTOM_HEADERS_CONFIG);
         if (headerValues != null) {
             clientConnectorConfig.addHeaders(getCustomHeaders(headerValues));
         }
 
-        long idleTimeoutInSeconds = clientEndpointConfig.getIntField(WebSocketConstants.CLIENT_IDLETIMOUT_CONFIG);
+        long idleTimeoutInSeconds = clientEndpointConfig.getIntField(WebSocketConstants.CLIENT_IDLE_TIMOUT_CONFIG);
         if (idleTimeoutInSeconds > 0) {
             clientConnectorConfig.setIdleTimeoutInMillis((int) (idleTimeoutInSeconds * 1000));
+        }
+        Struct secureSocket = clientEndpointConfig.getStructField(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
+        if (secureSocket != null) {
+            HttpUtil.populateSSLConfiguration(clientConnectorConfig, secureSocket);
+        } else {
+            HttpUtil.setDefaultTrustStore(clientConnectorConfig);
         }
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/InitEndpoint.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/InitEndpoint.java
@@ -41,8 +41,8 @@ import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.websocket.ClientHandshakeFuture;
 import org.wso2.transport.http.netty.contract.websocket.ClientHandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnector;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnectorConfig;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
-import org.wso2.transport.http.netty.contract.websocket.WsClientConnectorConfig;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 
 import java.util.Arrays;
@@ -83,7 +83,7 @@ public class InitEndpoint extends BlockingNativeCallableUnit {
         }
         if (WebSocketConstants.WEBSOCKET_CLIENT_ENDPOINT_NAME.equals(service.getEndpointName())) {
             WebSocketService wsService = new WebSocketService(service);
-            WsClientConnectorConfig clientConnectorConfig = new WsClientConnectorConfig(remoteUrl);
+            WebSocketClientConnectorConfig clientConnectorConfig = new WebSocketClientConnectorConfig(remoteUrl);
             populateClientConnectorConfig(clientEndpointConfig, clientConnectorConfig);
 
             HttpWsConnectorFactory connectorFactory = HttpUtil.createHttpWsConnectionFactory();
@@ -112,7 +112,7 @@ public class InitEndpoint extends BlockingNativeCallableUnit {
     }
 
     private void populateClientConnectorConfig(Struct clientEndpointConfig,
-                                               WsClientConnectorConfig clientConnectorConfig) {
+                                               WebSocketClientConnectorConfig clientConnectorConfig) {
         clientConnectorConfig.setAutoRead(false); // Frames are read sequentially in ballerina.
         Value[] subProtocolValues = clientEndpointConfig
                 .getArrayField(WebSocketConstants.CLIENT_SUBPROTOCOLS_CONFIG);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
@@ -38,8 +38,7 @@ public class WebSocketCompilationTest {
 
     @Test(description = "Successfully compiling WebSocketClientService")
     public void testSuccessClient() {
-        CompileResult compileResult = BCompileUtil.compileAndSetup(
-                "test-src/net/websocket/compilation/success_client.bal");
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/success_client.bal");
 
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }


### PR DESCRIPTION
## Purpose
> Add secure socket support for WebSocket client
> Please review and merge https://github.com/wso2/transport-http/pull/205 before merging this PR

## Goals
> Resolve https://github.com/ballerina-platform/ballerina-lang/issues/8942

## Approach
> Use the existing secureSocket object in the WebSocketClientConfig and configure WebSocket client accordingly. 
> transport-http changes for this feature is included in https://github.com/wso2/transport-http/pull/205.
