### PR TITLE
Fix Welcome page close tab icon

### DIFF
--- a/composer/modules/web/scss/modules/help-plugin.scss
+++ b/composer/modules/web/scss/modules/help-plugin.scss
@@ -41,6 +41,7 @@
                 height: 30px;
                 .close-tab {
                     background: $primaryBackgroundColor !important;
+                    color: #7D7D7D;
                     &:hover{
                         color: #474747;
                     }


### PR DESCRIPTION
## Purpose
> This PR will fix the missing close icon on the welcome page tab.

Issue 
![image](https://user-images.githubusercontent.com/10986966/41708460-4b183bf8-755e-11e8-94cd-9cd027b78d66.png)

Fix 
![image](https://user-images.githubusercontent.com/10986966/41708437-3cbef9c0-755e-11e8-8913-92b3a66b5e68.png)
