### PR TITLE
Update test run order on Testerina

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -40,6 +40,8 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -187,7 +189,11 @@ public class BTestRunner {
 
         AtomicBoolean shouldSkip = new AtomicBoolean();
 
-        testSuites.forEach((packageName, suite) -> {
+        LinkedList<String> keys = new LinkedList<>(testSuites.keySet());
+        Collections.sort(keys);
+
+        keys.forEach(packageName -> {
+            TestSuite suite = testSuites.get(packageName);
             outStream.println("---------------------------------------------------------------------------");
             outStream.println("Running Tests of Package: " + packageName);
             outStream.println("---------------------------------------------------------------------------");

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaReport.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaReport.java
@@ -20,7 +20,9 @@ package org.ballerinalang.testerina.core.entity;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -85,7 +87,10 @@ public class TesterinaReport {
         if (testReportOfPackage.size() == 0) {
             outStream.println("Test Suites: 0");
         } else {
-            testReportOfPackage.forEach((packageName, summary) -> {
+            LinkedList<String> keys = new LinkedList<>(testReportOfPackage.keySet());
+            Collections.sort(keys);
+            keys.forEach(packageName -> {
+                TestSummary summary = testReportOfPackage.get(packageName);
                 outStream.println();
                 outStream.print(String.format("%-" + 67 + "s", packageName).replaceAll("\\s(?=\\s+$|$)", "."));
                 outStream.print(" " + ((summary.failedTests.size() > 0 || summary.skippedTests.size() > 0) ?


### PR DESCRIPTION
## Purpose
This PR updates the test run order so that the packages will be in alphabetical order when tests are executed. Also this updates the summary so it is in alphabetical order.

Resolves #9195