### PR TITLE
Fix alignment in the top menu

### DIFF
--- a/composer/modules/web/scss/modules/ballerina-editor.scss
+++ b/composer/modules/web/scss/modules/ballerina-editor.scss
@@ -393,7 +393,7 @@ swagger-ui h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 
 .top-menu {
   position: fixed;
-  padding: 3px 26px 6px !important;
+  padding: 3px 34px 6px 26px !important;
   height: 40px;
   &.hidden{
     display: none !important;
@@ -531,7 +531,6 @@ a.item.menu-button.ui.button.primary {
   line-height: 1.3em;
   color: #ccc;
 }
-
 .endpoint-item {
   cursor: pointer;
 }


### PR DESCRIPTION
## Purpose
> Fixing the miss-alignment in the top menu bar
 
## Issue 
![image](https://user-images.githubusercontent.com/10986966/41703270-649af48e-7550-11e8-921a-70691f06c213.png)

## Fix
![image](https://user-images.githubusercontent.com/10986966/41703055-b83155c6-754f-11e8-8028-432bbf80a91c.png)
