### PR TITLE
Add generateToc to docerina maven plugin

### DIFF
--- a/misc/ballerina-maven-plugins/docerina-maven-plugin/src/main/java/org/ballerinalang/plugin/maven/doc/DocerinaMojo.java
+++ b/misc/ballerina-maven-plugins/docerina-maven-plugin/src/main/java/org/ballerinalang/plugin/maven/doc/DocerinaMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -89,8 +89,8 @@ public class DocerinaMojo extends AbstractMojo {
     /**
      * Generates the table of content file for the package.
      */
-    @Parameter(property = "generateToc", required = false, defaultValue = "false")
-    private boolean generateToc;
+    @Parameter(property = "generateTOC", required = false, defaultValue = "false")
+    private boolean generateTOC;
 
     /**
      * enable debug level logs.
@@ -112,7 +112,7 @@ public class DocerinaMojo extends AbstractMojo {
             System.setProperty(BallerinaDocConstants.ORG_NAME, orgName);
         }
         
-        ConfigRegistry.getInstance().addConfiguration(BallerinaDocConstants.GENERATE_TOC, generateToc);
+        ConfigRegistry.getInstance().addConfiguration(BallerinaDocConstants.GENERATE_TOC, generateTOC);
 
         Path sourceRootPath = LauncherUtils.getSourceRootPath(sourceRoot);
         List<String> sources;

--- a/misc/ballerina-maven-plugins/docerina-maven-plugin/src/main/java/org/ballerinalang/plugin/maven/doc/DocerinaMojo.java
+++ b/misc/ballerina-maven-plugins/docerina-maven-plugin/src/main/java/org/ballerinalang/plugin/maven/doc/DocerinaMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,6 +23,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.docgen.docs.BallerinaDocConstants;
 import org.ballerinalang.docgen.docs.BallerinaDocGenerator;
 import org.ballerinalang.launcher.LauncherUtils;
@@ -84,6 +85,12 @@ public class DocerinaMojo extends AbstractMojo {
 
     @Parameter(property = "outputZip", required = false)
     private String outputZip;
+    
+    /**
+     * Generates the table of content file for the package.
+     */
+    @Parameter(property = "generateToc", required = false, defaultValue = "false")
+    private boolean generateToc;
 
     /**
      * enable debug level logs.
@@ -104,6 +111,8 @@ public class DocerinaMojo extends AbstractMojo {
         if (orgName != null) {
             System.setProperty(BallerinaDocConstants.ORG_NAME, orgName);
         }
+        
+        ConfigRegistry.getInstance().addConfiguration(BallerinaDocConstants.GENERATE_TOC, generateToc);
 
         Path sourceRootPath = LauncherUtils.getSourceRootPath(sourceRoot);
         List<String> sources;
@@ -119,6 +128,12 @@ public class DocerinaMojo extends AbstractMojo {
                     (new String[sources.size()]));
         } catch (Throwable e) {
             err.println(ExceptionUtils.getStackTrace(e));
+        } finally {
+            System.clearProperty(BallerinaDocConstants.ENABLE_DEBUG_LOGS);
+            System.clearProperty(BallerinaDocConstants.TEMPLATES_FOLDER_PATH_KEY);
+            System.clearProperty(BallerinaDocConstants.OUTPUT_ZIP_PATH);
+            System.clearProperty(BallerinaDocConstants.ORG_NAME);
+            ConfigRegistry.getInstance().removeConfiguration(BallerinaDocConstants.GENERATE_TOC);
         }
     }
 }

--- a/misc/ballerina-maven-plugins/docs/DocerinaMavenPlugin.md
+++ b/misc/ballerina-maven-plugins/docs/DocerinaMavenPlugin.md
@@ -65,11 +65,11 @@ paths to Ballerina files which does not belong to a package.
  DEFAULT value is none.
  Example: `<packageFilter>org.ballerinalang.abc.a,org.ballerinalang.xyz.x</packageFilter>`
 
-* `generateToc`: Generate table of content for package(s).
+* `generateTOC`: Generate table of content for package(s).
 
  OPTIONAL property.
  DEFAULT value is false.
- Example: `<generateToc>false</generateToc>`
+ Example: `<generateTOC>false</generateTOC>`
 
 * `debugDocerina`: Enable debug level logs.
 

--- a/misc/ballerina-maven-plugins/docs/DocerinaMavenPlugin.md
+++ b/misc/ballerina-maven-plugins/docs/DocerinaMavenPlugin.md
@@ -65,6 +65,12 @@ paths to Ballerina files which does not belong to a package.
  DEFAULT value is none.
  Example: `<packageFilter>org.ballerinalang.abc.a,org.ballerinalang.xyz.x</packageFilter>`
 
+* `generateToc`: Generate table of content for package(s).
+
+ OPTIONAL property.
+ DEFAULT value is false.
+ Example: `<generateToc>false</generateToc>`
+
 * `debugDocerina`: Enable debug level logs.
 
  OPTIONAL property.

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocConstants.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocConstants.java
@@ -34,5 +34,5 @@ public class BallerinaDocConstants {
 
     // config registry environment variables -e flags
     public static final String ORG_NAME = "orgName";
-    public static final String GENERATE_TOC = "generateToc";
+    public static final String GENERATE_TOC = "generateTOC";
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -165,6 +165,7 @@ public class BallerinaDocGenerator {
 
                 if (ConfigRegistry.getInstance().getAsBoolean(BallerinaDocConstants.GENERATE_TOC)) {
                     // generates ToC into a separate HTML - requirement of Central
+                    out.println("docerina: generating toc: " + output + File.separator + packagePath + "-toc" + HTML);
                     String tocFilePath = output + File.separator + packagePath + "-toc" + HTML;
                     Writer.writeHtmlDocument(page, packageToCTemplateName, tocFilePath);
                 }


### PR DESCRIPTION
Generating the toc of a package was not doable through the docerina
maven plugin. This adds the ability to generate table of contents using
the maven plugin.

## Purpose
> Generate table of content of a package through docerina maven plugin.

## Goals
> Generate table of content.

## Approach
> Update docerina maven plugin configuration fields.
