### PR TITLE
Add exclude flag to Testerina

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
@@ -86,6 +86,9 @@ public class TestCmd implements BLauncherCmd {
     @Parameter(names = "--disable-groups", description = "test groups to be disabled")
     private List<String> disableGroupList;
 
+    @Parameter(names = "--exclude", description = "packages to be excluded")
+    private List<String> excludedTestList;
+
     public void execute() {
         if (helpFlag) {
             outStream.println(BLauncherCmd.getCommandUsageInfo("test"));
@@ -140,7 +143,11 @@ public class TestCmd implements BLauncherCmd {
             throw new RuntimeException("failed to read the specified configuration file: " + configFilePath, e);
         }
 
-        Path[] paths = sourceFileList.stream().map(Paths::get).toArray(Path[]::new);
+        Path[] paths = sourceFileList.stream()
+                .filter(s -> excludedTestList == null || !excludedTestList.contains(s))
+                .map(Paths::get)
+                .sorted()
+                .toArray(Path[]::new);
 
         if (srcDirectory != null) {
             Manifest manifest = readManifestConfigurations();

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
@@ -86,8 +86,8 @@ public class TestCmd implements BLauncherCmd {
     @Parameter(names = "--disable-groups", description = "test groups to be disabled")
     private List<String> disableGroupList;
 
-    @Parameter(names = "--exclude", description = "packages to be excluded")
-    private List<String> excludedTestList;
+    @Parameter(names = "--exclude-packages", description = "packages to be excluded")
+    private List<String> excludedPackageList;
 
     public void execute() {
         if (helpFlag) {
@@ -144,7 +144,7 @@ public class TestCmd implements BLauncherCmd {
         }
 
         Path[] paths = sourceFileList.stream()
-                .filter(s -> excludedTestList == null || !excludedTestList.contains(s))
+                .filter(source -> excludedPackageList == null || !excludedPackageList.contains(source))
                 .map(Paths::get)
                 .sorted()
                 .toArray(Path[]::new);


### PR DESCRIPTION
## Purpose
This PR adds `--exclude-package` flag to Testerina so a user can specify packages which needs to be excluded.

Eg - `ballerina test --exclude-package pack1,pack2`

Resolves #9191 