### PR TITLE
Avoid rendering breaking when function has no body

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/endpoint-aggregator-util.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/endpoint-aggregator-util.js
@@ -42,6 +42,10 @@ class EndpointAggregatorUtil {
     }
 
     aggregateAllVisibleEndpoints(node) {
+        if (!node.body) {
+            return;
+        }
+
         const visibleOuterEndpoints = TreeUtil.getAllEndpoints(node.parent);
         const invocationStmts = [];
 


### PR DESCRIPTION
## Purpose
Avoid throwing during rendering because of function nodes not having a body property.
This could happen because body is optional for object function definitions.
eg: 
```ballerina
public type DummyObject object {
    public function doThatOnObject(string paramOne) returns (boolean);
};
```

Fixes #9204