### PR TITLE
Add initial source formatting support

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/model/tree/node.js
+++ b/composer/modules/web/src/plugins/ballerina/model/tree/node.js
@@ -415,14 +415,7 @@ class Node extends EventChannel {
      * @memberof Node
      */
     clearWS() {
-        this.accept({
-            beginVisit: (node) => {
-                delete node.ws;
-            },
-            endVisit: (node) => {
-                // do nothing.
-            },
-        });
+        // TODO:remove clearWS properly
     }
 
     /**

--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -52,6 +52,8 @@ import SyncErrorsVisitor from './../visitors/sync-errors';
 import { EVENTS, RESPOSIVE_MENU_TRIGGER } from '../constants';
 import ViewButton from './view-button';
 import MonacoBasedUndoManager from './../utils/monaco-based-undo-manager';
+import FormattingUtil from './../model/formatting-util';
+import FormatVisitor from "../visitors/format-visitor";
 
 /**
  * React component for BallerinaFileEditor.
@@ -103,15 +105,20 @@ class BallerinaFileEditor extends React.Component {
         props.commandProxy.on('resize', () => {
             this.update();
         }, this);
+
+        this.formatSource = new FormatVisitor();
         // Format the source code.
         props.commandProxy.on(FORMAT, () => {
             if (this.props.isActive()) {
-                let newContent = this.state.model.getSource(true);
-                newContent = _.trim(newContent, '\n');
+                const formattingUtil = new FormattingUtil();
+                this.formatSource.setFormattingUtil(formattingUtil);
+                this.state.model.accept(this.formatSource);
+                let newContent = this.state.model.getSource();
                 // set the underlaying file.
                 this.props.file.setContent(newContent, {
                     type: CHANGE_EVT_TYPES.CODE_FORMAT,
                 });
+                this.sourceEditorRef.setContent(newContent, true);
             }
         });
 
@@ -173,7 +180,10 @@ class BallerinaFileEditor extends React.Component {
      * On ast modifications
      */
     onASTModified(evt) {
+        const formattingUtil = new FormattingUtil();
+        this.formatSource.setFormattingUtil(formattingUtil);
         TreeBuilder.modify(evt.origin);
+        this.state.model.accept(this.formatSource);
         const newContent = this.state.model.getSource();
         // set breakpoints to model
         // this.reCalculateBreakpoints(this.state.model);

--- a/composer/modules/web/src/plugins/ballerina/visitors/format-visitor.js
+++ b/composer/modules/web/src/plugins/ballerina/visitors/format-visitor.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import _ from 'lodash';
+
+class FormatVisitor {
+
+    setFormattingUtil(formattingUtil) {
+        this.util = formattingUtil;
+    }
+
+    beginVisit(node) {
+        if (_.isFunction(this.util[`format${node.getKind()}Node`])) {
+            this.util[`format${node.getKind()}Node`](node);
+        }
+        return undefined;
+    }
+
+    endVisit() {
+        // do nothing.
+        return undefined;
+    }
+}
+
+export default FormatVisitor;


### PR DESCRIPTION
## Purpose
> This commit will add initial source formatting support for composer. User will be able to format 
* function definitions 
* service definitions
* endpoints
* global variables
* function invocations
* variables defs
* assignment
* imports 

with this commit.

*related issue: #8972*

## Goals
> 
![formatting](https://user-images.githubusercontent.com/9109762/41674218-ffa62080-74dc-11e8-9257-8c19a7571b39.gif)

