### PR TITLE
Make 'record' keyword mandatory for record type defs

### DIFF
--- a/benchmarks/benchmarktypes/benchmark-type-constrained-json.bal
+++ b/benchmarks/benchmarktypes/benchmark-type-constrained-json.bal
@@ -1,10 +1,10 @@
-type Person {
+type Person record {
     string name;
     int age;
     string address;
 };
 
-type Student {
+type Student record {
     string name;
     int age;
     string address;
@@ -35,21 +35,21 @@ public function benchmarkGetPersonJson() {
     json<Person> j = { name: "John Doe", age: 30, address: "London" };
 }
 
-type Employee {
+type Employee record {
     string first_name;
     string last_name;
     int age;
     Address address;
 };
 
-type Address {
+type Address record {
     string number;
     string street;
     string city;
     PhoneNumber phoneNumber;
 };
 
-type PhoneNumber {
+type PhoneNumber record {
     string areaCode;
     string number;
 };

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/antlr4/BallerinaParser.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/antlr4/BallerinaParser.java
@@ -395,7 +395,7 @@ public class BallerinaParser extends Parser {
 			setState(412);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << PUBLIC) | (1L << NATIVE) | (1L << SERVICE) | (1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << ANNOTATION) | (1L << ENDPOINT))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || ((((_la - 151)) & ~0x3f) == 0 && ((1L << (_la - 151)) & ((1L << (AT - 151)) | (1L << (Identifier - 151)) | (1L << (DocumentationTemplateStart - 151)) | (1L << (DeprecatedTemplateStart - 151)))) != 0)) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << PUBLIC) | (1L << NATIVE) | (1L << SERVICE) | (1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << ANNOTATION) | (1L << ENDPOINT))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || ((((_la - 151)) & ~0x3f) == 0 && ((1L << (_la - 151)) & ((1L << (AT - 151)) | (1L << (Identifier - 151)) | (1L << (DocumentationTemplateStart - 151)) | (1L << (DeprecatedTemplateStart - 151)))) != 0)) {
 				{
 				{
 				setState(398);
@@ -1028,7 +1028,6 @@ public class BallerinaParser extends Parser {
 					case TYPE_ANY:
 					case TYPE_DESC:
 					case TYPE_FUTURE:
-					case LEFT_BRACE:
 					case LEFT_PARENTHESIS:
 					case Identifier:
 						{
@@ -1161,7 +1160,7 @@ public class BallerinaParser extends Parser {
 			match(LEFT_PARENTHESIS);
 			setState(517);
 			_la = _input.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << ENDPOINT))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << ENDPOINT))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				setState(516);
 				resourceParameterList();
@@ -1249,7 +1248,6 @@ public class BallerinaParser extends Parser {
 			case TYPE_ANY:
 			case TYPE_DESC:
 			case TYPE_FUTURE:
-			case LEFT_BRACE:
 			case LEFT_PARENTHESIS:
 			case AT:
 			case Identifier:
@@ -1602,7 +1600,7 @@ public class BallerinaParser extends Parser {
 			match(LEFT_PARENTHESIS);
 			setState(574);
 			_la = _input.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				setState(573);
 				formalParameterList();
@@ -1614,15 +1612,14 @@ public class BallerinaParser extends Parser {
 			setState(577);
 			match(EQUAL_GT);
 			setState(579);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,35,_ctx) ) {
-			case 1:
+			_la = _input.LA(1);
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				setState(578);
 				lambdaReturnParameter();
 				}
-				break;
 			}
+
 			setState(581);
 			callableUnitBody();
 			}
@@ -1677,7 +1674,7 @@ public class BallerinaParser extends Parser {
 			match(LEFT_PARENTHESIS);
 			setState(586);
 			_la = _input.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				setState(585);
 				formalParameterList();
@@ -1890,7 +1887,7 @@ public class BallerinaParser extends Parser {
 			setState(617);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				{
 				setState(614);
@@ -1954,7 +1951,7 @@ public class BallerinaParser extends Parser {
 			setState(627);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				{
 				setState(624);
@@ -2101,7 +2098,7 @@ public class BallerinaParser extends Parser {
 			match(LEFT_PARENTHESIS);
 			setState(650);
 			_la = _input.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				setState(649);
 				objectParameterList();
@@ -2677,7 +2674,7 @@ public class BallerinaParser extends Parser {
 			match(LEFT_PARENTHESIS);
 			setState(736);
 			_la = _input.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				setState(735);
 				formalParameterList();
@@ -3424,12 +3421,12 @@ public class BallerinaParser extends Parser {
 		}
 	}
 	public static class RecordTypeNameLabelContext extends TypeNameContext {
+		public TerminalNode RECORD() { return getToken(BallerinaParser.RECORD, 0); }
 		public TerminalNode LEFT_BRACE() { return getToken(BallerinaParser.LEFT_BRACE, 0); }
 		public FieldDefinitionListContext fieldDefinitionList() {
 			return getRuleContext(FieldDefinitionListContext.class,0);
 		}
 		public TerminalNode RIGHT_BRACE() { return getToken(BallerinaParser.RIGHT_BRACE, 0); }
-		public TerminalNode RECORD() { return getToken(BallerinaParser.RECORD, 0); }
 		public RecordTypeNameLabelContext(TypeNameContext ctx) { copyFrom(ctx); }
 		@Override
 		public void enterRule(ParseTreeListener listener) {
@@ -3562,9 +3559,9 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(858);
+			setState(856);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,82,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,81,_ctx) ) {
 			case 1:
 				{
 				_localctx = new SimpleTypeNameLabelContext(_localctx);
@@ -3637,43 +3634,36 @@ public class BallerinaParser extends Parser {
 				_localctx = new RecordTypeNameLabelContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
+				setState(851);
+				match(RECORD);
 				setState(852);
-				_la = _input.LA(1);
-				if (_la==RECORD) {
-					{
-					setState(851);
-					match(RECORD);
-					}
-				}
-
-				setState(854);
 				match(LEFT_BRACE);
-				setState(855);
+				setState(853);
 				fieldDefinitionList();
-				setState(856);
+				setState(854);
 				match(RIGHT_BRACE);
 				}
 				break;
 			}
 			_ctx.stop = _input.LT(-1);
-			setState(878);
+			setState(876);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,86,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,85,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) triggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					setState(876);
+					setState(874);
 					_errHandler.sync(this);
-					switch ( getInterpreter().adaptivePredict(_input,85,_ctx) ) {
+					switch ( getInterpreter().adaptivePredict(_input,84,_ctx) ) {
 					case 1:
 						{
 						_localctx = new ArrayTypeNameLabelContext(new TypeNameContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_typeName);
-						setState(860);
+						setState(858);
 						if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
-						setState(863); 
+						setState(861); 
 						_errHandler.sync(this);
 						_alt = 1;
 						do {
@@ -3681,9 +3671,9 @@ public class BallerinaParser extends Parser {
 							case 1:
 								{
 								{
-								setState(861);
+								setState(859);
 								match(LEFT_BRACKET);
-								setState(862);
+								setState(860);
 								match(RIGHT_BRACKET);
 								}
 								}
@@ -3691,9 +3681,9 @@ public class BallerinaParser extends Parser {
 							default:
 								throw new NoViableAltException(this);
 							}
-							setState(865); 
+							setState(863); 
 							_errHandler.sync(this);
-							_alt = getInterpreter().adaptivePredict(_input,83,_ctx);
+							_alt = getInterpreter().adaptivePredict(_input,82,_ctx);
 						} while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
 						}
 						break;
@@ -3701,9 +3691,9 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new UnionTypeNameLabelContext(new TypeNameContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_typeName);
-						setState(867);
+						setState(865);
 						if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
-						setState(870); 
+						setState(868); 
 						_errHandler.sync(this);
 						_alt = 1;
 						do {
@@ -3711,9 +3701,9 @@ public class BallerinaParser extends Parser {
 							case 1:
 								{
 								{
-								setState(868);
+								setState(866);
 								match(PIPE);
-								setState(869);
+								setState(867);
 								typeName(0);
 								}
 								}
@@ -3721,9 +3711,9 @@ public class BallerinaParser extends Parser {
 							default:
 								throw new NoViableAltException(this);
 							}
-							setState(872); 
+							setState(870); 
 							_errHandler.sync(this);
-							_alt = getInterpreter().adaptivePredict(_input,84,_ctx);
+							_alt = getInterpreter().adaptivePredict(_input,83,_ctx);
 						} while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
 						}
 						break;
@@ -3731,18 +3721,18 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new NullableTypeNameLabelContext(new TypeNameContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_typeName);
-						setState(874);
+						setState(872);
 						if (!(precpred(_ctx, 5))) throw new FailedPredicateException(this, "precpred(_ctx, 5)");
-						setState(875);
+						setState(873);
 						match(QUESTION_MARK);
 						}
 						break;
 					}
 					} 
 				}
-				setState(880);
+				setState(878);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,86,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,85,_ctx);
 			}
 			}
 		}
@@ -3785,17 +3775,17 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(884);
+			setState(882);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
+			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==AT || _la==Identifier) {
 				{
 				{
-				setState(881);
+				setState(879);
 				fieldDefinition();
 				}
 				}
-				setState(886);
+				setState(884);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -3842,19 +3832,19 @@ public class BallerinaParser extends Parser {
 		SimpleTypeNameContext _localctx = new SimpleTypeNameContext(_ctx, getState());
 		enterRule(_localctx, 82, RULE_simpleTypeName);
 		try {
-			setState(892);
+			setState(890);
 			switch (_input.LA(1)) {
 			case TYPE_ANY:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(887);
+				setState(885);
 				match(TYPE_ANY);
 				}
 				break;
 			case TYPE_DESC:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(888);
+				setState(886);
 				match(TYPE_DESC);
 				}
 				break;
@@ -3865,7 +3855,7 @@ public class BallerinaParser extends Parser {
 			case TYPE_BLOB:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(889);
+				setState(887);
 				valueTypeName();
 				}
 				break;
@@ -3879,14 +3869,14 @@ public class BallerinaParser extends Parser {
 			case Identifier:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(890);
+				setState(888);
 				referenceTypeName();
 				}
 				break;
 			case LEFT_PARENTHESIS:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(891);
+				setState(889);
 				emptyTupleLiteral();
 				}
 				break;
@@ -3930,7 +3920,7 @@ public class BallerinaParser extends Parser {
 		ReferenceTypeNameContext _localctx = new ReferenceTypeNameContext(_ctx, getState());
 		enterRule(_localctx, 84, RULE_referenceTypeName);
 		try {
-			setState(896);
+			setState(894);
 			switch (_input.LA(1)) {
 			case FUNCTION:
 			case TYPE_MAP:
@@ -3941,14 +3931,14 @@ public class BallerinaParser extends Parser {
 			case TYPE_FUTURE:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(894);
+				setState(892);
 				builtInReferenceTypeName();
 				}
 				break;
 			case Identifier:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(895);
+				setState(893);
 				userDefineTypeName();
 				}
 				break;
@@ -3991,7 +3981,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(898);
+			setState(896);
 			nameReference();
 			}
 		}
@@ -4033,7 +4023,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(900);
+			setState(898);
 			_la = _input.LA(1);
 			if ( !(((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -4098,23 +4088,23 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 90, RULE_builtInReferenceTypeName);
 		int _la;
 		try {
-			setState(951);
+			setState(949);
 			switch (_input.LA(1)) {
 			case TYPE_MAP:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(902);
+				setState(900);
 				match(TYPE_MAP);
-				setState(907);
+				setState(905);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,90,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,89,_ctx) ) {
 				case 1:
 					{
-					setState(903);
+					setState(901);
 					match(LT);
-					setState(904);
+					setState(902);
 					typeName(0);
-					setState(905);
+					setState(903);
 					match(GT);
 					}
 					break;
@@ -4124,18 +4114,18 @@ public class BallerinaParser extends Parser {
 			case TYPE_FUTURE:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(909);
+				setState(907);
 				match(TYPE_FUTURE);
-				setState(914);
+				setState(912);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,91,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,90,_ctx) ) {
 				case 1:
 					{
-					setState(910);
+					setState(908);
 					match(LT);
-					setState(911);
+					setState(909);
 					typeName(0);
-					setState(912);
+					setState(910);
 					match(GT);
 					}
 					break;
@@ -4145,31 +4135,31 @@ public class BallerinaParser extends Parser {
 			case TYPE_XML:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(916);
+				setState(914);
 				match(TYPE_XML);
-				setState(927);
+				setState(925);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,93,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,92,_ctx) ) {
 				case 1:
 					{
-					setState(917);
+					setState(915);
 					match(LT);
-					setState(922);
+					setState(920);
 					_la = _input.LA(1);
 					if (_la==LEFT_BRACE) {
 						{
-						setState(918);
+						setState(916);
 						match(LEFT_BRACE);
-						setState(919);
+						setState(917);
 						xmlNamespaceName();
-						setState(920);
+						setState(918);
 						match(RIGHT_BRACE);
 						}
 					}
 
-					setState(924);
+					setState(922);
 					xmlLocalName();
-					setState(925);
+					setState(923);
 					match(GT);
 					}
 					break;
@@ -4179,18 +4169,18 @@ public class BallerinaParser extends Parser {
 			case TYPE_JSON:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(929);
+				setState(927);
 				match(TYPE_JSON);
-				setState(934);
+				setState(932);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,94,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,93,_ctx) ) {
 				case 1:
 					{
-					setState(930);
+					setState(928);
 					match(LT);
-					setState(931);
+					setState(929);
 					nameReference();
-					setState(932);
+					setState(930);
 					match(GT);
 					}
 					break;
@@ -4200,18 +4190,18 @@ public class BallerinaParser extends Parser {
 			case TYPE_TABLE:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(936);
+				setState(934);
 				match(TYPE_TABLE);
-				setState(941);
+				setState(939);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,95,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,94,_ctx) ) {
 				case 1:
 					{
-					setState(937);
+					setState(935);
 					match(LT);
-					setState(938);
+					setState(936);
 					nameReference();
-					setState(939);
+					setState(937);
 					match(GT);
 					}
 					break;
@@ -4221,18 +4211,18 @@ public class BallerinaParser extends Parser {
 			case TYPE_STREAM:
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(943);
+				setState(941);
 				match(TYPE_STREAM);
-				setState(948);
+				setState(946);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,96,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,95,_ctx) ) {
 				case 1:
 					{
-					setState(944);
+					setState(942);
 					match(LT);
-					setState(945);
+					setState(943);
 					typeName(0);
-					setState(946);
+					setState(944);
 					match(GT);
 					}
 					break;
@@ -4242,7 +4232,7 @@ public class BallerinaParser extends Parser {
 			case FUNCTION:
 				enterOuterAlt(_localctx, 7);
 				{
-				setState(950);
+				setState(948);
 				functionTypeName();
 				}
 				break;
@@ -4294,34 +4284,34 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(953);
+			setState(951);
 			match(FUNCTION);
-			setState(954);
+			setState(952);
 			match(LEFT_PARENTHESIS);
-			setState(957);
+			setState(955);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,98,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,97,_ctx) ) {
 			case 1:
 				{
-				setState(955);
+				setState(953);
 				parameterList();
 				}
 				break;
 			case 2:
 				{
-				setState(956);
+				setState(954);
 				parameterTypeNameList();
 				}
 				break;
 			}
-			setState(959);
+			setState(957);
 			match(RIGHT_PARENTHESIS);
-			setState(961);
+			setState(959);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,99,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,98,_ctx) ) {
 			case 1:
 				{
-				setState(960);
+				setState(958);
 				returnParameter();
 				}
 				break;
@@ -4361,7 +4351,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(963);
+			setState(961);
 			match(QuotedStringLiteral);
 			}
 		}
@@ -4398,7 +4388,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(965);
+			setState(963);
 			match(Identifier);
 			}
 		}
@@ -4438,23 +4428,23 @@ public class BallerinaParser extends Parser {
 	public final AnnotationAttachmentContext annotationAttachment() throws RecognitionException {
 		AnnotationAttachmentContext _localctx = new AnnotationAttachmentContext(_ctx, getState());
 		enterRule(_localctx, 98, RULE_annotationAttachment);
+		int _la;
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(967);
+			setState(965);
 			match(AT);
-			setState(968);
+			setState(966);
 			nameReference();
-			setState(970);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,100,_ctx) ) {
-			case 1:
+			setState(968);
+			_la = _input.LA(1);
+			if (_la==LEFT_BRACE) {
 				{
-				setState(969);
+				setState(967);
 				recordLiteral();
 				}
-				break;
 			}
+
 			}
 		}
 		catch (RecognitionException re) {
@@ -4562,181 +4552,181 @@ public class BallerinaParser extends Parser {
 		StatementContext _localctx = new StatementContext(_ctx, getState());
 		enterRule(_localctx, 100, RULE_statement);
 		try {
-			setState(997);
+			setState(995);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,101,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,100,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(972);
+				setState(970);
 				variableDefinitionStatement();
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(973);
+				setState(971);
 				assignmentStatement();
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(974);
+				setState(972);
 				tupleDestructuringStatement();
 				}
 				break;
 			case 4:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(975);
+				setState(973);
 				compoundAssignmentStatement();
 				}
 				break;
 			case 5:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(976);
+				setState(974);
 				postIncrementStatement();
 				}
 				break;
 			case 6:
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(977);
+				setState(975);
 				ifElseStatement();
 				}
 				break;
 			case 7:
 				enterOuterAlt(_localctx, 7);
 				{
-				setState(978);
+				setState(976);
 				matchStatement();
 				}
 				break;
 			case 8:
 				enterOuterAlt(_localctx, 8);
 				{
-				setState(979);
+				setState(977);
 				foreachStatement();
 				}
 				break;
 			case 9:
 				enterOuterAlt(_localctx, 9);
 				{
-				setState(980);
+				setState(978);
 				whileStatement();
 				}
 				break;
 			case 10:
 				enterOuterAlt(_localctx, 10);
 				{
-				setState(981);
+				setState(979);
 				continueStatement();
 				}
 				break;
 			case 11:
 				enterOuterAlt(_localctx, 11);
 				{
-				setState(982);
+				setState(980);
 				breakStatement();
 				}
 				break;
 			case 12:
 				enterOuterAlt(_localctx, 12);
 				{
-				setState(983);
+				setState(981);
 				forkJoinStatement();
 				}
 				break;
 			case 13:
 				enterOuterAlt(_localctx, 13);
 				{
-				setState(984);
+				setState(982);
 				tryCatchStatement();
 				}
 				break;
 			case 14:
 				enterOuterAlt(_localctx, 14);
 				{
-				setState(985);
+				setState(983);
 				throwStatement();
 				}
 				break;
 			case 15:
 				enterOuterAlt(_localctx, 15);
 				{
-				setState(986);
+				setState(984);
 				returnStatement();
 				}
 				break;
 			case 16:
 				enterOuterAlt(_localctx, 16);
 				{
-				setState(987);
+				setState(985);
 				workerInteractionStatement();
 				}
 				break;
 			case 17:
 				enterOuterAlt(_localctx, 17);
 				{
-				setState(988);
+				setState(986);
 				expressionStmt();
 				}
 				break;
 			case 18:
 				enterOuterAlt(_localctx, 18);
 				{
-				setState(989);
+				setState(987);
 				transactionStatement();
 				}
 				break;
 			case 19:
 				enterOuterAlt(_localctx, 19);
 				{
-				setState(990);
+				setState(988);
 				abortStatement();
 				}
 				break;
 			case 20:
 				enterOuterAlt(_localctx, 20);
 				{
-				setState(991);
+				setState(989);
 				retryStatement();
 				}
 				break;
 			case 21:
 				enterOuterAlt(_localctx, 21);
 				{
-				setState(992);
+				setState(990);
 				lockStatement();
 				}
 				break;
 			case 22:
 				enterOuterAlt(_localctx, 22);
 				{
-				setState(993);
+				setState(991);
 				namespaceDeclarationStatement();
 				}
 				break;
 			case 23:
 				enterOuterAlt(_localctx, 23);
 				{
-				setState(994);
+				setState(992);
 				foreverStatement();
 				}
 				break;
 			case 24:
 				enterOuterAlt(_localctx, 24);
 				{
-				setState(995);
+				setState(993);
 				streamingQueryStatement();
 				}
 				break;
 			case 25:
 				enterOuterAlt(_localctx, 25);
 				{
-				setState(996);
+				setState(994);
 				doneStatement();
 				}
 				break;
@@ -4784,22 +4774,22 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(999);
+			setState(997);
 			typeName(0);
-			setState(1000);
+			setState(998);
 			match(Identifier);
-			setState(1003);
+			setState(1001);
 			_la = _input.LA(1);
 			if (_la==ASSIGN) {
 				{
-				setState(1001);
+				setState(999);
 				match(ASSIGN);
-				setState(1002);
+				setState(1000);
 				expression(0);
 				}
 			}
 
-			setState(1005);
+			setState(1003);
 			match(SEMICOLON);
 			}
 		}
@@ -4848,34 +4838,34 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1007);
+			setState(1005);
 			match(LEFT_BRACE);
-			setState(1016);
+			setState(1014);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 				{
-				setState(1008);
+				setState(1006);
 				recordKeyValue();
-				setState(1013);
+				setState(1011);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					setState(1009);
+					setState(1007);
 					match(COMMA);
-					setState(1010);
+					setState(1008);
 					recordKeyValue();
 					}
 					}
-					setState(1015);
+					setState(1013);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
 				}
 			}
 
-			setState(1018);
+			setState(1016);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -4918,11 +4908,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1020);
+			setState(1018);
 			recordKey();
-			setState(1021);
+			setState(1019);
 			match(COLON);
-			setState(1022);
+			setState(1020);
 			expression(0);
 			}
 		}
@@ -4960,20 +4950,20 @@ public class BallerinaParser extends Parser {
 		RecordKeyContext _localctx = new RecordKeyContext(_ctx, getState());
 		enterRule(_localctx, 108, RULE_recordKey);
 		try {
-			setState(1026);
+			setState(1024);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,105,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,104,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1024);
+				setState(1022);
 				match(Identifier);
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1025);
+				setState(1023);
 				expression(0);
 				}
 				break;
@@ -5015,9 +5005,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1028);
+			setState(1026);
 			match(TYPE_TABLE);
-			setState(1029);
+			setState(1027);
 			tableInitialization();
 			}
 		}
@@ -5056,7 +5046,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1031);
+			setState(1029);
 			recordLiteral();
 			}
 		}
@@ -5098,18 +5088,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1033);
+			setState(1031);
 			match(LEFT_BRACKET);
-			setState(1035);
+			setState(1033);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 				{
-				setState(1034);
+				setState(1032);
 				expressionList();
 				}
 			}
 
-			setState(1037);
+			setState(1035);
 			match(RIGHT_BRACKET);
 			}
 		}
@@ -5153,31 +5143,31 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 116, RULE_typeInitExpr);
 		int _la;
 		try {
-			setState(1055);
+			setState(1053);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,110,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,109,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1039);
+				setState(1037);
 				match(NEW);
-				setState(1045);
+				setState(1043);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,108,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,107,_ctx) ) {
 				case 1:
 					{
-					setState(1040);
+					setState(1038);
 					match(LEFT_PARENTHESIS);
-					setState(1042);
+					setState(1040);
 					_la = _input.LA(1);
 					if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (ELLIPSIS - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 						{
-						setState(1041);
+						setState(1039);
 						invocationArgList();
 						}
 					}
 
-					setState(1044);
+					setState(1042);
 					match(RIGHT_PARENTHESIS);
 					}
 					break;
@@ -5187,22 +5177,22 @@ public class BallerinaParser extends Parser {
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1047);
+				setState(1045);
 				match(NEW);
-				setState(1048);
+				setState(1046);
 				userDefineTypeName();
-				setState(1049);
+				setState(1047);
 				match(LEFT_PARENTHESIS);
-				setState(1051);
+				setState(1049);
 				_la = _input.LA(1);
 				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (ELLIPSIS - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 					{
-					setState(1050);
+					setState(1048);
 					invocationArgList();
 					}
 				}
 
-				setState(1053);
+				setState(1051);
 				match(RIGHT_PARENTHESIS);
 				}
 				break;
@@ -5250,22 +5240,22 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1058);
+			setState(1056);
 			_la = _input.LA(1);
 			if (_la==VAR) {
 				{
-				setState(1057);
+				setState(1055);
 				match(VAR);
 				}
 			}
 
-			setState(1060);
+			setState(1058);
 			variableReference(0);
-			setState(1061);
+			setState(1059);
 			match(ASSIGN);
-			setState(1062);
+			setState(1060);
 			expression(0);
-			setState(1063);
+			setState(1061);
 			match(SEMICOLON);
 			}
 		}
@@ -5314,49 +5304,49 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 120, RULE_tupleDestructuringStatement);
 		int _la;
 		try {
-			setState(1082);
+			setState(1080);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,113,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,112,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1066);
+				setState(1064);
 				_la = _input.LA(1);
 				if (_la==VAR) {
 					{
-					setState(1065);
+					setState(1063);
 					match(VAR);
 					}
 				}
 
-				setState(1068);
+				setState(1066);
 				match(LEFT_PARENTHESIS);
-				setState(1069);
+				setState(1067);
 				variableReferenceList();
-				setState(1070);
+				setState(1068);
 				match(RIGHT_PARENTHESIS);
-				setState(1071);
+				setState(1069);
 				match(ASSIGN);
-				setState(1072);
+				setState(1070);
 				expression(0);
-				setState(1073);
+				setState(1071);
 				match(SEMICOLON);
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1075);
+				setState(1073);
 				match(LEFT_PARENTHESIS);
-				setState(1076);
+				setState(1074);
 				parameterList();
-				setState(1077);
+				setState(1075);
 				match(RIGHT_PARENTHESIS);
-				setState(1078);
+				setState(1076);
 				match(ASSIGN);
-				setState(1079);
+				setState(1077);
 				expression(0);
-				setState(1080);
+				setState(1078);
 				match(SEMICOLON);
 				}
 				break;
@@ -5404,13 +5394,13 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1084);
+			setState(1082);
 			variableReference(0);
-			setState(1085);
+			setState(1083);
 			compoundOperator();
-			setState(1086);
+			setState(1084);
 			expression(0);
-			setState(1087);
+			setState(1085);
 			match(SEMICOLON);
 			}
 		}
@@ -5451,7 +5441,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1089);
+			setState(1087);
 			_la = _input.LA(1);
 			if ( !(((((_la - 158)) & ~0x3f) == 0 && ((1L << (_la - 158)) & ((1L << (COMPOUND_ADD - 158)) | (1L << (COMPOUND_SUB - 158)) | (1L << (COMPOUND_MUL - 158)) | (1L << (COMPOUND_DIV - 158)))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -5499,11 +5489,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1091);
+			setState(1089);
 			variableReference(0);
-			setState(1092);
+			setState(1090);
 			postArithmeticOperator();
-			setState(1093);
+			setState(1091);
 			match(SEMICOLON);
 			}
 		}
@@ -5542,7 +5532,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1095);
+			setState(1093);
 			_la = _input.LA(1);
 			if ( !(_la==INCREMENT || _la==DECREMENT) ) {
 			_errHandler.recoverInline(this);
@@ -5594,25 +5584,25 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1097);
+			setState(1095);
 			variableReference(0);
-			setState(1102);
+			setState(1100);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,114,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,113,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					setState(1098);
+					setState(1096);
 					match(COMMA);
-					setState(1099);
+					setState(1097);
 					variableReference(0);
 					}
 					} 
 				}
-				setState(1104);
+				setState(1102);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,114,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,113,_ctx);
 			}
 			}
 		}
@@ -5662,29 +5652,29 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1105);
+			setState(1103);
 			ifClause();
-			setState(1109);
+			setState(1107);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,115,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,114,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					setState(1106);
+					setState(1104);
 					elseIfClause();
 					}
 					} 
 				}
-				setState(1111);
+				setState(1109);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,115,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,114,_ctx);
 			}
-			setState(1113);
+			setState(1111);
 			_la = _input.LA(1);
 			if (_la==ELSE) {
 				{
-				setState(1112);
+				setState(1110);
 				elseClause();
 				}
 			}
@@ -5736,27 +5726,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1115);
+			setState(1113);
 			match(IF);
-			setState(1116);
+			setState(1114);
 			expression(0);
-			setState(1117);
+			setState(1115);
 			match(LEFT_BRACE);
-			setState(1121);
+			setState(1119);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1118);
+				setState(1116);
 				statement();
 				}
 				}
-				setState(1123);
+				setState(1121);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1124);
+			setState(1122);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -5806,29 +5796,29 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1126);
+			setState(1124);
 			match(ELSE);
-			setState(1127);
+			setState(1125);
 			match(IF);
-			setState(1128);
+			setState(1126);
 			expression(0);
-			setState(1129);
+			setState(1127);
 			match(LEFT_BRACE);
-			setState(1133);
+			setState(1131);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1130);
+				setState(1128);
 				statement();
 				}
 				}
-				setState(1135);
+				setState(1133);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1136);
+			setState(1134);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -5874,25 +5864,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1138);
+			setState(1136);
 			match(ELSE);
-			setState(1139);
+			setState(1137);
 			match(LEFT_BRACE);
-			setState(1143);
+			setState(1141);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1140);
+				setState(1138);
 				statement();
 				}
 				}
-				setState(1145);
+				setState(1143);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1146);
+			setState(1144);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -5941,27 +5931,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1148);
+			setState(1146);
 			match(MATCH);
-			setState(1149);
+			setState(1147);
 			expression(0);
-			setState(1150);
+			setState(1148);
 			match(LEFT_BRACE);
-			setState(1152); 
+			setState(1150); 
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			do {
 				{
 				{
-				setState(1151);
+				setState(1149);
 				matchPatternClause();
 				}
 				}
-				setState(1154); 
+				setState(1152); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
-			} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==Identifier );
-			setState(1156);
+			} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (LEFT_PARENTHESIS - 71)))) != 0) || _la==Identifier );
+			setState(1154);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -6009,45 +5999,45 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 142, RULE_matchPatternClause);
 		int _la;
 		try {
-			setState(1185);
+			setState(1183);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,125,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,124,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1158);
+				setState(1156);
 				typeName(0);
-				setState(1159);
+				setState(1157);
 				match(EQUAL_GT);
-				setState(1169);
+				setState(1167);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,122,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,121,_ctx) ) {
 				case 1:
 					{
-					setState(1160);
+					setState(1158);
 					statement();
 					}
 					break;
 				case 2:
 					{
 					{
-					setState(1161);
+					setState(1159);
 					match(LEFT_BRACE);
-					setState(1165);
+					setState(1163);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 					while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 						{
 						{
-						setState(1162);
+						setState(1160);
 						statement();
 						}
 						}
-						setState(1167);
+						setState(1165);
 						_errHandler.sync(this);
 						_la = _input.LA(1);
 					}
-					setState(1168);
+					setState(1166);
 					match(RIGHT_BRACE);
 					}
 					}
@@ -6058,41 +6048,41 @@ public class BallerinaParser extends Parser {
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1171);
+				setState(1169);
 				typeName(0);
-				setState(1172);
+				setState(1170);
 				match(Identifier);
-				setState(1173);
+				setState(1171);
 				match(EQUAL_GT);
-				setState(1183);
+				setState(1181);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,124,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,123,_ctx) ) {
 				case 1:
 					{
-					setState(1174);
+					setState(1172);
 					statement();
 					}
 					break;
 				case 2:
 					{
 					{
-					setState(1175);
+					setState(1173);
 					match(LEFT_BRACE);
-					setState(1179);
+					setState(1177);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 					while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 						{
 						{
-						setState(1176);
+						setState(1174);
 						statement();
 						}
 						}
-						setState(1181);
+						setState(1179);
 						_errHandler.sync(this);
 						_la = _input.LA(1);
 					}
-					setState(1182);
+					setState(1180);
 					match(RIGHT_BRACE);
 					}
 					}
@@ -6153,49 +6143,49 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1187);
+			setState(1185);
 			match(FOREACH);
-			setState(1189);
+			setState(1187);
 			_la = _input.LA(1);
 			if (_la==LEFT_PARENTHESIS) {
 				{
-				setState(1188);
+				setState(1186);
 				match(LEFT_PARENTHESIS);
 				}
 			}
 
-			setState(1191);
+			setState(1189);
 			variableReferenceList();
-			setState(1192);
+			setState(1190);
 			match(IN);
-			setState(1193);
+			setState(1191);
 			expression(0);
-			setState(1195);
+			setState(1193);
 			_la = _input.LA(1);
 			if (_la==RIGHT_PARENTHESIS) {
 				{
-				setState(1194);
+				setState(1192);
 				match(RIGHT_PARENTHESIS);
 				}
 			}
 
-			setState(1197);
+			setState(1195);
 			match(LEFT_BRACE);
-			setState(1201);
+			setState(1199);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1198);
+				setState(1196);
 				statement();
 				}
 				}
-				setState(1203);
+				setState(1201);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1204);
+			setState(1202);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -6243,27 +6233,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1206);
+			setState(1204);
 			_la = _input.LA(1);
 			if ( !(_la==LEFT_PARENTHESIS || _la==LEFT_BRACKET) ) {
 			_errHandler.recoverInline(this);
 			} else {
 				consume();
 			}
-			setState(1207);
+			setState(1205);
 			expression(0);
-			setState(1208);
+			setState(1206);
 			match(RANGE);
-			setState(1210);
+			setState(1208);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 				{
-				setState(1209);
+				setState(1207);
 				expression(0);
 				}
 			}
 
-			setState(1212);
+			setState(1210);
 			_la = _input.LA(1);
 			if ( !(_la==RIGHT_PARENTHESIS || _la==RIGHT_BRACKET) ) {
 			_errHandler.recoverInline(this);
@@ -6317,27 +6307,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1214);
+			setState(1212);
 			match(WHILE);
-			setState(1215);
+			setState(1213);
 			expression(0);
-			setState(1216);
+			setState(1214);
 			match(LEFT_BRACE);
-			setState(1220);
+			setState(1218);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1217);
+				setState(1215);
 				statement();
 				}
 				}
-				setState(1222);
+				setState(1220);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1223);
+			setState(1221);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -6375,9 +6365,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1225);
+			setState(1223);
 			match(CONTINUE);
-			setState(1226);
+			setState(1224);
 			match(SEMICOLON);
 			}
 		}
@@ -6415,9 +6405,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1228);
+			setState(1226);
 			match(BREAK);
-			setState(1229);
+			setState(1227);
 			match(SEMICOLON);
 			}
 		}
@@ -6469,40 +6459,40 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1231);
+			setState(1229);
 			match(FORK);
-			setState(1232);
+			setState(1230);
 			match(LEFT_BRACE);
-			setState(1236);
+			setState(1234);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==WORKER) {
 				{
 				{
-				setState(1233);
+				setState(1231);
 				workerDeclaration();
 				}
 				}
-				setState(1238);
+				setState(1236);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1239);
+			setState(1237);
 			match(RIGHT_BRACE);
-			setState(1241);
+			setState(1239);
 			_la = _input.LA(1);
 			if (_la==JOIN) {
 				{
-				setState(1240);
+				setState(1238);
 				joinClause();
 				}
 			}
 
-			setState(1244);
+			setState(1242);
 			_la = _input.LA(1);
 			if (_la==TIMEOUT) {
 				{
-				setState(1243);
+				setState(1241);
 				timeoutClause();
 				}
 			}
@@ -6566,47 +6556,47 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1246);
+			setState(1244);
 			match(JOIN);
-			setState(1251);
+			setState(1249);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,134,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,133,_ctx) ) {
 			case 1:
 				{
-				setState(1247);
+				setState(1245);
 				match(LEFT_PARENTHESIS);
-				setState(1248);
+				setState(1246);
 				joinConditions();
-				setState(1249);
+				setState(1247);
 				match(RIGHT_PARENTHESIS);
 				}
 				break;
 			}
-			setState(1253);
+			setState(1251);
 			match(LEFT_PARENTHESIS);
-			setState(1254);
+			setState(1252);
 			typeName(0);
-			setState(1255);
+			setState(1253);
 			match(Identifier);
-			setState(1256);
+			setState(1254);
 			match(RIGHT_PARENTHESIS);
-			setState(1257);
+			setState(1255);
 			match(LEFT_BRACE);
-			setState(1261);
+			setState(1259);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1258);
+				setState(1256);
 				statement();
 				}
 				}
-				setState(1263);
+				setState(1261);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1264);
+			setState(1262);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -6681,35 +6671,35 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 158, RULE_joinConditions);
 		int _la;
 		try {
-			setState(1289);
+			setState(1287);
 			switch (_input.LA(1)) {
 			case SOME:
 				_localctx = new AnyJoinConditionContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1266);
+				setState(1264);
 				match(SOME);
-				setState(1267);
+				setState(1265);
 				integerLiteral();
-				setState(1276);
+				setState(1274);
 				_la = _input.LA(1);
 				if (_la==Identifier) {
 					{
-					setState(1268);
+					setState(1266);
 					match(Identifier);
-					setState(1273);
+					setState(1271);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 					while (_la==COMMA) {
 						{
 						{
-						setState(1269);
+						setState(1267);
 						match(COMMA);
-						setState(1270);
+						setState(1268);
 						match(Identifier);
 						}
 						}
-						setState(1275);
+						setState(1273);
 						_errHandler.sync(this);
 						_la = _input.LA(1);
 					}
@@ -6722,27 +6712,27 @@ public class BallerinaParser extends Parser {
 				_localctx = new AllJoinConditionContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1278);
+				setState(1276);
 				match(ALL);
-				setState(1287);
+				setState(1285);
 				_la = _input.LA(1);
 				if (_la==Identifier) {
 					{
-					setState(1279);
+					setState(1277);
 					match(Identifier);
-					setState(1284);
+					setState(1282);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 					while (_la==COMMA) {
 						{
 						{
-						setState(1280);
+						setState(1278);
 						match(COMMA);
-						setState(1281);
+						setState(1279);
 						match(Identifier);
 						}
 						}
-						setState(1286);
+						setState(1284);
 						_errHandler.sync(this);
 						_la = _input.LA(1);
 					}
@@ -6812,39 +6802,39 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1291);
+			setState(1289);
 			match(TIMEOUT);
-			setState(1292);
+			setState(1290);
 			match(LEFT_PARENTHESIS);
-			setState(1293);
+			setState(1291);
 			expression(0);
-			setState(1294);
+			setState(1292);
 			match(RIGHT_PARENTHESIS);
-			setState(1295);
+			setState(1293);
 			match(LEFT_PARENTHESIS);
-			setState(1296);
+			setState(1294);
 			typeName(0);
-			setState(1297);
+			setState(1295);
 			match(Identifier);
-			setState(1298);
+			setState(1296);
 			match(RIGHT_PARENTHESIS);
-			setState(1299);
+			setState(1297);
 			match(LEFT_BRACE);
-			setState(1303);
+			setState(1301);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1300);
+				setState(1298);
 				statement();
 				}
 				}
-				setState(1305);
+				setState(1303);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1306);
+			setState(1304);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -6893,27 +6883,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1308);
+			setState(1306);
 			match(TRY);
-			setState(1309);
+			setState(1307);
 			match(LEFT_BRACE);
-			setState(1313);
+			setState(1311);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1310);
+				setState(1308);
 				statement();
 				}
 				}
-				setState(1315);
+				setState(1313);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1316);
+			setState(1314);
 			match(RIGHT_BRACE);
-			setState(1317);
+			setState(1315);
 			catchClauses();
 			}
 		}
@@ -6957,30 +6947,30 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 164, RULE_catchClauses);
 		int _la;
 		try {
-			setState(1328);
+			setState(1326);
 			switch (_input.LA(1)) {
 			case CATCH:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1320); 
+				setState(1318); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				do {
 					{
 					{
-					setState(1319);
+					setState(1317);
 					catchClause();
 					}
 					}
-					setState(1322); 
+					setState(1320); 
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				} while ( _la==CATCH );
-				setState(1325);
+				setState(1323);
 				_la = _input.LA(1);
 				if (_la==FINALLY) {
 					{
-					setState(1324);
+					setState(1322);
 					finallyClause();
 					}
 				}
@@ -6990,7 +6980,7 @@ public class BallerinaParser extends Parser {
 			case FINALLY:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1327);
+				setState(1325);
 				finallyClause();
 				}
 				break;
@@ -7046,33 +7036,33 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1330);
+			setState(1328);
 			match(CATCH);
-			setState(1331);
+			setState(1329);
 			match(LEFT_PARENTHESIS);
-			setState(1332);
+			setState(1330);
 			typeName(0);
-			setState(1333);
+			setState(1331);
 			match(Identifier);
-			setState(1334);
+			setState(1332);
 			match(RIGHT_PARENTHESIS);
-			setState(1335);
+			setState(1333);
 			match(LEFT_BRACE);
-			setState(1339);
+			setState(1337);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1336);
+				setState(1334);
 				statement();
 				}
 				}
-				setState(1341);
+				setState(1339);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1342);
+			setState(1340);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -7118,25 +7108,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1344);
+			setState(1342);
 			match(FINALLY);
-			setState(1345);
+			setState(1343);
 			match(LEFT_BRACE);
-			setState(1349);
+			setState(1347);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1346);
+				setState(1344);
 				statement();
 				}
 				}
-				setState(1351);
+				setState(1349);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1352);
+			setState(1350);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -7177,11 +7167,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1354);
+			setState(1352);
 			match(THROW);
-			setState(1355);
+			setState(1353);
 			expression(0);
-			setState(1356);
+			setState(1354);
 			match(SEMICOLON);
 			}
 		}
@@ -7223,18 +7213,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1358);
+			setState(1356);
 			match(RETURN);
-			setState(1360);
+			setState(1358);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 				{
-				setState(1359);
+				setState(1357);
 				expression(0);
 				}
 			}
 
-			setState(1362);
+			setState(1360);
 			match(SEMICOLON);
 			}
 		}
@@ -7274,20 +7264,20 @@ public class BallerinaParser extends Parser {
 		WorkerInteractionStatementContext _localctx = new WorkerInteractionStatementContext(_ctx, getState());
 		enterRule(_localctx, 174, RULE_workerInteractionStatement);
 		try {
-			setState(1366);
+			setState(1364);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,149,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,148,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1364);
+				setState(1362);
 				triggerWorker();
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1365);
+				setState(1363);
 				workerReply();
 				}
 				break;
@@ -7354,20 +7344,20 @@ public class BallerinaParser extends Parser {
 		TriggerWorkerContext _localctx = new TriggerWorkerContext(_ctx, getState());
 		enterRule(_localctx, 176, RULE_triggerWorker);
 		try {
-			setState(1378);
+			setState(1376);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,150,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,149,_ctx) ) {
 			case 1:
 				_localctx = new InvokeWorkerContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1368);
+				setState(1366);
 				expression(0);
-				setState(1369);
+				setState(1367);
 				match(RARROW);
-				setState(1370);
+				setState(1368);
 				match(Identifier);
-				setState(1371);
+				setState(1369);
 				match(SEMICOLON);
 				}
 				break;
@@ -7375,13 +7365,13 @@ public class BallerinaParser extends Parser {
 				_localctx = new InvokeForkContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1373);
+				setState(1371);
 				expression(0);
-				setState(1374);
+				setState(1372);
 				match(RARROW);
-				setState(1375);
+				setState(1373);
 				match(FORK);
-				setState(1376);
+				setState(1374);
 				match(SEMICOLON);
 				}
 				break;
@@ -7425,13 +7415,13 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1380);
+			setState(1378);
 			expression(0);
-			setState(1381);
+			setState(1379);
 			match(LARROW);
-			setState(1382);
+			setState(1380);
 			match(Identifier);
-			setState(1383);
+			setState(1381);
 			match(SEMICOLON);
 			}
 		}
@@ -7569,16 +7559,16 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1388);
+			setState(1386);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,151,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,150,_ctx) ) {
 			case 1:
 				{
 				_localctx = new SimpleVariableReferenceContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				setState(1386);
+				setState(1384);
 				nameReference();
 				}
 				break;
@@ -7587,30 +7577,30 @@ public class BallerinaParser extends Parser {
 				_localctx = new FunctionInvocationReferenceContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1387);
+				setState(1385);
 				functionInvocation();
 				}
 				break;
 			}
 			_ctx.stop = _input.LT(-1);
-			setState(1400);
+			setState(1398);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,153,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,152,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) triggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					setState(1398);
+					setState(1396);
 					_errHandler.sync(this);
-					switch ( getInterpreter().adaptivePredict(_input,152,_ctx) ) {
+					switch ( getInterpreter().adaptivePredict(_input,151,_ctx) ) {
 					case 1:
 						{
 						_localctx = new MapArrayVariableReferenceContext(new VariableReferenceContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_variableReference);
-						setState(1390);
+						setState(1388);
 						if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
-						setState(1391);
+						setState(1389);
 						index();
 						}
 						break;
@@ -7618,9 +7608,9 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new FieldVariableReferenceContext(new VariableReferenceContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_variableReference);
-						setState(1392);
+						setState(1390);
 						if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-						setState(1393);
+						setState(1391);
 						field();
 						}
 						break;
@@ -7628,9 +7618,9 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new XmlAttribVariableReferenceContext(new VariableReferenceContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_variableReference);
-						setState(1394);
+						setState(1392);
 						if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-						setState(1395);
+						setState(1393);
 						xmlAttrib();
 						}
 						break;
@@ -7638,18 +7628,18 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new InvocationReferenceContext(new VariableReferenceContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_variableReference);
-						setState(1396);
+						setState(1394);
 						if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-						setState(1397);
+						setState(1395);
 						invocation();
 						}
 						break;
 					}
 					} 
 				}
-				setState(1402);
+				setState(1400);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,153,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,152,_ctx);
 			}
 			}
 		}
@@ -7690,14 +7680,14 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1403);
+			setState(1401);
 			_la = _input.LA(1);
 			if ( !(_la==DOT || _la==NOT) ) {
 			_errHandler.recoverInline(this);
 			} else {
 				consume();
 			}
-			setState(1404);
+			setState(1402);
 			_la = _input.LA(1);
 			if ( !(_la==MUL || _la==Identifier) ) {
 			_errHandler.recoverInline(this);
@@ -7743,11 +7733,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1406);
+			setState(1404);
 			match(LEFT_BRACKET);
-			setState(1407);
+			setState(1405);
 			expression(0);
-			setState(1408);
+			setState(1406);
 			match(RIGHT_BRACKET);
 			}
 		}
@@ -7789,18 +7779,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1410);
+			setState(1408);
 			match(AT);
-			setState(1415);
+			setState(1413);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,154,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,153,_ctx) ) {
 			case 1:
 				{
-				setState(1411);
+				setState(1409);
 				match(LEFT_BRACKET);
-				setState(1412);
+				setState(1410);
 				expression(0);
-				setState(1413);
+				setState(1411);
 				match(RIGHT_BRACKET);
 				}
 				break;
@@ -7848,20 +7838,20 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1417);
+			setState(1415);
 			functionNameReference();
-			setState(1418);
+			setState(1416);
 			match(LEFT_PARENTHESIS);
-			setState(1420);
+			setState(1418);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (ELLIPSIS - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 				{
-				setState(1419);
+				setState(1417);
 				invocationArgList();
 				}
 			}
 
-			setState(1422);
+			setState(1420);
 			match(RIGHT_PARENTHESIS);
 			}
 		}
@@ -7908,27 +7898,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1424);
+			setState(1422);
 			_la = _input.LA(1);
 			if ( !(_la==DOT || _la==NOT) ) {
 			_errHandler.recoverInline(this);
 			} else {
 				consume();
 			}
-			setState(1425);
+			setState(1423);
 			anyIdentifierName();
-			setState(1426);
+			setState(1424);
 			match(LEFT_PARENTHESIS);
-			setState(1428);
+			setState(1426);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << FROM))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (TYPE_INT - 71)) | (1L << (TYPE_FLOAT - 71)) | (1L << (TYPE_BOOL - 71)) | (1L << (TYPE_STRING - 71)) | (1L << (TYPE_BLOB - 71)) | (1L << (TYPE_MAP - 71)) | (1L << (TYPE_JSON - 71)) | (1L << (TYPE_XML - 71)) | (1L << (TYPE_TABLE - 71)) | (1L << (TYPE_STREAM - 71)) | (1L << (TYPE_ANY - 71)) | (1L << (TYPE_DESC - 71)) | (1L << (TYPE_FUTURE - 71)) | (1L << (NEW - 71)) | (1L << (FOREACH - 71)) | (1L << (CONTINUE - 71)) | (1L << (LENGTHOF - 71)) | (1L << (UNTAINT - 71)) | (1L << (START - 71)) | (1L << (AWAIT - 71)) | (1L << (CHECK - 71)) | (1L << (LEFT_BRACE - 71)) | (1L << (LEFT_PARENTHESIS - 71)) | (1L << (LEFT_BRACKET - 71)) | (1L << (ADD - 71)))) != 0) || ((((_la - 135)) & ~0x3f) == 0 && ((1L << (_la - 135)) & ((1L << (SUB - 135)) | (1L << (NOT - 135)) | (1L << (LT - 135)) | (1L << (ELLIPSIS - 135)) | (1L << (DecimalIntegerLiteral - 135)) | (1L << (HexIntegerLiteral - 135)) | (1L << (OctalIntegerLiteral - 135)) | (1L << (BinaryIntegerLiteral - 135)) | (1L << (FloatingPointLiteral - 135)) | (1L << (BooleanLiteral - 135)) | (1L << (QuotedStringLiteral - 135)) | (1L << (Base16BlobLiteral - 135)) | (1L << (Base64BlobLiteral - 135)) | (1L << (NullLiteral - 135)) | (1L << (Identifier - 135)) | (1L << (XMLLiteralStart - 135)) | (1L << (StringTemplateLiteralStart - 135)))) != 0)) {
 				{
-				setState(1427);
+				setState(1425);
 				invocationArgList();
 				}
 			}
 
-			setState(1430);
+			setState(1428);
 			match(RIGHT_PARENTHESIS);
 			}
 		}
@@ -7975,21 +7965,21 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1432);
+			setState(1430);
 			invocationArg();
-			setState(1437);
+			setState(1435);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(1433);
+				setState(1431);
 				match(COMMA);
-				setState(1434);
+				setState(1432);
 				invocationArg();
 				}
 				}
-				setState(1439);
+				setState(1437);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -8034,27 +8024,27 @@ public class BallerinaParser extends Parser {
 		InvocationArgContext _localctx = new InvocationArgContext(_ctx, getState());
 		enterRule(_localctx, 194, RULE_invocationArg);
 		try {
-			setState(1443);
+			setState(1441);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,158,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,157,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1440);
+				setState(1438);
 				expression(0);
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1441);
+				setState(1439);
 				namedArgs();
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(1442);
+				setState(1440);
 				restArgs();
 				}
 				break;
@@ -8101,20 +8091,20 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1446);
+			setState(1444);
 			_la = _input.LA(1);
 			if (_la==START) {
 				{
-				setState(1445);
+				setState(1443);
 				match(START);
 				}
 			}
 
-			setState(1448);
+			setState(1446);
 			nameReference();
-			setState(1449);
+			setState(1447);
 			match(RARROW);
-			setState(1450);
+			setState(1448);
 			functionInvocation();
 			}
 		}
@@ -8161,21 +8151,21 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1452);
+			setState(1450);
 			expression(0);
-			setState(1457);
+			setState(1455);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(1453);
+				setState(1451);
 				match(COMMA);
-				setState(1454);
+				setState(1452);
 				expression(0);
 				}
 				}
-				setState(1459);
+				setState(1457);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -8217,9 +8207,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1460);
+			setState(1458);
 			expression(0);
-			setState(1461);
+			setState(1459);
 			match(SEMICOLON);
 			}
 		}
@@ -8262,13 +8252,13 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1463);
+			setState(1461);
 			transactionClause();
-			setState(1465);
+			setState(1463);
 			_la = _input.LA(1);
 			if (_la==ONRETRY) {
 				{
-				setState(1464);
+				setState(1462);
 				onretryClause();
 				}
 			}
@@ -8321,36 +8311,36 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1467);
+			setState(1465);
 			match(TRANSACTION);
-			setState(1470);
+			setState(1468);
 			_la = _input.LA(1);
 			if (_la==WITH) {
 				{
-				setState(1468);
+				setState(1466);
 				match(WITH);
-				setState(1469);
+				setState(1467);
 				transactionPropertyInitStatementList();
 				}
 			}
 
-			setState(1472);
+			setState(1470);
 			match(LEFT_BRACE);
-			setState(1476);
+			setState(1474);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1473);
+				setState(1471);
 				statement();
 				}
 				}
-				setState(1478);
+				setState(1476);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1479);
+			setState(1477);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -8393,26 +8383,26 @@ public class BallerinaParser extends Parser {
 		TransactionPropertyInitStatementContext _localctx = new TransactionPropertyInitStatementContext(_ctx, getState());
 		enterRule(_localctx, 206, RULE_transactionPropertyInitStatement);
 		try {
-			setState(1484);
+			setState(1482);
 			switch (_input.LA(1)) {
 			case RETRIES:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1481);
+				setState(1479);
 				retriesStatement();
 				}
 				break;
 			case ONCOMMIT:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1482);
+				setState(1480);
 				oncommitStatement();
 				}
 				break;
 			case ONABORT:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(1483);
+				setState(1481);
 				onabortStatement();
 				}
 				break;
@@ -8463,21 +8453,21 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1486);
+			setState(1484);
 			transactionPropertyInitStatement();
-			setState(1491);
+			setState(1489);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(1487);
+				setState(1485);
 				match(COMMA);
-				setState(1488);
+				setState(1486);
 				transactionPropertyInitStatement();
 				}
 				}
-				setState(1493);
+				setState(1491);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -8525,25 +8515,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1494);
+			setState(1492);
 			match(LOCK);
-			setState(1495);
+			setState(1493);
 			match(LEFT_BRACE);
-			setState(1499);
+			setState(1497);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1496);
+				setState(1494);
 				statement();
 				}
 				}
-				setState(1501);
+				setState(1499);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1502);
+			setState(1500);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -8589,25 +8579,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1504);
+			setState(1502);
 			match(ONRETRY);
-			setState(1505);
+			setState(1503);
 			match(LEFT_BRACE);
-			setState(1509);
+			setState(1507);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(1506);
+				setState(1504);
 				statement();
 				}
 				}
-				setState(1511);
+				setState(1509);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1512);
+			setState(1510);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -8645,9 +8635,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1514);
+			setState(1512);
 			match(ABORT);
-			setState(1515);
+			setState(1513);
 			match(SEMICOLON);
 			}
 		}
@@ -8685,9 +8675,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1517);
+			setState(1515);
 			match(RETRY);
-			setState(1518);
+			setState(1516);
 			match(SEMICOLON);
 			}
 		}
@@ -8728,11 +8718,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1520);
+			setState(1518);
 			match(RETRIES);
-			setState(1521);
+			setState(1519);
 			match(ASSIGN);
-			setState(1522);
+			setState(1520);
 			expression(0);
 			}
 		}
@@ -8773,11 +8763,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1524);
+			setState(1522);
 			match(ONCOMMIT);
-			setState(1525);
+			setState(1523);
 			match(ASSIGN);
-			setState(1526);
+			setState(1524);
 			expression(0);
 			}
 		}
@@ -8818,11 +8808,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1528);
+			setState(1526);
 			match(ONABORT);
-			setState(1529);
+			setState(1527);
 			match(ASSIGN);
-			setState(1530);
+			setState(1528);
 			expression(0);
 			}
 		}
@@ -8861,7 +8851,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1532);
+			setState(1530);
 			namespaceDeclaration();
 			}
 		}
@@ -8903,22 +8893,22 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1534);
+			setState(1532);
 			match(XMLNS);
-			setState(1535);
+			setState(1533);
 			match(QuotedStringLiteral);
-			setState(1538);
+			setState(1536);
 			_la = _input.LA(1);
 			if (_la==AS) {
 				{
-				setState(1536);
+				setState(1534);
 				match(AS);
-				setState(1537);
+				setState(1535);
 				match(Identifier);
 				}
 			}
 
-			setState(1540);
+			setState(1538);
 			match(SEMICOLON);
 			}
 		}
@@ -9430,16 +9420,16 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1583);
+			setState(1581);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,172,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,171,_ctx) ) {
 			case 1:
 				{
 				_localctx = new SimpleLiteralExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
 
-				setState(1543);
+				setState(1541);
 				simpleLiteral();
 				}
 				break;
@@ -9448,7 +9438,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new ArrayLiteralExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1544);
+				setState(1542);
 				arrayLiteral();
 				}
 				break;
@@ -9457,7 +9447,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new RecordLiteralExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1545);
+				setState(1543);
 				recordLiteral();
 				}
 				break;
@@ -9466,7 +9456,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new XmlLiteralExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1546);
+				setState(1544);
 				xmlLiteral();
 				}
 				break;
@@ -9475,7 +9465,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new TableLiteralExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1547);
+				setState(1545);
 				tableLiteral();
 				}
 				break;
@@ -9484,7 +9474,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new StringTemplateLiteralExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1548);
+				setState(1546);
 				stringTemplateLiteral();
 				}
 				break;
@@ -9493,17 +9483,17 @@ public class BallerinaParser extends Parser {
 				_localctx = new VariableReferenceExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1550);
+				setState(1548);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,169,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,168,_ctx) ) {
 				case 1:
 					{
-					setState(1549);
+					setState(1547);
 					match(START);
 					}
 					break;
 				}
-				setState(1552);
+				setState(1550);
 				variableReference(0);
 				}
 				break;
@@ -9512,7 +9502,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new ActionInvocationExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1553);
+				setState(1551);
 				actionInvocation();
 				}
 				break;
@@ -9521,7 +9511,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new LambdaFunctionExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1554);
+				setState(1552);
 				lambdaFunction();
 				}
 				break;
@@ -9530,7 +9520,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new TypeInitExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1555);
+				setState(1553);
 				typeInitExpr();
 				}
 				break;
@@ -9539,7 +9529,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new TableQueryExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1556);
+				setState(1554);
 				tableQuery();
 				}
 				break;
@@ -9548,24 +9538,24 @@ public class BallerinaParser extends Parser {
 				_localctx = new TypeConversionExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1557);
+				setState(1555);
 				match(LT);
-				setState(1558);
+				setState(1556);
 				typeName(0);
-				setState(1561);
+				setState(1559);
 				_la = _input.LA(1);
 				if (_la==COMMA) {
 					{
-					setState(1559);
+					setState(1557);
 					match(COMMA);
-					setState(1560);
+					setState(1558);
 					functionInvocation();
 					}
 				}
 
-				setState(1563);
+				setState(1561);
 				match(GT);
-				setState(1564);
+				setState(1562);
 				expression(17);
 				}
 				break;
@@ -9574,14 +9564,14 @@ public class BallerinaParser extends Parser {
 				_localctx = new UnaryExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1566);
+				setState(1564);
 				_la = _input.LA(1);
 				if ( !(((((_la - 111)) & ~0x3f) == 0 && ((1L << (_la - 111)) & ((1L << (LENGTHOF - 111)) | (1L << (UNTAINT - 111)) | (1L << (ADD - 111)) | (1L << (SUB - 111)) | (1L << (NOT - 111)))) != 0)) ) {
 				_errHandler.recoverInline(this);
 				} else {
 					consume();
 				}
-				setState(1567);
+				setState(1565);
 				expression(16);
 				}
 				break;
@@ -9590,27 +9580,27 @@ public class BallerinaParser extends Parser {
 				_localctx = new BracedOrTupleExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1568);
+				setState(1566);
 				match(LEFT_PARENTHESIS);
-				setState(1569);
+				setState(1567);
 				expression(0);
-				setState(1574);
+				setState(1572);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					setState(1570);
+					setState(1568);
 					match(COMMA);
-					setState(1571);
+					setState(1569);
 					expression(0);
 					}
 					}
-					setState(1576);
+					setState(1574);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
-				setState(1577);
+				setState(1575);
 				match(RIGHT_PARENTHESIS);
 				}
 				break;
@@ -9619,7 +9609,7 @@ public class BallerinaParser extends Parser {
 				_localctx = new AwaitExprExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1579);
+				setState(1577);
 				awaitExpression();
 				}
 				break;
@@ -9628,9 +9618,9 @@ public class BallerinaParser extends Parser {
 				_localctx = new CheckedExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1580);
+				setState(1578);
 				match(CHECK);
-				setState(1581);
+				setState(1579);
 				expression(3);
 				}
 				break;
@@ -9639,32 +9629,32 @@ public class BallerinaParser extends Parser {
 				_localctx = new TypeAccessExpressionContext(_localctx);
 				_ctx = _localctx;
 				_prevctx = _localctx;
-				setState(1582);
+				setState(1580);
 				typeName(0);
 				}
 				break;
 			}
 			_ctx.stop = _input.LT(-1);
-			setState(1622);
+			setState(1620);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,174,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,173,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) triggerExitRuleEvent();
 					_prevctx = _localctx;
 					{
-					setState(1620);
+					setState(1618);
 					_errHandler.sync(this);
-					switch ( getInterpreter().adaptivePredict(_input,173,_ctx) ) {
+					switch ( getInterpreter().adaptivePredict(_input,172,_ctx) ) {
 					case 1:
 						{
 						_localctx = new BinaryPowExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1585);
+						setState(1583);
 						if (!(precpred(_ctx, 14))) throw new FailedPredicateException(this, "precpred(_ctx, 14)");
-						setState(1586);
+						setState(1584);
 						match(POW);
-						setState(1587);
+						setState(1585);
 						expression(15);
 						}
 						break;
@@ -9672,16 +9662,16 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new BinaryDivMulModExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1588);
+						setState(1586);
 						if (!(precpred(_ctx, 13))) throw new FailedPredicateException(this, "precpred(_ctx, 13)");
-						setState(1589);
+						setState(1587);
 						_la = _input.LA(1);
 						if ( !(((((_la - 136)) & ~0x3f) == 0 && ((1L << (_la - 136)) & ((1L << (MUL - 136)) | (1L << (DIV - 136)) | (1L << (MOD - 136)))) != 0)) ) {
 						_errHandler.recoverInline(this);
 						} else {
 							consume();
 						}
-						setState(1590);
+						setState(1588);
 						expression(14);
 						}
 						break;
@@ -9689,16 +9679,16 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new BinaryAddSubExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1591);
+						setState(1589);
 						if (!(precpred(_ctx, 12))) throw new FailedPredicateException(this, "precpred(_ctx, 12)");
-						setState(1592);
+						setState(1590);
 						_la = _input.LA(1);
 						if ( !(_la==ADD || _la==SUB) ) {
 						_errHandler.recoverInline(this);
 						} else {
 							consume();
 						}
-						setState(1593);
+						setState(1591);
 						expression(13);
 						}
 						break;
@@ -9706,16 +9696,16 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new BinaryCompareExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1594);
+						setState(1592);
 						if (!(precpred(_ctx, 11))) throw new FailedPredicateException(this, "precpred(_ctx, 11)");
-						setState(1595);
+						setState(1593);
 						_la = _input.LA(1);
 						if ( !(((((_la - 143)) & ~0x3f) == 0 && ((1L << (_la - 143)) & ((1L << (GT - 143)) | (1L << (LT - 143)) | (1L << (GT_EQUAL - 143)) | (1L << (LT_EQUAL - 143)))) != 0)) ) {
 						_errHandler.recoverInline(this);
 						} else {
 							consume();
 						}
-						setState(1596);
+						setState(1594);
 						expression(12);
 						}
 						break;
@@ -9723,16 +9713,16 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new BinaryEqualExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1597);
+						setState(1595);
 						if (!(precpred(_ctx, 10))) throw new FailedPredicateException(this, "precpred(_ctx, 10)");
-						setState(1598);
+						setState(1596);
 						_la = _input.LA(1);
 						if ( !(_la==EQUAL || _la==NOT_EQUAL) ) {
 						_errHandler.recoverInline(this);
 						} else {
 							consume();
 						}
-						setState(1599);
+						setState(1597);
 						expression(11);
 						}
 						break;
@@ -9740,11 +9730,11 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new BinaryAndExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1600);
+						setState(1598);
 						if (!(precpred(_ctx, 9))) throw new FailedPredicateException(this, "precpred(_ctx, 9)");
-						setState(1601);
+						setState(1599);
 						match(AND);
-						setState(1602);
+						setState(1600);
 						expression(10);
 						}
 						break;
@@ -9752,11 +9742,11 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new BinaryOrExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1603);
+						setState(1601);
 						if (!(precpred(_ctx, 8))) throw new FailedPredicateException(this, "precpred(_ctx, 8)");
-						setState(1604);
+						setState(1602);
 						match(OR);
-						setState(1605);
+						setState(1603);
 						expression(9);
 						}
 						break;
@@ -9764,16 +9754,16 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new IntegerRangeExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1606);
+						setState(1604);
 						if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
-						setState(1607);
+						setState(1605);
 						_la = _input.LA(1);
 						if ( !(_la==ELLIPSIS || _la==HALF_OPEN_RANGE) ) {
 						_errHandler.recoverInline(this);
 						} else {
 							consume();
 						}
-						setState(1608);
+						setState(1606);
 						expression(8);
 						}
 						break;
@@ -9781,15 +9771,15 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new TernaryExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1609);
+						setState(1607);
 						if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
-						setState(1610);
+						setState(1608);
 						match(QUESTION_MARK);
-						setState(1611);
+						setState(1609);
 						expression(0);
-						setState(1612);
+						setState(1610);
 						match(COLON);
-						setState(1613);
+						setState(1611);
 						expression(7);
 						}
 						break;
@@ -9797,11 +9787,11 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new ElvisExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1615);
+						setState(1613);
 						if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-						setState(1616);
+						setState(1614);
 						match(ELVIS);
-						setState(1617);
+						setState(1615);
 						expression(3);
 						}
 						break;
@@ -9809,18 +9799,18 @@ public class BallerinaParser extends Parser {
 						{
 						_localctx = new MatchExprExpressionContext(new ExpressionContext(_parentctx, _parentState));
 						pushNewRecursionContext(_localctx, _startState, RULE_expression);
-						setState(1618);
+						setState(1616);
 						if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
-						setState(1619);
+						setState(1617);
 						matchExpression();
 						}
 						break;
 					}
 					} 
 				}
-				setState(1624);
+				setState(1622);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,174,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,173,_ctx);
 			}
 			}
 		}
@@ -9869,9 +9859,9 @@ public class BallerinaParser extends Parser {
 			_localctx = new AwaitExprContext(_localctx);
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1625);
+			setState(1623);
 			match(AWAIT);
-			setState(1626);
+			setState(1624);
 			expression(0);
 			}
 		}
@@ -9921,29 +9911,29 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1628);
+			setState(1626);
 			match(BUT);
-			setState(1629);
+			setState(1627);
 			match(LEFT_BRACE);
-			setState(1630);
+			setState(1628);
 			matchExpressionPatternClause();
-			setState(1635);
+			setState(1633);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(1631);
+				setState(1629);
 				match(COMMA);
-				setState(1632);
+				setState(1630);
 				matchExpressionPatternClause();
 				}
 				}
-				setState(1637);
+				setState(1635);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1638);
+			setState(1636);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -9988,20 +9978,20 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1640);
+			setState(1638);
 			typeName(0);
-			setState(1642);
+			setState(1640);
 			_la = _input.LA(1);
 			if (_la==Identifier) {
 				{
-				setState(1641);
+				setState(1639);
 				match(Identifier);
 				}
 			}
 
-			setState(1644);
+			setState(1642);
 			match(EQUAL_GT);
-			setState(1645);
+			setState(1643);
 			expression(0);
 			}
 		}
@@ -10042,19 +10032,19 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1649);
+			setState(1647);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,177,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,176,_ctx) ) {
 			case 1:
 				{
-				setState(1647);
+				setState(1645);
 				match(Identifier);
-				setState(1648);
+				setState(1646);
 				match(COLON);
 				}
 				break;
 			}
-			setState(1651);
+			setState(1649);
 			match(Identifier);
 			}
 		}
@@ -10095,19 +10085,19 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1655);
+			setState(1653);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,178,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,177,_ctx) ) {
 			case 1:
 				{
-				setState(1653);
+				setState(1651);
 				match(Identifier);
-				setState(1654);
+				setState(1652);
 				match(COLON);
 				}
 				break;
 			}
-			setState(1657);
+			setState(1655);
 			anyIdentifierName();
 			}
 		}
@@ -10154,23 +10144,23 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1659);
+			setState(1657);
 			match(RETURNS);
-			setState(1663);
+			setState(1661);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==AT) {
 				{
 				{
-				setState(1660);
+				setState(1658);
 				annotationAttachment();
 				}
 				}
-				setState(1665);
+				setState(1663);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1666);
+			setState(1664);
 			typeName(0);
 			}
 		}
@@ -10216,21 +10206,21 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1671);
+			setState(1669);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==AT) {
 				{
 				{
-				setState(1668);
+				setState(1666);
 				annotationAttachment();
 				}
 				}
-				setState(1673);
+				setState(1671);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1674);
+			setState(1672);
 			typeName(0);
 			}
 		}
@@ -10277,21 +10267,21 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1676);
+			setState(1674);
 			parameterTypeName();
-			setState(1681);
+			setState(1679);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(1677);
+				setState(1675);
 				match(COMMA);
-				setState(1678);
+				setState(1676);
 				parameterTypeName();
 				}
 				}
-				setState(1683);
+				setState(1681);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -10332,7 +10322,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1684);
+			setState(1682);
 			typeName(0);
 			}
 		}
@@ -10379,21 +10369,21 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1686);
+			setState(1684);
 			parameter();
-			setState(1691);
+			setState(1689);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(1687);
+				setState(1685);
 				match(COMMA);
-				setState(1688);
+				setState(1686);
 				parameter();
 				}
 				}
-				setState(1693);
+				setState(1691);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -10481,30 +10471,30 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 250, RULE_parameter);
 		int _la;
 		try {
-			setState(1723);
+			setState(1721);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,186,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,185,_ctx) ) {
 			case 1:
 				_localctx = new SimpleParameterContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1697);
+				setState(1695);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (_la==AT) {
 					{
 					{
-					setState(1694);
+					setState(1692);
 					annotationAttachment();
 					}
 					}
-					setState(1699);
+					setState(1697);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
-				setState(1700);
+				setState(1698);
 				typeName(0);
-				setState(1701);
+				setState(1699);
 				match(Identifier);
 				}
 				break;
@@ -10512,45 +10502,45 @@ public class BallerinaParser extends Parser {
 				_localctx = new TupleParameterContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1706);
+				setState(1704);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (_la==AT) {
 					{
 					{
-					setState(1703);
+					setState(1701);
 					annotationAttachment();
 					}
 					}
-					setState(1708);
+					setState(1706);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
-				setState(1709);
+				setState(1707);
 				match(LEFT_PARENTHESIS);
-				setState(1710);
+				setState(1708);
 				typeName(0);
-				setState(1711);
+				setState(1709);
 				match(Identifier);
-				setState(1718);
+				setState(1716);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					setState(1712);
+					setState(1710);
 					match(COMMA);
-					setState(1713);
+					setState(1711);
 					typeName(0);
-					setState(1714);
+					setState(1712);
 					match(Identifier);
 					}
 					}
-					setState(1720);
+					setState(1718);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
-				setState(1721);
+				setState(1719);
 				match(RIGHT_PARENTHESIS);
 				}
 				break;
@@ -10595,11 +10585,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1725);
+			setState(1723);
 			parameter();
-			setState(1726);
+			setState(1724);
 			match(ASSIGN);
-			setState(1727);
+			setState(1725);
 			expression(0);
 			}
 		}
@@ -10647,25 +10637,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1732);
+			setState(1730);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==AT) {
 				{
 				{
-				setState(1729);
+				setState(1727);
 				annotationAttachment();
 				}
 				}
-				setState(1734);
+				setState(1732);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1735);
+			setState(1733);
 			typeName(0);
-			setState(1736);
+			setState(1734);
 			match(ELLIPSIS);
-			setState(1737);
+			setState(1735);
 			match(Identifier);
 			}
 		}
@@ -10720,49 +10710,49 @@ public class BallerinaParser extends Parser {
 		int _la;
 		try {
 			int _alt;
-			setState(1758);
+			setState(1756);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,192,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,191,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1741);
+				setState(1739);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,188,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,187,_ctx) ) {
 				case 1:
 					{
-					setState(1739);
+					setState(1737);
 					parameter();
 					}
 					break;
 				case 2:
 					{
-					setState(1740);
+					setState(1738);
 					defaultableParameter();
 					}
 					break;
 				}
-				setState(1750);
+				setState(1748);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,190,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,189,_ctx);
 				while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 					if ( _alt==1 ) {
 						{
 						{
-						setState(1743);
+						setState(1741);
 						match(COMMA);
-						setState(1746);
+						setState(1744);
 						_errHandler.sync(this);
-						switch ( getInterpreter().adaptivePredict(_input,189,_ctx) ) {
+						switch ( getInterpreter().adaptivePredict(_input,188,_ctx) ) {
 						case 1:
 							{
-							setState(1744);
+							setState(1742);
 							parameter();
 							}
 							break;
 						case 2:
 							{
-							setState(1745);
+							setState(1743);
 							defaultableParameter();
 							}
 							break;
@@ -10770,17 +10760,17 @@ public class BallerinaParser extends Parser {
 						}
 						} 
 					}
-					setState(1752);
+					setState(1750);
 					_errHandler.sync(this);
-					_alt = getInterpreter().adaptivePredict(_input,190,_ctx);
+					_alt = getInterpreter().adaptivePredict(_input,189,_ctx);
 				}
-				setState(1755);
+				setState(1753);
 				_la = _input.LA(1);
 				if (_la==COMMA) {
 					{
-					setState(1753);
+					setState(1751);
 					match(COMMA);
-					setState(1754);
+					setState(1752);
 					restParameter();
 					}
 				}
@@ -10790,7 +10780,7 @@ public class BallerinaParser extends Parser {
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1757);
+				setState(1755);
 				restParameter();
 				}
 				break;
@@ -10841,73 +10831,73 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 258, RULE_simpleLiteral);
 		int _la;
 		try {
-			setState(1773);
+			setState(1771);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,195,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,194,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1761);
+				setState(1759);
 				_la = _input.LA(1);
 				if (_la==SUB) {
 					{
-					setState(1760);
+					setState(1758);
 					match(SUB);
 					}
 				}
 
-				setState(1763);
+				setState(1761);
 				integerLiteral();
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1765);
+				setState(1763);
 				_la = _input.LA(1);
 				if (_la==SUB) {
 					{
-					setState(1764);
+					setState(1762);
 					match(SUB);
 					}
 				}
 
-				setState(1767);
+				setState(1765);
 				match(FloatingPointLiteral);
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(1768);
+				setState(1766);
 				match(QuotedStringLiteral);
 				}
 				break;
 			case 4:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(1769);
+				setState(1767);
 				match(BooleanLiteral);
 				}
 				break;
 			case 5:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(1770);
+				setState(1768);
 				emptyTupleLiteral();
 				}
 				break;
 			case 6:
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(1771);
+				setState(1769);
 				blobLiteral();
 				}
 				break;
 			case 7:
 				enterOuterAlt(_localctx, 7);
 				{
-				setState(1772);
+				setState(1770);
 				match(NullLiteral);
 				}
 				break;
@@ -10950,7 +10940,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1775);
+			setState(1773);
 			_la = _input.LA(1);
 			if ( !(((((_la - 165)) & ~0x3f) == 0 && ((1L << (_la - 165)) & ((1L << (DecimalIntegerLiteral - 165)) | (1L << (HexIntegerLiteral - 165)) | (1L << (OctalIntegerLiteral - 165)) | (1L << (BinaryIntegerLiteral - 165)))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -10993,9 +10983,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1777);
+			setState(1775);
 			match(LEFT_PARENTHESIS);
-			setState(1778);
+			setState(1776);
 			match(RIGHT_PARENTHESIS);
 			}
 		}
@@ -11034,7 +11024,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1780);
+			setState(1778);
 			_la = _input.LA(1);
 			if ( !(_la==Base16BlobLiteral || _la==Base64BlobLiteral) ) {
 			_errHandler.recoverInline(this);
@@ -11080,11 +11070,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1782);
+			setState(1780);
 			match(Identifier);
-			setState(1783);
+			setState(1781);
 			match(ASSIGN);
-			setState(1784);
+			setState(1782);
 			expression(0);
 			}
 		}
@@ -11124,9 +11114,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1786);
+			setState(1784);
 			match(ELLIPSIS);
-			setState(1787);
+			setState(1785);
 			expression(0);
 			}
 		}
@@ -11167,11 +11157,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1789);
+			setState(1787);
 			match(XMLLiteralStart);
-			setState(1790);
+			setState(1788);
 			xmlItem();
-			setState(1791);
+			setState(1789);
 			match(XMLLiteralEnd);
 			}
 		}
@@ -11218,26 +11208,26 @@ public class BallerinaParser extends Parser {
 		XmlItemContext _localctx = new XmlItemContext(_ctx, getState());
 		enterRule(_localctx, 272, RULE_xmlItem);
 		try {
-			setState(1798);
+			setState(1796);
 			switch (_input.LA(1)) {
 			case XML_TAG_OPEN:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1793);
+				setState(1791);
 				element();
 				}
 				break;
 			case XML_TAG_SPECIAL_OPEN:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1794);
+				setState(1792);
 				procIns();
 				}
 				break;
 			case XML_COMMENT_START:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(1795);
+				setState(1793);
 				comment();
 				}
 				break;
@@ -11245,14 +11235,14 @@ public class BallerinaParser extends Parser {
 			case XMLText:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(1796);
+				setState(1794);
 				text();
 				}
 				break;
 			case CDATA:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(1797);
+				setState(1795);
 				match(CDATA);
 				}
 				break;
@@ -11321,62 +11311,62 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1801);
+			setState(1799);
 			_la = _input.LA(1);
 			if (_la==XMLTemplateText || _la==XMLText) {
 				{
-				setState(1800);
+				setState(1798);
 				text();
 				}
 			}
 
-			setState(1814);
+			setState(1812);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (((((_la - 185)) & ~0x3f) == 0 && ((1L << (_la - 185)) & ((1L << (XML_COMMENT_START - 185)) | (1L << (CDATA - 185)) | (1L << (XML_TAG_OPEN - 185)) | (1L << (XML_TAG_SPECIAL_OPEN - 185)))) != 0)) {
 				{
 				{
-				setState(1807);
+				setState(1805);
 				switch (_input.LA(1)) {
 				case XML_TAG_OPEN:
 					{
-					setState(1803);
+					setState(1801);
 					element();
 					}
 					break;
 				case CDATA:
 					{
-					setState(1804);
+					setState(1802);
 					match(CDATA);
 					}
 					break;
 				case XML_TAG_SPECIAL_OPEN:
 					{
-					setState(1805);
+					setState(1803);
 					procIns();
 					}
 					break;
 				case XML_COMMENT_START:
 					{
-					setState(1806);
+					setState(1804);
 					comment();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				setState(1810);
+				setState(1808);
 				_la = _input.LA(1);
 				if (_la==XMLTemplateText || _la==XMLText) {
 					{
-					setState(1809);
+					setState(1807);
 					text();
 					}
 				}
 
 				}
 				}
-				setState(1816);
+				setState(1814);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -11431,27 +11421,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1817);
+			setState(1815);
 			match(XML_COMMENT_START);
-			setState(1824);
+			setState(1822);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==XMLCommentTemplateText) {
 				{
 				{
-				setState(1818);
+				setState(1816);
 				match(XMLCommentTemplateText);
-				setState(1819);
+				setState(1817);
 				expression(0);
-				setState(1820);
+				setState(1818);
 				match(ExpressionEnd);
 				}
 				}
-				setState(1826);
+				setState(1824);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1827);
+			setState(1825);
 			match(XMLCommentText);
 			}
 		}
@@ -11497,24 +11487,24 @@ public class BallerinaParser extends Parser {
 		ElementContext _localctx = new ElementContext(_ctx, getState());
 		enterRule(_localctx, 278, RULE_element);
 		try {
-			setState(1834);
+			setState(1832);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,202,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,201,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1829);
+				setState(1827);
 				startTag();
-				setState(1830);
+				setState(1828);
 				content();
-				setState(1831);
+				setState(1829);
 				closeTag();
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1833);
+				setState(1831);
 				emptyTag();
 				}
 				break;
@@ -11564,25 +11554,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1836);
+			setState(1834);
 			match(XML_TAG_OPEN);
-			setState(1837);
+			setState(1835);
 			xmlQualifiedName();
-			setState(1841);
+			setState(1839);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==XMLQName || _la==XMLTagExpressionStart) {
 				{
 				{
-				setState(1838);
+				setState(1836);
 				attribute();
 				}
 				}
-				setState(1843);
+				setState(1841);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1844);
+			setState(1842);
 			match(XML_TAG_CLOSE);
 			}
 		}
@@ -11623,11 +11613,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1846);
+			setState(1844);
 			match(XML_TAG_OPEN_SLASH);
-			setState(1847);
+			setState(1845);
 			xmlQualifiedName();
-			setState(1848);
+			setState(1846);
 			match(XML_TAG_CLOSE);
 			}
 		}
@@ -11675,25 +11665,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1850);
+			setState(1848);
 			match(XML_TAG_OPEN);
-			setState(1851);
+			setState(1849);
 			xmlQualifiedName();
-			setState(1855);
+			setState(1853);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==XMLQName || _la==XMLTagExpressionStart) {
 				{
 				{
-				setState(1852);
+				setState(1850);
 				attribute();
 				}
 				}
-				setState(1857);
+				setState(1855);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1858);
+			setState(1856);
 			match(XML_TAG_SLASH_CLOSE);
 			}
 		}
@@ -11746,27 +11736,27 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1860);
+			setState(1858);
 			match(XML_TAG_SPECIAL_OPEN);
-			setState(1867);
+			setState(1865);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==XMLPITemplateText) {
 				{
 				{
-				setState(1861);
+				setState(1859);
 				match(XMLPITemplateText);
-				setState(1862);
+				setState(1860);
 				expression(0);
-				setState(1863);
+				setState(1861);
 				match(ExpressionEnd);
 				}
 				}
-				setState(1869);
+				setState(1867);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1870);
+			setState(1868);
 			match(XMLPIText);
 			}
 		}
@@ -11809,11 +11799,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1872);
+			setState(1870);
 			xmlQualifiedName();
-			setState(1873);
+			setState(1871);
 			match(EQUALS);
-			setState(1874);
+			setState(1872);
 			xmlQuotedString();
 			}
 		}
@@ -11863,34 +11853,34 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 290, RULE_text);
 		int _la;
 		try {
-			setState(1888);
+			setState(1886);
 			switch (_input.LA(1)) {
 			case XMLTemplateText:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1880); 
+				setState(1878); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				do {
 					{
 					{
-					setState(1876);
+					setState(1874);
 					match(XMLTemplateText);
-					setState(1877);
+					setState(1875);
 					expression(0);
-					setState(1878);
+					setState(1876);
 					match(ExpressionEnd);
 					}
 					}
-					setState(1882); 
+					setState(1880); 
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				} while ( _la==XMLTemplateText );
-				setState(1885);
+				setState(1883);
 				_la = _input.LA(1);
 				if (_la==XMLText) {
 					{
-					setState(1884);
+					setState(1882);
 					match(XMLText);
 					}
 				}
@@ -11900,7 +11890,7 @@ public class BallerinaParser extends Parser {
 			case XMLText:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1887);
+				setState(1885);
 				match(XMLText);
 				}
 				break;
@@ -11944,19 +11934,19 @@ public class BallerinaParser extends Parser {
 		XmlQuotedStringContext _localctx = new XmlQuotedStringContext(_ctx, getState());
 		enterRule(_localctx, 292, RULE_xmlQuotedString);
 		try {
-			setState(1892);
+			setState(1890);
 			switch (_input.LA(1)) {
 			case SINGLE_QUOTE:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1890);
+				setState(1888);
 				xmlSingleQuotedString();
 				}
 				break;
 			case DOUBLE_QUOTE:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1891);
+				setState(1889);
 				xmlDoubleQuotedString();
 				}
 				break;
@@ -12014,36 +12004,36 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1894);
+			setState(1892);
 			match(SINGLE_QUOTE);
-			setState(1901);
+			setState(1899);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==XMLSingleQuotedTemplateString) {
 				{
 				{
-				setState(1895);
+				setState(1893);
 				match(XMLSingleQuotedTemplateString);
-				setState(1896);
+				setState(1894);
 				expression(0);
-				setState(1897);
+				setState(1895);
 				match(ExpressionEnd);
 				}
 				}
-				setState(1903);
+				setState(1901);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1905);
+			setState(1903);
 			_la = _input.LA(1);
 			if (_la==XMLSingleQuotedString) {
 				{
-				setState(1904);
+				setState(1902);
 				match(XMLSingleQuotedString);
 				}
 			}
 
-			setState(1907);
+			setState(1905);
 			match(SINGLE_QUOTE_END);
 			}
 		}
@@ -12097,36 +12087,36 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1909);
+			setState(1907);
 			match(DOUBLE_QUOTE);
-			setState(1916);
+			setState(1914);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==XMLDoubleQuotedTemplateString) {
 				{
 				{
-				setState(1910);
+				setState(1908);
 				match(XMLDoubleQuotedTemplateString);
-				setState(1911);
+				setState(1909);
 				expression(0);
-				setState(1912);
+				setState(1910);
 				match(ExpressionEnd);
 				}
 				}
-				setState(1918);
+				setState(1916);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(1920);
+			setState(1918);
 			_la = _input.LA(1);
 			if (_la==XMLDoubleQuotedString) {
 				{
-				setState(1919);
+				setState(1917);
 				match(XMLDoubleQuotedString);
 				}
 			}
 
-			setState(1922);
+			setState(1920);
 			match(DOUBLE_QUOTE_END);
 			}
 		}
@@ -12170,35 +12160,35 @@ public class BallerinaParser extends Parser {
 		XmlQualifiedNameContext _localctx = new XmlQualifiedNameContext(_ctx, getState());
 		enterRule(_localctx, 298, RULE_xmlQualifiedName);
 		try {
-			setState(1933);
+			setState(1931);
 			switch (_input.LA(1)) {
 			case XMLQName:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1926);
+				setState(1924);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,214,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,213,_ctx) ) {
 				case 1:
 					{
-					setState(1924);
+					setState(1922);
 					match(XMLQName);
-					setState(1925);
+					setState(1923);
 					match(QNAME_SEPARATOR);
 					}
 					break;
 				}
-				setState(1928);
+				setState(1926);
 				match(XMLQName);
 				}
 				break;
 			case XMLTagExpressionStart:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1929);
+				setState(1927);
 				match(XMLTagExpressionStart);
-				setState(1930);
+				setState(1928);
 				expression(0);
-				setState(1931);
+				setState(1929);
 				match(ExpressionEnd);
 				}
 				break;
@@ -12244,18 +12234,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1935);
+			setState(1933);
 			match(StringTemplateLiteralStart);
-			setState(1937);
+			setState(1935);
 			_la = _input.LA(1);
 			if (_la==StringTemplateExpressionStart || _la==StringTemplateText) {
 				{
-				setState(1936);
+				setState(1934);
 				stringTemplateContent();
 				}
 			}
 
-			setState(1939);
+			setState(1937);
 			match(StringTemplateLiteralEnd);
 			}
 		}
@@ -12305,34 +12295,34 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 302, RULE_stringTemplateContent);
 		int _la;
 		try {
-			setState(1953);
+			setState(1951);
 			switch (_input.LA(1)) {
 			case StringTemplateExpressionStart:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1945); 
+				setState(1943); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				do {
 					{
 					{
-					setState(1941);
+					setState(1939);
 					match(StringTemplateExpressionStart);
-					setState(1942);
+					setState(1940);
 					expression(0);
-					setState(1943);
+					setState(1941);
 					match(ExpressionEnd);
 					}
 					}
-					setState(1947); 
+					setState(1945); 
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				} while ( _la==StringTemplateExpressionStart );
-				setState(1950);
+				setState(1948);
 				_la = _input.LA(1);
 				if (_la==StringTemplateText) {
 					{
-					setState(1949);
+					setState(1947);
 					match(StringTemplateText);
 					}
 				}
@@ -12342,7 +12332,7 @@ public class BallerinaParser extends Parser {
 			case StringTemplateText:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1952);
+				setState(1950);
 				match(StringTemplateText);
 				}
 				break;
@@ -12384,12 +12374,12 @@ public class BallerinaParser extends Parser {
 		AnyIdentifierNameContext _localctx = new AnyIdentifierNameContext(_ctx, getState());
 		enterRule(_localctx, 304, RULE_anyIdentifierName);
 		try {
-			setState(1957);
+			setState(1955);
 			switch (_input.LA(1)) {
 			case Identifier:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(1955);
+				setState(1953);
 				match(Identifier);
 				}
 				break;
@@ -12399,7 +12389,7 @@ public class BallerinaParser extends Parser {
 			case START:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(1956);
+				setState(1954);
 				reservedWord();
 				}
 				break;
@@ -12444,7 +12434,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1959);
+			setState(1957);
 			_la = _input.LA(1);
 			if ( !(((((_la - 76)) & ~0x3f) == 0 && ((1L << (_la - 76)) & ((1L << (TYPE_MAP - 76)) | (1L << (FOREACH - 76)) | (1L << (CONTINUE - 76)) | (1L << (START - 76)))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -12501,46 +12491,46 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1961);
+			setState(1959);
 			match(FROM);
-			setState(1962);
+			setState(1960);
 			streamingInput();
-			setState(1964);
+			setState(1962);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,221,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,220,_ctx) ) {
 			case 1:
 				{
-				setState(1963);
+				setState(1961);
 				joinStreamingInput();
 				}
 				break;
 			}
-			setState(1967);
+			setState(1965);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,222,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,221,_ctx) ) {
 			case 1:
 				{
-				setState(1966);
+				setState(1964);
 				selectClause();
 				}
 				break;
 			}
-			setState(1970);
+			setState(1968);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,223,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,222,_ctx) ) {
 			case 1:
 				{
-				setState(1969);
+				setState(1967);
 				orderByClause();
 				}
 				break;
 			}
-			setState(1973);
+			setState(1971);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,224,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,223,_ctx) ) {
 			case 1:
 				{
-				setState(1972);
+				setState(1970);
 				limitClause();
 				}
 				break;
@@ -12589,25 +12579,25 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1975);
+			setState(1973);
 			match(FOREVER);
-			setState(1976);
+			setState(1974);
 			match(LEFT_BRACE);
-			setState(1978); 
+			setState(1976); 
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			do {
 				{
 				{
-				setState(1977);
+				setState(1975);
 				streamingQueryStatement();
 				}
 				}
-				setState(1980); 
+				setState(1978); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			} while ( _la==FROM );
-			setState(1982);
+			setState(1980);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -12645,9 +12635,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1984);
+			setState(1982);
 			match(DONE);
-			setState(1985);
+			setState(1983);
 			match(SEMICOLON);
 			}
 		}
@@ -12706,20 +12696,20 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(1987);
+			setState(1985);
 			match(FROM);
-			setState(1993);
+			setState(1991);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,227,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,226,_ctx) ) {
 			case 1:
 				{
-				setState(1988);
+				setState(1986);
 				streamingInput();
-				setState(1990);
+				setState(1988);
 				_la = _input.LA(1);
 				if (((((_la - 48)) & ~0x3f) == 0 && ((1L << (_la - 48)) & ((1L << (INNER - 48)) | (1L << (OUTER - 48)) | (1L << (RIGHT - 48)) | (1L << (LEFT - 48)) | (1L << (FULL - 48)) | (1L << (UNIDIRECTIONAL - 48)) | (1L << (JOIN - 48)))) != 0)) {
 					{
-					setState(1989);
+					setState(1987);
 					joinStreamingInput();
 					}
 				}
@@ -12728,39 +12718,39 @@ public class BallerinaParser extends Parser {
 				break;
 			case 2:
 				{
-				setState(1992);
+				setState(1990);
 				patternClause();
 				}
 				break;
 			}
-			setState(1996);
+			setState(1994);
 			_la = _input.LA(1);
 			if (_la==SELECT) {
 				{
-				setState(1995);
+				setState(1993);
 				selectClause();
 				}
 			}
 
-			setState(1999);
+			setState(1997);
 			_la = _input.LA(1);
 			if (_la==ORDER) {
 				{
-				setState(1998);
+				setState(1996);
 				orderByClause();
 				}
 			}
 
-			setState(2002);
+			setState(2000);
 			_la = _input.LA(1);
 			if (_la==OUTPUT) {
 				{
-				setState(2001);
+				setState(1999);
 				outputRateLimit();
 				}
 			}
 
-			setState(2004);
+			setState(2002);
 			streamingAction();
 			}
 		}
@@ -12804,22 +12794,22 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2007);
+			setState(2005);
 			_la = _input.LA(1);
 			if (_la==EVERY) {
 				{
-				setState(2006);
+				setState(2004);
 				match(EVERY);
 				}
 			}
 
-			setState(2009);
+			setState(2007);
 			patternStreamingInput();
-			setState(2011);
+			setState(2009);
 			_la = _input.LA(1);
 			if (_la==WITHIN) {
 				{
-				setState(2010);
+				setState(2008);
 				withinClause();
 				}
 			}
@@ -12863,11 +12853,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2013);
+			setState(2011);
 			match(WITHIN);
-			setState(2014);
+			setState(2012);
 			match(DecimalIntegerLiteral);
-			setState(2015);
+			setState(2013);
 			timeScale();
 			}
 		}
@@ -12916,29 +12906,29 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2017);
+			setState(2015);
 			match(ORDER);
-			setState(2018);
+			setState(2016);
 			match(BY);
-			setState(2019);
+			setState(2017);
 			orderByVariable();
-			setState(2024);
+			setState(2022);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,233,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,232,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					setState(2020);
+					setState(2018);
 					match(COMMA);
-					setState(2021);
+					setState(2019);
 					orderByVariable();
 					}
 					} 
 				}
-				setState(2026);
+				setState(2024);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,233,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,232,_ctx);
 			}
 			}
 		}
@@ -12980,14 +12970,14 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2027);
+			setState(2025);
 			variableReference(0);
-			setState(2029);
+			setState(2027);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,234,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,233,_ctx) ) {
 			case 1:
 				{
-				setState(2028);
+				setState(2026);
 				orderByType();
 				}
 				break;
@@ -13028,9 +13018,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2031);
+			setState(2029);
 			match(LIMIT);
-			setState(2032);
+			setState(2030);
 			match(DecimalIntegerLiteral);
 			}
 		}
@@ -13077,13 +13067,13 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2034);
+			setState(2032);
 			match(SELECT);
-			setState(2037);
+			setState(2035);
 			switch (_input.LA(1)) {
 			case MUL:
 				{
-				setState(2035);
+				setState(2033);
 				match(MUL);
 				}
 				break;
@@ -13133,29 +13123,29 @@ public class BallerinaParser extends Parser {
 			case XMLLiteralStart:
 			case StringTemplateLiteralStart:
 				{
-				setState(2036);
+				setState(2034);
 				selectExpressionList();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			setState(2040);
+			setState(2038);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,236,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,235,_ctx) ) {
 			case 1:
 				{
-				setState(2039);
+				setState(2037);
 				groupByClause();
 				}
 				break;
 			}
-			setState(2043);
+			setState(2041);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,237,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,236,_ctx) ) {
 			case 1:
 				{
-				setState(2042);
+				setState(2040);
 				havingClause();
 				}
 				break;
@@ -13205,25 +13195,25 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2045);
+			setState(2043);
 			selectExpression();
-			setState(2050);
+			setState(2048);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,238,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,237,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					setState(2046);
+					setState(2044);
 					match(COMMA);
-					setState(2047);
+					setState(2045);
 					selectExpression();
 					}
 					} 
 				}
-				setState(2052);
+				setState(2050);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,238,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,237,_ctx);
 			}
 			}
 		}
@@ -13264,16 +13254,16 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2053);
+			setState(2051);
 			expression(0);
-			setState(2056);
+			setState(2054);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,239,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,238,_ctx) ) {
 			case 1:
 				{
-				setState(2054);
+				setState(2052);
 				match(AS);
-				setState(2055);
+				setState(2053);
 				match(Identifier);
 				}
 				break;
@@ -13317,11 +13307,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2058);
+			setState(2056);
 			match(GROUP);
-			setState(2059);
+			setState(2057);
 			match(BY);
-			setState(2060);
+			setState(2058);
 			variableReferenceList();
 			}
 		}
@@ -13361,9 +13351,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2062);
+			setState(2060);
 			match(HAVING);
-			setState(2063);
+			setState(2061);
 			expression(0);
 			}
 		}
@@ -13414,31 +13404,31 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2065);
+			setState(2063);
 			match(EQUAL_GT);
-			setState(2066);
+			setState(2064);
 			match(LEFT_PARENTHESIS);
-			setState(2067);
+			setState(2065);
 			parameter();
-			setState(2068);
+			setState(2066);
 			match(RIGHT_PARENTHESIS);
-			setState(2069);
+			setState(2067);
 			match(LEFT_BRACE);
-			setState(2073);
+			setState(2071);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << XMLNS) | (1L << FROM))) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & ((1L << (FOREVER - 67)) | (1L << (TYPE_INT - 67)) | (1L << (TYPE_FLOAT - 67)) | (1L << (TYPE_BOOL - 67)) | (1L << (TYPE_STRING - 67)) | (1L << (TYPE_BLOB - 67)) | (1L << (TYPE_MAP - 67)) | (1L << (TYPE_JSON - 67)) | (1L << (TYPE_XML - 67)) | (1L << (TYPE_TABLE - 67)) | (1L << (TYPE_STREAM - 67)) | (1L << (TYPE_ANY - 67)) | (1L << (TYPE_DESC - 67)) | (1L << (TYPE_FUTURE - 67)) | (1L << (VAR - 67)) | (1L << (NEW - 67)) | (1L << (IF - 67)) | (1L << (MATCH - 67)) | (1L << (FOREACH - 67)) | (1L << (WHILE - 67)) | (1L << (CONTINUE - 67)) | (1L << (BREAK - 67)) | (1L << (FORK - 67)) | (1L << (TRY - 67)) | (1L << (THROW - 67)) | (1L << (RETURN - 67)) | (1L << (TRANSACTION - 67)) | (1L << (ABORT - 67)) | (1L << (RETRY - 67)) | (1L << (LENGTHOF - 67)) | (1L << (LOCK - 67)) | (1L << (UNTAINT - 67)) | (1L << (START - 67)) | (1L << (AWAIT - 67)) | (1L << (CHECK - 67)) | (1L << (DONE - 67)) | (1L << (LEFT_BRACE - 67)) | (1L << (LEFT_PARENTHESIS - 67)) | (1L << (LEFT_BRACKET - 67)))) != 0) || ((((_la - 134)) & ~0x3f) == 0 && ((1L << (_la - 134)) & ((1L << (ADD - 134)) | (1L << (SUB - 134)) | (1L << (NOT - 134)) | (1L << (LT - 134)) | (1L << (DecimalIntegerLiteral - 134)) | (1L << (HexIntegerLiteral - 134)) | (1L << (OctalIntegerLiteral - 134)) | (1L << (BinaryIntegerLiteral - 134)) | (1L << (FloatingPointLiteral - 134)) | (1L << (BooleanLiteral - 134)) | (1L << (QuotedStringLiteral - 134)) | (1L << (Base16BlobLiteral - 134)) | (1L << (Base64BlobLiteral - 134)) | (1L << (NullLiteral - 134)) | (1L << (Identifier - 134)) | (1L << (XMLLiteralStart - 134)) | (1L << (StringTemplateLiteralStart - 134)))) != 0)) {
 				{
 				{
-				setState(2070);
+				setState(2068);
 				statement();
 				}
 				}
-				setState(2075);
+				setState(2073);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
-			setState(2076);
+			setState(2074);
 			match(RIGHT_BRACE);
 			}
 		}
@@ -13486,23 +13476,23 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2078);
+			setState(2076);
 			match(SET);
-			setState(2079);
+			setState(2077);
 			setAssignmentClause();
-			setState(2084);
+			setState(2082);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				setState(2080);
+				setState(2078);
 				match(COMMA);
-				setState(2081);
+				setState(2079);
 				setAssignmentClause();
 				}
 				}
-				setState(2086);
+				setState(2084);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -13547,11 +13537,11 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2087);
+			setState(2085);
 			variableReference(0);
-			setState(2088);
+			setState(2086);
 			match(ASSIGN);
-			setState(2089);
+			setState(2087);
 			expression(0);
 			}
 		}
@@ -13609,78 +13599,78 @@ public class BallerinaParser extends Parser {
 			int _alt;
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2091);
+			setState(2089);
 			variableReference(0);
-			setState(2093);
+			setState(2091);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,242,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,241,_ctx) ) {
 			case 1:
 				{
-				setState(2092);
+				setState(2090);
 				whereClause();
 				}
 				break;
 			}
-			setState(2098);
+			setState(2096);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,243,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,242,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					setState(2095);
+					setState(2093);
 					functionInvocation();
 					}
 					} 
 				}
-				setState(2100);
+				setState(2098);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,243,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,242,_ctx);
 			}
-			setState(2102);
+			setState(2100);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,244,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,243,_ctx) ) {
 			case 1:
 				{
-				setState(2101);
+				setState(2099);
 				windowClause();
 				}
 				break;
 			}
-			setState(2107);
+			setState(2105);
 			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,245,_ctx);
+			_alt = getInterpreter().adaptivePredict(_input,244,_ctx);
 			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					setState(2104);
+					setState(2102);
 					functionInvocation();
 					}
 					} 
 				}
-				setState(2109);
+				setState(2107);
 				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,245,_ctx);
+				_alt = getInterpreter().adaptivePredict(_input,244,_ctx);
 			}
-			setState(2111);
+			setState(2109);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,246,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,245,_ctx) ) {
 			case 1:
 				{
-				setState(2110);
+				setState(2108);
 				whereClause();
 				}
 				break;
 			}
-			setState(2115);
+			setState(2113);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,247,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,246,_ctx) ) {
 			case 1:
 				{
-				setState(2113);
+				setState(2111);
 				match(AS);
-				setState(2114);
+				setState(2112);
 				((StreamingInputContext)_localctx).alias = match(Identifier);
 				}
 				break;
@@ -13730,37 +13720,37 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2123);
+			setState(2121);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,248,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,247,_ctx) ) {
 			case 1:
 				{
-				setState(2117);
+				setState(2115);
 				match(UNIDIRECTIONAL);
-				setState(2118);
+				setState(2116);
 				joinType();
 				}
 				break;
 			case 2:
 				{
-				setState(2119);
+				setState(2117);
 				joinType();
-				setState(2120);
+				setState(2118);
 				match(UNIDIRECTIONAL);
 				}
 				break;
 			case 3:
 				{
-				setState(2122);
+				setState(2120);
 				joinType();
 				}
 				break;
 			}
-			setState(2125);
+			setState(2123);
 			streamingInput();
-			setState(2126);
+			setState(2124);
 			match(ON);
-			setState(2127);
+			setState(2125);
 			expression(0);
 			}
 		}
@@ -13806,39 +13796,39 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 346, RULE_outputRateLimit);
 		int _la;
 		try {
-			setState(2143);
+			setState(2141);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,250,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,249,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2129);
+				setState(2127);
 				match(OUTPUT);
-				setState(2130);
+				setState(2128);
 				_la = _input.LA(1);
 				if ( !(((((_la - 44)) & ~0x3f) == 0 && ((1L << (_la - 44)) & ((1L << (LAST - 44)) | (1L << (FIRST - 44)) | (1L << (ALL - 44)))) != 0)) ) {
 				_errHandler.recoverInline(this);
 				} else {
 					consume();
 				}
-				setState(2131);
+				setState(2129);
 				match(EVERY);
-				setState(2136);
+				setState(2134);
 				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,249,_ctx) ) {
+				switch ( getInterpreter().adaptivePredict(_input,248,_ctx) ) {
 				case 1:
 					{
-					setState(2132);
+					setState(2130);
 					match(DecimalIntegerLiteral);
-					setState(2133);
+					setState(2131);
 					timeScale();
 					}
 					break;
 				case 2:
 					{
-					setState(2134);
+					setState(2132);
 					match(DecimalIntegerLiteral);
-					setState(2135);
+					setState(2133);
 					match(EVENTS);
 					}
 					break;
@@ -13848,15 +13838,15 @@ public class BallerinaParser extends Parser {
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2138);
+				setState(2136);
 				match(OUTPUT);
-				setState(2139);
+				setState(2137);
 				match(SNAPSHOT);
-				setState(2140);
+				setState(2138);
 				match(EVERY);
-				setState(2141);
+				setState(2139);
 				match(DecimalIntegerLiteral);
-				setState(2142);
+				setState(2140);
 				timeScale();
 				}
 				break;
@@ -13915,72 +13905,72 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 348, RULE_patternStreamingInput);
 		int _la;
 		try {
-			setState(2171);
+			setState(2169);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,253,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,252,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2145);
+				setState(2143);
 				patternStreamingEdgeInput();
-				setState(2149);
+				setState(2147);
 				switch (_input.LA(1)) {
 				case FOLLOWED:
 					{
-					setState(2146);
+					setState(2144);
 					match(FOLLOWED);
-					setState(2147);
+					setState(2145);
 					match(BY);
 					}
 					break;
 				case COMMA:
 					{
-					setState(2148);
+					setState(2146);
 					match(COMMA);
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				setState(2151);
+				setState(2149);
 				patternStreamingInput();
 				}
 				break;
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2153);
+				setState(2151);
 				match(LEFT_PARENTHESIS);
-				setState(2154);
+				setState(2152);
 				patternStreamingInput();
-				setState(2155);
+				setState(2153);
 				match(RIGHT_PARENTHESIS);
 				}
 				break;
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(2157);
+				setState(2155);
 				match(NOT);
-				setState(2158);
+				setState(2156);
 				patternStreamingEdgeInput();
-				setState(2164);
+				setState(2162);
 				switch (_input.LA(1)) {
 				case AND:
 					{
-					setState(2159);
+					setState(2157);
 					match(AND);
-					setState(2160);
+					setState(2158);
 					patternStreamingEdgeInput();
 					}
 					break;
 				case FOR:
 					{
-					setState(2161);
+					setState(2159);
 					match(FOR);
-					setState(2162);
+					setState(2160);
 					match(DecimalIntegerLiteral);
-					setState(2163);
+					setState(2161);
 					timeScale();
 					}
 					break;
@@ -13992,23 +13982,23 @@ public class BallerinaParser extends Parser {
 			case 4:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(2166);
+				setState(2164);
 				patternStreamingEdgeInput();
-				setState(2167);
+				setState(2165);
 				_la = _input.LA(1);
 				if ( !(_la==AND || _la==OR) ) {
 				_errHandler.recoverInline(this);
 				} else {
 					consume();
 				}
-				setState(2168);
+				setState(2166);
 				patternStreamingEdgeInput();
 				}
 				break;
 			case 5:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(2170);
+				setState(2168);
 				patternStreamingEdgeInput();
 				}
 				break;
@@ -14059,33 +14049,33 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2173);
+			setState(2171);
 			variableReference(0);
-			setState(2175);
+			setState(2173);
 			_la = _input.LA(1);
 			if (_la==WHERE) {
 				{
-				setState(2174);
+				setState(2172);
 				whereClause();
 				}
 			}
 
-			setState(2178);
+			setState(2176);
 			_la = _input.LA(1);
 			if (_la==LEFT_PARENTHESIS || _la==LEFT_BRACKET) {
 				{
-				setState(2177);
+				setState(2175);
 				intRangeExpression();
 				}
 			}
 
-			setState(2182);
+			setState(2180);
 			_la = _input.LA(1);
 			if (_la==AS) {
 				{
-				setState(2180);
+				setState(2178);
 				match(AS);
-				setState(2181);
+				setState(2179);
 				((PatternStreamingEdgeInputContext)_localctx).alias = match(Identifier);
 				}
 			}
@@ -14128,9 +14118,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2184);
+			setState(2182);
 			match(WHERE);
-			setState(2185);
+			setState(2183);
 			expression(0);
 			}
 		}
@@ -14170,9 +14160,9 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2187);
+			setState(2185);
 			match(WINDOW);
-			setState(2188);
+			setState(2186);
 			functionInvocation();
 			}
 		}
@@ -14211,7 +14201,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2190);
+			setState(2188);
 			_la = _input.LA(1);
 			if ( !(_la==ASCENDING || _la==DESCENDING) ) {
 			_errHandler.recoverInline(this);
@@ -14257,47 +14247,47 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 358, RULE_joinType);
 		int _la;
 		try {
-			setState(2207);
+			setState(2205);
 			switch (_input.LA(1)) {
 			case LEFT:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2192);
+				setState(2190);
 				match(LEFT);
-				setState(2193);
+				setState(2191);
 				match(OUTER);
-				setState(2194);
+				setState(2192);
 				match(JOIN);
 				}
 				break;
 			case RIGHT:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2195);
+				setState(2193);
 				match(RIGHT);
-				setState(2196);
+				setState(2194);
 				match(OUTER);
-				setState(2197);
+				setState(2195);
 				match(JOIN);
 				}
 				break;
 			case FULL:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(2198);
+				setState(2196);
 				match(FULL);
-				setState(2199);
+				setState(2197);
 				match(OUTER);
-				setState(2200);
+				setState(2198);
 				match(JOIN);
 				}
 				break;
 			case OUTER:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(2201);
+				setState(2199);
 				match(OUTER);
-				setState(2202);
+				setState(2200);
 				match(JOIN);
 				}
 				break;
@@ -14305,16 +14295,16 @@ public class BallerinaParser extends Parser {
 			case JOIN:
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(2204);
+				setState(2202);
 				_la = _input.LA(1);
 				if (_la==INNER) {
 					{
-					setState(2203);
+					setState(2201);
 					match(INNER);
 					}
 				}
 
-				setState(2206);
+				setState(2204);
 				match(JOIN);
 				}
 				break;
@@ -14367,7 +14357,7 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2209);
+			setState(2207);
 			_la = _input.LA(1);
 			if ( !(((((_la - 55)) & ~0x3f) == 0 && ((1L << (_la - 55)) & ((1L << (SECOND - 55)) | (1L << (MINUTE - 55)) | (1L << (HOUR - 55)) | (1L << (DAY - 55)) | (1L << (MONTH - 55)) | (1L << (YEAR - 55)) | (1L << (SECONDS - 55)) | (1L << (MINUTES - 55)) | (1L << (HOURS - 55)) | (1L << (DAYS - 55)) | (1L << (MONTHS - 55)) | (1L << (YEARS - 55)))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -14414,18 +14404,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2211);
+			setState(2209);
 			match(DeprecatedTemplateStart);
-			setState(2213);
+			setState(2211);
 			_la = _input.LA(1);
 			if (((((_la - 230)) & ~0x3f) == 0 && ((1L << (_la - 230)) & ((1L << (SBDeprecatedInlineCodeStart - 230)) | (1L << (DBDeprecatedInlineCodeStart - 230)) | (1L << (TBDeprecatedInlineCodeStart - 230)) | (1L << (DeprecatedTemplateText - 230)))) != 0)) {
 				{
-				setState(2212);
+				setState(2210);
 				deprecatedText();
 				}
 			}
 
-			setState(2215);
+			setState(2213);
 			match(DeprecatedTemplateEnd);
 			}
 		}
@@ -14470,25 +14460,25 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 364, RULE_deprecatedText);
 		int _la;
 		try {
-			setState(2233);
+			setState(2231);
 			switch (_input.LA(1)) {
 			case SBDeprecatedInlineCodeStart:
 			case DBDeprecatedInlineCodeStart:
 			case TBDeprecatedInlineCodeStart:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2217);
+				setState(2215);
 				deprecatedTemplateInlineCode();
-				setState(2222);
+				setState(2220);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (((((_la - 230)) & ~0x3f) == 0 && ((1L << (_la - 230)) & ((1L << (SBDeprecatedInlineCodeStart - 230)) | (1L << (DBDeprecatedInlineCodeStart - 230)) | (1L << (TBDeprecatedInlineCodeStart - 230)) | (1L << (DeprecatedTemplateText - 230)))) != 0)) {
 					{
-					setState(2220);
+					setState(2218);
 					switch (_input.LA(1)) {
 					case DeprecatedTemplateText:
 						{
-						setState(2218);
+						setState(2216);
 						match(DeprecatedTemplateText);
 						}
 						break;
@@ -14496,7 +14486,7 @@ public class BallerinaParser extends Parser {
 					case DBDeprecatedInlineCodeStart:
 					case TBDeprecatedInlineCodeStart:
 						{
-						setState(2219);
+						setState(2217);
 						deprecatedTemplateInlineCode();
 						}
 						break;
@@ -14504,7 +14494,7 @@ public class BallerinaParser extends Parser {
 						throw new NoViableAltException(this);
 					}
 					}
-					setState(2224);
+					setState(2222);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
@@ -14513,18 +14503,18 @@ public class BallerinaParser extends Parser {
 			case DeprecatedTemplateText:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2225);
+				setState(2223);
 				match(DeprecatedTemplateText);
-				setState(2230);
+				setState(2228);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (((((_la - 230)) & ~0x3f) == 0 && ((1L << (_la - 230)) & ((1L << (SBDeprecatedInlineCodeStart - 230)) | (1L << (DBDeprecatedInlineCodeStart - 230)) | (1L << (TBDeprecatedInlineCodeStart - 230)) | (1L << (DeprecatedTemplateText - 230)))) != 0)) {
 					{
-					setState(2228);
+					setState(2226);
 					switch (_input.LA(1)) {
 					case DeprecatedTemplateText:
 						{
-						setState(2226);
+						setState(2224);
 						match(DeprecatedTemplateText);
 						}
 						break;
@@ -14532,7 +14522,7 @@ public class BallerinaParser extends Parser {
 					case DBDeprecatedInlineCodeStart:
 					case TBDeprecatedInlineCodeStart:
 						{
-						setState(2227);
+						setState(2225);
 						deprecatedTemplateInlineCode();
 						}
 						break;
@@ -14540,7 +14530,7 @@ public class BallerinaParser extends Parser {
 						throw new NoViableAltException(this);
 					}
 					}
-					setState(2232);
+					setState(2230);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
@@ -14589,26 +14579,26 @@ public class BallerinaParser extends Parser {
 		DeprecatedTemplateInlineCodeContext _localctx = new DeprecatedTemplateInlineCodeContext(_ctx, getState());
 		enterRule(_localctx, 366, RULE_deprecatedTemplateInlineCode);
 		try {
-			setState(2238);
+			setState(2236);
 			switch (_input.LA(1)) {
 			case SBDeprecatedInlineCodeStart:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2235);
+				setState(2233);
 				singleBackTickDeprecatedInlineCode();
 				}
 				break;
 			case DBDeprecatedInlineCodeStart:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2236);
+				setState(2234);
 				doubleBackTickDeprecatedInlineCode();
 				}
 				break;
 			case TBDeprecatedInlineCodeStart:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(2237);
+				setState(2235);
 				tripleBackTickDeprecatedInlineCode();
 				}
 				break;
@@ -14652,18 +14642,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2240);
+			setState(2238);
 			match(SBDeprecatedInlineCodeStart);
-			setState(2242);
+			setState(2240);
 			_la = _input.LA(1);
 			if (_la==SingleBackTickInlineCode) {
 				{
-				setState(2241);
+				setState(2239);
 				match(SingleBackTickInlineCode);
 				}
 			}
 
-			setState(2244);
+			setState(2242);
 			match(SingleBackTickInlineCodeEnd);
 			}
 		}
@@ -14703,18 +14693,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2246);
+			setState(2244);
 			match(DBDeprecatedInlineCodeStart);
-			setState(2248);
+			setState(2246);
 			_la = _input.LA(1);
 			if (_la==DoubleBackTickInlineCode) {
 				{
-				setState(2247);
+				setState(2245);
 				match(DoubleBackTickInlineCode);
 				}
 			}
 
-			setState(2250);
+			setState(2248);
 			match(DoubleBackTickInlineCodeEnd);
 			}
 		}
@@ -14754,18 +14744,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2252);
+			setState(2250);
 			match(TBDeprecatedInlineCodeStart);
-			setState(2254);
+			setState(2252);
 			_la = _input.LA(1);
 			if (_la==TripleBackTickInlineCode) {
 				{
-				setState(2253);
+				setState(2251);
 				match(TripleBackTickInlineCode);
 				}
 			}
 
-			setState(2256);
+			setState(2254);
 			match(TripleBackTickInlineCodeEnd);
 			}
 		}
@@ -14807,18 +14797,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2258);
+			setState(2256);
 			match(DocumentationTemplateStart);
-			setState(2260);
+			setState(2258);
 			_la = _input.LA(1);
 			if (((((_la - 218)) & ~0x3f) == 0 && ((1L << (_la - 218)) & ((1L << (DocumentationTemplateAttributeStart - 218)) | (1L << (SBDocInlineCodeStart - 218)) | (1L << (DBDocInlineCodeStart - 218)) | (1L << (TBDocInlineCodeStart - 218)) | (1L << (DocumentationTemplateText - 218)))) != 0)) {
 				{
-				setState(2259);
+				setState(2257);
 				documentationTemplateContent();
 				}
 			}
 
-			setState(2262);
+			setState(2260);
 			match(DocumentationTemplateEnd);
 			}
 		}
@@ -14862,32 +14852,32 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 376, RULE_documentationTemplateContent);
 		int _la;
 		try {
-			setState(2273);
+			setState(2271);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,272,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,271,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2265);
+				setState(2263);
 				_la = _input.LA(1);
 				if (((((_la - 219)) & ~0x3f) == 0 && ((1L << (_la - 219)) & ((1L << (SBDocInlineCodeStart - 219)) | (1L << (DBDocInlineCodeStart - 219)) | (1L << (TBDocInlineCodeStart - 219)) | (1L << (DocumentationTemplateText - 219)))) != 0)) {
 					{
-					setState(2264);
+					setState(2262);
 					docText();
 					}
 				}
 
-				setState(2268); 
+				setState(2266); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				do {
 					{
 					{
-					setState(2267);
+					setState(2265);
 					documentationTemplateAttributeDescription();
 					}
 					}
-					setState(2270); 
+					setState(2268); 
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				} while ( _la==DocumentationTemplateAttributeStart );
@@ -14896,7 +14886,7 @@ public class BallerinaParser extends Parser {
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2272);
+				setState(2270);
 				docText();
 				}
 				break;
@@ -14941,24 +14931,24 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2275);
+			setState(2273);
 			match(DocumentationTemplateAttributeStart);
-			setState(2277);
+			setState(2275);
 			_la = _input.LA(1);
 			if (_la==Identifier) {
 				{
-				setState(2276);
+				setState(2274);
 				match(Identifier);
 				}
 			}
 
-			setState(2279);
+			setState(2277);
 			match(DocumentationTemplateAttributeEnd);
-			setState(2281);
+			setState(2279);
 			_la = _input.LA(1);
 			if (((((_la - 219)) & ~0x3f) == 0 && ((1L << (_la - 219)) & ((1L << (SBDocInlineCodeStart - 219)) | (1L << (DBDocInlineCodeStart - 219)) | (1L << (TBDocInlineCodeStart - 219)) | (1L << (DocumentationTemplateText - 219)))) != 0)) {
 				{
-				setState(2280);
+				setState(2278);
 				docText();
 				}
 			}
@@ -15006,25 +14996,25 @@ public class BallerinaParser extends Parser {
 		enterRule(_localctx, 380, RULE_docText);
 		int _la;
 		try {
-			setState(2299);
+			setState(2297);
 			switch (_input.LA(1)) {
 			case SBDocInlineCodeStart:
 			case DBDocInlineCodeStart:
 			case TBDocInlineCodeStart:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2283);
+				setState(2281);
 				documentationTemplateInlineCode();
-				setState(2288);
+				setState(2286);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (((((_la - 219)) & ~0x3f) == 0 && ((1L << (_la - 219)) & ((1L << (SBDocInlineCodeStart - 219)) | (1L << (DBDocInlineCodeStart - 219)) | (1L << (TBDocInlineCodeStart - 219)) | (1L << (DocumentationTemplateText - 219)))) != 0)) {
 					{
-					setState(2286);
+					setState(2284);
 					switch (_input.LA(1)) {
 					case DocumentationTemplateText:
 						{
-						setState(2284);
+						setState(2282);
 						match(DocumentationTemplateText);
 						}
 						break;
@@ -15032,7 +15022,7 @@ public class BallerinaParser extends Parser {
 					case DBDocInlineCodeStart:
 					case TBDocInlineCodeStart:
 						{
-						setState(2285);
+						setState(2283);
 						documentationTemplateInlineCode();
 						}
 						break;
@@ -15040,7 +15030,7 @@ public class BallerinaParser extends Parser {
 						throw new NoViableAltException(this);
 					}
 					}
-					setState(2290);
+					setState(2288);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
@@ -15049,18 +15039,18 @@ public class BallerinaParser extends Parser {
 			case DocumentationTemplateText:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2291);
+				setState(2289);
 				match(DocumentationTemplateText);
-				setState(2296);
+				setState(2294);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				while (((((_la - 219)) & ~0x3f) == 0 && ((1L << (_la - 219)) & ((1L << (SBDocInlineCodeStart - 219)) | (1L << (DBDocInlineCodeStart - 219)) | (1L << (TBDocInlineCodeStart - 219)) | (1L << (DocumentationTemplateText - 219)))) != 0)) {
 					{
-					setState(2294);
+					setState(2292);
 					switch (_input.LA(1)) {
 					case DocumentationTemplateText:
 						{
-						setState(2292);
+						setState(2290);
 						match(DocumentationTemplateText);
 						}
 						break;
@@ -15068,7 +15058,7 @@ public class BallerinaParser extends Parser {
 					case DBDocInlineCodeStart:
 					case TBDocInlineCodeStart:
 						{
-						setState(2293);
+						setState(2291);
 						documentationTemplateInlineCode();
 						}
 						break;
@@ -15076,7 +15066,7 @@ public class BallerinaParser extends Parser {
 						throw new NoViableAltException(this);
 					}
 					}
-					setState(2298);
+					setState(2296);
 					_errHandler.sync(this);
 					_la = _input.LA(1);
 				}
@@ -15125,26 +15115,26 @@ public class BallerinaParser extends Parser {
 		DocumentationTemplateInlineCodeContext _localctx = new DocumentationTemplateInlineCodeContext(_ctx, getState());
 		enterRule(_localctx, 382, RULE_documentationTemplateInlineCode);
 		try {
-			setState(2304);
+			setState(2302);
 			switch (_input.LA(1)) {
 			case SBDocInlineCodeStart:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(2301);
+				setState(2299);
 				singleBackTickDocInlineCode();
 				}
 				break;
 			case DBDocInlineCodeStart:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(2302);
+				setState(2300);
 				doubleBackTickDocInlineCode();
 				}
 				break;
 			case TBDocInlineCodeStart:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(2303);
+				setState(2301);
 				tripleBackTickDocInlineCode();
 				}
 				break;
@@ -15188,18 +15178,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2306);
+			setState(2304);
 			match(SBDocInlineCodeStart);
-			setState(2308);
+			setState(2306);
 			_la = _input.LA(1);
 			if (_la==SingleBackTickInlineCode) {
 				{
-				setState(2307);
+				setState(2305);
 				match(SingleBackTickInlineCode);
 				}
 			}
 
-			setState(2310);
+			setState(2308);
 			match(SingleBackTickInlineCodeEnd);
 			}
 		}
@@ -15239,18 +15229,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2312);
+			setState(2310);
 			match(DBDocInlineCodeStart);
-			setState(2314);
+			setState(2312);
 			_la = _input.LA(1);
 			if (_la==DoubleBackTickInlineCode) {
 				{
-				setState(2313);
+				setState(2311);
 				match(DoubleBackTickInlineCode);
 				}
 			}
 
-			setState(2316);
+			setState(2314);
 			match(DoubleBackTickInlineCodeEnd);
 			}
 		}
@@ -15290,18 +15280,18 @@ public class BallerinaParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(2318);
+			setState(2316);
 			match(TBDocInlineCodeStart);
-			setState(2320);
+			setState(2318);
 			_la = _input.LA(1);
 			if (_la==TripleBackTickInlineCode) {
 				{
-				setState(2319);
+				setState(2317);
 				match(TripleBackTickInlineCode);
 				}
 			}
 
-			setState(2322);
+			setState(2320);
 			match(TripleBackTickInlineCodeEnd);
 			}
 		}
@@ -15380,7 +15370,7 @@ public class BallerinaParser extends Parser {
 	}
 
 	public static final String _serializedATN =
-		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3\u00ee\u0917\4\2\t"+
+		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3\u00ee\u0915\4\2\t"+
 		"\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
 		"\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
 		"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -15447,250 +15437,250 @@ public class BallerinaParser extends Parser {
 		"#\3#\3$\7$\u0320\n$\f$\16$\u0323\13$\3$\3$\3$\3$\5$\u0329\n$\3$\3$\3%"+
 		"\3%\3&\3&\3&\5&\u0332\n&\3\'\3\'\3\'\7\'\u0337\n\'\f\'\16\'\u033a\13\'"+
 		"\3(\3(\5(\u033e\n(\3)\3)\3)\3)\3)\3)\3)\3)\3)\3)\7)\u034a\n)\f)\16)\u034d"+
-		"\13)\3)\3)\3)\3)\3)\3)\3)\3)\5)\u0357\n)\3)\3)\3)\3)\5)\u035d\n)\3)\3"+
-		")\3)\6)\u0362\n)\r)\16)\u0363\3)\3)\3)\6)\u0369\n)\r)\16)\u036a\3)\3)"+
-		"\7)\u036f\n)\f)\16)\u0372\13)\3*\7*\u0375\n*\f*\16*\u0378\13*\3+\3+\3"+
-		"+\3+\3+\5+\u037f\n+\3,\3,\5,\u0383\n,\3-\3-\3.\3.\3/\3/\3/\3/\3/\5/\u038e"+
-		"\n/\3/\3/\3/\3/\3/\5/\u0395\n/\3/\3/\3/\3/\3/\3/\5/\u039d\n/\3/\3/\3/"+
-		"\5/\u03a2\n/\3/\3/\3/\3/\3/\5/\u03a9\n/\3/\3/\3/\3/\3/\5/\u03b0\n/\3/"+
-		"\3/\3/\3/\3/\5/\u03b7\n/\3/\5/\u03ba\n/\3\60\3\60\3\60\3\60\5\60\u03c0"+
-		"\n\60\3\60\3\60\5\60\u03c4\n\60\3\61\3\61\3\62\3\62\3\63\3\63\3\63\5\63"+
-		"\u03cd\n\63\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64"+
-		"\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\5\64"+
-		"\u03e8\n\64\3\65\3\65\3\65\3\65\5\65\u03ee\n\65\3\65\3\65\3\66\3\66\3"+
-		"\66\3\66\7\66\u03f6\n\66\f\66\16\66\u03f9\13\66\5\66\u03fb\n\66\3\66\3"+
-		"\66\3\67\3\67\3\67\3\67\38\38\58\u0405\n8\39\39\39\3:\3:\3;\3;\5;\u040e"+
-		"\n;\3;\3;\3<\3<\3<\5<\u0415\n<\3<\5<\u0418\n<\3<\3<\3<\3<\5<\u041e\n<"+
-		"\3<\3<\5<\u0422\n<\3=\5=\u0425\n=\3=\3=\3=\3=\3=\3>\5>\u042d\n>\3>\3>"+
-		"\3>\3>\3>\3>\3>\3>\3>\3>\3>\3>\3>\3>\5>\u043d\n>\3?\3?\3?\3?\3?\3@\3@"+
-		"\3A\3A\3A\3A\3B\3B\3C\3C\3C\7C\u044f\nC\fC\16C\u0452\13C\3D\3D\7D\u0456"+
-		"\nD\fD\16D\u0459\13D\3D\5D\u045c\nD\3E\3E\3E\3E\7E\u0462\nE\fE\16E\u0465"+
-		"\13E\3E\3E\3F\3F\3F\3F\3F\7F\u046e\nF\fF\16F\u0471\13F\3F\3F\3G\3G\3G"+
-		"\7G\u0478\nG\fG\16G\u047b\13G\3G\3G\3H\3H\3H\3H\6H\u0483\nH\rH\16H\u0484"+
-		"\3H\3H\3I\3I\3I\3I\3I\7I\u048e\nI\fI\16I\u0491\13I\3I\5I\u0494\nI\3I\3"+
-		"I\3I\3I\3I\3I\7I\u049c\nI\fI\16I\u049f\13I\3I\5I\u04a2\nI\5I\u04a4\nI"+
-		"\3J\3J\5J\u04a8\nJ\3J\3J\3J\3J\5J\u04ae\nJ\3J\3J\7J\u04b2\nJ\fJ\16J\u04b5"+
-		"\13J\3J\3J\3K\3K\3K\3K\5K\u04bd\nK\3K\3K\3L\3L\3L\3L\7L\u04c5\nL\fL\16"+
-		"L\u04c8\13L\3L\3L\3M\3M\3M\3N\3N\3N\3O\3O\3O\7O\u04d5\nO\fO\16O\u04d8"+
-		"\13O\3O\3O\5O\u04dc\nO\3O\5O\u04df\nO\3P\3P\3P\3P\3P\5P\u04e6\nP\3P\3"+
-		"P\3P\3P\3P\3P\7P\u04ee\nP\fP\16P\u04f1\13P\3P\3P\3Q\3Q\3Q\3Q\3Q\7Q\u04fa"+
-		"\nQ\fQ\16Q\u04fd\13Q\5Q\u04ff\nQ\3Q\3Q\3Q\3Q\7Q\u0505\nQ\fQ\16Q\u0508"+
-		"\13Q\5Q\u050a\nQ\5Q\u050c\nQ\3R\3R\3R\3R\3R\3R\3R\3R\3R\3R\7R\u0518\n"+
-		"R\fR\16R\u051b\13R\3R\3R\3S\3S\3S\7S\u0522\nS\fS\16S\u0525\13S\3S\3S\3"+
-		"S\3T\6T\u052b\nT\rT\16T\u052c\3T\5T\u0530\nT\3T\5T\u0533\nT\3U\3U\3U\3"+
-		"U\3U\3U\3U\7U\u053c\nU\fU\16U\u053f\13U\3U\3U\3V\3V\3V\7V\u0546\nV\fV"+
-		"\16V\u0549\13V\3V\3V\3W\3W\3W\3W\3X\3X\5X\u0553\nX\3X\3X\3Y\3Y\5Y\u0559"+
-		"\nY\3Z\3Z\3Z\3Z\3Z\3Z\3Z\3Z\3Z\3Z\5Z\u0565\nZ\3[\3[\3[\3[\3[\3\\\3\\\3"+
-		"\\\5\\\u056f\n\\\3\\\3\\\3\\\3\\\3\\\3\\\3\\\3\\\7\\\u0579\n\\\f\\\16"+
-		"\\\u057c\13\\\3]\3]\3]\3^\3^\3^\3^\3_\3_\3_\3_\3_\5_\u058a\n_\3`\3`\3"+
-		"`\5`\u058f\n`\3`\3`\3a\3a\3a\3a\5a\u0597\na\3a\3a\3b\3b\3b\7b\u059e\n"+
-		"b\fb\16b\u05a1\13b\3c\3c\3c\5c\u05a6\nc\3d\5d\u05a9\nd\3d\3d\3d\3d\3e"+
-		"\3e\3e\7e\u05b2\ne\fe\16e\u05b5\13e\3f\3f\3f\3g\3g\5g\u05bc\ng\3h\3h\3"+
-		"h\5h\u05c1\nh\3h\3h\7h\u05c5\nh\fh\16h\u05c8\13h\3h\3h\3i\3i\3i\5i\u05cf"+
-		"\ni\3j\3j\3j\7j\u05d4\nj\fj\16j\u05d7\13j\3k\3k\3k\7k\u05dc\nk\fk\16k"+
-		"\u05df\13k\3k\3k\3l\3l\3l\7l\u05e6\nl\fl\16l\u05e9\13l\3l\3l\3m\3m\3m"+
-		"\3n\3n\3n\3o\3o\3o\3o\3p\3p\3p\3p\3q\3q\3q\3q\3r\3r\3s\3s\3s\3s\5s\u0605"+
-		"\ns\3s\3s\3t\3t\3t\3t\3t\3t\3t\3t\5t\u0611\nt\3t\3t\3t\3t\3t\3t\3t\3t"+
-		"\3t\5t\u061c\nt\3t\3t\3t\3t\3t\3t\3t\3t\3t\7t\u0627\nt\ft\16t\u062a\13"+
-		"t\3t\3t\3t\3t\3t\3t\5t\u0632\nt\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3"+
-		"t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\7"+
-		"t\u0657\nt\ft\16t\u065a\13t\3u\3u\3u\3v\3v\3v\3v\3v\7v\u0664\nv\fv\16"+
-		"v\u0667\13v\3v\3v\3w\3w\5w\u066d\nw\3w\3w\3w\3x\3x\5x\u0674\nx\3x\3x\3"+
-		"y\3y\5y\u067a\ny\3y\3y\3z\3z\7z\u0680\nz\fz\16z\u0683\13z\3z\3z\3{\7{"+
-		"\u0688\n{\f{\16{\u068b\13{\3{\3{\3|\3|\3|\7|\u0692\n|\f|\16|\u0695\13"+
-		"|\3}\3}\3~\3~\3~\7~\u069c\n~\f~\16~\u069f\13~\3\177\7\177\u06a2\n\177"+
-		"\f\177\16\177\u06a5\13\177\3\177\3\177\3\177\3\177\7\177\u06ab\n\177\f"+
-		"\177\16\177\u06ae\13\177\3\177\3\177\3\177\3\177\3\177\3\177\3\177\7\177"+
-		"\u06b7\n\177\f\177\16\177\u06ba\13\177\3\177\3\177\5\177\u06be\n\177\3"+
-		"\u0080\3\u0080\3\u0080\3\u0080\3\u0081\7\u0081\u06c5\n\u0081\f\u0081\16"+
-		"\u0081\u06c8\13\u0081\3\u0081\3\u0081\3\u0081\3\u0081\3\u0082\3\u0082"+
-		"\5\u0082\u06d0\n\u0082\3\u0082\3\u0082\3\u0082\5\u0082\u06d5\n\u0082\7"+
-		"\u0082\u06d7\n\u0082\f\u0082\16\u0082\u06da\13\u0082\3\u0082\3\u0082\5"+
-		"\u0082\u06de\n\u0082\3\u0082\5\u0082\u06e1\n\u0082\3\u0083\5\u0083\u06e4"+
-		"\n\u0083\3\u0083\3\u0083\5\u0083\u06e8\n\u0083\3\u0083\3\u0083\3\u0083"+
-		"\3\u0083\3\u0083\3\u0083\5\u0083\u06f0\n\u0083\3\u0084\3\u0084\3\u0085"+
-		"\3\u0085\3\u0085\3\u0086\3\u0086\3\u0087\3\u0087\3\u0087\3\u0087\3\u0088"+
-		"\3\u0088\3\u0088\3\u0089\3\u0089\3\u0089\3\u0089\3\u008a\3\u008a\3\u008a"+
-		"\3\u008a\3\u008a\5\u008a\u0709\n\u008a\3\u008b\5\u008b\u070c\n\u008b\3"+
-		"\u008b\3\u008b\3\u008b\3\u008b\5\u008b\u0712\n\u008b\3\u008b\5\u008b\u0715"+
-		"\n\u008b\7\u008b\u0717\n\u008b\f\u008b\16\u008b\u071a\13\u008b\3\u008c"+
-		"\3\u008c\3\u008c\3\u008c\3\u008c\7\u008c\u0721\n\u008c\f\u008c\16\u008c"+
-		"\u0724\13\u008c\3\u008c\3\u008c\3\u008d\3\u008d\3\u008d\3\u008d\3\u008d"+
-		"\5\u008d\u072d\n\u008d\3\u008e\3\u008e\3\u008e\7\u008e\u0732\n\u008e\f"+
-		"\u008e\16\u008e\u0735\13\u008e\3\u008e\3\u008e\3\u008f\3\u008f\3\u008f"+
-		"\3\u008f\3\u0090\3\u0090\3\u0090\7\u0090\u0740\n\u0090\f\u0090\16\u0090"+
-		"\u0743\13\u0090\3\u0090\3\u0090\3\u0091\3\u0091\3\u0091\3\u0091\3\u0091"+
-		"\7\u0091\u074c\n\u0091\f\u0091\16\u0091\u074f\13\u0091\3\u0091\3\u0091"+
-		"\3\u0092\3\u0092\3\u0092\3\u0092\3\u0093\3\u0093\3\u0093\3\u0093\6\u0093"+
-		"\u075b\n\u0093\r\u0093\16\u0093\u075c\3\u0093\5\u0093\u0760\n\u0093\3"+
-		"\u0093\5\u0093\u0763\n\u0093\3\u0094\3\u0094\5\u0094\u0767\n\u0094\3\u0095"+
-		"\3\u0095\3\u0095\3\u0095\3\u0095\7\u0095\u076e\n\u0095\f\u0095\16\u0095"+
-		"\u0771\13\u0095\3\u0095\5\u0095\u0774\n\u0095\3\u0095\3\u0095\3\u0096"+
-		"\3\u0096\3\u0096\3\u0096\3\u0096\7\u0096\u077d\n\u0096\f\u0096\16\u0096"+
-		"\u0780\13\u0096\3\u0096\5\u0096\u0783\n\u0096\3\u0096\3\u0096\3\u0097"+
-		"\3\u0097\5\u0097\u0789\n\u0097\3\u0097\3\u0097\3\u0097\3\u0097\3\u0097"+
-		"\5\u0097\u0790\n\u0097\3\u0098\3\u0098\5\u0098\u0794\n\u0098\3\u0098\3"+
-		"\u0098\3\u0099\3\u0099\3\u0099\3\u0099\6\u0099\u079c\n\u0099\r\u0099\16"+
-		"\u0099\u079d\3\u0099\5\u0099\u07a1\n\u0099\3\u0099\5\u0099\u07a4\n\u0099"+
-		"\3\u009a\3\u009a\5\u009a\u07a8\n\u009a\3\u009b\3\u009b\3\u009c\3\u009c"+
-		"\3\u009c\5\u009c\u07af\n\u009c\3\u009c\5\u009c\u07b2\n\u009c\3\u009c\5"+
-		"\u009c\u07b5\n\u009c\3\u009c\5\u009c\u07b8\n\u009c\3\u009d\3\u009d\3\u009d"+
-		"\6\u009d\u07bd\n\u009d\r\u009d\16\u009d\u07be\3\u009d\3\u009d\3\u009e"+
-		"\3\u009e\3\u009e\3\u009f\3\u009f\3\u009f\5\u009f\u07c9\n\u009f\3\u009f"+
-		"\5\u009f\u07cc\n\u009f\3\u009f\5\u009f\u07cf\n\u009f\3\u009f\5\u009f\u07d2"+
-		"\n\u009f\3\u009f\5\u009f\u07d5\n\u009f\3\u009f\3\u009f\3\u00a0\5\u00a0"+
-		"\u07da\n\u00a0\3\u00a0\3\u00a0\5\u00a0\u07de\n\u00a0\3\u00a1\3\u00a1\3"+
-		"\u00a1\3\u00a1\3\u00a2\3\u00a2\3\u00a2\3\u00a2\3\u00a2\7\u00a2\u07e9\n"+
-		"\u00a2\f\u00a2\16\u00a2\u07ec\13\u00a2\3\u00a3\3\u00a3\5\u00a3\u07f0\n"+
-		"\u00a3\3\u00a4\3\u00a4\3\u00a4\3\u00a5\3\u00a5\3\u00a5\5\u00a5\u07f8\n"+
-		"\u00a5\3\u00a5\5\u00a5\u07fb\n\u00a5\3\u00a5\5\u00a5\u07fe\n\u00a5\3\u00a6"+
-		"\3\u00a6\3\u00a6\7\u00a6\u0803\n\u00a6\f\u00a6\16\u00a6\u0806\13\u00a6"+
-		"\3\u00a7\3\u00a7\3\u00a7\5\u00a7\u080b\n\u00a7\3\u00a8\3\u00a8\3\u00a8"+
-		"\3\u00a8\3\u00a9\3\u00a9\3\u00a9\3\u00aa\3\u00aa\3\u00aa\3\u00aa\3\u00aa"+
-		"\3\u00aa\7\u00aa\u081a\n\u00aa\f\u00aa\16\u00aa\u081d\13\u00aa\3\u00aa"+
-		"\3\u00aa\3\u00ab\3\u00ab\3\u00ab\3\u00ab\7\u00ab\u0825\n\u00ab\f\u00ab"+
-		"\16\u00ab\u0828\13\u00ab\3\u00ac\3\u00ac\3\u00ac\3\u00ac\3\u00ad\3\u00ad"+
-		"\5\u00ad\u0830\n\u00ad\3\u00ad\7\u00ad\u0833\n\u00ad\f\u00ad\16\u00ad"+
-		"\u0836\13\u00ad\3\u00ad\5\u00ad\u0839\n\u00ad\3\u00ad\7\u00ad\u083c\n"+
-		"\u00ad\f\u00ad\16\u00ad\u083f\13\u00ad\3\u00ad\5\u00ad\u0842\n\u00ad\3"+
-		"\u00ad\3\u00ad\5\u00ad\u0846\n\u00ad\3\u00ae\3\u00ae\3\u00ae\3\u00ae\3"+
-		"\u00ae\3\u00ae\5\u00ae\u084e\n\u00ae\3\u00ae\3\u00ae\3\u00ae\3\u00ae\3"+
-		"\u00af\3\u00af\3\u00af\3\u00af\3\u00af\3\u00af\3\u00af\5\u00af\u085b\n"+
-		"\u00af\3\u00af\3\u00af\3\u00af\3\u00af\3\u00af\5\u00af\u0862\n\u00af\3"+
-		"\u00b0\3\u00b0\3\u00b0\3\u00b0\5\u00b0\u0868\n\u00b0\3\u00b0\3\u00b0\3"+
+		"\13)\3)\3)\3)\3)\3)\3)\3)\3)\3)\3)\3)\3)\5)\u035b\n)\3)\3)\3)\6)\u0360"+
+		"\n)\r)\16)\u0361\3)\3)\3)\6)\u0367\n)\r)\16)\u0368\3)\3)\7)\u036d\n)\f"+
+		")\16)\u0370\13)\3*\7*\u0373\n*\f*\16*\u0376\13*\3+\3+\3+\3+\3+\5+\u037d"+
+		"\n+\3,\3,\5,\u0381\n,\3-\3-\3.\3.\3/\3/\3/\3/\3/\5/\u038c\n/\3/\3/\3/"+
+		"\3/\3/\5/\u0393\n/\3/\3/\3/\3/\3/\3/\5/\u039b\n/\3/\3/\3/\5/\u03a0\n/"+
+		"\3/\3/\3/\3/\3/\5/\u03a7\n/\3/\3/\3/\3/\3/\5/\u03ae\n/\3/\3/\3/\3/\3/"+
+		"\5/\u03b5\n/\3/\5/\u03b8\n/\3\60\3\60\3\60\3\60\5\60\u03be\n\60\3\60\3"+
+		"\60\5\60\u03c2\n\60\3\61\3\61\3\62\3\62\3\63\3\63\3\63\5\63\u03cb\n\63"+
+		"\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64"+
+		"\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\3\64\5\64\u03e6\n\64"+
+		"\3\65\3\65\3\65\3\65\5\65\u03ec\n\65\3\65\3\65\3\66\3\66\3\66\3\66\7\66"+
+		"\u03f4\n\66\f\66\16\66\u03f7\13\66\5\66\u03f9\n\66\3\66\3\66\3\67\3\67"+
+		"\3\67\3\67\38\38\58\u0403\n8\39\39\39\3:\3:\3;\3;\5;\u040c\n;\3;\3;\3"+
+		"<\3<\3<\5<\u0413\n<\3<\5<\u0416\n<\3<\3<\3<\3<\5<\u041c\n<\3<\3<\5<\u0420"+
+		"\n<\3=\5=\u0423\n=\3=\3=\3=\3=\3=\3>\5>\u042b\n>\3>\3>\3>\3>\3>\3>\3>"+
+		"\3>\3>\3>\3>\3>\3>\3>\5>\u043b\n>\3?\3?\3?\3?\3?\3@\3@\3A\3A\3A\3A\3B"+
+		"\3B\3C\3C\3C\7C\u044d\nC\fC\16C\u0450\13C\3D\3D\7D\u0454\nD\fD\16D\u0457"+
+		"\13D\3D\5D\u045a\nD\3E\3E\3E\3E\7E\u0460\nE\fE\16E\u0463\13E\3E\3E\3F"+
+		"\3F\3F\3F\3F\7F\u046c\nF\fF\16F\u046f\13F\3F\3F\3G\3G\3G\7G\u0476\nG\f"+
+		"G\16G\u0479\13G\3G\3G\3H\3H\3H\3H\6H\u0481\nH\rH\16H\u0482\3H\3H\3I\3"+
+		"I\3I\3I\3I\7I\u048c\nI\fI\16I\u048f\13I\3I\5I\u0492\nI\3I\3I\3I\3I\3I"+
+		"\3I\7I\u049a\nI\fI\16I\u049d\13I\3I\5I\u04a0\nI\5I\u04a2\nI\3J\3J\5J\u04a6"+
+		"\nJ\3J\3J\3J\3J\5J\u04ac\nJ\3J\3J\7J\u04b0\nJ\fJ\16J\u04b3\13J\3J\3J\3"+
+		"K\3K\3K\3K\5K\u04bb\nK\3K\3K\3L\3L\3L\3L\7L\u04c3\nL\fL\16L\u04c6\13L"+
+		"\3L\3L\3M\3M\3M\3N\3N\3N\3O\3O\3O\7O\u04d3\nO\fO\16O\u04d6\13O\3O\3O\5"+
+		"O\u04da\nO\3O\5O\u04dd\nO\3P\3P\3P\3P\3P\5P\u04e4\nP\3P\3P\3P\3P\3P\3"+
+		"P\7P\u04ec\nP\fP\16P\u04ef\13P\3P\3P\3Q\3Q\3Q\3Q\3Q\7Q\u04f8\nQ\fQ\16"+
+		"Q\u04fb\13Q\5Q\u04fd\nQ\3Q\3Q\3Q\3Q\7Q\u0503\nQ\fQ\16Q\u0506\13Q\5Q\u0508"+
+		"\nQ\5Q\u050a\nQ\3R\3R\3R\3R\3R\3R\3R\3R\3R\3R\7R\u0516\nR\fR\16R\u0519"+
+		"\13R\3R\3R\3S\3S\3S\7S\u0520\nS\fS\16S\u0523\13S\3S\3S\3S\3T\6T\u0529"+
+		"\nT\rT\16T\u052a\3T\5T\u052e\nT\3T\5T\u0531\nT\3U\3U\3U\3U\3U\3U\3U\7"+
+		"U\u053a\nU\fU\16U\u053d\13U\3U\3U\3V\3V\3V\7V\u0544\nV\fV\16V\u0547\13"+
+		"V\3V\3V\3W\3W\3W\3W\3X\3X\5X\u0551\nX\3X\3X\3Y\3Y\5Y\u0557\nY\3Z\3Z\3"+
+		"Z\3Z\3Z\3Z\3Z\3Z\3Z\3Z\5Z\u0563\nZ\3[\3[\3[\3[\3[\3\\\3\\\3\\\5\\\u056d"+
+		"\n\\\3\\\3\\\3\\\3\\\3\\\3\\\3\\\3\\\7\\\u0577\n\\\f\\\16\\\u057a\13\\"+
+		"\3]\3]\3]\3^\3^\3^\3^\3_\3_\3_\3_\3_\5_\u0588\n_\3`\3`\3`\5`\u058d\n`"+
+		"\3`\3`\3a\3a\3a\3a\5a\u0595\na\3a\3a\3b\3b\3b\7b\u059c\nb\fb\16b\u059f"+
+		"\13b\3c\3c\3c\5c\u05a4\nc\3d\5d\u05a7\nd\3d\3d\3d\3d\3e\3e\3e\7e\u05b0"+
+		"\ne\fe\16e\u05b3\13e\3f\3f\3f\3g\3g\5g\u05ba\ng\3h\3h\3h\5h\u05bf\nh\3"+
+		"h\3h\7h\u05c3\nh\fh\16h\u05c6\13h\3h\3h\3i\3i\3i\5i\u05cd\ni\3j\3j\3j"+
+		"\7j\u05d2\nj\fj\16j\u05d5\13j\3k\3k\3k\7k\u05da\nk\fk\16k\u05dd\13k\3"+
+		"k\3k\3l\3l\3l\7l\u05e4\nl\fl\16l\u05e7\13l\3l\3l\3m\3m\3m\3n\3n\3n\3o"+
+		"\3o\3o\3o\3p\3p\3p\3p\3q\3q\3q\3q\3r\3r\3s\3s\3s\3s\5s\u0603\ns\3s\3s"+
+		"\3t\3t\3t\3t\3t\3t\3t\3t\5t\u060f\nt\3t\3t\3t\3t\3t\3t\3t\3t\3t\5t\u061a"+
+		"\nt\3t\3t\3t\3t\3t\3t\3t\3t\3t\7t\u0625\nt\ft\16t\u0628\13t\3t\3t\3t\3"+
+		"t\3t\3t\5t\u0630\nt\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3"+
+		"t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\3t\7t\u0655\nt\f"+
+		"t\16t\u0658\13t\3u\3u\3u\3v\3v\3v\3v\3v\7v\u0662\nv\fv\16v\u0665\13v\3"+
+		"v\3v\3w\3w\5w\u066b\nw\3w\3w\3w\3x\3x\5x\u0672\nx\3x\3x\3y\3y\5y\u0678"+
+		"\ny\3y\3y\3z\3z\7z\u067e\nz\fz\16z\u0681\13z\3z\3z\3{\7{\u0686\n{\f{\16"+
+		"{\u0689\13{\3{\3{\3|\3|\3|\7|\u0690\n|\f|\16|\u0693\13|\3}\3}\3~\3~\3"+
+		"~\7~\u069a\n~\f~\16~\u069d\13~\3\177\7\177\u06a0\n\177\f\177\16\177\u06a3"+
+		"\13\177\3\177\3\177\3\177\3\177\7\177\u06a9\n\177\f\177\16\177\u06ac\13"+
+		"\177\3\177\3\177\3\177\3\177\3\177\3\177\3\177\7\177\u06b5\n\177\f\177"+
+		"\16\177\u06b8\13\177\3\177\3\177\5\177\u06bc\n\177\3\u0080\3\u0080\3\u0080"+
+		"\3\u0080\3\u0081\7\u0081\u06c3\n\u0081\f\u0081\16\u0081\u06c6\13\u0081"+
+		"\3\u0081\3\u0081\3\u0081\3\u0081\3\u0082\3\u0082\5\u0082\u06ce\n\u0082"+
+		"\3\u0082\3\u0082\3\u0082\5\u0082\u06d3\n\u0082\7\u0082\u06d5\n\u0082\f"+
+		"\u0082\16\u0082\u06d8\13\u0082\3\u0082\3\u0082\5\u0082\u06dc\n\u0082\3"+
+		"\u0082\5\u0082\u06df\n\u0082\3\u0083\5\u0083\u06e2\n\u0083\3\u0083\3\u0083"+
+		"\5\u0083\u06e6\n\u0083\3\u0083\3\u0083\3\u0083\3\u0083\3\u0083\3\u0083"+
+		"\5\u0083\u06ee\n\u0083\3\u0084\3\u0084\3\u0085\3\u0085\3\u0085\3\u0086"+
+		"\3\u0086\3\u0087\3\u0087\3\u0087\3\u0087\3\u0088\3\u0088\3\u0088\3\u0089"+
+		"\3\u0089\3\u0089\3\u0089\3\u008a\3\u008a\3\u008a\3\u008a\3\u008a\5\u008a"+
+		"\u0707\n\u008a\3\u008b\5\u008b\u070a\n\u008b\3\u008b\3\u008b\3\u008b\3"+
+		"\u008b\5\u008b\u0710\n\u008b\3\u008b\5\u008b\u0713\n\u008b\7\u008b\u0715"+
+		"\n\u008b\f\u008b\16\u008b\u0718\13\u008b\3\u008c\3\u008c\3\u008c\3\u008c"+
+		"\3\u008c\7\u008c\u071f\n\u008c\f\u008c\16\u008c\u0722\13\u008c\3\u008c"+
+		"\3\u008c\3\u008d\3\u008d\3\u008d\3\u008d\3\u008d\5\u008d\u072b\n\u008d"+
+		"\3\u008e\3\u008e\3\u008e\7\u008e\u0730\n\u008e\f\u008e\16\u008e\u0733"+
+		"\13\u008e\3\u008e\3\u008e\3\u008f\3\u008f\3\u008f\3\u008f\3\u0090\3\u0090"+
+		"\3\u0090\7\u0090\u073e\n\u0090\f\u0090\16\u0090\u0741\13\u0090\3\u0090"+
+		"\3\u0090\3\u0091\3\u0091\3\u0091\3\u0091\3\u0091\7\u0091\u074a\n\u0091"+
+		"\f\u0091\16\u0091\u074d\13\u0091\3\u0091\3\u0091\3\u0092\3\u0092\3\u0092"+
+		"\3\u0092\3\u0093\3\u0093\3\u0093\3\u0093\6\u0093\u0759\n\u0093\r\u0093"+
+		"\16\u0093\u075a\3\u0093\5\u0093\u075e\n\u0093\3\u0093\5\u0093\u0761\n"+
+		"\u0093\3\u0094\3\u0094\5\u0094\u0765\n\u0094\3\u0095\3\u0095\3\u0095\3"+
+		"\u0095\3\u0095\7\u0095\u076c\n\u0095\f\u0095\16\u0095\u076f\13\u0095\3"+
+		"\u0095\5\u0095\u0772\n\u0095\3\u0095\3\u0095\3\u0096\3\u0096\3\u0096\3"+
+		"\u0096\3\u0096\7\u0096\u077b\n\u0096\f\u0096\16\u0096\u077e\13\u0096\3"+
+		"\u0096\5\u0096\u0781\n\u0096\3\u0096\3\u0096\3\u0097\3\u0097\5\u0097\u0787"+
+		"\n\u0097\3\u0097\3\u0097\3\u0097\3\u0097\3\u0097\5\u0097\u078e\n\u0097"+
+		"\3\u0098\3\u0098\5\u0098\u0792\n\u0098\3\u0098\3\u0098\3\u0099\3\u0099"+
+		"\3\u0099\3\u0099\6\u0099\u079a\n\u0099\r\u0099\16\u0099\u079b\3\u0099"+
+		"\5\u0099\u079f\n\u0099\3\u0099\5\u0099\u07a2\n\u0099\3\u009a\3\u009a\5"+
+		"\u009a\u07a6\n\u009a\3\u009b\3\u009b\3\u009c\3\u009c\3\u009c\5\u009c\u07ad"+
+		"\n\u009c\3\u009c\5\u009c\u07b0\n\u009c\3\u009c\5\u009c\u07b3\n\u009c\3"+
+		"\u009c\5\u009c\u07b6\n\u009c\3\u009d\3\u009d\3\u009d\6\u009d\u07bb\n\u009d"+
+		"\r\u009d\16\u009d\u07bc\3\u009d\3\u009d\3\u009e\3\u009e\3\u009e\3\u009f"+
+		"\3\u009f\3\u009f\5\u009f\u07c7\n\u009f\3\u009f\5\u009f\u07ca\n\u009f\3"+
+		"\u009f\5\u009f\u07cd\n\u009f\3\u009f\5\u009f\u07d0\n\u009f\3\u009f\5\u009f"+
+		"\u07d3\n\u009f\3\u009f\3\u009f\3\u00a0\5\u00a0\u07d8\n\u00a0\3\u00a0\3"+
+		"\u00a0\5\u00a0\u07dc\n\u00a0\3\u00a1\3\u00a1\3\u00a1\3\u00a1\3\u00a2\3"+
+		"\u00a2\3\u00a2\3\u00a2\3\u00a2\7\u00a2\u07e7\n\u00a2\f\u00a2\16\u00a2"+
+		"\u07ea\13\u00a2\3\u00a3\3\u00a3\5\u00a3\u07ee\n\u00a3\3\u00a4\3\u00a4"+
+		"\3\u00a4\3\u00a5\3\u00a5\3\u00a5\5\u00a5\u07f6\n\u00a5\3\u00a5\5\u00a5"+
+		"\u07f9\n\u00a5\3\u00a5\5\u00a5\u07fc\n\u00a5\3\u00a6\3\u00a6\3\u00a6\7"+
+		"\u00a6\u0801\n\u00a6\f\u00a6\16\u00a6\u0804\13\u00a6\3\u00a7\3\u00a7\3"+
+		"\u00a7\5\u00a7\u0809\n\u00a7\3\u00a8\3\u00a8\3\u00a8\3\u00a8\3\u00a9\3"+
+		"\u00a9\3\u00a9\3\u00aa\3\u00aa\3\u00aa\3\u00aa\3\u00aa\3\u00aa\7\u00aa"+
+		"\u0818\n\u00aa\f\u00aa\16\u00aa\u081b\13\u00aa\3\u00aa\3\u00aa\3\u00ab"+
+		"\3\u00ab\3\u00ab\3\u00ab\7\u00ab\u0823\n\u00ab\f\u00ab\16\u00ab\u0826"+
+		"\13\u00ab\3\u00ac\3\u00ac\3\u00ac\3\u00ac\3\u00ad\3\u00ad\5\u00ad\u082e"+
+		"\n\u00ad\3\u00ad\7\u00ad\u0831\n\u00ad\f\u00ad\16\u00ad\u0834\13\u00ad"+
+		"\3\u00ad\5\u00ad\u0837\n\u00ad\3\u00ad\7\u00ad\u083a\n\u00ad\f\u00ad\16"+
+		"\u00ad\u083d\13\u00ad\3\u00ad\5\u00ad\u0840\n\u00ad\3\u00ad\3\u00ad\5"+
+		"\u00ad\u0844\n\u00ad\3\u00ae\3\u00ae\3\u00ae\3\u00ae\3\u00ae\3\u00ae\5"+
+		"\u00ae\u084c\n\u00ae\3\u00ae\3\u00ae\3\u00ae\3\u00ae\3\u00af\3\u00af\3"+
+		"\u00af\3\u00af\3\u00af\3\u00af\3\u00af\5\u00af\u0859\n\u00af\3\u00af\3"+
+		"\u00af\3\u00af\3\u00af\3\u00af\5\u00af\u0860\n\u00af\3\u00b0\3\u00b0\3"+
+		"\u00b0\3\u00b0\5\u00b0\u0866\n\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\3"+
 		"\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0"+
-		"\3\u00b0\3\u00b0\5\u00b0\u0877\n\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0"+
-		"\3\u00b0\5\u00b0\u087e\n\u00b0\3\u00b1\3\u00b1\5\u00b1\u0882\n\u00b1\3"+
-		"\u00b1\5\u00b1\u0885\n\u00b1\3\u00b1\3\u00b1\5\u00b1\u0889\n\u00b1\3\u00b2"+
-		"\3\u00b2\3\u00b2\3\u00b3\3\u00b3\3\u00b3\3\u00b4\3\u00b4\3\u00b5\3\u00b5"+
-		"\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5"+
-		"\3\u00b5\5\u00b5\u089f\n\u00b5\3\u00b5\5\u00b5\u08a2\n\u00b5\3\u00b6\3"+
-		"\u00b6\3\u00b7\3\u00b7\5\u00b7\u08a8\n\u00b7\3\u00b7\3\u00b7\3\u00b8\3"+
-		"\u00b8\3\u00b8\7\u00b8\u08af\n\u00b8\f\u00b8\16\u00b8\u08b2\13\u00b8\3"+
-		"\u00b8\3\u00b8\3\u00b8\7\u00b8\u08b7\n\u00b8\f\u00b8\16\u00b8\u08ba\13"+
-		"\u00b8\5\u00b8\u08bc\n\u00b8\3\u00b9\3\u00b9\3\u00b9\5\u00b9\u08c1\n\u00b9"+
-		"\3\u00ba\3\u00ba\5\u00ba\u08c5\n\u00ba\3\u00ba\3\u00ba\3\u00bb\3\u00bb"+
-		"\5\u00bb\u08cb\n\u00bb\3\u00bb\3\u00bb\3\u00bc\3\u00bc\5\u00bc\u08d1\n"+
-		"\u00bc\3\u00bc\3\u00bc\3\u00bd\3\u00bd\5\u00bd\u08d7\n\u00bd\3\u00bd\3"+
-		"\u00bd\3\u00be\5\u00be\u08dc\n\u00be\3\u00be\6\u00be\u08df\n\u00be\r\u00be"+
-		"\16\u00be\u08e0\3\u00be\5\u00be\u08e4\n\u00be\3\u00bf\3\u00bf\5\u00bf"+
-		"\u08e8\n\u00bf\3\u00bf\3\u00bf\5\u00bf\u08ec\n\u00bf\3\u00c0\3\u00c0\3"+
-		"\u00c0\7\u00c0\u08f1\n\u00c0\f\u00c0\16\u00c0\u08f4\13\u00c0\3\u00c0\3"+
-		"\u00c0\3\u00c0\7\u00c0\u08f9\n\u00c0\f\u00c0\16\u00c0\u08fc\13\u00c0\5"+
-		"\u00c0\u08fe\n\u00c0\3\u00c1\3\u00c1\3\u00c1\5\u00c1\u0903\n\u00c1\3\u00c2"+
-		"\3\u00c2\5\u00c2\u0907\n\u00c2\3\u00c2\3\u00c2\3\u00c3\3\u00c3\5\u00c3"+
-		"\u090d\n\u00c3\3\u00c3\3\u00c3\3\u00c4\3\u00c4\5\u00c4\u0913\n\u00c4\3"+
-		"\u00c4\3\u00c4\3\u00c4\2\5P\u00b6\u00e6\u00c5\2\4\6\b\n\f\16\20\22\24"+
-		"\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`bdfhjlnprtv"+
-		"xz|~\u0080\u0082\u0084\u0086\u0088\u008a\u008c\u008e\u0090\u0092\u0094"+
-		"\u0096\u0098\u009a\u009c\u009e\u00a0\u00a2\u00a4\u00a6\u00a8\u00aa\u00ac"+
-		"\u00ae\u00b0\u00b2\u00b4\u00b6\u00b8\u00ba\u00bc\u00be\u00c0\u00c2\u00c4"+
-		"\u00c6\u00c8\u00ca\u00cc\u00ce\u00d0\u00d2\u00d4\u00d6\u00d8\u00da\u00dc"+
-		"\u00de\u00e0\u00e2\u00e4\u00e6\u00e8\u00ea\u00ec\u00ee\u00f0\u00f2\u00f4"+
-		"\u00f6\u00f8\u00fa\u00fc\u00fe\u0100\u0102\u0104\u0106\u0108\u010a\u010c"+
-		"\u010e\u0110\u0112\u0114\u0116\u0118\u011a\u011c\u011e\u0120\u0122\u0124"+
-		"\u0126\u0128\u012a\u012c\u012e\u0130\u0132\u0134\u0136\u0138\u013a\u013c"+
-		"\u013e\u0140\u0142\u0144\u0146\u0148\u014a\u014c\u014e\u0150\u0152\u0154"+
-		"\u0156\u0158\u015a\u015c\u015e\u0160\u0162\u0164\u0166\u0168\u016a\u016c"+
-		"\u016e\u0170\u0172\u0174\u0176\u0178\u017a\u017c\u017e\u0180\u0182\u0184"+
-		"\u0186\2\30\4\2{{\177\177\6\2\b\13\r\16\21\21UU\3\2IM\3\2\u00a0\u00a3"+
-		"\3\2\u00a4\u00a5\4\2\u0082\u0082\u0084\u0084\4\2\u0083\u0083\u0085\u0085"+
-		"\4\2~~\u008e\u008e\4\2\u008a\u008a\u00b1\u00b1\6\2qquu\u0088\u0089\u008e"+
-		"\u008e\4\2\u008a\u008b\u008d\u008d\3\2\u0088\u0089\3\2\u0091\u0094\3\2"+
-		"\u008f\u0090\4\2\u009c\u009c\u00a6\u00a6\3\2\u00a7\u00aa\3\2\u00ae\u00af"+
-		"\6\2NN\\\\^^vv\4\2./cc\3\2\u0095\u0096\3\2GH\3\29D\u09c6\2\u018c\3\2\2"+
-		"\2\4\u01a3\3\2\2\2\6\u01ae\3\2\2\2\b\u01b1\3\2\2\2\n\u01be\3\2\2\2\f\u01c6"+
-		"\3\2\2\2\16\u01c8\3\2\2\2\20\u01e0\3\2\2\2\22\u01e2\3\2\2\2\24\u01fb\3"+
-		"\2\2\2\26\u0213\3\2\2\2\30\u0215\3\2\2\2\32\u022c\3\2\2\2\34\u023e\3\2"+
-		"\2\2\36\u0249\3\2\2\2 \u0253\3\2\2\2\"\u025b\3\2\2\2$\u0266\3\2\2\2&\u0270"+
-		"\3\2\2\2(\u027d\3\2\2\2*\u028a\3\2\2\2,\u0291\3\2\2\2.\u0298\3\2\2\2\60"+
-		"\u02b6\3\2\2\2\62\u02bb\3\2\2\2\64\u02c3\3\2\2\2\66\u02ca\3\2\2\28\u02df"+
-		"\3\2\2\2:\u02e9\3\2\2\2<\u0300\3\2\2\2>\u030a\3\2\2\2@\u030c\3\2\2\2B"+
-		"\u0316\3\2\2\2D\u031a\3\2\2\2F\u0321\3\2\2\2H\u032c\3\2\2\2J\u0331\3\2"+
-		"\2\2L\u0333\3\2\2\2N\u033d\3\2\2\2P\u035c\3\2\2\2R\u0376\3\2\2\2T\u037e"+
-		"\3\2\2\2V\u0382\3\2\2\2X\u0384\3\2\2\2Z\u0386\3\2\2\2\\\u03b9\3\2\2\2"+
-		"^\u03bb\3\2\2\2`\u03c5\3\2\2\2b\u03c7\3\2\2\2d\u03c9\3\2\2\2f\u03e7\3"+
-		"\2\2\2h\u03e9\3\2\2\2j\u03f1\3\2\2\2l\u03fe\3\2\2\2n\u0404\3\2\2\2p\u0406"+
-		"\3\2\2\2r\u0409\3\2\2\2t\u040b\3\2\2\2v\u0421\3\2\2\2x\u0424\3\2\2\2z"+
-		"\u043c\3\2\2\2|\u043e\3\2\2\2~\u0443\3\2\2\2\u0080\u0445\3\2\2\2\u0082"+
-		"\u0449\3\2\2\2\u0084\u044b\3\2\2\2\u0086\u0453\3\2\2\2\u0088\u045d\3\2"+
-		"\2\2\u008a\u0468\3\2\2\2\u008c\u0474\3\2\2\2\u008e\u047e\3\2\2\2\u0090"+
-		"\u04a3\3\2\2\2\u0092\u04a5\3\2\2\2\u0094\u04b8\3\2\2\2\u0096\u04c0\3\2"+
-		"\2\2\u0098\u04cb\3\2\2\2\u009a\u04ce\3\2\2\2\u009c\u04d1\3\2\2\2\u009e"+
-		"\u04e0\3\2\2\2\u00a0\u050b\3\2\2\2\u00a2\u050d\3\2\2\2\u00a4\u051e\3\2"+
-		"\2\2\u00a6\u0532\3\2\2\2\u00a8\u0534\3\2\2\2\u00aa\u0542\3\2\2\2\u00ac"+
-		"\u054c\3\2\2\2\u00ae\u0550\3\2\2\2\u00b0\u0558\3\2\2\2\u00b2\u0564\3\2"+
-		"\2\2\u00b4\u0566\3\2\2\2\u00b6\u056e\3\2\2\2\u00b8\u057d\3\2\2\2\u00ba"+
-		"\u0580\3\2\2\2\u00bc\u0584\3\2\2\2\u00be\u058b\3\2\2\2\u00c0\u0592\3\2"+
-		"\2\2\u00c2\u059a\3\2\2\2\u00c4\u05a5\3\2\2\2\u00c6\u05a8\3\2\2\2\u00c8"+
-		"\u05ae\3\2\2\2\u00ca\u05b6\3\2\2\2\u00cc\u05b9\3\2\2\2\u00ce\u05bd\3\2"+
-		"\2\2\u00d0\u05ce\3\2\2\2\u00d2\u05d0\3\2\2\2\u00d4\u05d8\3\2\2\2\u00d6"+
-		"\u05e2\3\2\2\2\u00d8\u05ec\3\2\2\2\u00da\u05ef\3\2\2\2\u00dc\u05f2\3\2"+
-		"\2\2\u00de\u05f6\3\2\2\2\u00e0\u05fa\3\2\2\2\u00e2\u05fe\3\2\2\2\u00e4"+
-		"\u0600\3\2\2\2\u00e6\u0631\3\2\2\2\u00e8\u065b\3\2\2\2\u00ea\u065e\3\2"+
-		"\2\2\u00ec\u066a\3\2\2\2\u00ee\u0673\3\2\2\2\u00f0\u0679\3\2\2\2\u00f2"+
-		"\u067d\3\2\2\2\u00f4\u0689\3\2\2\2\u00f6\u068e\3\2\2\2\u00f8\u0696\3\2"+
-		"\2\2\u00fa\u0698\3\2\2\2\u00fc\u06bd\3\2\2\2\u00fe\u06bf\3\2\2\2\u0100"+
-		"\u06c6\3\2\2\2\u0102\u06e0\3\2\2\2\u0104\u06ef\3\2\2\2\u0106\u06f1\3\2"+
-		"\2\2\u0108\u06f3\3\2\2\2\u010a\u06f6\3\2\2\2\u010c\u06f8\3\2\2\2\u010e"+
-		"\u06fc\3\2\2\2\u0110\u06ff\3\2\2\2\u0112\u0708\3\2\2\2\u0114\u070b\3\2"+
-		"\2\2\u0116\u071b\3\2\2\2\u0118\u072c\3\2\2\2\u011a\u072e\3\2\2\2\u011c"+
-		"\u0738\3\2\2\2\u011e\u073c\3\2\2\2\u0120\u0746\3\2\2\2\u0122\u0752\3\2"+
-		"\2\2\u0124\u0762\3\2\2\2\u0126\u0766\3\2\2\2\u0128\u0768\3\2\2\2\u012a"+
-		"\u0777\3\2\2\2\u012c\u078f\3\2\2\2\u012e\u0791\3\2\2\2\u0130\u07a3\3\2"+
-		"\2\2\u0132\u07a7\3\2\2\2\u0134\u07a9\3\2\2\2\u0136\u07ab\3\2\2\2\u0138"+
-		"\u07b9\3\2\2\2\u013a\u07c2\3\2\2\2\u013c\u07c5\3\2\2\2\u013e\u07d9\3\2"+
-		"\2\2\u0140\u07df\3\2\2\2\u0142\u07e3\3\2\2\2\u0144\u07ed\3\2\2\2\u0146"+
-		"\u07f1\3\2\2\2\u0148\u07f4\3\2\2\2\u014a\u07ff\3\2\2\2\u014c\u0807\3\2"+
-		"\2\2\u014e\u080c\3\2\2\2\u0150\u0810\3\2\2\2\u0152\u0813\3\2\2\2\u0154"+
-		"\u0820\3\2\2\2\u0156\u0829\3\2\2\2\u0158\u082d\3\2\2\2\u015a\u084d\3\2"+
-		"\2\2\u015c\u0861\3\2\2\2\u015e\u087d\3\2\2\2\u0160\u087f\3\2\2\2\u0162"+
-		"\u088a\3\2\2\2\u0164\u088d\3\2\2\2\u0166\u0890\3\2\2\2\u0168\u08a1\3\2"+
-		"\2\2\u016a\u08a3\3\2\2\2\u016c\u08a5\3\2\2\2\u016e\u08bb\3\2\2\2\u0170"+
-		"\u08c0\3\2\2\2\u0172\u08c2\3\2\2\2\u0174\u08c8\3\2\2\2\u0176\u08ce\3\2"+
-		"\2\2\u0178\u08d4\3\2\2\2\u017a\u08e3\3\2\2\2\u017c\u08e5\3\2\2\2\u017e"+
-		"\u08fd\3\2\2\2\u0180\u0902\3\2\2\2\u0182\u0904\3\2\2\2\u0184\u090a\3\2"+
-		"\2\2\u0186\u0910\3\2\2\2\u0188\u018b\5\b\5\2\u0189\u018b\5\u00e4s\2\u018a"+
-		"\u0188\3\2\2\2\u018a\u0189\3\2\2\2\u018b\u018e\3\2\2\2\u018c\u018a\3\2"+
-		"\2\2\u018c\u018d\3\2\2\2\u018d\u019e\3\2\2\2\u018e\u018c\3\2\2\2\u018f"+
-		"\u0191\5\u0178\u00bd\2\u0190\u018f\3\2\2\2\u0190\u0191\3\2\2\2\u0191\u0193"+
-		"\3\2\2\2\u0192\u0194\5\u016c\u00b7\2\u0193\u0192\3\2\2\2\u0193\u0194\3"+
-		"\2\2\2\u0194\u0198\3\2\2\2\u0195\u0197\5d\63\2\u0196\u0195\3\2\2\2\u0197"+
-		"\u019a\3\2\2\2\u0198\u0196\3\2\2\2\u0198\u0199\3\2\2\2\u0199\u019b\3\2"+
-		"\2\2\u019a\u0198\3\2\2\2\u019b\u019d\5\f\7\2\u019c\u0190\3\2\2\2\u019d"+
-		"\u01a0\3\2\2\2\u019e\u019c\3\2\2\2\u019e\u019f\3\2\2\2\u019f\u01a1\3\2"+
-		"\2\2\u01a0\u019e\3\2\2\2\u01a1\u01a2\7\2\2\3\u01a2\3\3\2\2\2\u01a3\u01a8"+
-		"\7\u00b1\2\2\u01a4\u01a5\7~\2\2\u01a5\u01a7\7\u00b1\2\2\u01a6\u01a4\3"+
-		"\2\2\2\u01a7\u01aa\3\2\2\2\u01a8\u01a6\3\2\2\2\u01a8\u01a9\3\2\2\2\u01a9"+
-		"\u01ac\3\2\2\2\u01aa\u01a8\3\2\2\2\u01ab\u01ad\5\6\4\2\u01ac\u01ab\3\2"+
-		"\2\2\u01ac\u01ad\3\2\2\2\u01ad\5\3\2\2\2\u01ae\u01af\7\25\2\2\u01af\u01b0"+
-		"\7\u00b1\2\2\u01b0\7\3\2\2\2\u01b1\u01b5\7\3\2\2\u01b2\u01b3\5\n\6\2\u01b3"+
-		"\u01b4\7\u008b\2\2\u01b4\u01b6\3\2\2\2\u01b5\u01b2\3\2\2\2\u01b5\u01b6"+
-		"\3\2\2\2\u01b6\u01b7\3\2\2\2\u01b7\u01ba\5\4\3\2\u01b8\u01b9\7\4\2\2\u01b9"+
-		"\u01bb\7\u00b1\2\2\u01ba\u01b8\3\2\2\2\u01ba\u01bb\3\2\2\2\u01bb\u01bc"+
-		"\3\2\2\2\u01bc\u01bd\7{\2\2\u01bd\t\3\2\2\2\u01be\u01bf\7\u00b1\2\2\u01bf"+
-		"\13\3\2\2\2\u01c0\u01c7\5\16\b\2\u01c1\u01c7\5\32\16\2\u01c2\u01c7\5 "+
-		"\21\2\u01c3\u01c7\5:\36\2\u01c4\u01c7\5<\37\2\u01c5\u01c7\5D#\2\u01c6"+
-		"\u01c0\3\2\2\2\u01c6\u01c1\3\2\2\2\u01c6\u01c2\3\2\2\2\u01c6\u01c3\3\2"+
-		"\2\2\u01c6\u01c4\3\2\2\2\u01c6\u01c5\3\2\2\2\u01c7\r\3\2\2\2\u01c8\u01cd"+
-		"\7\b\2\2\u01c9\u01ca\7\u0092\2\2\u01ca\u01cb\5\u00eex\2\u01cb\u01cc\7"+
-		"\u0091\2\2\u01cc\u01ce\3\2\2\2\u01cd\u01c9\3\2\2\2\u01cd\u01ce\3\2\2\2"+
-		"\u01ce\u01cf\3\2\2\2\u01cf\u01d1\7\u00b1\2\2\u01d0\u01d2\5\20\t\2\u01d1"+
-		"\u01d0\3\2\2\2\u01d1\u01d2\3\2\2\2\u01d2\u01d3\3\2\2\2\u01d3\u01d4\5\22"+
-		"\n\2\u01d4\17\3\2\2\2\u01d5\u01d6\7\22\2\2\u01d6\u01db\5\u00eex\2\u01d7"+
-		"\u01d8\7\177\2\2\u01d8\u01da\5\u00eex\2\u01d9\u01d7\3\2\2\2\u01da\u01dd"+
-		"\3\2\2\2\u01db\u01d9\3\2\2\2\u01db\u01dc\3\2\2\2\u01dc\u01e1\3\2\2\2\u01dd"+
-		"\u01db\3\2\2\2\u01de\u01df\7\22\2\2\u01df\u01e1\5j\66\2\u01e0\u01d5\3"+
-		"\2\2\2\u01e0\u01de\3\2\2\2\u01e1\21\3\2\2\2\u01e2\u01e6\7\u0080\2\2\u01e3"+
-		"\u01e5\5F$\2\u01e4\u01e3\3\2\2\2\u01e5\u01e8\3\2\2\2\u01e6\u01e4\3\2\2"+
-		"\2\u01e6\u01e7\3\2\2\2\u01e7\u01ed\3\2\2\2\u01e8\u01e6\3\2\2\2\u01e9\u01ec"+
-		"\5h\65\2\u01ea\u01ec\5\u00e2r\2\u01eb\u01e9\3\2\2\2\u01eb\u01ea\3\2\2"+
-		"\2\u01ec\u01ef\3\2\2\2\u01ed\u01eb\3\2\2\2\u01ed\u01ee\3\2\2\2\u01ee\u01f3"+
-		"\3\2\2\2\u01ef\u01ed\3\2\2\2\u01f0\u01f2\5\24\13\2\u01f1\u01f0\3\2\2\2"+
-		"\u01f2\u01f5\3\2\2\2\u01f3\u01f1\3\2\2\2\u01f3\u01f4\3\2\2\2\u01f4\u01f6"+
-		"\3\2\2\2\u01f5\u01f3\3\2\2\2\u01f6\u01f7\7\u0081\2\2\u01f7\23\3\2\2\2"+
-		"\u01f8\u01fa\5d\63\2\u01f9\u01f8\3\2\2\2\u01fa\u01fd\3\2\2\2\u01fb\u01f9"+
-		"\3\2\2\2\u01fb\u01fc\3\2\2\2\u01fc\u01ff\3\2\2\2\u01fd\u01fb\3\2\2\2\u01fe"+
+		"\5\u00b0\u0875\n\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\3\u00b0\5\u00b0"+
+		"\u087c\n\u00b0\3\u00b1\3\u00b1\5\u00b1\u0880\n\u00b1\3\u00b1\5\u00b1\u0883"+
+		"\n\u00b1\3\u00b1\3\u00b1\5\u00b1\u0887\n\u00b1\3\u00b2\3\u00b2\3\u00b2"+
+		"\3\u00b3\3\u00b3\3\u00b3\3\u00b4\3\u00b4\3\u00b5\3\u00b5\3\u00b5\3\u00b5"+
+		"\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\3\u00b5\5\u00b5"+
+		"\u089d\n\u00b5\3\u00b5\5\u00b5\u08a0\n\u00b5\3\u00b6\3\u00b6\3\u00b7\3"+
+		"\u00b7\5\u00b7\u08a6\n\u00b7\3\u00b7\3\u00b7\3\u00b8\3\u00b8\3\u00b8\7"+
+		"\u00b8\u08ad\n\u00b8\f\u00b8\16\u00b8\u08b0\13\u00b8\3\u00b8\3\u00b8\3"+
+		"\u00b8\7\u00b8\u08b5\n\u00b8\f\u00b8\16\u00b8\u08b8\13\u00b8\5\u00b8\u08ba"+
+		"\n\u00b8\3\u00b9\3\u00b9\3\u00b9\5\u00b9\u08bf\n\u00b9\3\u00ba\3\u00ba"+
+		"\5\u00ba\u08c3\n\u00ba\3\u00ba\3\u00ba\3\u00bb\3\u00bb\5\u00bb\u08c9\n"+
+		"\u00bb\3\u00bb\3\u00bb\3\u00bc\3\u00bc\5\u00bc\u08cf\n\u00bc\3\u00bc\3"+
+		"\u00bc\3\u00bd\3\u00bd\5\u00bd\u08d5\n\u00bd\3\u00bd\3\u00bd\3\u00be\5"+
+		"\u00be\u08da\n\u00be\3\u00be\6\u00be\u08dd\n\u00be\r\u00be\16\u00be\u08de"+
+		"\3\u00be\5\u00be\u08e2\n\u00be\3\u00bf\3\u00bf\5\u00bf\u08e6\n\u00bf\3"+
+		"\u00bf\3\u00bf\5\u00bf\u08ea\n\u00bf\3\u00c0\3\u00c0\3\u00c0\7\u00c0\u08ef"+
+		"\n\u00c0\f\u00c0\16\u00c0\u08f2\13\u00c0\3\u00c0\3\u00c0\3\u00c0\7\u00c0"+
+		"\u08f7\n\u00c0\f\u00c0\16\u00c0\u08fa\13\u00c0\5\u00c0\u08fc\n\u00c0\3"+
+		"\u00c1\3\u00c1\3\u00c1\5\u00c1\u0901\n\u00c1\3\u00c2\3\u00c2\5\u00c2\u0905"+
+		"\n\u00c2\3\u00c2\3\u00c2\3\u00c3\3\u00c3\5\u00c3\u090b\n\u00c3\3\u00c3"+
+		"\3\u00c3\3\u00c4\3\u00c4\5\u00c4\u0911\n\u00c4\3\u00c4\3\u00c4\3\u00c4"+
+		"\2\5P\u00b6\u00e6\u00c5\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*"+
+		",.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`bdfhjlnprtvxz|~\u0080\u0082\u0084"+
+		"\u0086\u0088\u008a\u008c\u008e\u0090\u0092\u0094\u0096\u0098\u009a\u009c"+
+		"\u009e\u00a0\u00a2\u00a4\u00a6\u00a8\u00aa\u00ac\u00ae\u00b0\u00b2\u00b4"+
+		"\u00b6\u00b8\u00ba\u00bc\u00be\u00c0\u00c2\u00c4\u00c6\u00c8\u00ca\u00cc"+
+		"\u00ce\u00d0\u00d2\u00d4\u00d6\u00d8\u00da\u00dc\u00de\u00e0\u00e2\u00e4"+
+		"\u00e6\u00e8\u00ea\u00ec\u00ee\u00f0\u00f2\u00f4\u00f6\u00f8\u00fa\u00fc"+
+		"\u00fe\u0100\u0102\u0104\u0106\u0108\u010a\u010c\u010e\u0110\u0112\u0114"+
+		"\u0116\u0118\u011a\u011c\u011e\u0120\u0122\u0124\u0126\u0128\u012a\u012c"+
+		"\u012e\u0130\u0132\u0134\u0136\u0138\u013a\u013c\u013e\u0140\u0142\u0144"+
+		"\u0146\u0148\u014a\u014c\u014e\u0150\u0152\u0154\u0156\u0158\u015a\u015c"+
+		"\u015e\u0160\u0162\u0164\u0166\u0168\u016a\u016c\u016e\u0170\u0172\u0174"+
+		"\u0176\u0178\u017a\u017c\u017e\u0180\u0182\u0184\u0186\2\30\4\2{{\177"+
+		"\177\6\2\b\13\r\16\21\21UU\3\2IM\3\2\u00a0\u00a3\3\2\u00a4\u00a5\4\2\u0082"+
+		"\u0082\u0084\u0084\4\2\u0083\u0083\u0085\u0085\4\2~~\u008e\u008e\4\2\u008a"+
+		"\u008a\u00b1\u00b1\6\2qquu\u0088\u0089\u008e\u008e\4\2\u008a\u008b\u008d"+
+		"\u008d\3\2\u0088\u0089\3\2\u0091\u0094\3\2\u008f\u0090\4\2\u009c\u009c"+
+		"\u00a6\u00a6\3\2\u00a7\u00aa\3\2\u00ae\u00af\6\2NN\\\\^^vv\4\2./cc\3\2"+
+		"\u0095\u0096\3\2GH\3\29D\u09c3\2\u018c\3\2\2\2\4\u01a3\3\2\2\2\6\u01ae"+
+		"\3\2\2\2\b\u01b1\3\2\2\2\n\u01be\3\2\2\2\f\u01c6\3\2\2\2\16\u01c8\3\2"+
+		"\2\2\20\u01e0\3\2\2\2\22\u01e2\3\2\2\2\24\u01fb\3\2\2\2\26\u0213\3\2\2"+
+		"\2\30\u0215\3\2\2\2\32\u022c\3\2\2\2\34\u023e\3\2\2\2\36\u0249\3\2\2\2"+
+		" \u0253\3\2\2\2\"\u025b\3\2\2\2$\u0266\3\2\2\2&\u0270\3\2\2\2(\u027d\3"+
+		"\2\2\2*\u028a\3\2\2\2,\u0291\3\2\2\2.\u0298\3\2\2\2\60\u02b6\3\2\2\2\62"+
+		"\u02bb\3\2\2\2\64\u02c3\3\2\2\2\66\u02ca\3\2\2\28\u02df\3\2\2\2:\u02e9"+
+		"\3\2\2\2<\u0300\3\2\2\2>\u030a\3\2\2\2@\u030c\3\2\2\2B\u0316\3\2\2\2D"+
+		"\u031a\3\2\2\2F\u0321\3\2\2\2H\u032c\3\2\2\2J\u0331\3\2\2\2L\u0333\3\2"+
+		"\2\2N\u033d\3\2\2\2P\u035a\3\2\2\2R\u0374\3\2\2\2T\u037c\3\2\2\2V\u0380"+
+		"\3\2\2\2X\u0382\3\2\2\2Z\u0384\3\2\2\2\\\u03b7\3\2\2\2^\u03b9\3\2\2\2"+
+		"`\u03c3\3\2\2\2b\u03c5\3\2\2\2d\u03c7\3\2\2\2f\u03e5\3\2\2\2h\u03e7\3"+
+		"\2\2\2j\u03ef\3\2\2\2l\u03fc\3\2\2\2n\u0402\3\2\2\2p\u0404\3\2\2\2r\u0407"+
+		"\3\2\2\2t\u0409\3\2\2\2v\u041f\3\2\2\2x\u0422\3\2\2\2z\u043a\3\2\2\2|"+
+		"\u043c\3\2\2\2~\u0441\3\2\2\2\u0080\u0443\3\2\2\2\u0082\u0447\3\2\2\2"+
+		"\u0084\u0449\3\2\2\2\u0086\u0451\3\2\2\2\u0088\u045b\3\2\2\2\u008a\u0466"+
+		"\3\2\2\2\u008c\u0472\3\2\2\2\u008e\u047c\3\2\2\2\u0090\u04a1\3\2\2\2\u0092"+
+		"\u04a3\3\2\2\2\u0094\u04b6\3\2\2\2\u0096\u04be\3\2\2\2\u0098\u04c9\3\2"+
+		"\2\2\u009a\u04cc\3\2\2\2\u009c\u04cf\3\2\2\2\u009e\u04de\3\2\2\2\u00a0"+
+		"\u0509\3\2\2\2\u00a2\u050b\3\2\2\2\u00a4\u051c\3\2\2\2\u00a6\u0530\3\2"+
+		"\2\2\u00a8\u0532\3\2\2\2\u00aa\u0540\3\2\2\2\u00ac\u054a\3\2\2\2\u00ae"+
+		"\u054e\3\2\2\2\u00b0\u0556\3\2\2\2\u00b2\u0562\3\2\2\2\u00b4\u0564\3\2"+
+		"\2\2\u00b6\u056c\3\2\2\2\u00b8\u057b\3\2\2\2\u00ba\u057e\3\2\2\2\u00bc"+
+		"\u0582\3\2\2\2\u00be\u0589\3\2\2\2\u00c0\u0590\3\2\2\2\u00c2\u0598\3\2"+
+		"\2\2\u00c4\u05a3\3\2\2\2\u00c6\u05a6\3\2\2\2\u00c8\u05ac\3\2\2\2\u00ca"+
+		"\u05b4\3\2\2\2\u00cc\u05b7\3\2\2\2\u00ce\u05bb\3\2\2\2\u00d0\u05cc\3\2"+
+		"\2\2\u00d2\u05ce\3\2\2\2\u00d4\u05d6\3\2\2\2\u00d6\u05e0\3\2\2\2\u00d8"+
+		"\u05ea\3\2\2\2\u00da\u05ed\3\2\2\2\u00dc\u05f0\3\2\2\2\u00de\u05f4\3\2"+
+		"\2\2\u00e0\u05f8\3\2\2\2\u00e2\u05fc\3\2\2\2\u00e4\u05fe\3\2\2\2\u00e6"+
+		"\u062f\3\2\2\2\u00e8\u0659\3\2\2\2\u00ea\u065c\3\2\2\2\u00ec\u0668\3\2"+
+		"\2\2\u00ee\u0671\3\2\2\2\u00f0\u0677\3\2\2\2\u00f2\u067b\3\2\2\2\u00f4"+
+		"\u0687\3\2\2\2\u00f6\u068c\3\2\2\2\u00f8\u0694\3\2\2\2\u00fa\u0696\3\2"+
+		"\2\2\u00fc\u06bb\3\2\2\2\u00fe\u06bd\3\2\2\2\u0100\u06c4\3\2\2\2\u0102"+
+		"\u06de\3\2\2\2\u0104\u06ed\3\2\2\2\u0106\u06ef\3\2\2\2\u0108\u06f1\3\2"+
+		"\2\2\u010a\u06f4\3\2\2\2\u010c\u06f6\3\2\2\2\u010e\u06fa\3\2\2\2\u0110"+
+		"\u06fd\3\2\2\2\u0112\u0706\3\2\2\2\u0114\u0709\3\2\2\2\u0116\u0719\3\2"+
+		"\2\2\u0118\u072a\3\2\2\2\u011a\u072c\3\2\2\2\u011c\u0736\3\2\2\2\u011e"+
+		"\u073a\3\2\2\2\u0120\u0744\3\2\2\2\u0122\u0750\3\2\2\2\u0124\u0760\3\2"+
+		"\2\2\u0126\u0764\3\2\2\2\u0128\u0766\3\2\2\2\u012a\u0775\3\2\2\2\u012c"+
+		"\u078d\3\2\2\2\u012e\u078f\3\2\2\2\u0130\u07a1\3\2\2\2\u0132\u07a5\3\2"+
+		"\2\2\u0134\u07a7\3\2\2\2\u0136\u07a9\3\2\2\2\u0138\u07b7\3\2\2\2\u013a"+
+		"\u07c0\3\2\2\2\u013c\u07c3\3\2\2\2\u013e\u07d7\3\2\2\2\u0140\u07dd\3\2"+
+		"\2\2\u0142\u07e1\3\2\2\2\u0144\u07eb\3\2\2\2\u0146\u07ef\3\2\2\2\u0148"+
+		"\u07f2\3\2\2\2\u014a\u07fd\3\2\2\2\u014c\u0805\3\2\2\2\u014e\u080a\3\2"+
+		"\2\2\u0150\u080e\3\2\2\2\u0152\u0811\3\2\2\2\u0154\u081e\3\2\2\2\u0156"+
+		"\u0827\3\2\2\2\u0158\u082b\3\2\2\2\u015a\u084b\3\2\2\2\u015c\u085f\3\2"+
+		"\2\2\u015e\u087b\3\2\2\2\u0160\u087d\3\2\2\2\u0162\u0888\3\2\2\2\u0164"+
+		"\u088b\3\2\2\2\u0166\u088e\3\2\2\2\u0168\u089f\3\2\2\2\u016a\u08a1\3\2"+
+		"\2\2\u016c\u08a3\3\2\2\2\u016e\u08b9\3\2\2\2\u0170\u08be\3\2\2\2\u0172"+
+		"\u08c0\3\2\2\2\u0174\u08c6\3\2\2\2\u0176\u08cc\3\2\2\2\u0178\u08d2\3\2"+
+		"\2\2\u017a\u08e1\3\2\2\2\u017c\u08e3\3\2\2\2\u017e\u08fb\3\2\2\2\u0180"+
+		"\u0900\3\2\2\2\u0182\u0902\3\2\2\2\u0184\u0908\3\2\2\2\u0186\u090e\3\2"+
+		"\2\2\u0188\u018b\5\b\5\2\u0189\u018b\5\u00e4s\2\u018a\u0188\3\2\2\2\u018a"+
+		"\u0189\3\2\2\2\u018b\u018e\3\2\2\2\u018c\u018a\3\2\2\2\u018c\u018d\3\2"+
+		"\2\2\u018d\u019e\3\2\2\2\u018e\u018c\3\2\2\2\u018f\u0191\5\u0178\u00bd"+
+		"\2\u0190\u018f\3\2\2\2\u0190\u0191\3\2\2\2\u0191\u0193\3\2\2\2\u0192\u0194"+
+		"\5\u016c\u00b7\2\u0193\u0192\3\2\2\2\u0193\u0194\3\2\2\2\u0194\u0198\3"+
+		"\2\2\2\u0195\u0197\5d\63\2\u0196\u0195\3\2\2\2\u0197\u019a\3\2\2\2\u0198"+
+		"\u0196\3\2\2\2\u0198\u0199\3\2\2\2\u0199\u019b\3\2\2\2\u019a\u0198\3\2"+
+		"\2\2\u019b\u019d\5\f\7\2\u019c\u0190\3\2\2\2\u019d\u01a0\3\2\2\2\u019e"+
+		"\u019c\3\2\2\2\u019e\u019f\3\2\2\2\u019f\u01a1\3\2\2\2\u01a0\u019e\3\2"+
+		"\2\2\u01a1\u01a2\7\2\2\3\u01a2\3\3\2\2\2\u01a3\u01a8\7\u00b1\2\2\u01a4"+
+		"\u01a5\7~\2\2\u01a5\u01a7\7\u00b1\2\2\u01a6\u01a4\3\2\2\2\u01a7\u01aa"+
+		"\3\2\2\2\u01a8\u01a6\3\2\2\2\u01a8\u01a9\3\2\2\2\u01a9\u01ac\3\2\2\2\u01aa"+
+		"\u01a8\3\2\2\2\u01ab\u01ad\5\6\4\2\u01ac\u01ab\3\2\2\2\u01ac\u01ad\3\2"+
+		"\2\2\u01ad\5\3\2\2\2\u01ae\u01af\7\25\2\2\u01af\u01b0\7\u00b1\2\2\u01b0"+
+		"\7\3\2\2\2\u01b1\u01b5\7\3\2\2\u01b2\u01b3\5\n\6\2\u01b3\u01b4\7\u008b"+
+		"\2\2\u01b4\u01b6\3\2\2\2\u01b5\u01b2\3\2\2\2\u01b5\u01b6\3\2\2\2\u01b6"+
+		"\u01b7\3\2\2\2\u01b7\u01ba\5\4\3\2\u01b8\u01b9\7\4\2\2\u01b9\u01bb\7\u00b1"+
+		"\2\2\u01ba\u01b8\3\2\2\2\u01ba\u01bb\3\2\2\2\u01bb\u01bc\3\2\2\2\u01bc"+
+		"\u01bd\7{\2\2\u01bd\t\3\2\2\2\u01be\u01bf\7\u00b1\2\2\u01bf\13\3\2\2\2"+
+		"\u01c0\u01c7\5\16\b\2\u01c1\u01c7\5\32\16\2\u01c2\u01c7\5 \21\2\u01c3"+
+		"\u01c7\5:\36\2\u01c4\u01c7\5<\37\2\u01c5\u01c7\5D#\2\u01c6\u01c0\3\2\2"+
+		"\2\u01c6\u01c1\3\2\2\2\u01c6\u01c2\3\2\2\2\u01c6\u01c3\3\2\2\2\u01c6\u01c4"+
+		"\3\2\2\2\u01c6\u01c5\3\2\2\2\u01c7\r\3\2\2\2\u01c8\u01cd\7\b\2\2\u01c9"+
+		"\u01ca\7\u0092\2\2\u01ca\u01cb\5\u00eex\2\u01cb\u01cc\7\u0091\2\2\u01cc"+
+		"\u01ce\3\2\2\2\u01cd\u01c9\3\2\2\2\u01cd\u01ce\3\2\2\2\u01ce\u01cf\3\2"+
+		"\2\2\u01cf\u01d1\7\u00b1\2\2\u01d0\u01d2\5\20\t\2\u01d1\u01d0\3\2\2\2"+
+		"\u01d1\u01d2\3\2\2\2\u01d2\u01d3\3\2\2\2\u01d3\u01d4\5\22\n\2\u01d4\17"+
+		"\3\2\2\2\u01d5\u01d6\7\22\2\2\u01d6\u01db\5\u00eex\2\u01d7\u01d8\7\177"+
+		"\2\2\u01d8\u01da\5\u00eex\2\u01d9\u01d7\3\2\2\2\u01da\u01dd\3\2\2\2\u01db"+
+		"\u01d9\3\2\2\2\u01db\u01dc\3\2\2\2\u01dc\u01e1\3\2\2\2\u01dd\u01db\3\2"+
+		"\2\2\u01de\u01df\7\22\2\2\u01df\u01e1\5j\66\2\u01e0\u01d5\3\2\2\2\u01e0"+
+		"\u01de\3\2\2\2\u01e1\21\3\2\2\2\u01e2\u01e6\7\u0080\2\2\u01e3\u01e5\5"+
+		"F$\2\u01e4\u01e3\3\2\2\2\u01e5\u01e8\3\2\2\2\u01e6\u01e4\3\2\2\2\u01e6"+
+		"\u01e7\3\2\2\2\u01e7\u01ed\3\2\2\2\u01e8\u01e6\3\2\2\2\u01e9\u01ec\5h"+
+		"\65\2\u01ea\u01ec\5\u00e2r\2\u01eb\u01e9\3\2\2\2\u01eb\u01ea\3\2\2\2\u01ec"+
+		"\u01ef\3\2\2\2\u01ed\u01eb\3\2\2\2\u01ed\u01ee\3\2\2\2\u01ee\u01f3\3\2"+
+		"\2\2\u01ef\u01ed\3\2\2\2\u01f0\u01f2\5\24\13\2\u01f1\u01f0\3\2\2\2\u01f2"+
+		"\u01f5\3\2\2\2\u01f3\u01f1\3\2\2\2\u01f3\u01f4\3\2\2\2\u01f4\u01f6\3\2"+
+		"\2\2\u01f5\u01f3\3\2\2\2\u01f6\u01f7\7\u0081\2\2\u01f7\23\3\2\2\2\u01f8"+
+		"\u01fa\5d\63\2\u01f9\u01f8\3\2\2\2\u01fa\u01fd\3\2\2\2\u01fb\u01f9\3\2"+
+		"\2\2\u01fb\u01fc\3\2\2\2\u01fc\u01ff\3\2\2\2\u01fd\u01fb\3\2\2\2\u01fe"+
 		"\u0200\5\u0178\u00bd\2\u01ff\u01fe\3\2\2\2\u01ff\u0200\3\2\2\2\u0200\u0202"+
 		"\3\2\2\2\u0201\u0203\5\u016c\u00b7\2\u0202\u0201\3\2\2\2\u0202\u0203\3"+
 		"\2\2\2\u0203\u0204\3\2\2\2\u0204\u0205\7\u00b1\2\2\u0205\u0207\7\u0082"+
@@ -15800,563 +15790,561 @@ public class BallerinaParser extends Parser {
 		"\u0336\u0334\3\2\2\2\u0337\u033a\3\2\2\2\u0338\u0336\3\2\2\2\u0338\u0339"+
 		"\3\2\2\2\u0339M\3\2\2\2\u033a\u0338\3\2\2\2\u033b\u033e\5\u0104\u0083"+
 		"\2\u033c\u033e\5P)\2\u033d\u033b\3\2\2\2\u033d\u033c\3\2\2\2\u033eO\3"+
-		"\2\2\2\u033f\u0340\b)\1\2\u0340\u035d\5T+\2\u0341\u0342\7\u0082\2\2\u0342"+
-		"\u0343\5P)\2\u0343\u0344\7\u0083\2\2\u0344\u035d\3\2\2\2\u0345\u0346\7"+
+		"\2\2\2\u033f\u0340\b)\1\2\u0340\u035b\5T+\2\u0341\u0342\7\u0082\2\2\u0342"+
+		"\u0343\5P)\2\u0343\u0344\7\u0083\2\2\u0344\u035b\3\2\2\2\u0345\u0346\7"+
 		"\u0082\2\2\u0346\u034b\5P)\2\u0347\u0348\7\177\2\2\u0348\u034a\5P)\2\u0349"+
 		"\u0347\3\2\2\2\u034a\u034d\3\2\2\2\u034b\u0349\3\2\2\2\u034b\u034c\3\2"+
 		"\2\2\u034c\u034e\3\2\2\2\u034d\u034b\3\2\2\2\u034e\u034f\7\u0083\2\2\u034f"+
-		"\u035d\3\2\2\2\u0350\u0351\7\13\2\2\u0351\u0352\7\u0080\2\2\u0352\u0353"+
-		"\5\"\22\2\u0353\u0354\7\u0081\2\2\u0354\u035d\3\2\2\2\u0355\u0357\7\f"+
-		"\2\2\u0356\u0355\3\2\2\2\u0356\u0357\3\2\2\2\u0357\u0358\3\2\2\2\u0358"+
-		"\u0359\7\u0080\2\2\u0359\u035a\5R*\2\u035a\u035b\7\u0081\2\2\u035b\u035d"+
-		"\3\2\2\2\u035c\u033f\3\2\2\2\u035c\u0341\3\2\2\2\u035c\u0345\3\2\2\2\u035c"+
-		"\u0350\3\2\2\2\u035c\u0356\3\2\2\2\u035d\u0370\3\2\2\2\u035e\u0361\f\t"+
-		"\2\2\u035f\u0360\7\u0084\2\2\u0360\u0362\7\u0085\2\2\u0361\u035f\3\2\2"+
-		"\2\u0362\u0363\3\2\2\2\u0363\u0361\3\2\2\2\u0363\u0364\3\2\2\2\u0364\u036f"+
-		"\3\2\2\2\u0365\u0368\f\b\2\2\u0366\u0367\7\u009d\2\2\u0367\u0369\5P)\2"+
-		"\u0368\u0366\3\2\2\2\u0369\u036a\3\2\2\2\u036a\u0368\3\2\2\2\u036a\u036b"+
-		"\3\2\2\2\u036b\u036f\3\2\2\2\u036c\u036d\f\7\2\2\u036d\u036f\7\u0086\2"+
-		"\2\u036e\u035e\3\2\2\2\u036e\u0365\3\2\2\2\u036e\u036c\3\2\2\2\u036f\u0372"+
-		"\3\2\2\2\u0370\u036e\3\2\2\2\u0370\u0371\3\2\2\2\u0371Q\3\2\2\2\u0372"+
-		"\u0370\3\2\2\2\u0373\u0375\5.\30\2\u0374\u0373\3\2\2\2\u0375\u0378\3\2"+
-		"\2\2\u0376\u0374\3\2\2\2\u0376\u0377\3\2\2\2\u0377S\3\2\2\2\u0378\u0376"+
-		"\3\2\2\2\u0379\u037f\7S\2\2\u037a\u037f\7T\2\2\u037b\u037f\5Z.\2\u037c"+
-		"\u037f\5V,\2\u037d\u037f\5\u0108\u0085\2\u037e\u0379\3\2\2\2\u037e\u037a"+
-		"\3\2\2\2\u037e\u037b\3\2\2\2\u037e\u037c\3\2\2\2\u037e\u037d\3\2\2\2\u037f"+
-		"U\3\2\2\2\u0380\u0383\5\\/\2\u0381\u0383\5X-\2\u0382\u0380\3\2\2\2\u0382"+
-		"\u0381\3\2\2\2\u0383W\3\2\2\2\u0384\u0385\5\u00eex\2\u0385Y\3\2\2\2\u0386"+
-		"\u0387\t\4\2\2\u0387[\3\2\2\2\u0388\u038d\7N\2\2\u0389\u038a\7\u0092\2"+
-		"\2\u038a\u038b\5P)\2\u038b\u038c\7\u0091\2\2\u038c\u038e\3\2\2\2\u038d"+
-		"\u0389\3\2\2\2\u038d\u038e\3\2\2\2\u038e\u03ba\3\2\2\2\u038f\u0394\7V"+
-		"\2\2\u0390\u0391\7\u0092\2\2\u0391\u0392\5P)\2\u0392\u0393\7\u0091\2\2"+
-		"\u0393\u0395\3\2\2\2\u0394\u0390\3\2\2\2\u0394\u0395\3\2\2\2\u0395\u03ba"+
-		"\3\2\2\2\u0396\u03a1\7P\2\2\u0397\u039c\7\u0092\2\2\u0398\u0399\7\u0080"+
-		"\2\2\u0399\u039a\5`\61\2\u039a\u039b\7\u0081\2\2\u039b\u039d\3\2\2\2\u039c"+
-		"\u0398\3\2\2\2\u039c\u039d\3\2\2\2\u039d\u039e\3\2\2\2\u039e\u039f\5b"+
-		"\62\2\u039f\u03a0\7\u0091\2\2\u03a0\u03a2\3\2\2\2\u03a1\u0397\3\2\2\2"+
-		"\u03a1\u03a2\3\2\2\2\u03a2\u03ba\3\2\2\2\u03a3\u03a8\7O\2\2\u03a4\u03a5"+
-		"\7\u0092\2\2\u03a5\u03a6\5\u00eex\2\u03a6\u03a7\7\u0091\2\2\u03a7\u03a9"+
-		"\3\2\2\2\u03a8\u03a4\3\2\2\2\u03a8\u03a9\3\2\2\2\u03a9\u03ba\3\2\2\2\u03aa"+
-		"\u03af\7Q\2\2\u03ab\u03ac\7\u0092\2\2\u03ac\u03ad\5\u00eex\2\u03ad\u03ae"+
-		"\7\u0091\2\2\u03ae\u03b0\3\2\2\2\u03af\u03ab\3\2\2\2\u03af\u03b0\3\2\2"+
-		"\2\u03b0\u03ba\3\2\2\2\u03b1\u03b6\7R\2\2\u03b2\u03b3\7\u0092\2\2\u03b3"+
-		"\u03b4\5P)\2\u03b4\u03b5\7\u0091\2\2\u03b5\u03b7\3\2\2\2\u03b6\u03b2\3"+
-		"\2\2\2\u03b6\u03b7\3\2\2\2\u03b7\u03ba\3\2\2\2\u03b8\u03ba\5^\60\2\u03b9"+
-		"\u0388\3\2\2\2\u03b9\u038f\3\2\2\2\u03b9\u0396\3\2\2\2\u03b9\u03a3\3\2"+
-		"\2\2\u03b9\u03aa\3\2\2\2\u03b9\u03b1\3\2\2\2\u03b9\u03b8\3\2\2\2\u03ba"+
-		"]\3\2\2\2\u03bb\u03bc\7\n\2\2\u03bc\u03bf\7\u0082\2\2\u03bd\u03c0\5\u00fa"+
-		"~\2\u03be\u03c0\5\u00f6|\2\u03bf\u03bd\3\2\2\2\u03bf\u03be\3\2\2\2\u03bf"+
-		"\u03c0\3\2\2\2\u03c0\u03c1\3\2\2\2\u03c1\u03c3\7\u0083\2\2\u03c2\u03c4"+
-		"\5\u00f2z\2\u03c3\u03c2\3\2\2\2\u03c3\u03c4\3\2\2\2\u03c4_\3\2\2\2\u03c5"+
-		"\u03c6\7\u00ad\2\2\u03c6a\3\2\2\2\u03c7\u03c8\7\u00b1\2\2\u03c8c\3\2\2"+
-		"\2\u03c9\u03ca\7\u0099\2\2\u03ca\u03cc\5\u00eex\2\u03cb\u03cd\5j\66\2"+
-		"\u03cc\u03cb\3\2\2\2\u03cc\u03cd\3\2\2\2\u03cde\3\2\2\2\u03ce\u03e8\5"+
-		"h\65\2\u03cf\u03e8\5x=\2\u03d0\u03e8\5z>\2\u03d1\u03e8\5|?\2\u03d2\u03e8"+
-		"\5\u0080A\2\u03d3\u03e8\5\u0086D\2\u03d4\u03e8\5\u008eH\2\u03d5\u03e8"+
-		"\5\u0092J\2\u03d6\u03e8\5\u0096L\2\u03d7\u03e8\5\u0098M\2\u03d8\u03e8"+
-		"\5\u009aN\2\u03d9\u03e8\5\u009cO\2\u03da\u03e8\5\u00a4S\2\u03db\u03e8"+
-		"\5\u00acW\2\u03dc\u03e8\5\u00aeX\2\u03dd\u03e8\5\u00b0Y\2\u03de\u03e8"+
-		"\5\u00caf\2\u03df\u03e8\5\u00ccg\2\u03e0\u03e8\5\u00d8m\2\u03e1\u03e8"+
-		"\5\u00dan\2\u03e2\u03e8\5\u00d4k\2\u03e3\u03e8\5\u00e2r\2\u03e4\u03e8"+
-		"\5\u0138\u009d\2\u03e5\u03e8\5\u013c\u009f\2\u03e6\u03e8\5\u013a\u009e"+
-		"\2\u03e7\u03ce\3\2\2\2\u03e7\u03cf\3\2\2\2\u03e7\u03d0\3\2\2\2\u03e7\u03d1"+
-		"\3\2\2\2\u03e7\u03d2\3\2\2\2\u03e7\u03d3\3\2\2\2\u03e7\u03d4\3\2\2\2\u03e7"+
-		"\u03d5\3\2\2\2\u03e7\u03d6\3\2\2\2\u03e7\u03d7\3\2\2\2\u03e7\u03d8\3\2"+
-		"\2\2\u03e7\u03d9\3\2\2\2\u03e7\u03da\3\2\2\2\u03e7\u03db\3\2\2\2\u03e7"+
-		"\u03dc\3\2\2\2\u03e7\u03dd\3\2\2\2\u03e7\u03de\3\2\2\2\u03e7\u03df\3\2"+
-		"\2\2\u03e7\u03e0\3\2\2\2\u03e7\u03e1\3\2\2\2\u03e7\u03e2\3\2\2\2\u03e7"+
-		"\u03e3\3\2\2\2\u03e7\u03e4\3\2\2\2\u03e7\u03e5\3\2\2\2\u03e7\u03e6\3\2"+
-		"\2\2\u03e8g\3\2\2\2\u03e9\u03ea\5P)\2\u03ea\u03ed\7\u00b1\2\2\u03eb\u03ec"+
-		"\7\u0087\2\2\u03ec\u03ee\5\u00e6t\2\u03ed\u03eb\3\2\2\2\u03ed\u03ee\3"+
-		"\2\2\2\u03ee\u03ef\3\2\2\2\u03ef\u03f0\7{\2\2\u03f0i\3\2\2\2\u03f1\u03fa"+
-		"\7\u0080\2\2\u03f2\u03f7\5l\67\2\u03f3\u03f4\7\177\2\2\u03f4\u03f6\5l"+
-		"\67\2\u03f5\u03f3\3\2\2\2\u03f6\u03f9\3\2\2\2\u03f7\u03f5\3\2\2\2\u03f7"+
-		"\u03f8\3\2\2\2\u03f8\u03fb\3\2\2\2\u03f9\u03f7\3\2\2\2\u03fa\u03f2\3\2"+
-		"\2\2\u03fa\u03fb\3\2\2\2\u03fb\u03fc\3\2\2\2\u03fc\u03fd\7\u0081\2\2\u03fd"+
-		"k\3\2\2\2\u03fe\u03ff\5n8\2\u03ff\u0400\7|\2\2\u0400\u0401\5\u00e6t\2"+
-		"\u0401m\3\2\2\2\u0402\u0405\7\u00b1\2\2\u0403\u0405\5\u00e6t\2\u0404\u0402"+
-		"\3\2\2\2\u0404\u0403\3\2\2\2\u0405o\3\2\2\2\u0406\u0407\7Q\2\2\u0407\u0408"+
-		"\5r:\2\u0408q\3\2\2\2\u0409\u040a\5j\66\2\u040as\3\2\2\2\u040b\u040d\7"+
-		"\u0084\2\2\u040c\u040e\5\u00c8e\2\u040d\u040c\3\2\2\2\u040d\u040e\3\2"+
-		"\2\2\u040e\u040f\3\2\2\2\u040f\u0410\7\u0085\2\2\u0410u\3\2\2\2\u0411"+
-		"\u0417\7X\2\2\u0412\u0414\7\u0082\2\2\u0413\u0415\5\u00c2b\2\u0414\u0413"+
-		"\3\2\2\2\u0414\u0415\3\2\2\2\u0415\u0416\3\2\2\2\u0416\u0418\7\u0083\2"+
-		"\2\u0417\u0412\3\2\2\2\u0417\u0418\3\2\2\2\u0418\u0422\3\2\2\2\u0419\u041a"+
-		"\7X\2\2\u041a\u041b\5X-\2\u041b\u041d\7\u0082\2\2\u041c\u041e\5\u00c2"+
-		"b\2\u041d\u041c\3\2\2\2\u041d\u041e\3\2\2\2\u041e\u041f\3\2\2\2\u041f"+
-		"\u0420\7\u0083\2\2\u0420\u0422\3\2\2\2\u0421\u0411\3\2\2\2\u0421\u0419"+
-		"\3\2\2\2\u0422w\3\2\2\2\u0423\u0425\7W\2\2\u0424\u0423\3\2\2\2\u0424\u0425"+
-		"\3\2\2\2\u0425\u0426\3\2\2\2\u0426\u0427\5\u00b6\\\2\u0427\u0428\7\u0087"+
-		"\2\2\u0428\u0429\5\u00e6t\2\u0429\u042a\7{\2\2\u042ay\3\2\2\2\u042b\u042d"+
-		"\7W\2\2\u042c\u042b\3\2\2\2\u042c\u042d\3\2\2\2\u042d\u042e\3\2\2\2\u042e"+
-		"\u042f\7\u0082\2\2\u042f\u0430\5\u0084C\2\u0430\u0431\7\u0083\2\2\u0431"+
-		"\u0432\7\u0087\2\2\u0432\u0433\5\u00e6t\2\u0433\u0434\7{\2\2\u0434\u043d"+
-		"\3\2\2\2\u0435\u0436\7\u0082\2\2\u0436\u0437\5\u00fa~\2\u0437\u0438\7"+
-		"\u0083\2\2\u0438\u0439\7\u0087\2\2\u0439\u043a\5\u00e6t\2\u043a\u043b"+
-		"\7{\2\2\u043b\u043d\3\2\2\2\u043c\u042c\3\2\2\2\u043c\u0435\3\2\2\2\u043d"+
-		"{\3\2\2\2\u043e\u043f\5\u00b6\\\2\u043f\u0440\5~@\2\u0440\u0441\5\u00e6"+
-		"t\2\u0441\u0442\7{\2\2\u0442}\3\2\2\2\u0443\u0444\t\5\2\2\u0444\177\3"+
-		"\2\2\2\u0445\u0446\5\u00b6\\\2\u0446\u0447\5\u0082B\2\u0447\u0448\7{\2"+
-		"\2\u0448\u0081\3\2\2\2\u0449\u044a\t\6\2\2\u044a\u0083\3\2\2\2\u044b\u0450"+
-		"\5\u00b6\\\2\u044c\u044d\7\177\2\2\u044d\u044f\5\u00b6\\\2\u044e\u044c"+
-		"\3\2\2\2\u044f\u0452\3\2\2\2\u0450\u044e\3\2\2\2\u0450\u0451\3\2\2\2\u0451"+
-		"\u0085\3\2\2\2\u0452\u0450\3\2\2\2\u0453\u0457\5\u0088E\2\u0454\u0456"+
-		"\5\u008aF\2\u0455\u0454\3\2\2\2\u0456\u0459\3\2\2\2\u0457\u0455\3\2\2"+
-		"\2\u0457\u0458\3\2\2\2\u0458\u045b\3\2\2\2\u0459\u0457\3\2\2\2\u045a\u045c"+
-		"\5\u008cG\2\u045b\u045a\3\2\2\2\u045b\u045c\3\2\2\2\u045c\u0087\3\2\2"+
-		"\2\u045d\u045e\7Y\2\2\u045e\u045f\5\u00e6t\2\u045f\u0463\7\u0080\2\2\u0460"+
-		"\u0462\5f\64\2\u0461\u0460\3\2\2\2\u0462\u0465\3\2\2\2\u0463\u0461\3\2"+
-		"\2\2\u0463\u0464\3\2\2\2\u0464\u0466\3\2\2\2\u0465\u0463\3\2\2\2\u0466"+
-		"\u0467\7\u0081\2\2\u0467\u0089\3\2\2\2\u0468\u0469\7[\2\2\u0469\u046a"+
-		"\7Y\2\2\u046a\u046b\5\u00e6t\2\u046b\u046f\7\u0080\2\2\u046c\u046e\5f"+
-		"\64\2\u046d\u046c\3\2\2\2\u046e\u0471\3\2\2\2\u046f\u046d\3\2\2\2\u046f"+
-		"\u0470\3\2\2\2\u0470\u0472\3\2\2\2\u0471\u046f\3\2\2\2\u0472\u0473\7\u0081"+
-		"\2\2\u0473\u008b\3\2\2\2\u0474\u0475\7[\2\2\u0475\u0479\7\u0080\2\2\u0476"+
-		"\u0478\5f\64\2\u0477\u0476\3\2\2\2\u0478\u047b\3\2\2\2\u0479\u0477\3\2"+
-		"\2\2\u0479\u047a\3\2\2\2\u047a\u047c\3\2\2\2\u047b\u0479\3\2\2\2\u047c"+
-		"\u047d\7\u0081\2\2\u047d\u008d\3\2\2\2\u047e\u047f\7Z\2\2\u047f\u0480"+
-		"\5\u00e6t\2\u0480\u0482\7\u0080\2\2\u0481\u0483\5\u0090I\2\u0482\u0481"+
-		"\3\2\2\2\u0483\u0484\3\2\2\2\u0484\u0482\3\2\2\2\u0484\u0485\3\2\2\2\u0485"+
-		"\u0486\3\2\2\2\u0486\u0487\7\u0081\2\2\u0487\u008f\3\2\2\2\u0488\u0489"+
-		"\5P)\2\u0489\u0493\7\u009e\2\2\u048a\u0494\5f\64\2\u048b\u048f\7\u0080"+
-		"\2\2\u048c\u048e\5f\64\2\u048d\u048c\3\2\2\2\u048e\u0491\3\2\2\2\u048f"+
-		"\u048d\3\2\2\2\u048f\u0490\3\2\2\2\u0490\u0492\3\2\2\2\u0491\u048f\3\2"+
-		"\2\2\u0492\u0494\7\u0081\2\2\u0493\u048a\3\2\2\2\u0493\u048b\3\2\2\2\u0494"+
-		"\u04a4\3\2\2\2\u0495\u0496\5P)\2\u0496\u0497\7\u00b1\2\2\u0497\u04a1\7"+
-		"\u009e\2\2\u0498\u04a2\5f\64\2\u0499\u049d\7\u0080\2\2\u049a\u049c\5f"+
-		"\64\2\u049b\u049a\3\2\2\2\u049c\u049f\3\2\2\2\u049d\u049b\3\2\2\2\u049d"+
-		"\u049e\3\2\2\2\u049e\u04a0\3\2\2\2\u049f\u049d\3\2\2\2\u04a0\u04a2\7\u0081"+
-		"\2\2\u04a1\u0498\3\2\2\2\u04a1\u0499\3\2\2\2\u04a2\u04a4\3\2\2\2\u04a3"+
-		"\u0488\3\2\2\2\u04a3\u0495\3\2\2\2\u04a4\u0091\3\2\2\2\u04a5\u04a7\7\\"+
-		"\2\2\u04a6\u04a8\7\u0082\2\2\u04a7\u04a6\3\2\2\2\u04a7\u04a8\3\2\2\2\u04a8"+
-		"\u04a9\3\2\2\2\u04a9\u04aa\5\u0084C\2\u04aa\u04ab\7s\2\2\u04ab\u04ad\5"+
-		"\u00e6t\2\u04ac\u04ae\7\u0083\2\2\u04ad\u04ac\3\2\2\2\u04ad\u04ae\3\2"+
-		"\2\2\u04ae\u04af\3\2\2\2\u04af\u04b3\7\u0080\2\2\u04b0\u04b2\5f\64\2\u04b1"+
-		"\u04b0\3\2\2\2\u04b2\u04b5\3\2\2\2\u04b3\u04b1\3\2\2\2\u04b3\u04b4\3\2"+
-		"\2\2\u04b4\u04b6\3\2\2\2\u04b5\u04b3\3\2\2\2\u04b6\u04b7\7\u0081\2\2\u04b7"+
-		"\u0093\3\2\2\2\u04b8\u04b9\t\7\2\2\u04b9\u04ba\5\u00e6t\2\u04ba\u04bc"+
-		"\7\u009b\2\2\u04bb\u04bd\5\u00e6t\2\u04bc\u04bb\3\2\2\2\u04bc\u04bd\3"+
-		"\2\2\2\u04bd\u04be\3\2\2\2\u04be\u04bf\t\b\2\2\u04bf\u0095\3\2\2\2\u04c0"+
-		"\u04c1\7]\2\2\u04c1\u04c2\5\u00e6t\2\u04c2\u04c6\7\u0080\2\2\u04c3\u04c5"+
-		"\5f\64\2\u04c4\u04c3\3\2\2\2\u04c5\u04c8\3\2\2\2\u04c6\u04c4\3\2\2\2\u04c6"+
-		"\u04c7\3\2\2\2\u04c7\u04c9\3\2\2\2\u04c8\u04c6\3\2\2\2\u04c9\u04ca\7\u0081"+
-		"\2\2\u04ca\u0097\3\2\2\2\u04cb\u04cc\7^\2\2\u04cc\u04cd\7{\2\2\u04cd\u0099"+
-		"\3\2\2\2\u04ce\u04cf\7_\2\2\u04cf\u04d0\7{\2\2\u04d0\u009b\3\2\2\2\u04d1"+
-		"\u04d2\7`\2\2\u04d2\u04d6\7\u0080\2\2\u04d3\u04d5\5@!\2\u04d4\u04d3\3"+
-		"\2\2\2\u04d5\u04d8\3\2\2\2\u04d6\u04d4\3\2\2\2\u04d6\u04d7\3\2\2\2\u04d7"+
-		"\u04d9\3\2\2\2\u04d8\u04d6\3\2\2\2\u04d9\u04db\7\u0081\2\2\u04da\u04dc"+
-		"\5\u009eP\2\u04db\u04da\3\2\2\2\u04db\u04dc\3\2\2\2\u04dc\u04de\3\2\2"+
-		"\2\u04dd\u04df\5\u00a2R\2\u04de\u04dd\3\2\2\2\u04de\u04df\3\2\2\2\u04df"+
-		"\u009d\3\2\2\2\u04e0\u04e5\7a\2\2\u04e1\u04e2\7\u0082\2\2\u04e2\u04e3"+
-		"\5\u00a0Q\2\u04e3\u04e4\7\u0083\2\2\u04e4\u04e6\3\2\2\2\u04e5\u04e1\3"+
-		"\2\2\2\u04e5\u04e6\3\2\2\2\u04e6\u04e7\3\2\2\2\u04e7\u04e8\7\u0082\2\2"+
-		"\u04e8\u04e9\5P)\2\u04e9\u04ea\7\u00b1\2\2\u04ea\u04eb\7\u0083\2\2\u04eb"+
-		"\u04ef\7\u0080\2\2\u04ec\u04ee\5f\64\2\u04ed\u04ec\3\2\2\2\u04ee\u04f1"+
-		"\3\2\2\2\u04ef\u04ed\3\2\2\2\u04ef\u04f0\3\2\2\2\u04f0\u04f2\3\2\2\2\u04f1"+
-		"\u04ef\3\2\2\2\u04f2\u04f3\7\u0081\2\2\u04f3\u009f\3\2\2\2\u04f4\u04f5"+
-		"\7b\2\2\u04f5\u04fe\5\u0106\u0084\2\u04f6\u04fb\7\u00b1\2\2\u04f7\u04f8"+
-		"\7\177\2\2\u04f8\u04fa\7\u00b1\2\2\u04f9\u04f7\3\2\2\2\u04fa\u04fd\3\2"+
-		"\2\2\u04fb\u04f9\3\2\2\2\u04fb\u04fc\3\2\2\2\u04fc\u04ff\3\2\2\2\u04fd"+
-		"\u04fb\3\2\2\2\u04fe\u04f6\3\2\2\2\u04fe\u04ff\3\2\2\2\u04ff\u050c\3\2"+
-		"\2\2\u0500\u0509\7c\2\2\u0501\u0506\7\u00b1\2\2\u0502\u0503\7\177\2\2"+
-		"\u0503\u0505\7\u00b1\2\2\u0504\u0502\3\2\2\2\u0505\u0508\3\2\2\2\u0506"+
-		"\u0504\3\2\2\2\u0506\u0507\3\2\2\2\u0507\u050a\3\2\2\2\u0508\u0506\3\2"+
-		"\2\2\u0509\u0501\3\2\2\2\u0509\u050a\3\2\2\2\u050a\u050c\3\2\2\2\u050b"+
-		"\u04f4\3\2\2\2\u050b\u0500\3\2\2\2\u050c\u00a1\3\2\2\2\u050d\u050e\7d"+
-		"\2\2\u050e\u050f\7\u0082\2\2\u050f\u0510\5\u00e6t\2\u0510\u0511\7\u0083"+
-		"\2\2\u0511\u0512\7\u0082\2\2\u0512\u0513\5P)\2\u0513\u0514\7\u00b1\2\2"+
-		"\u0514\u0515\7\u0083\2\2\u0515\u0519\7\u0080\2\2\u0516\u0518\5f\64\2\u0517"+
-		"\u0516\3\2\2\2\u0518\u051b\3\2\2\2\u0519\u0517\3\2\2\2\u0519\u051a\3\2"+
-		"\2\2\u051a\u051c\3\2\2\2\u051b\u0519\3\2\2\2\u051c\u051d\7\u0081\2\2\u051d"+
-		"\u00a3\3\2\2\2\u051e\u051f\7e\2\2\u051f\u0523\7\u0080\2\2\u0520\u0522"+
-		"\5f\64\2\u0521\u0520\3\2\2\2\u0522\u0525\3\2\2\2\u0523\u0521\3\2\2\2\u0523"+
-		"\u0524\3\2\2\2\u0524\u0526\3\2\2\2\u0525\u0523\3\2\2\2\u0526\u0527\7\u0081"+
-		"\2\2\u0527\u0528\5\u00a6T\2\u0528\u00a5\3\2\2\2\u0529\u052b\5\u00a8U\2"+
-		"\u052a\u0529\3\2\2\2\u052b\u052c\3\2\2\2\u052c\u052a\3\2\2\2\u052c\u052d"+
-		"\3\2\2\2\u052d\u052f\3\2\2\2\u052e\u0530\5\u00aaV\2\u052f\u052e\3\2\2"+
-		"\2\u052f\u0530\3\2\2\2\u0530\u0533\3\2\2\2\u0531\u0533\5\u00aaV\2\u0532"+
-		"\u052a\3\2\2\2\u0532\u0531\3\2\2\2\u0533\u00a7\3\2\2\2\u0534\u0535\7f"+
-		"\2\2\u0535\u0536\7\u0082\2\2\u0536\u0537\5P)\2\u0537\u0538\7\u00b1\2\2"+
-		"\u0538\u0539\7\u0083\2\2\u0539\u053d\7\u0080\2\2\u053a\u053c\5f\64\2\u053b"+
-		"\u053a\3\2\2\2\u053c\u053f\3\2\2\2\u053d\u053b\3\2\2\2\u053d\u053e\3\2"+
-		"\2\2\u053e\u0540\3\2\2\2\u053f\u053d\3\2\2\2\u0540\u0541\7\u0081\2\2\u0541"+
-		"\u00a9\3\2\2\2\u0542\u0543\7g\2\2\u0543\u0547\7\u0080\2\2\u0544\u0546"+
-		"\5f\64\2\u0545\u0544\3\2\2\2\u0546\u0549\3\2\2\2\u0547\u0545\3\2\2\2\u0547"+
-		"\u0548\3\2\2\2\u0548\u054a\3\2\2\2\u0549\u0547\3\2\2\2\u054a\u054b\7\u0081"+
-		"\2\2\u054b\u00ab\3\2\2\2\u054c\u054d\7h\2\2\u054d\u054e\5\u00e6t\2\u054e"+
-		"\u054f\7{\2\2\u054f\u00ad\3\2\2\2\u0550\u0552\7i\2\2\u0551\u0553\5\u00e6"+
-		"t\2\u0552\u0551\3\2\2\2\u0552\u0553\3\2\2\2\u0553\u0554\3\2\2\2\u0554"+
-		"\u0555\7{\2\2\u0555\u00af\3\2\2\2\u0556\u0559\5\u00b2Z\2\u0557\u0559\5"+
-		"\u00b4[\2\u0558\u0556\3\2\2\2\u0558\u0557\3\2\2\2\u0559\u00b1\3\2\2\2"+
-		"\u055a\u055b\5\u00e6t\2\u055b\u055c\7\u0097\2\2\u055c\u055d\7\u00b1\2"+
-		"\2\u055d\u055e\7{\2\2\u055e\u0565\3\2\2\2\u055f\u0560\5\u00e6t\2\u0560"+
-		"\u0561\7\u0097\2\2\u0561\u0562\7`\2\2\u0562\u0563\7{\2\2\u0563\u0565\3"+
-		"\2\2\2\u0564\u055a\3\2\2\2\u0564\u055f\3\2\2\2\u0565\u00b3\3\2\2\2\u0566"+
-		"\u0567\5\u00e6t\2\u0567\u0568\7\u0098\2\2\u0568\u0569\7\u00b1\2\2\u0569"+
-		"\u056a\7{\2\2\u056a\u00b5\3\2\2\2\u056b\u056c\b\\\1\2\u056c\u056f\5\u00ee"+
-		"x\2\u056d\u056f\5\u00be`\2\u056e\u056b\3\2\2\2\u056e\u056d\3\2\2\2\u056f"+
-		"\u057a\3\2\2\2\u0570\u0571\f\6\2\2\u0571\u0579\5\u00ba^\2\u0572\u0573"+
-		"\f\5\2\2\u0573\u0579\5\u00b8]\2\u0574\u0575\f\4\2\2\u0575\u0579\5\u00bc"+
-		"_\2\u0576\u0577\f\3\2\2\u0577\u0579\5\u00c0a\2\u0578\u0570\3\2\2\2\u0578"+
-		"\u0572\3\2\2\2\u0578\u0574\3\2\2\2\u0578\u0576\3\2\2\2\u0579\u057c\3\2"+
-		"\2\2\u057a\u0578\3\2\2\2\u057a\u057b\3\2\2\2\u057b\u00b7\3\2\2\2\u057c"+
-		"\u057a\3\2\2\2\u057d\u057e\t\t\2\2\u057e\u057f\t\n\2\2\u057f\u00b9\3\2"+
-		"\2\2\u0580\u0581\7\u0084\2\2\u0581\u0582\5\u00e6t\2\u0582\u0583\7\u0085"+
-		"\2\2\u0583\u00bb\3\2\2\2\u0584\u0589\7\u0099\2\2\u0585\u0586\7\u0084\2"+
-		"\2\u0586\u0587\5\u00e6t\2\u0587\u0588\7\u0085\2\2\u0588\u058a\3\2\2\2"+
-		"\u0589\u0585\3\2\2\2\u0589\u058a\3\2\2\2\u058a\u00bd\3\2\2\2\u058b\u058c"+
-		"\5\u00f0y\2\u058c\u058e\7\u0082\2\2\u058d\u058f\5\u00c2b\2\u058e\u058d"+
-		"\3\2\2\2\u058e\u058f\3\2\2\2\u058f\u0590\3\2\2\2\u0590\u0591\7\u0083\2"+
-		"\2\u0591\u00bf\3\2\2\2\u0592\u0593\t\t\2\2\u0593\u0594\5\u0132\u009a\2"+
-		"\u0594\u0596\7\u0082\2\2\u0595\u0597\5\u00c2b\2\u0596\u0595\3\2\2\2\u0596"+
-		"\u0597\3\2\2\2\u0597\u0598\3\2\2\2\u0598\u0599\7\u0083\2\2\u0599\u00c1"+
-		"\3\2\2\2\u059a\u059f\5\u00c4c\2\u059b\u059c\7\177\2\2\u059c\u059e\5\u00c4"+
-		"c\2\u059d\u059b\3\2\2\2\u059e\u05a1\3\2\2\2\u059f\u059d\3\2\2\2\u059f"+
-		"\u05a0\3\2\2\2\u05a0\u00c3\3\2\2\2\u05a1\u059f\3\2\2\2\u05a2\u05a6\5\u00e6"+
-		"t\2\u05a3\u05a6\5\u010c\u0087\2\u05a4\u05a6\5\u010e\u0088\2\u05a5\u05a2"+
-		"\3\2\2\2\u05a5\u05a3\3\2\2\2\u05a5\u05a4\3\2\2\2\u05a6\u00c5\3\2\2\2\u05a7"+
-		"\u05a9\7v\2\2\u05a8\u05a7\3\2\2\2\u05a8\u05a9\3\2\2\2\u05a9\u05aa\3\2"+
-		"\2\2\u05aa\u05ab\5\u00eex\2\u05ab\u05ac\7\u0097\2\2\u05ac\u05ad\5\u00be"+
-		"`\2\u05ad\u00c7\3\2\2\2\u05ae\u05b3\5\u00e6t\2\u05af\u05b0\7\177\2\2\u05b0"+
-		"\u05b2\5\u00e6t\2\u05b1\u05af\3\2\2\2\u05b2\u05b5\3\2\2\2\u05b3\u05b1"+
-		"\3\2\2\2\u05b3\u05b4\3\2\2\2\u05b4\u00c9\3\2\2\2\u05b5\u05b3\3\2\2\2\u05b6"+
-		"\u05b7\5\u00e6t\2\u05b7\u05b8\7{\2\2\u05b8\u00cb\3\2\2\2\u05b9\u05bb\5"+
-		"\u00ceh\2\u05ba\u05bc\5\u00d6l\2\u05bb\u05ba\3\2\2\2\u05bb\u05bc\3\2\2"+
-		"\2\u05bc\u00cd\3\2\2\2\u05bd\u05c0\7j\2\2\u05be\u05bf\7r\2\2\u05bf\u05c1"+
-		"\5\u00d2j\2\u05c0\u05be\3\2\2\2\u05c0\u05c1\3\2\2\2\u05c1\u05c2\3\2\2"+
-		"\2\u05c2\u05c6\7\u0080\2\2\u05c3\u05c5\5f\64\2\u05c4\u05c3\3\2\2\2\u05c5"+
-		"\u05c8\3\2\2\2\u05c6\u05c4\3\2\2\2\u05c6\u05c7\3\2\2\2\u05c7\u05c9\3\2"+
-		"\2\2\u05c8\u05c6\3\2\2\2\u05c9\u05ca\7\u0081\2\2\u05ca\u00cf\3\2\2\2\u05cb"+
-		"\u05cf\5\u00dco\2\u05cc\u05cf\5\u00dep\2\u05cd\u05cf\5\u00e0q\2\u05ce"+
-		"\u05cb\3\2\2\2\u05ce\u05cc\3\2\2\2\u05ce\u05cd\3\2\2\2\u05cf\u00d1\3\2"+
-		"\2\2\u05d0\u05d5\5\u00d0i\2\u05d1\u05d2\7\177\2\2\u05d2\u05d4\5\u00d0"+
-		"i\2\u05d3\u05d1\3\2\2\2\u05d4\u05d7\3\2\2\2\u05d5\u05d3\3\2\2\2\u05d5"+
-		"\u05d6\3\2\2\2\u05d6\u00d3\3\2\2\2\u05d7\u05d5\3\2\2\2\u05d8\u05d9\7t"+
-		"\2\2\u05d9\u05dd\7\u0080\2\2\u05da\u05dc\5f\64\2\u05db\u05da\3\2\2\2\u05dc"+
-		"\u05df\3\2\2\2\u05dd\u05db\3\2\2\2\u05dd\u05de\3\2\2\2\u05de\u05e0\3\2"+
-		"\2\2\u05df\u05dd\3\2\2\2\u05e0\u05e1\7\u0081\2\2\u05e1\u00d5\3\2\2\2\u05e2"+
-		"\u05e3\7m\2\2\u05e3\u05e7\7\u0080\2\2\u05e4\u05e6\5f\64\2\u05e5\u05e4"+
-		"\3\2\2\2\u05e6\u05e9\3\2\2\2\u05e7\u05e5\3\2\2\2\u05e7\u05e8\3\2\2\2\u05e8"+
-		"\u05ea\3\2\2\2\u05e9\u05e7\3\2\2\2\u05ea\u05eb\7\u0081\2\2\u05eb\u00d7"+
-		"\3\2\2\2\u05ec\u05ed\7k\2\2\u05ed\u05ee\7{\2\2\u05ee\u00d9\3\2\2\2\u05ef"+
-		"\u05f0\7l\2\2\u05f0\u05f1\7{\2\2\u05f1\u00db\3\2\2\2\u05f2\u05f3\7n\2"+
-		"\2\u05f3\u05f4\7\u0087\2\2\u05f4\u05f5\5\u00e6t\2\u05f5\u00dd\3\2\2\2"+
-		"\u05f6\u05f7\7p\2\2\u05f7\u05f8\7\u0087\2\2\u05f8\u05f9\5\u00e6t\2\u05f9"+
-		"\u00df\3\2\2\2\u05fa\u05fb\7o\2\2\u05fb\u05fc\7\u0087\2\2\u05fc\u05fd"+
-		"\5\u00e6t\2\u05fd\u00e1\3\2\2\2\u05fe\u05ff\5\u00e4s\2\u05ff\u00e3\3\2"+
-		"\2\2\u0600\u0601\7\23\2\2\u0601\u0604\7\u00ad\2\2\u0602\u0603\7\4\2\2"+
-		"\u0603\u0605\7\u00b1\2\2\u0604\u0602\3\2\2\2\u0604\u0605\3\2\2\2\u0605"+
-		"\u0606\3\2\2\2\u0606\u0607\7{\2\2\u0607\u00e5\3\2\2\2\u0608\u0609\bt\1"+
-		"\2\u0609\u0632\5\u0104\u0083\2\u060a\u0632\5t;\2\u060b\u0632\5j\66\2\u060c"+
-		"\u0632\5\u0110\u0089\2\u060d\u0632\5p9\2\u060e\u0632\5\u012e\u0098\2\u060f"+
-		"\u0611\7v\2\2\u0610\u060f\3\2\2\2\u0610\u0611\3\2\2\2\u0611\u0612\3\2"+
-		"\2\2\u0612\u0632\5\u00b6\\\2\u0613\u0632\5\u00c6d\2\u0614\u0632\5\34\17"+
-		"\2\u0615\u0632\5v<\2\u0616\u0632\5\u0136\u009c\2\u0617\u0618\7\u0092\2"+
-		"\2\u0618\u061b\5P)\2\u0619\u061a\7\177\2\2\u061a\u061c\5\u00be`\2\u061b"+
-		"\u0619\3\2\2\2\u061b\u061c\3\2\2\2\u061c\u061d\3\2\2\2\u061d\u061e\7\u0091"+
-		"\2\2\u061e\u061f\5\u00e6t\23\u061f\u0632\3\2\2\2\u0620\u0621\t\13\2\2"+
-		"\u0621\u0632\5\u00e6t\22\u0622\u0623\7\u0082\2\2\u0623\u0628\5\u00e6t"+
-		"\2\u0624\u0625\7\177\2\2\u0625\u0627\5\u00e6t\2\u0626\u0624\3\2\2\2\u0627"+
-		"\u062a\3\2\2\2\u0628\u0626\3\2\2\2\u0628\u0629\3\2\2\2\u0629\u062b\3\2"+
-		"\2\2\u062a\u0628\3\2\2\2\u062b\u062c\7\u0083\2\2\u062c\u0632\3\2\2\2\u062d"+
-		"\u0632\5\u00e8u\2\u062e\u062f\7y\2\2\u062f\u0632\5\u00e6t\5\u0630\u0632"+
-		"\5P)\2\u0631\u0608\3\2\2\2\u0631\u060a\3\2\2\2\u0631\u060b\3\2\2\2\u0631"+
-		"\u060c\3\2\2\2\u0631\u060d\3\2\2\2\u0631\u060e\3\2\2\2\u0631\u0610\3\2"+
-		"\2\2\u0631\u0613\3\2\2\2\u0631\u0614\3\2\2\2\u0631\u0615\3\2\2\2\u0631"+
-		"\u0616\3\2\2\2\u0631\u0617\3\2\2\2\u0631\u0620\3\2\2\2\u0631\u0622\3\2"+
-		"\2\2\u0631\u062d\3\2\2\2\u0631\u062e\3\2\2\2\u0631\u0630\3\2\2\2\u0632"+
-		"\u0658\3\2\2\2\u0633\u0634\f\20\2\2\u0634\u0635\7\u008c\2\2\u0635\u0657"+
-		"\5\u00e6t\21\u0636\u0637\f\17\2\2\u0637\u0638\t\f\2\2\u0638\u0657\5\u00e6"+
-		"t\20\u0639\u063a\f\16\2\2\u063a\u063b\t\r\2\2\u063b\u0657\5\u00e6t\17"+
-		"\u063c\u063d\f\r\2\2\u063d\u063e\t\16\2\2\u063e\u0657\5\u00e6t\16\u063f"+
-		"\u0640\f\f\2\2\u0640\u0641\t\17\2\2\u0641\u0657\5\u00e6t\r\u0642\u0643"+
-		"\f\13\2\2\u0643\u0644\7\u0095\2\2\u0644\u0657\5\u00e6t\f\u0645\u0646\f"+
-		"\n\2\2\u0646\u0647\7\u0096\2\2\u0647\u0657\5\u00e6t\13\u0648\u0649\f\t"+
-		"\2\2\u0649\u064a\t\20\2\2\u064a\u0657\5\u00e6t\n\u064b\u064c\f\b\2\2\u064c"+
-		"\u064d\7\u0086\2\2\u064d\u064e\5\u00e6t\2\u064e\u064f\7|\2\2\u064f\u0650"+
-		"\5\u00e6t\t\u0650\u0657\3\2\2\2\u0651\u0652\f\4\2\2\u0652\u0653\7\u009f"+
-		"\2\2\u0653\u0657\5\u00e6t\5\u0654\u0655\f\6\2\2\u0655\u0657\5\u00eav\2"+
-		"\u0656\u0633\3\2\2\2\u0656\u0636\3\2\2\2\u0656\u0639\3\2\2\2\u0656\u063c"+
-		"\3\2\2\2\u0656\u063f\3\2\2\2\u0656\u0642\3\2\2\2\u0656\u0645\3\2\2\2\u0656"+
-		"\u0648\3\2\2\2\u0656\u064b\3\2\2\2\u0656\u0651\3\2\2\2\u0656\u0654\3\2"+
-		"\2\2\u0657\u065a\3\2\2\2\u0658\u0656\3\2\2\2\u0658\u0659\3\2\2\2\u0659"+
-		"\u00e7\3\2\2\2\u065a\u0658\3\2\2\2\u065b\u065c\7w\2\2\u065c\u065d\5\u00e6"+
-		"t\2\u065d\u00e9\3\2\2\2\u065e\u065f\7x\2\2\u065f\u0660\7\u0080\2\2\u0660"+
-		"\u0665\5\u00ecw\2\u0661\u0662\7\177\2\2\u0662\u0664\5\u00ecw\2\u0663\u0661"+
-		"\3\2\2\2\u0664\u0667\3\2\2\2\u0665\u0663\3\2\2\2\u0665\u0666\3\2\2\2\u0666"+
-		"\u0668\3\2\2\2\u0667\u0665\3\2\2\2\u0668\u0669\7\u0081\2\2\u0669\u00eb"+
-		"\3\2\2\2\u066a\u066c\5P)\2\u066b\u066d\7\u00b1\2\2\u066c\u066b\3\2\2\2"+
-		"\u066c\u066d\3\2\2\2\u066d\u066e\3\2\2\2\u066e\u066f\7\u009e\2\2\u066f"+
-		"\u0670\5\u00e6t\2\u0670\u00ed\3\2\2\2\u0671\u0672\7\u00b1\2\2\u0672\u0674"+
-		"\7|\2\2\u0673\u0671\3\2\2\2\u0673\u0674\3\2\2\2\u0674\u0675\3\2\2\2\u0675"+
-		"\u0676\7\u00b1\2\2\u0676\u00ef\3\2\2\2\u0677\u0678\7\u00b1\2\2\u0678\u067a"+
-		"\7|\2\2\u0679\u0677\3\2\2\2\u0679\u067a\3\2\2\2\u067a\u067b\3\2\2\2\u067b"+
-		"\u067c\5\u0132\u009a\2\u067c\u00f1\3\2\2\2\u067d\u0681\7\24\2\2\u067e"+
-		"\u0680\5d\63\2\u067f\u067e\3\2\2\2\u0680\u0683\3\2\2\2\u0681\u067f\3\2"+
-		"\2\2\u0681\u0682\3\2\2\2\u0682\u0684\3\2\2\2\u0683\u0681\3\2\2\2\u0684"+
-		"\u0685\5P)\2\u0685\u00f3\3\2\2\2\u0686\u0688\5d\63\2\u0687\u0686\3\2\2"+
-		"\2\u0688\u068b\3\2\2\2\u0689\u0687\3\2\2\2\u0689\u068a\3\2\2\2\u068a\u068c"+
-		"\3\2\2\2\u068b\u0689\3\2\2\2\u068c\u068d\5P)\2\u068d\u00f5\3\2\2\2\u068e"+
-		"\u0693\5\u00f8}\2\u068f\u0690\7\177\2\2\u0690\u0692\5\u00f8}\2\u0691\u068f"+
-		"\3\2\2\2\u0692\u0695\3\2\2\2\u0693\u0691\3\2\2\2\u0693\u0694\3\2\2\2\u0694"+
-		"\u00f7\3\2\2\2\u0695\u0693\3\2\2\2\u0696\u0697\5P)\2\u0697\u00f9\3\2\2"+
-		"\2\u0698\u069d\5\u00fc\177\2\u0699\u069a\7\177\2\2\u069a\u069c\5\u00fc"+
-		"\177\2\u069b\u0699\3\2\2\2\u069c\u069f\3\2\2\2\u069d\u069b\3\2\2\2\u069d"+
-		"\u069e\3\2\2\2\u069e\u00fb\3\2\2\2\u069f\u069d\3\2\2\2\u06a0\u06a2\5d"+
-		"\63\2\u06a1\u06a0\3\2\2\2\u06a2\u06a5\3\2\2\2\u06a3\u06a1\3\2\2\2\u06a3"+
-		"\u06a4\3\2\2\2\u06a4\u06a6\3\2\2\2\u06a5\u06a3\3\2\2\2\u06a6\u06a7\5P"+
-		")\2\u06a7\u06a8\7\u00b1\2\2\u06a8\u06be\3\2\2\2\u06a9\u06ab\5d\63\2\u06aa"+
-		"\u06a9\3\2\2\2\u06ab\u06ae\3\2\2\2\u06ac\u06aa\3\2\2\2\u06ac\u06ad\3\2"+
-		"\2\2\u06ad\u06af\3\2\2\2\u06ae\u06ac\3\2\2\2\u06af\u06b0\7\u0082\2\2\u06b0"+
-		"\u06b1\5P)\2\u06b1\u06b8\7\u00b1\2\2\u06b2\u06b3\7\177\2\2\u06b3\u06b4"+
-		"\5P)\2\u06b4\u06b5\7\u00b1\2\2\u06b5\u06b7\3\2\2\2\u06b6\u06b2\3\2\2\2"+
-		"\u06b7\u06ba\3\2\2\2\u06b8\u06b6\3\2\2\2\u06b8\u06b9\3\2\2\2\u06b9\u06bb"+
-		"\3\2\2\2\u06ba\u06b8\3\2\2\2\u06bb\u06bc\7\u0083\2\2\u06bc\u06be\3\2\2"+
-		"\2\u06bd\u06a3\3\2\2\2\u06bd\u06ac\3\2\2\2\u06be\u00fd\3\2\2\2\u06bf\u06c0"+
-		"\5\u00fc\177\2\u06c0\u06c1\7\u0087\2\2\u06c1\u06c2\5\u00e6t\2\u06c2\u00ff"+
-		"\3\2\2\2\u06c3\u06c5\5d\63\2\u06c4\u06c3\3\2\2\2\u06c5\u06c8\3\2\2\2\u06c6"+
-		"\u06c4\3\2\2\2\u06c6\u06c7\3\2\2\2\u06c7\u06c9\3\2\2\2\u06c8\u06c6\3\2"+
-		"\2\2\u06c9\u06ca\5P)\2\u06ca\u06cb\7\u009c\2\2\u06cb\u06cc\7\u00b1\2\2"+
-		"\u06cc\u0101\3\2\2\2\u06cd\u06d0\5\u00fc\177\2\u06ce\u06d0\5\u00fe\u0080"+
-		"\2\u06cf\u06cd\3\2\2\2\u06cf\u06ce\3\2\2\2\u06d0\u06d8\3\2\2\2\u06d1\u06d4"+
-		"\7\177\2\2\u06d2\u06d5\5\u00fc\177\2\u06d3\u06d5\5\u00fe\u0080\2\u06d4"+
-		"\u06d2\3\2\2\2\u06d4\u06d3\3\2\2\2\u06d5\u06d7\3\2\2\2\u06d6\u06d1\3\2"+
-		"\2\2\u06d7\u06da\3\2\2\2\u06d8\u06d6\3\2\2\2\u06d8\u06d9\3\2\2\2\u06d9"+
-		"\u06dd\3\2\2\2\u06da\u06d8\3\2\2\2\u06db\u06dc\7\177\2\2\u06dc\u06de\5"+
-		"\u0100\u0081\2\u06dd\u06db\3\2\2\2\u06dd\u06de\3\2\2\2\u06de\u06e1\3\2"+
-		"\2\2\u06df\u06e1\5\u0100\u0081\2\u06e0\u06cf\3\2\2\2\u06e0\u06df\3\2\2"+
-		"\2\u06e1\u0103\3\2\2\2\u06e2\u06e4\7\u0089\2\2\u06e3\u06e2\3\2\2\2\u06e3"+
-		"\u06e4\3\2\2\2\u06e4\u06e5\3\2\2\2\u06e5\u06f0\5\u0106\u0084\2\u06e6\u06e8"+
-		"\7\u0089\2\2\u06e7\u06e6\3\2\2\2\u06e7\u06e8\3\2\2\2\u06e8\u06e9\3\2\2"+
-		"\2\u06e9\u06f0\7\u00ab\2\2\u06ea\u06f0\7\u00ad\2\2\u06eb\u06f0\7\u00ac"+
-		"\2\2\u06ec\u06f0\5\u0108\u0085\2\u06ed\u06f0\5\u010a\u0086\2\u06ee\u06f0"+
-		"\7\u00b0\2\2\u06ef\u06e3\3\2\2\2\u06ef\u06e7\3\2\2\2\u06ef\u06ea\3\2\2"+
-		"\2\u06ef\u06eb\3\2\2\2\u06ef\u06ec\3\2\2\2\u06ef\u06ed\3\2\2\2\u06ef\u06ee"+
-		"\3\2\2\2\u06f0\u0105\3\2\2\2\u06f1\u06f2\t\21\2\2\u06f2\u0107\3\2\2\2"+
-		"\u06f3\u06f4\7\u0082\2\2\u06f4\u06f5\7\u0083\2\2\u06f5\u0109\3\2\2\2\u06f6"+
-		"\u06f7\t\22\2\2\u06f7\u010b\3\2\2\2\u06f8\u06f9\7\u00b1\2\2\u06f9\u06fa"+
-		"\7\u0087\2\2\u06fa\u06fb\5\u00e6t\2\u06fb\u010d\3\2\2\2\u06fc\u06fd\7"+
-		"\u009c\2\2\u06fd\u06fe\5\u00e6t\2\u06fe\u010f\3\2\2\2\u06ff\u0700\7\u00b2"+
-		"\2\2\u0700\u0701\5\u0112\u008a\2\u0701\u0702\7\u00c3\2\2\u0702\u0111\3"+
-		"\2\2\2\u0703\u0709\5\u0118\u008d\2\u0704\u0709\5\u0120\u0091\2\u0705\u0709"+
-		"\5\u0116\u008c\2\u0706\u0709\5\u0124\u0093\2\u0707\u0709\7\u00bc\2\2\u0708"+
-		"\u0703\3\2\2\2\u0708\u0704\3\2\2\2\u0708\u0705\3\2\2\2\u0708\u0706\3\2"+
-		"\2\2\u0708\u0707\3\2\2\2\u0709\u0113\3\2\2\2\u070a\u070c\5\u0124\u0093"+
-		"\2\u070b\u070a\3\2\2\2\u070b\u070c\3\2\2\2\u070c\u0718\3\2\2\2\u070d\u0712"+
-		"\5\u0118\u008d\2\u070e\u0712\7\u00bc\2\2\u070f\u0712\5\u0120\u0091\2\u0710"+
-		"\u0712\5\u0116\u008c\2\u0711\u070d\3\2\2\2\u0711\u070e\3\2\2\2\u0711\u070f"+
-		"\3\2\2\2\u0711\u0710\3\2\2\2\u0712\u0714\3\2\2\2\u0713\u0715\5\u0124\u0093"+
-		"\2\u0714\u0713\3\2\2\2\u0714\u0715\3\2\2\2\u0715\u0717\3\2\2\2\u0716\u0711"+
-		"\3\2\2\2\u0717\u071a\3\2\2\2\u0718\u0716\3\2\2\2\u0718\u0719\3\2\2\2\u0719"+
-		"\u0115\3\2\2\2\u071a\u0718\3\2\2\2\u071b\u0722\7\u00bb\2\2\u071c\u071d"+
-		"\7\u00da\2\2\u071d\u071e\5\u00e6t\2\u071e\u071f\7\u00b6\2\2\u071f\u0721"+
-		"\3\2\2\2\u0720\u071c\3\2\2\2\u0721\u0724\3\2\2\2\u0722\u0720\3\2\2\2\u0722"+
-		"\u0723\3\2\2\2\u0723\u0725\3\2\2\2\u0724\u0722\3\2\2\2\u0725\u0726\7\u00d9"+
-		"\2\2\u0726\u0117\3\2\2\2\u0727\u0728\5\u011a\u008e\2\u0728\u0729\5\u0114"+
-		"\u008b\2\u0729\u072a\5\u011c\u008f\2\u072a\u072d\3\2\2\2\u072b\u072d\5"+
-		"\u011e\u0090\2\u072c\u0727\3\2\2\2\u072c\u072b\3\2\2\2\u072d\u0119\3\2"+
-		"\2\2\u072e\u072f\7\u00c0\2\2\u072f\u0733\5\u012c\u0097\2\u0730\u0732\5"+
-		"\u0122\u0092\2\u0731\u0730\3\2\2\2\u0732\u0735\3\2\2\2\u0733\u0731\3\2"+
-		"\2\2\u0733\u0734\3\2\2\2\u0734\u0736\3\2\2\2\u0735\u0733\3\2\2\2\u0736"+
-		"\u0737\7\u00c6\2\2\u0737\u011b\3\2\2\2\u0738\u0739\7\u00c1\2\2\u0739\u073a"+
-		"\5\u012c\u0097\2\u073a\u073b\7\u00c6\2\2\u073b\u011d\3\2\2\2\u073c\u073d"+
-		"\7\u00c0\2\2\u073d\u0741\5\u012c\u0097\2\u073e\u0740\5\u0122\u0092\2\u073f"+
-		"\u073e\3\2\2\2\u0740\u0743\3\2\2\2\u0741\u073f\3\2\2\2\u0741\u0742\3\2"+
-		"\2\2\u0742\u0744\3\2\2\2\u0743\u0741\3\2\2\2\u0744\u0745\7\u00c8\2\2\u0745"+
-		"\u011f\3\2\2\2\u0746\u074d\7\u00c2\2\2\u0747\u0748\7\u00d8\2\2\u0748\u0749"+
-		"\5\u00e6t\2\u0749\u074a\7\u00b6\2\2\u074a\u074c\3\2\2\2\u074b\u0747\3"+
-		"\2\2\2\u074c\u074f\3\2\2\2\u074d\u074b\3\2\2\2\u074d\u074e\3\2\2\2\u074e"+
-		"\u0750\3\2\2\2\u074f\u074d\3\2\2\2\u0750\u0751\7\u00d7\2\2\u0751\u0121"+
-		"\3\2\2\2\u0752\u0753\5\u012c\u0097\2\u0753\u0754\7\u00cb\2\2\u0754\u0755"+
-		"\5\u0126\u0094\2\u0755\u0123\3\2\2\2\u0756\u0757\7\u00c4\2\2\u0757\u0758"+
-		"\5\u00e6t\2\u0758\u0759\7\u00b6\2\2\u0759\u075b\3\2\2\2\u075a\u0756\3"+
-		"\2\2\2\u075b\u075c\3\2\2\2\u075c\u075a\3\2\2\2\u075c\u075d\3\2\2\2\u075d"+
-		"\u075f\3\2\2\2\u075e\u0760\7\u00c5\2\2\u075f\u075e\3\2\2\2\u075f\u0760"+
-		"\3\2\2\2\u0760\u0763\3\2\2\2\u0761\u0763\7\u00c5\2\2\u0762\u075a\3\2\2"+
-		"\2\u0762\u0761\3\2\2\2\u0763\u0125\3\2\2\2\u0764\u0767\5\u0128\u0095\2"+
-		"\u0765\u0767\5\u012a\u0096\2\u0766\u0764\3\2\2\2\u0766\u0765\3\2\2\2\u0767"+
-		"\u0127\3\2\2\2\u0768\u076f\7\u00cd\2\2\u0769\u076a\7\u00d5\2\2\u076a\u076b"+
-		"\5\u00e6t\2\u076b\u076c\7\u00b6\2\2\u076c\u076e\3\2\2\2\u076d\u0769\3"+
-		"\2\2\2\u076e\u0771\3\2\2\2\u076f\u076d\3\2\2\2\u076f\u0770\3\2\2\2\u0770"+
-		"\u0773\3\2\2\2\u0771\u076f\3\2\2\2\u0772\u0774\7\u00d6\2\2\u0773\u0772"+
-		"\3\2\2\2\u0773\u0774\3\2\2\2\u0774\u0775\3\2\2\2\u0775\u0776\7\u00d4\2"+
-		"\2\u0776\u0129\3\2\2\2\u0777\u077e\7\u00cc\2\2\u0778\u0779\7\u00d2\2\2"+
-		"\u0779\u077a\5\u00e6t\2\u077a\u077b\7\u00b6\2\2\u077b\u077d\3\2\2\2\u077c"+
-		"\u0778\3\2\2\2\u077d\u0780\3\2\2\2\u077e\u077c\3\2\2\2\u077e\u077f\3\2"+
-		"\2\2\u077f\u0782\3\2\2\2\u0780\u077e\3\2\2\2\u0781\u0783\7\u00d3\2\2\u0782"+
-		"\u0781\3\2\2\2\u0782\u0783\3\2\2\2\u0783\u0784\3\2\2\2\u0784\u0785\7\u00d1"+
-		"\2\2\u0785\u012b\3\2\2\2\u0786\u0787\7\u00ce\2\2\u0787\u0789\7\u00ca\2"+
-		"\2\u0788\u0786\3\2\2\2\u0788\u0789\3\2\2\2\u0789\u078a\3\2\2\2\u078a\u0790"+
-		"\7\u00ce\2\2\u078b\u078c\7\u00d0\2\2\u078c\u078d\5\u00e6t\2\u078d\u078e"+
-		"\7\u00b6\2\2\u078e\u0790\3\2\2\2\u078f\u0788\3\2\2\2\u078f\u078b\3\2\2"+
-		"\2\u0790\u012d\3\2\2\2\u0791\u0793\7\u00b3\2\2\u0792\u0794\5\u0130\u0099"+
-		"\2\u0793\u0792\3\2\2\2\u0793\u0794\3\2\2\2\u0794\u0795\3\2\2\2\u0795\u0796"+
-		"\7\u00ec\2\2\u0796\u012f\3\2\2\2\u0797\u0798\7\u00ed\2\2\u0798\u0799\5"+
-		"\u00e6t\2\u0799\u079a\7\u00b6\2\2\u079a\u079c\3\2\2\2\u079b\u0797\3\2"+
-		"\2\2\u079c\u079d\3\2\2\2\u079d\u079b\3\2\2\2\u079d\u079e\3\2\2\2\u079e"+
-		"\u07a0\3\2\2\2\u079f\u07a1\7\u00ee\2\2\u07a0\u079f\3\2\2\2\u07a0\u07a1"+
-		"\3\2\2\2\u07a1\u07a4\3\2\2\2\u07a2\u07a4\7\u00ee\2\2\u07a3\u079b\3\2\2"+
-		"\2\u07a3\u07a2\3\2\2\2\u07a4\u0131\3\2\2\2\u07a5\u07a8\7\u00b1\2\2\u07a6"+
-		"\u07a8\5\u0134\u009b\2\u07a7\u07a5\3\2\2\2\u07a7\u07a6\3\2\2\2\u07a8\u0133"+
-		"\3\2\2\2\u07a9\u07aa\t\23\2\2\u07aa\u0135\3\2\2\2\u07ab\u07ac\7\30\2\2"+
-		"\u07ac\u07ae\5\u0158\u00ad\2\u07ad\u07af\5\u015a\u00ae\2\u07ae\u07ad\3"+
-		"\2\2\2\u07ae\u07af\3\2\2\2\u07af\u07b1\3\2\2\2\u07b0\u07b2\5\u0148\u00a5"+
-		"\2\u07b1\u07b0\3\2\2\2\u07b1\u07b2\3\2\2\2\u07b2\u07b4\3\2\2\2\u07b3\u07b5"+
-		"\5\u0142\u00a2\2\u07b4\u07b3\3\2\2\2\u07b4\u07b5\3\2\2\2\u07b5\u07b7\3"+
-		"\2\2\2\u07b6\u07b8\5\u0146\u00a4\2\u07b7\u07b6\3\2\2\2\u07b7\u07b8\3\2"+
-		"\2\2\u07b8\u0137\3\2\2\2\u07b9\u07ba\7E\2\2\u07ba\u07bc\7\u0080\2\2\u07bb"+
-		"\u07bd\5\u013c\u009f\2\u07bc\u07bb\3\2\2\2\u07bd\u07be\3\2\2\2\u07be\u07bc"+
-		"\3\2\2\2\u07be\u07bf\3\2\2\2\u07bf\u07c0\3\2\2\2\u07c0\u07c1\7\u0081\2"+
-		"\2\u07c1\u0139\3\2\2\2\u07c2\u07c3\7z\2\2\u07c3\u07c4\7{\2\2\u07c4\u013b"+
-		"\3\2\2\2\u07c5\u07cb\7\30\2\2\u07c6\u07c8\5\u0158\u00ad\2\u07c7\u07c9"+
-		"\5\u015a\u00ae\2\u07c8\u07c7\3\2\2\2\u07c8\u07c9\3\2\2\2\u07c9\u07cc\3"+
-		"\2\2\2\u07ca\u07cc\5\u013e\u00a0\2\u07cb\u07c6\3\2\2\2\u07cb\u07ca\3\2"+
-		"\2\2\u07cc\u07ce\3\2\2\2\u07cd\u07cf\5\u0148\u00a5\2\u07ce\u07cd\3\2\2"+
-		"\2\u07ce\u07cf\3\2\2\2\u07cf\u07d1\3\2\2\2\u07d0\u07d2\5\u0142\u00a2\2"+
-		"\u07d1\u07d0\3\2\2\2\u07d1\u07d2\3\2\2\2\u07d2\u07d4\3\2\2\2\u07d3\u07d5"+
-		"\5\u015c\u00af\2\u07d4\u07d3\3\2\2\2\u07d4\u07d5\3\2\2\2\u07d5\u07d6\3"+
-		"\2\2\2\u07d6\u07d7\5\u0152\u00aa\2\u07d7\u013d\3\2\2\2\u07d8\u07da\7,"+
-		"\2\2\u07d9\u07d8\3\2\2\2\u07d9\u07da\3\2\2\2\u07da\u07db\3\2\2\2\u07db"+
-		"\u07dd\5\u015e\u00b0\2\u07dc\u07de\5\u0140\u00a1\2\u07dd\u07dc\3\2\2\2"+
-		"\u07dd\u07de\3\2\2\2\u07de\u013f\3\2\2\2\u07df\u07e0\7-\2\2\u07e0\u07e1"+
-		"\7\u00a7\2\2\u07e1\u07e2\5\u016a\u00b6\2\u07e2\u0141\3\2\2\2\u07e3\u07e4"+
-		"\7\36\2\2\u07e4\u07e5\7\34\2\2\u07e5\u07ea\5\u0144\u00a3\2\u07e6\u07e7"+
-		"\7\177\2\2\u07e7\u07e9\5\u0144\u00a3\2\u07e8\u07e6\3\2\2\2\u07e9\u07ec"+
-		"\3\2\2\2\u07ea\u07e8\3\2\2\2\u07ea\u07eb\3\2\2\2\u07eb\u0143\3\2\2\2\u07ec"+
-		"\u07ea\3\2\2\2\u07ed\u07ef\5\u00b6\\\2\u07ee\u07f0\5\u0166\u00b4\2\u07ef"+
-		"\u07ee\3\2\2\2\u07ef\u07f0\3\2\2\2\u07f0\u0145\3\2\2\2\u07f1\u07f2\7F"+
-		"\2\2\u07f2\u07f3\7\u00a7\2\2\u07f3\u0147\3\2\2\2\u07f4\u07f7\7\32\2\2"+
-		"\u07f5\u07f8\7\u008a\2\2\u07f6\u07f8\5\u014a\u00a6\2\u07f7\u07f5\3\2\2"+
-		"\2\u07f7\u07f6\3\2\2\2\u07f8\u07fa\3\2\2\2\u07f9\u07fb\5\u014e\u00a8\2"+
-		"\u07fa\u07f9\3\2\2\2\u07fa\u07fb\3\2\2\2\u07fb\u07fd\3\2\2\2\u07fc\u07fe"+
-		"\5\u0150\u00a9\2\u07fd\u07fc\3\2\2\2\u07fd\u07fe\3\2\2\2\u07fe\u0149\3"+
-		"\2\2\2\u07ff\u0804\5\u014c\u00a7\2\u0800\u0801\7\177\2\2\u0801\u0803\5"+
-		"\u014c\u00a7\2\u0802\u0800\3\2\2\2\u0803\u0806\3\2\2\2\u0804\u0802\3\2"+
-		"\2\2\u0804\u0805\3\2\2\2\u0805\u014b\3\2\2\2\u0806\u0804\3\2\2\2\u0807"+
-		"\u080a\5\u00e6t\2\u0808\u0809\7\4\2\2\u0809\u080b\7\u00b1\2\2\u080a\u0808"+
-		"\3\2\2\2\u080a\u080b\3\2\2\2\u080b\u014d\3\2\2\2\u080c\u080d\7\33\2\2"+
-		"\u080d\u080e\7\34\2\2\u080e\u080f\5\u0084C\2\u080f\u014f\3\2\2\2\u0810"+
-		"\u0811\7\35\2\2\u0811\u0812\5\u00e6t\2\u0812\u0151\3\2\2\2\u0813\u0814"+
-		"\7\u009e\2\2\u0814\u0815\7\u0082\2\2\u0815\u0816\5\u00fc\177\2\u0816\u0817"+
-		"\7\u0083\2\2\u0817\u081b\7\u0080\2\2\u0818\u081a\5f\64\2\u0819\u0818\3"+
-		"\2\2\2\u081a\u081d\3\2\2\2\u081b\u0819\3\2\2\2\u081b\u081c\3\2\2\2\u081c"+
-		"\u081e\3\2\2\2\u081d\u081b\3\2\2\2\u081e\u081f\7\u0081\2\2\u081f\u0153"+
-		"\3\2\2\2\u0820\u0821\7%\2\2\u0821\u0826\5\u0156\u00ac\2\u0822\u0823\7"+
-		"\177\2\2\u0823\u0825\5\u0156\u00ac\2\u0824\u0822\3\2\2\2\u0825\u0828\3"+
-		"\2\2\2\u0826\u0824\3\2\2\2\u0826\u0827\3\2\2\2\u0827\u0155\3\2\2\2\u0828"+
-		"\u0826\3\2\2\2\u0829\u082a\5\u00b6\\\2\u082a\u082b\7\u0087\2\2\u082b\u082c"+
-		"\5\u00e6t\2\u082c\u0157\3\2\2\2\u082d\u082f\5\u00b6\\\2\u082e\u0830\5"+
-		"\u0162\u00b2\2\u082f\u082e\3\2\2\2\u082f\u0830\3\2\2\2\u0830\u0834\3\2"+
-		"\2\2\u0831\u0833\5\u00be`\2\u0832\u0831\3\2\2\2\u0833\u0836\3\2\2\2\u0834"+
-		"\u0832\3\2\2\2\u0834\u0835\3\2\2\2\u0835\u0838\3\2\2\2\u0836\u0834\3\2"+
-		"\2\2\u0837\u0839\5\u0164\u00b3\2\u0838\u0837\3\2\2\2\u0838\u0839\3\2\2"+
-		"\2\u0839\u083d\3\2\2\2\u083a\u083c\5\u00be`\2\u083b\u083a\3\2\2\2\u083c"+
-		"\u083f\3\2\2\2\u083d\u083b\3\2\2\2\u083d\u083e\3\2\2\2\u083e\u0841\3\2"+
-		"\2\2\u083f\u083d\3\2\2\2\u0840\u0842\5\u0162\u00b2\2\u0841\u0840\3\2\2"+
-		"\2\u0841\u0842\3\2\2\2\u0842\u0845\3\2\2\2\u0843\u0844\7\4\2\2\u0844\u0846"+
-		"\7\u00b1\2\2\u0845\u0843\3\2\2\2\u0845\u0846\3\2\2\2\u0846\u0159\3\2\2"+
-		"\2\u0847\u0848\7\67\2\2\u0848\u084e\5\u0168\u00b5\2\u0849\u084a\5\u0168"+
-		"\u00b5\2\u084a\u084b\7\67\2\2\u084b\u084e\3\2\2\2\u084c\u084e\5\u0168"+
-		"\u00b5\2\u084d\u0847\3\2\2\2\u084d\u0849\3\2\2\2\u084d\u084c\3\2\2\2\u084e"+
-		"\u084f\3\2\2\2\u084f\u0850\5\u0158\u00ad\2\u0850\u0851\7\31\2\2\u0851"+
-		"\u0852\5\u00e6t\2\u0852\u015b\3\2\2\2\u0853\u0854\7\61\2\2\u0854\u0855"+
-		"\t\24\2\2\u0855\u085a\7,\2\2\u0856\u0857\7\u00a7\2\2\u0857\u085b\5\u016a"+
-		"\u00b6\2\u0858\u0859\7\u00a7\2\2\u0859\u085b\7+\2\2\u085a\u0856\3\2\2"+
-		"\2\u085a\u0858\3\2\2\2\u085b\u0862\3\2\2\2\u085c\u085d\7\61\2\2\u085d"+
-		"\u085e\7\60\2\2\u085e\u085f\7,\2\2\u085f\u0860\7\u00a7\2\2\u0860\u0862"+
-		"\5\u016a\u00b6\2\u0861\u0853\3\2\2\2\u0861\u085c\3\2\2\2\u0862\u015d\3"+
-		"\2\2\2\u0863\u0867\5\u0160\u00b1\2\u0864\u0865\7 \2\2\u0865\u0868\7\34"+
-		"\2\2\u0866\u0868\7\177\2\2\u0867\u0864\3\2\2\2\u0867\u0866\3\2\2\2\u0868"+
-		"\u0869\3\2\2\2\u0869\u086a\5\u015e\u00b0\2\u086a\u087e\3\2\2\2\u086b\u086c"+
-		"\7\u0082\2\2\u086c\u086d\5\u015e\u00b0\2\u086d\u086e\7\u0083\2\2\u086e"+
-		"\u087e\3\2\2\2\u086f\u0870\7\u008e\2\2\u0870\u0876\5\u0160\u00b1\2\u0871"+
-		"\u0872\7\u0095\2\2\u0872\u0877\5\u0160\u00b1\2\u0873\u0874\7&\2\2\u0874"+
-		"\u0875\7\u00a7\2\2\u0875\u0877\5\u016a\u00b6\2\u0876\u0871\3\2\2\2\u0876"+
-		"\u0873\3\2\2\2\u0877\u087e\3\2\2\2\u0878\u0879\5\u0160\u00b1\2\u0879\u087a"+
-		"\t\25\2\2\u087a\u087b\5\u0160\u00b1\2\u087b\u087e\3\2\2\2\u087c\u087e"+
-		"\5\u0160\u00b1\2\u087d\u0863\3\2\2\2\u087d\u086b\3\2\2\2\u087d\u086f\3"+
-		"\2\2\2\u087d\u0878\3\2\2\2\u087d\u087c\3\2\2\2\u087e\u015f\3\2\2\2\u087f"+
-		"\u0881\5\u00b6\\\2\u0880\u0882\5\u0162\u00b2\2\u0881\u0880\3\2\2\2\u0881"+
-		"\u0882\3\2\2\2\u0882\u0884\3\2\2\2\u0883\u0885\5\u0094K\2\u0884\u0883"+
-		"\3\2\2\2\u0884\u0885\3\2\2\2\u0885\u0888\3\2\2\2\u0886\u0887\7\4\2\2\u0887"+
-		"\u0889\7\u00b1\2\2\u0888\u0886\3\2\2\2\u0888\u0889\3\2\2\2\u0889\u0161"+
-		"\3\2\2\2\u088a\u088b\7\37\2\2\u088b\u088c\5\u00e6t\2\u088c\u0163\3\2\2"+
-		"\2\u088d\u088e\7\'\2\2\u088e\u088f\5\u00be`\2\u088f\u0165\3\2\2\2\u0890"+
-		"\u0891\t\26\2\2\u0891\u0167\3\2\2\2\u0892\u0893\7\65\2\2\u0893\u0894\7"+
-		"\63\2\2\u0894\u08a2\7a\2\2\u0895\u0896\7\64\2\2\u0896\u0897\7\63\2\2\u0897"+
-		"\u08a2\7a\2\2\u0898\u0899\7\66\2\2\u0899\u089a\7\63\2\2\u089a\u08a2\7"+
-		"a\2\2\u089b\u089c\7\63\2\2\u089c\u08a2\7a\2\2\u089d\u089f\7\62\2\2\u089e"+
-		"\u089d\3\2\2\2\u089e\u089f\3\2\2\2\u089f\u08a0\3\2\2\2\u08a0\u08a2\7a"+
-		"\2\2\u08a1\u0892\3\2\2\2\u08a1\u0895\3\2\2\2\u08a1\u0898\3\2\2\2\u08a1"+
-		"\u089b\3\2\2\2\u08a1\u089e\3\2\2\2\u08a2\u0169\3\2\2\2\u08a3\u08a4\t\27"+
-		"\2\2\u08a4\u016b\3\2\2\2\u08a5\u08a7\7\u00b5\2\2\u08a6\u08a8\5\u016e\u00b8"+
-		"\2\u08a7\u08a6\3\2\2\2\u08a7\u08a8\3\2\2\2\u08a8\u08a9\3\2\2\2\u08a9\u08aa"+
-		"\7\u00e7\2\2\u08aa\u016d\3\2\2\2\u08ab\u08b0\5\u0170\u00b9\2\u08ac\u08af"+
-		"\7\u00eb\2\2\u08ad\u08af\5\u0170\u00b9\2\u08ae\u08ac\3\2\2\2\u08ae\u08ad"+
-		"\3\2\2\2\u08af\u08b2\3\2\2\2\u08b0\u08ae\3\2\2\2\u08b0\u08b1\3\2\2\2\u08b1"+
-		"\u08bc\3\2\2\2\u08b2\u08b0\3\2\2\2\u08b3\u08b8\7\u00eb\2\2\u08b4\u08b7"+
-		"\7\u00eb\2\2\u08b5\u08b7\5\u0170\u00b9\2\u08b6\u08b4\3\2\2\2\u08b6\u08b5"+
-		"\3\2\2\2\u08b7\u08ba\3\2\2\2\u08b8\u08b6\3\2\2\2\u08b8\u08b9\3\2\2\2\u08b9"+
-		"\u08bc\3\2\2\2\u08ba\u08b8\3\2\2\2\u08bb\u08ab\3\2\2\2\u08bb\u08b3\3\2"+
-		"\2\2\u08bc\u016f\3\2\2\2\u08bd\u08c1\5\u0172\u00ba\2\u08be\u08c1\5\u0174"+
-		"\u00bb\2\u08bf\u08c1\5\u0176\u00bc\2\u08c0\u08bd\3\2\2\2\u08c0\u08be\3"+
-		"\2\2\2\u08c0\u08bf\3\2\2\2\u08c1\u0171\3\2\2\2\u08c2\u08c4\7\u00e8\2\2"+
-		"\u08c3\u08c5\7\u00e6\2\2\u08c4\u08c3\3\2\2\2\u08c4\u08c5\3\2\2\2\u08c5"+
-		"\u08c6\3\2\2\2\u08c6\u08c7\7\u00e5\2\2\u08c7\u0173\3\2\2\2\u08c8\u08ca"+
-		"\7\u00e9\2\2\u08c9\u08cb\7\u00e4\2\2\u08ca\u08c9\3\2\2\2\u08ca\u08cb\3"+
-		"\2\2\2\u08cb\u08cc\3\2\2\2\u08cc\u08cd\7\u00e3\2\2\u08cd\u0175\3\2\2\2"+
-		"\u08ce\u08d0\7\u00ea\2\2\u08cf\u08d1\7\u00e2\2\2\u08d0\u08cf\3\2\2\2\u08d0"+
-		"\u08d1\3\2\2\2\u08d1\u08d2\3\2\2\2\u08d2\u08d3\7\u00e1\2\2\u08d3\u0177"+
-		"\3\2\2\2\u08d4\u08d6\7\u00b4\2\2\u08d5\u08d7\5\u017a\u00be\2\u08d6\u08d5"+
-		"\3\2\2\2\u08d6\u08d7\3\2\2\2\u08d7\u08d8\3\2\2\2\u08d8\u08d9\7\u00db\2"+
-		"\2\u08d9\u0179\3\2\2\2\u08da\u08dc\5\u017e\u00c0\2\u08db\u08da\3\2\2\2"+
-		"\u08db\u08dc\3\2\2\2\u08dc\u08de\3\2\2\2\u08dd\u08df\5\u017c\u00bf\2\u08de"+
-		"\u08dd\3\2\2\2\u08df\u08e0\3\2\2\2\u08e0\u08de\3\2\2\2\u08e0\u08e1\3\2"+
-		"\2\2\u08e1\u08e4\3\2\2\2\u08e2\u08e4\5\u017e\u00c0\2\u08e3\u08db\3\2\2"+
-		"\2\u08e3\u08e2\3\2\2\2\u08e4\u017b\3\2\2\2\u08e5\u08e7\7\u00dc\2\2\u08e6"+
-		"\u08e8\7\u00b1\2\2\u08e7\u08e6\3\2\2\2\u08e7\u08e8\3\2\2\2\u08e8\u08e9"+
-		"\3\2\2\2\u08e9\u08eb\7\u00b7\2\2\u08ea\u08ec\5\u017e\u00c0\2\u08eb\u08ea"+
-		"\3\2\2\2\u08eb\u08ec\3\2\2\2\u08ec\u017d\3\2\2\2\u08ed\u08f2\5\u0180\u00c1"+
-		"\2\u08ee\u08f1\7\u00e0\2\2\u08ef\u08f1\5\u0180\u00c1\2\u08f0\u08ee\3\2"+
-		"\2\2\u08f0\u08ef\3\2\2\2\u08f1\u08f4\3\2\2\2\u08f2\u08f0\3\2\2\2\u08f2"+
-		"\u08f3\3\2\2\2\u08f3\u08fe\3\2\2\2\u08f4\u08f2\3\2\2\2\u08f5\u08fa\7\u00e0"+
-		"\2\2\u08f6\u08f9\7\u00e0\2\2\u08f7\u08f9\5\u0180\u00c1\2\u08f8\u08f6\3"+
-		"\2\2\2\u08f8\u08f7\3\2\2\2\u08f9\u08fc\3\2\2\2\u08fa\u08f8\3\2\2\2\u08fa"+
-		"\u08fb\3\2\2\2\u08fb\u08fe\3\2\2\2\u08fc\u08fa\3\2\2\2\u08fd\u08ed\3\2"+
-		"\2\2\u08fd\u08f5\3\2\2\2\u08fe\u017f\3\2\2\2\u08ff\u0903\5\u0182\u00c2"+
-		"\2\u0900\u0903\5\u0184\u00c3\2\u0901\u0903\5\u0186\u00c4\2\u0902\u08ff"+
-		"\3\2\2\2\u0902\u0900\3\2\2\2\u0902\u0901\3\2\2\2\u0903\u0181\3\2\2\2\u0904"+
-		"\u0906\7\u00dd\2\2\u0905\u0907\7\u00e6\2\2\u0906\u0905\3\2\2\2\u0906\u0907"+
-		"\3\2\2\2\u0907\u0908\3\2\2\2\u0908\u0909\7\u00e5\2\2\u0909\u0183\3\2\2"+
-		"\2\u090a\u090c\7\u00de\2\2\u090b\u090d\7\u00e4\2\2\u090c\u090b\3\2\2\2"+
-		"\u090c\u090d\3\2\2\2\u090d\u090e\3\2\2\2\u090e\u090f\7\u00e3\2\2\u090f"+
-		"\u0185\3\2\2\2\u0910\u0912\7\u00df\2\2\u0911\u0913\7\u00e2\2\2\u0912\u0911"+
-		"\3\2\2\2\u0912\u0913\3\2\2\2\u0913\u0914\3\2\2\2\u0914\u0915\7\u00e1\2"+
-		"\2\u0915\u0187\3\2\2\2\u011e\u018a\u018c\u0190\u0193\u0198\u019e\u01a8"+
+		"\u035b\3\2\2\2\u0350\u0351\7\13\2\2\u0351\u0352\7\u0080\2\2\u0352\u0353"+
+		"\5\"\22\2\u0353\u0354\7\u0081\2\2\u0354\u035b\3\2\2\2\u0355\u0356\7\f"+
+		"\2\2\u0356\u0357\7\u0080\2\2\u0357\u0358\5R*\2\u0358\u0359\7\u0081\2\2"+
+		"\u0359\u035b\3\2\2\2\u035a\u033f\3\2\2\2\u035a\u0341\3\2\2\2\u035a\u0345"+
+		"\3\2\2\2\u035a\u0350\3\2\2\2\u035a\u0355\3\2\2\2\u035b\u036e\3\2\2\2\u035c"+
+		"\u035f\f\t\2\2\u035d\u035e\7\u0084\2\2\u035e\u0360\7\u0085\2\2\u035f\u035d"+
+		"\3\2\2\2\u0360\u0361\3\2\2\2\u0361\u035f\3\2\2\2\u0361\u0362\3\2\2\2\u0362"+
+		"\u036d\3\2\2\2\u0363\u0366\f\b\2\2\u0364\u0365\7\u009d\2\2\u0365\u0367"+
+		"\5P)\2\u0366\u0364\3\2\2\2\u0367\u0368\3\2\2\2\u0368\u0366\3\2\2\2\u0368"+
+		"\u0369\3\2\2\2\u0369\u036d\3\2\2\2\u036a\u036b\f\7\2\2\u036b\u036d\7\u0086"+
+		"\2\2\u036c\u035c\3\2\2\2\u036c\u0363\3\2\2\2\u036c\u036a\3\2\2\2\u036d"+
+		"\u0370\3\2\2\2\u036e\u036c\3\2\2\2\u036e\u036f\3\2\2\2\u036fQ\3\2\2\2"+
+		"\u0370\u036e\3\2\2\2\u0371\u0373\5.\30\2\u0372\u0371\3\2\2\2\u0373\u0376"+
+		"\3\2\2\2\u0374\u0372\3\2\2\2\u0374\u0375\3\2\2\2\u0375S\3\2\2\2\u0376"+
+		"\u0374\3\2\2\2\u0377\u037d\7S\2\2\u0378\u037d\7T\2\2\u0379\u037d\5Z.\2"+
+		"\u037a\u037d\5V,\2\u037b\u037d\5\u0108\u0085\2\u037c\u0377\3\2\2\2\u037c"+
+		"\u0378\3\2\2\2\u037c\u0379\3\2\2\2\u037c\u037a\3\2\2\2\u037c\u037b\3\2"+
+		"\2\2\u037dU\3\2\2\2\u037e\u0381\5\\/\2\u037f\u0381\5X-\2\u0380\u037e\3"+
+		"\2\2\2\u0380\u037f\3\2\2\2\u0381W\3\2\2\2\u0382\u0383\5\u00eex\2\u0383"+
+		"Y\3\2\2\2\u0384\u0385\t\4\2\2\u0385[\3\2\2\2\u0386\u038b\7N\2\2\u0387"+
+		"\u0388\7\u0092\2\2\u0388\u0389\5P)\2\u0389\u038a\7\u0091\2\2\u038a\u038c"+
+		"\3\2\2\2\u038b\u0387\3\2\2\2\u038b\u038c\3\2\2\2\u038c\u03b8\3\2\2\2\u038d"+
+		"\u0392\7V\2\2\u038e\u038f\7\u0092\2\2\u038f\u0390\5P)\2\u0390\u0391\7"+
+		"\u0091\2\2\u0391\u0393\3\2\2\2\u0392\u038e\3\2\2\2\u0392\u0393\3\2\2\2"+
+		"\u0393\u03b8\3\2\2\2\u0394\u039f\7P\2\2\u0395\u039a\7\u0092\2\2\u0396"+
+		"\u0397\7\u0080\2\2\u0397\u0398\5`\61\2\u0398\u0399\7\u0081\2\2\u0399\u039b"+
+		"\3\2\2\2\u039a\u0396\3\2\2\2\u039a\u039b\3\2\2\2\u039b\u039c\3\2\2\2\u039c"+
+		"\u039d\5b\62\2\u039d\u039e\7\u0091\2\2\u039e\u03a0\3\2\2\2\u039f\u0395"+
+		"\3\2\2\2\u039f\u03a0\3\2\2\2\u03a0\u03b8\3\2\2\2\u03a1\u03a6\7O\2\2\u03a2"+
+		"\u03a3\7\u0092\2\2\u03a3\u03a4\5\u00eex\2\u03a4\u03a5\7\u0091\2\2\u03a5"+
+		"\u03a7\3\2\2\2\u03a6\u03a2\3\2\2\2\u03a6\u03a7\3\2\2\2\u03a7\u03b8\3\2"+
+		"\2\2\u03a8\u03ad\7Q\2\2\u03a9\u03aa\7\u0092\2\2\u03aa\u03ab\5\u00eex\2"+
+		"\u03ab\u03ac\7\u0091\2\2\u03ac\u03ae\3\2\2\2\u03ad\u03a9\3\2\2\2\u03ad"+
+		"\u03ae\3\2\2\2\u03ae\u03b8\3\2\2\2\u03af\u03b4\7R\2\2\u03b0\u03b1\7\u0092"+
+		"\2\2\u03b1\u03b2\5P)\2\u03b2\u03b3\7\u0091\2\2\u03b3\u03b5\3\2\2\2\u03b4"+
+		"\u03b0\3\2\2\2\u03b4\u03b5\3\2\2\2\u03b5\u03b8\3\2\2\2\u03b6\u03b8\5^"+
+		"\60\2\u03b7\u0386\3\2\2\2\u03b7\u038d\3\2\2\2\u03b7\u0394\3\2\2\2\u03b7"+
+		"\u03a1\3\2\2\2\u03b7\u03a8\3\2\2\2\u03b7\u03af\3\2\2\2\u03b7\u03b6\3\2"+
+		"\2\2\u03b8]\3\2\2\2\u03b9\u03ba\7\n\2\2\u03ba\u03bd\7\u0082\2\2\u03bb"+
+		"\u03be\5\u00fa~\2\u03bc\u03be\5\u00f6|\2\u03bd\u03bb\3\2\2\2\u03bd\u03bc"+
+		"\3\2\2\2\u03bd\u03be\3\2\2\2\u03be\u03bf\3\2\2\2\u03bf\u03c1\7\u0083\2"+
+		"\2\u03c0\u03c2\5\u00f2z\2\u03c1\u03c0\3\2\2\2\u03c1\u03c2\3\2\2\2\u03c2"+
+		"_\3\2\2\2\u03c3\u03c4\7\u00ad\2\2\u03c4a\3\2\2\2\u03c5\u03c6\7\u00b1\2"+
+		"\2\u03c6c\3\2\2\2\u03c7\u03c8\7\u0099\2\2\u03c8\u03ca\5\u00eex\2\u03c9"+
+		"\u03cb\5j\66\2\u03ca\u03c9\3\2\2\2\u03ca\u03cb\3\2\2\2\u03cbe\3\2\2\2"+
+		"\u03cc\u03e6\5h\65\2\u03cd\u03e6\5x=\2\u03ce\u03e6\5z>\2\u03cf\u03e6\5"+
+		"|?\2\u03d0\u03e6\5\u0080A\2\u03d1\u03e6\5\u0086D\2\u03d2\u03e6\5\u008e"+
+		"H\2\u03d3\u03e6\5\u0092J\2\u03d4\u03e6\5\u0096L\2\u03d5\u03e6\5\u0098"+
+		"M\2\u03d6\u03e6\5\u009aN\2\u03d7\u03e6\5\u009cO\2\u03d8\u03e6\5\u00a4"+
+		"S\2\u03d9\u03e6\5\u00acW\2\u03da\u03e6\5\u00aeX\2\u03db\u03e6\5\u00b0"+
+		"Y\2\u03dc\u03e6\5\u00caf\2\u03dd\u03e6\5\u00ccg\2\u03de\u03e6\5\u00d8"+
+		"m\2\u03df\u03e6\5\u00dan\2\u03e0\u03e6\5\u00d4k\2\u03e1\u03e6\5\u00e2"+
+		"r\2\u03e2\u03e6\5\u0138\u009d\2\u03e3\u03e6\5\u013c\u009f\2\u03e4\u03e6"+
+		"\5\u013a\u009e\2\u03e5\u03cc\3\2\2\2\u03e5\u03cd\3\2\2\2\u03e5\u03ce\3"+
+		"\2\2\2\u03e5\u03cf\3\2\2\2\u03e5\u03d0\3\2\2\2\u03e5\u03d1\3\2\2\2\u03e5"+
+		"\u03d2\3\2\2\2\u03e5\u03d3\3\2\2\2\u03e5\u03d4\3\2\2\2\u03e5\u03d5\3\2"+
+		"\2\2\u03e5\u03d6\3\2\2\2\u03e5\u03d7\3\2\2\2\u03e5\u03d8\3\2\2\2\u03e5"+
+		"\u03d9\3\2\2\2\u03e5\u03da\3\2\2\2\u03e5\u03db\3\2\2\2\u03e5\u03dc\3\2"+
+		"\2\2\u03e5\u03dd\3\2\2\2\u03e5\u03de\3\2\2\2\u03e5\u03df\3\2\2\2\u03e5"+
+		"\u03e0\3\2\2\2\u03e5\u03e1\3\2\2\2\u03e5\u03e2\3\2\2\2\u03e5\u03e3\3\2"+
+		"\2\2\u03e5\u03e4\3\2\2\2\u03e6g\3\2\2\2\u03e7\u03e8\5P)\2\u03e8\u03eb"+
+		"\7\u00b1\2\2\u03e9\u03ea\7\u0087\2\2\u03ea\u03ec\5\u00e6t\2\u03eb\u03e9"+
+		"\3\2\2\2\u03eb\u03ec\3\2\2\2\u03ec\u03ed\3\2\2\2\u03ed\u03ee\7{\2\2\u03ee"+
+		"i\3\2\2\2\u03ef\u03f8\7\u0080\2\2\u03f0\u03f5\5l\67\2\u03f1\u03f2\7\177"+
+		"\2\2\u03f2\u03f4\5l\67\2\u03f3\u03f1\3\2\2\2\u03f4\u03f7\3\2\2\2\u03f5"+
+		"\u03f3\3\2\2\2\u03f5\u03f6\3\2\2\2\u03f6\u03f9\3\2\2\2\u03f7\u03f5\3\2"+
+		"\2\2\u03f8\u03f0\3\2\2\2\u03f8\u03f9\3\2\2\2\u03f9\u03fa\3\2\2\2\u03fa"+
+		"\u03fb\7\u0081\2\2\u03fbk\3\2\2\2\u03fc\u03fd\5n8\2\u03fd\u03fe\7|\2\2"+
+		"\u03fe\u03ff\5\u00e6t\2\u03ffm\3\2\2\2\u0400\u0403\7\u00b1\2\2\u0401\u0403"+
+		"\5\u00e6t\2\u0402\u0400\3\2\2\2\u0402\u0401\3\2\2\2\u0403o\3\2\2\2\u0404"+
+		"\u0405\7Q\2\2\u0405\u0406\5r:\2\u0406q\3\2\2\2\u0407\u0408\5j\66\2\u0408"+
+		"s\3\2\2\2\u0409\u040b\7\u0084\2\2\u040a\u040c\5\u00c8e\2\u040b\u040a\3"+
+		"\2\2\2\u040b\u040c\3\2\2\2\u040c\u040d\3\2\2\2\u040d\u040e\7\u0085\2\2"+
+		"\u040eu\3\2\2\2\u040f\u0415\7X\2\2\u0410\u0412\7\u0082\2\2\u0411\u0413"+
+		"\5\u00c2b\2\u0412\u0411\3\2\2\2\u0412\u0413\3\2\2\2\u0413\u0414\3\2\2"+
+		"\2\u0414\u0416\7\u0083\2\2\u0415\u0410\3\2\2\2\u0415\u0416\3\2\2\2\u0416"+
+		"\u0420\3\2\2\2\u0417\u0418\7X\2\2\u0418\u0419\5X-\2\u0419\u041b\7\u0082"+
+		"\2\2\u041a\u041c\5\u00c2b\2\u041b\u041a\3\2\2\2\u041b\u041c\3\2\2\2\u041c"+
+		"\u041d\3\2\2\2\u041d\u041e\7\u0083\2\2\u041e\u0420\3\2\2\2\u041f\u040f"+
+		"\3\2\2\2\u041f\u0417\3\2\2\2\u0420w\3\2\2\2\u0421\u0423\7W\2\2\u0422\u0421"+
+		"\3\2\2\2\u0422\u0423\3\2\2\2\u0423\u0424\3\2\2\2\u0424\u0425\5\u00b6\\"+
+		"\2\u0425\u0426\7\u0087\2\2\u0426\u0427\5\u00e6t\2\u0427\u0428\7{\2\2\u0428"+
+		"y\3\2\2\2\u0429\u042b\7W\2\2\u042a\u0429\3\2\2\2\u042a\u042b\3\2\2\2\u042b"+
+		"\u042c\3\2\2\2\u042c\u042d\7\u0082\2\2\u042d\u042e\5\u0084C\2\u042e\u042f"+
+		"\7\u0083\2\2\u042f\u0430\7\u0087\2\2\u0430\u0431\5\u00e6t\2\u0431\u0432"+
+		"\7{\2\2\u0432\u043b\3\2\2\2\u0433\u0434\7\u0082\2\2\u0434\u0435\5\u00fa"+
+		"~\2\u0435\u0436\7\u0083\2\2\u0436\u0437\7\u0087\2\2\u0437\u0438\5\u00e6"+
+		"t\2\u0438\u0439\7{\2\2\u0439\u043b\3\2\2\2\u043a\u042a\3\2\2\2\u043a\u0433"+
+		"\3\2\2\2\u043b{\3\2\2\2\u043c\u043d\5\u00b6\\\2\u043d\u043e\5~@\2\u043e"+
+		"\u043f\5\u00e6t\2\u043f\u0440\7{\2\2\u0440}\3\2\2\2\u0441\u0442\t\5\2"+
+		"\2\u0442\177\3\2\2\2\u0443\u0444\5\u00b6\\\2\u0444\u0445\5\u0082B\2\u0445"+
+		"\u0446\7{\2\2\u0446\u0081\3\2\2\2\u0447\u0448\t\6\2\2\u0448\u0083\3\2"+
+		"\2\2\u0449\u044e\5\u00b6\\\2\u044a\u044b\7\177\2\2\u044b\u044d\5\u00b6"+
+		"\\\2\u044c\u044a\3\2\2\2\u044d\u0450\3\2\2\2\u044e\u044c\3\2\2\2\u044e"+
+		"\u044f\3\2\2\2\u044f\u0085\3\2\2\2\u0450\u044e\3\2\2\2\u0451\u0455\5\u0088"+
+		"E\2\u0452\u0454\5\u008aF\2\u0453\u0452\3\2\2\2\u0454\u0457\3\2\2\2\u0455"+
+		"\u0453\3\2\2\2\u0455\u0456\3\2\2\2\u0456\u0459\3\2\2\2\u0457\u0455\3\2"+
+		"\2\2\u0458\u045a\5\u008cG\2\u0459\u0458\3\2\2\2\u0459\u045a\3\2\2\2\u045a"+
+		"\u0087\3\2\2\2\u045b\u045c\7Y\2\2\u045c\u045d\5\u00e6t\2\u045d\u0461\7"+
+		"\u0080\2\2\u045e\u0460\5f\64\2\u045f\u045e\3\2\2\2\u0460\u0463\3\2\2\2"+
+		"\u0461\u045f\3\2\2\2\u0461\u0462\3\2\2\2\u0462\u0464\3\2\2\2\u0463\u0461"+
+		"\3\2\2\2\u0464\u0465\7\u0081\2\2\u0465\u0089\3\2\2\2\u0466\u0467\7[\2"+
+		"\2\u0467\u0468\7Y\2\2\u0468\u0469\5\u00e6t\2\u0469\u046d\7\u0080\2\2\u046a"+
+		"\u046c\5f\64\2\u046b\u046a\3\2\2\2\u046c\u046f\3\2\2\2\u046d\u046b\3\2"+
+		"\2\2\u046d\u046e\3\2\2\2\u046e\u0470\3\2\2\2\u046f\u046d\3\2\2\2\u0470"+
+		"\u0471\7\u0081\2\2\u0471\u008b\3\2\2\2\u0472\u0473\7[\2\2\u0473\u0477"+
+		"\7\u0080\2\2\u0474\u0476\5f\64\2\u0475\u0474\3\2\2\2\u0476\u0479\3\2\2"+
+		"\2\u0477\u0475\3\2\2\2\u0477\u0478\3\2\2\2\u0478\u047a\3\2\2\2\u0479\u0477"+
+		"\3\2\2\2\u047a\u047b\7\u0081\2\2\u047b\u008d\3\2\2\2\u047c\u047d\7Z\2"+
+		"\2\u047d\u047e\5\u00e6t\2\u047e\u0480\7\u0080\2\2\u047f\u0481\5\u0090"+
+		"I\2\u0480\u047f\3\2\2\2\u0481\u0482\3\2\2\2\u0482\u0480\3\2\2\2\u0482"+
+		"\u0483\3\2\2\2\u0483\u0484\3\2\2\2\u0484\u0485\7\u0081\2\2\u0485\u008f"+
+		"\3\2\2\2\u0486\u0487\5P)\2\u0487\u0491\7\u009e\2\2\u0488\u0492\5f\64\2"+
+		"\u0489\u048d\7\u0080\2\2\u048a\u048c\5f\64\2\u048b\u048a\3\2\2\2\u048c"+
+		"\u048f\3\2\2\2\u048d\u048b\3\2\2\2\u048d\u048e\3\2\2\2\u048e\u0490\3\2"+
+		"\2\2\u048f\u048d\3\2\2\2\u0490\u0492\7\u0081\2\2\u0491\u0488\3\2\2\2\u0491"+
+		"\u0489\3\2\2\2\u0492\u04a2\3\2\2\2\u0493\u0494\5P)\2\u0494\u0495\7\u00b1"+
+		"\2\2\u0495\u049f\7\u009e\2\2\u0496\u04a0\5f\64\2\u0497\u049b\7\u0080\2"+
+		"\2\u0498\u049a\5f\64\2\u0499\u0498\3\2\2\2\u049a\u049d\3\2\2\2\u049b\u0499"+
+		"\3\2\2\2\u049b\u049c\3\2\2\2\u049c\u049e\3\2\2\2\u049d\u049b\3\2\2\2\u049e"+
+		"\u04a0\7\u0081\2\2\u049f\u0496\3\2\2\2\u049f\u0497\3\2\2\2\u04a0\u04a2"+
+		"\3\2\2\2\u04a1\u0486\3\2\2\2\u04a1\u0493\3\2\2\2\u04a2\u0091\3\2\2\2\u04a3"+
+		"\u04a5\7\\\2\2\u04a4\u04a6\7\u0082\2\2\u04a5\u04a4\3\2\2\2\u04a5\u04a6"+
+		"\3\2\2\2\u04a6\u04a7\3\2\2\2\u04a7\u04a8\5\u0084C\2\u04a8\u04a9\7s\2\2"+
+		"\u04a9\u04ab\5\u00e6t\2\u04aa\u04ac\7\u0083\2\2\u04ab\u04aa\3\2\2\2\u04ab"+
+		"\u04ac\3\2\2\2\u04ac\u04ad\3\2\2\2\u04ad\u04b1\7\u0080\2\2\u04ae\u04b0"+
+		"\5f\64\2\u04af\u04ae\3\2\2\2\u04b0\u04b3\3\2\2\2\u04b1\u04af\3\2\2\2\u04b1"+
+		"\u04b2\3\2\2\2\u04b2\u04b4\3\2\2\2\u04b3\u04b1\3\2\2\2\u04b4\u04b5\7\u0081"+
+		"\2\2\u04b5\u0093\3\2\2\2\u04b6\u04b7\t\7\2\2\u04b7\u04b8\5\u00e6t\2\u04b8"+
+		"\u04ba\7\u009b\2\2\u04b9\u04bb\5\u00e6t\2\u04ba\u04b9\3\2\2\2\u04ba\u04bb"+
+		"\3\2\2\2\u04bb\u04bc\3\2\2\2\u04bc\u04bd\t\b\2\2\u04bd\u0095\3\2\2\2\u04be"+
+		"\u04bf\7]\2\2\u04bf\u04c0\5\u00e6t\2\u04c0\u04c4\7\u0080\2\2\u04c1\u04c3"+
+		"\5f\64\2\u04c2\u04c1\3\2\2\2\u04c3\u04c6\3\2\2\2\u04c4\u04c2\3\2\2\2\u04c4"+
+		"\u04c5\3\2\2\2\u04c5\u04c7\3\2\2\2\u04c6\u04c4\3\2\2\2\u04c7\u04c8\7\u0081"+
+		"\2\2\u04c8\u0097\3\2\2\2\u04c9\u04ca\7^\2\2\u04ca\u04cb\7{\2\2\u04cb\u0099"+
+		"\3\2\2\2\u04cc\u04cd\7_\2\2\u04cd\u04ce\7{\2\2\u04ce\u009b\3\2\2\2\u04cf"+
+		"\u04d0\7`\2\2\u04d0\u04d4\7\u0080\2\2\u04d1\u04d3\5@!\2\u04d2\u04d1\3"+
+		"\2\2\2\u04d3\u04d6\3\2\2\2\u04d4\u04d2\3\2\2\2\u04d4\u04d5\3\2\2\2\u04d5"+
+		"\u04d7\3\2\2\2\u04d6\u04d4\3\2\2\2\u04d7\u04d9\7\u0081\2\2\u04d8\u04da"+
+		"\5\u009eP\2\u04d9\u04d8\3\2\2\2\u04d9\u04da\3\2\2\2\u04da\u04dc\3\2\2"+
+		"\2\u04db\u04dd\5\u00a2R\2\u04dc\u04db\3\2\2\2\u04dc\u04dd\3\2\2\2\u04dd"+
+		"\u009d\3\2\2\2\u04de\u04e3\7a\2\2\u04df\u04e0\7\u0082\2\2\u04e0\u04e1"+
+		"\5\u00a0Q\2\u04e1\u04e2\7\u0083\2\2\u04e2\u04e4\3\2\2\2\u04e3\u04df\3"+
+		"\2\2\2\u04e3\u04e4\3\2\2\2\u04e4\u04e5\3\2\2\2\u04e5\u04e6\7\u0082\2\2"+
+		"\u04e6\u04e7\5P)\2\u04e7\u04e8\7\u00b1\2\2\u04e8\u04e9\7\u0083\2\2\u04e9"+
+		"\u04ed\7\u0080\2\2\u04ea\u04ec\5f\64\2\u04eb\u04ea\3\2\2\2\u04ec\u04ef"+
+		"\3\2\2\2\u04ed\u04eb\3\2\2\2\u04ed\u04ee\3\2\2\2\u04ee\u04f0\3\2\2\2\u04ef"+
+		"\u04ed\3\2\2\2\u04f0\u04f1\7\u0081\2\2\u04f1\u009f\3\2\2\2\u04f2\u04f3"+
+		"\7b\2\2\u04f3\u04fc\5\u0106\u0084\2\u04f4\u04f9\7\u00b1\2\2\u04f5\u04f6"+
+		"\7\177\2\2\u04f6\u04f8\7\u00b1\2\2\u04f7\u04f5\3\2\2\2\u04f8\u04fb\3\2"+
+		"\2\2\u04f9\u04f7\3\2\2\2\u04f9\u04fa\3\2\2\2\u04fa\u04fd\3\2\2\2\u04fb"+
+		"\u04f9\3\2\2\2\u04fc\u04f4\3\2\2\2\u04fc\u04fd\3\2\2\2\u04fd\u050a\3\2"+
+		"\2\2\u04fe\u0507\7c\2\2\u04ff\u0504\7\u00b1\2\2\u0500\u0501\7\177\2\2"+
+		"\u0501\u0503\7\u00b1\2\2\u0502\u0500\3\2\2\2\u0503\u0506\3\2\2\2\u0504"+
+		"\u0502\3\2\2\2\u0504\u0505\3\2\2\2\u0505\u0508\3\2\2\2\u0506\u0504\3\2"+
+		"\2\2\u0507\u04ff\3\2\2\2\u0507\u0508\3\2\2\2\u0508\u050a\3\2\2\2\u0509"+
+		"\u04f2\3\2\2\2\u0509\u04fe\3\2\2\2\u050a\u00a1\3\2\2\2\u050b\u050c\7d"+
+		"\2\2\u050c\u050d\7\u0082\2\2\u050d\u050e\5\u00e6t\2\u050e\u050f\7\u0083"+
+		"\2\2\u050f\u0510\7\u0082\2\2\u0510\u0511\5P)\2\u0511\u0512\7\u00b1\2\2"+
+		"\u0512\u0513\7\u0083\2\2\u0513\u0517\7\u0080\2\2\u0514\u0516\5f\64\2\u0515"+
+		"\u0514\3\2\2\2\u0516\u0519\3\2\2\2\u0517\u0515\3\2\2\2\u0517\u0518\3\2"+
+		"\2\2\u0518\u051a\3\2\2\2\u0519\u0517\3\2\2\2\u051a\u051b\7\u0081\2\2\u051b"+
+		"\u00a3\3\2\2\2\u051c\u051d\7e\2\2\u051d\u0521\7\u0080\2\2\u051e\u0520"+
+		"\5f\64\2\u051f\u051e\3\2\2\2\u0520\u0523\3\2\2\2\u0521\u051f\3\2\2\2\u0521"+
+		"\u0522\3\2\2\2\u0522\u0524\3\2\2\2\u0523\u0521\3\2\2\2\u0524\u0525\7\u0081"+
+		"\2\2\u0525\u0526\5\u00a6T\2\u0526\u00a5\3\2\2\2\u0527\u0529\5\u00a8U\2"+
+		"\u0528\u0527\3\2\2\2\u0529\u052a\3\2\2\2\u052a\u0528\3\2\2\2\u052a\u052b"+
+		"\3\2\2\2\u052b\u052d\3\2\2\2\u052c\u052e\5\u00aaV\2\u052d\u052c\3\2\2"+
+		"\2\u052d\u052e\3\2\2\2\u052e\u0531\3\2\2\2\u052f\u0531\5\u00aaV\2\u0530"+
+		"\u0528\3\2\2\2\u0530\u052f\3\2\2\2\u0531\u00a7\3\2\2\2\u0532\u0533\7f"+
+		"\2\2\u0533\u0534\7\u0082\2\2\u0534\u0535\5P)\2\u0535\u0536\7\u00b1\2\2"+
+		"\u0536\u0537\7\u0083\2\2\u0537\u053b\7\u0080\2\2\u0538\u053a\5f\64\2\u0539"+
+		"\u0538\3\2\2\2\u053a\u053d\3\2\2\2\u053b\u0539\3\2\2\2\u053b\u053c\3\2"+
+		"\2\2\u053c\u053e\3\2\2\2\u053d\u053b\3\2\2\2\u053e\u053f\7\u0081\2\2\u053f"+
+		"\u00a9\3\2\2\2\u0540\u0541\7g\2\2\u0541\u0545\7\u0080\2\2\u0542\u0544"+
+		"\5f\64\2\u0543\u0542\3\2\2\2\u0544\u0547\3\2\2\2\u0545\u0543\3\2\2\2\u0545"+
+		"\u0546\3\2\2\2\u0546\u0548\3\2\2\2\u0547\u0545\3\2\2\2\u0548\u0549\7\u0081"+
+		"\2\2\u0549\u00ab\3\2\2\2\u054a\u054b\7h\2\2\u054b\u054c\5\u00e6t\2\u054c"+
+		"\u054d\7{\2\2\u054d\u00ad\3\2\2\2\u054e\u0550\7i\2\2\u054f\u0551\5\u00e6"+
+		"t\2\u0550\u054f\3\2\2\2\u0550\u0551\3\2\2\2\u0551\u0552\3\2\2\2\u0552"+
+		"\u0553\7{\2\2\u0553\u00af\3\2\2\2\u0554\u0557\5\u00b2Z\2\u0555\u0557\5"+
+		"\u00b4[\2\u0556\u0554\3\2\2\2\u0556\u0555\3\2\2\2\u0557\u00b1\3\2\2\2"+
+		"\u0558\u0559\5\u00e6t\2\u0559\u055a\7\u0097\2\2\u055a\u055b\7\u00b1\2"+
+		"\2\u055b\u055c\7{\2\2\u055c\u0563\3\2\2\2\u055d\u055e\5\u00e6t\2\u055e"+
+		"\u055f\7\u0097\2\2\u055f\u0560\7`\2\2\u0560\u0561\7{\2\2\u0561\u0563\3"+
+		"\2\2\2\u0562\u0558\3\2\2\2\u0562\u055d\3\2\2\2\u0563\u00b3\3\2\2\2\u0564"+
+		"\u0565\5\u00e6t\2\u0565\u0566\7\u0098\2\2\u0566\u0567\7\u00b1\2\2\u0567"+
+		"\u0568\7{\2\2\u0568\u00b5\3\2\2\2\u0569\u056a\b\\\1\2\u056a\u056d\5\u00ee"+
+		"x\2\u056b\u056d\5\u00be`\2\u056c\u0569\3\2\2\2\u056c\u056b\3\2\2\2\u056d"+
+		"\u0578\3\2\2\2\u056e\u056f\f\6\2\2\u056f\u0577\5\u00ba^\2\u0570\u0571"+
+		"\f\5\2\2\u0571\u0577\5\u00b8]\2\u0572\u0573\f\4\2\2\u0573\u0577\5\u00bc"+
+		"_\2\u0574\u0575\f\3\2\2\u0575\u0577\5\u00c0a\2\u0576\u056e\3\2\2\2\u0576"+
+		"\u0570\3\2\2\2\u0576\u0572\3\2\2\2\u0576\u0574\3\2\2\2\u0577\u057a\3\2"+
+		"\2\2\u0578\u0576\3\2\2\2\u0578\u0579\3\2\2\2\u0579\u00b7\3\2\2\2\u057a"+
+		"\u0578\3\2\2\2\u057b\u057c\t\t\2\2\u057c\u057d\t\n\2\2\u057d\u00b9\3\2"+
+		"\2\2\u057e\u057f\7\u0084\2\2\u057f\u0580\5\u00e6t\2\u0580\u0581\7\u0085"+
+		"\2\2\u0581\u00bb\3\2\2\2\u0582\u0587\7\u0099\2\2\u0583\u0584\7\u0084\2"+
+		"\2\u0584\u0585\5\u00e6t\2\u0585\u0586\7\u0085\2\2\u0586\u0588\3\2\2\2"+
+		"\u0587\u0583\3\2\2\2\u0587\u0588\3\2\2\2\u0588\u00bd\3\2\2\2\u0589\u058a"+
+		"\5\u00f0y\2\u058a\u058c\7\u0082\2\2\u058b\u058d\5\u00c2b\2\u058c\u058b"+
+		"\3\2\2\2\u058c\u058d\3\2\2\2\u058d\u058e\3\2\2\2\u058e\u058f\7\u0083\2"+
+		"\2\u058f\u00bf\3\2\2\2\u0590\u0591\t\t\2\2\u0591\u0592\5\u0132\u009a\2"+
+		"\u0592\u0594\7\u0082\2\2\u0593\u0595\5\u00c2b\2\u0594\u0593\3\2\2\2\u0594"+
+		"\u0595\3\2\2\2\u0595\u0596\3\2\2\2\u0596\u0597\7\u0083\2\2\u0597\u00c1"+
+		"\3\2\2\2\u0598\u059d\5\u00c4c\2\u0599\u059a\7\177\2\2\u059a\u059c\5\u00c4"+
+		"c\2\u059b\u0599\3\2\2\2\u059c\u059f\3\2\2\2\u059d\u059b\3\2\2\2\u059d"+
+		"\u059e\3\2\2\2\u059e\u00c3\3\2\2\2\u059f\u059d\3\2\2\2\u05a0\u05a4\5\u00e6"+
+		"t\2\u05a1\u05a4\5\u010c\u0087\2\u05a2\u05a4\5\u010e\u0088\2\u05a3\u05a0"+
+		"\3\2\2\2\u05a3\u05a1\3\2\2\2\u05a3\u05a2\3\2\2\2\u05a4\u00c5\3\2\2\2\u05a5"+
+		"\u05a7\7v\2\2\u05a6\u05a5\3\2\2\2\u05a6\u05a7\3\2\2\2\u05a7\u05a8\3\2"+
+		"\2\2\u05a8\u05a9\5\u00eex\2\u05a9\u05aa\7\u0097\2\2\u05aa\u05ab\5\u00be"+
+		"`\2\u05ab\u00c7\3\2\2\2\u05ac\u05b1\5\u00e6t\2\u05ad\u05ae\7\177\2\2\u05ae"+
+		"\u05b0\5\u00e6t\2\u05af\u05ad\3\2\2\2\u05b0\u05b3\3\2\2\2\u05b1\u05af"+
+		"\3\2\2\2\u05b1\u05b2\3\2\2\2\u05b2\u00c9\3\2\2\2\u05b3\u05b1\3\2\2\2\u05b4"+
+		"\u05b5\5\u00e6t\2\u05b5\u05b6\7{\2\2\u05b6\u00cb\3\2\2\2\u05b7\u05b9\5"+
+		"\u00ceh\2\u05b8\u05ba\5\u00d6l\2\u05b9\u05b8\3\2\2\2\u05b9\u05ba\3\2\2"+
+		"\2\u05ba\u00cd\3\2\2\2\u05bb\u05be\7j\2\2\u05bc\u05bd\7r\2\2\u05bd\u05bf"+
+		"\5\u00d2j\2\u05be\u05bc\3\2\2\2\u05be\u05bf\3\2\2\2\u05bf\u05c0\3\2\2"+
+		"\2\u05c0\u05c4\7\u0080\2\2\u05c1\u05c3\5f\64\2\u05c2\u05c1\3\2\2\2\u05c3"+
+		"\u05c6\3\2\2\2\u05c4\u05c2\3\2\2\2\u05c4\u05c5\3\2\2\2\u05c5\u05c7\3\2"+
+		"\2\2\u05c6\u05c4\3\2\2\2\u05c7\u05c8\7\u0081\2\2\u05c8\u00cf\3\2\2\2\u05c9"+
+		"\u05cd\5\u00dco\2\u05ca\u05cd\5\u00dep\2\u05cb\u05cd\5\u00e0q\2\u05cc"+
+		"\u05c9\3\2\2\2\u05cc\u05ca\3\2\2\2\u05cc\u05cb\3\2\2\2\u05cd\u00d1\3\2"+
+		"\2\2\u05ce\u05d3\5\u00d0i\2\u05cf\u05d0\7\177\2\2\u05d0\u05d2\5\u00d0"+
+		"i\2\u05d1\u05cf\3\2\2\2\u05d2\u05d5\3\2\2\2\u05d3\u05d1\3\2\2\2\u05d3"+
+		"\u05d4\3\2\2\2\u05d4\u00d3\3\2\2\2\u05d5\u05d3\3\2\2\2\u05d6\u05d7\7t"+
+		"\2\2\u05d7\u05db\7\u0080\2\2\u05d8\u05da\5f\64\2\u05d9\u05d8\3\2\2\2\u05da"+
+		"\u05dd\3\2\2\2\u05db\u05d9\3\2\2\2\u05db\u05dc\3\2\2\2\u05dc\u05de\3\2"+
+		"\2\2\u05dd\u05db\3\2\2\2\u05de\u05df\7\u0081\2\2\u05df\u00d5\3\2\2\2\u05e0"+
+		"\u05e1\7m\2\2\u05e1\u05e5\7\u0080\2\2\u05e2\u05e4\5f\64\2\u05e3\u05e2"+
+		"\3\2\2\2\u05e4\u05e7\3\2\2\2\u05e5\u05e3\3\2\2\2\u05e5\u05e6\3\2\2\2\u05e6"+
+		"\u05e8\3\2\2\2\u05e7\u05e5\3\2\2\2\u05e8\u05e9\7\u0081\2\2\u05e9\u00d7"+
+		"\3\2\2\2\u05ea\u05eb\7k\2\2\u05eb\u05ec\7{\2\2\u05ec\u00d9\3\2\2\2\u05ed"+
+		"\u05ee\7l\2\2\u05ee\u05ef\7{\2\2\u05ef\u00db\3\2\2\2\u05f0\u05f1\7n\2"+
+		"\2\u05f1\u05f2\7\u0087\2\2\u05f2\u05f3\5\u00e6t\2\u05f3\u00dd\3\2\2\2"+
+		"\u05f4\u05f5\7p\2\2\u05f5\u05f6\7\u0087\2\2\u05f6\u05f7\5\u00e6t\2\u05f7"+
+		"\u00df\3\2\2\2\u05f8\u05f9\7o\2\2\u05f9\u05fa\7\u0087\2\2\u05fa\u05fb"+
+		"\5\u00e6t\2\u05fb\u00e1\3\2\2\2\u05fc\u05fd\5\u00e4s\2\u05fd\u00e3\3\2"+
+		"\2\2\u05fe\u05ff\7\23\2\2\u05ff\u0602\7\u00ad\2\2\u0600\u0601\7\4\2\2"+
+		"\u0601\u0603\7\u00b1\2\2\u0602\u0600\3\2\2\2\u0602\u0603\3\2\2\2\u0603"+
+		"\u0604\3\2\2\2\u0604\u0605\7{\2\2\u0605\u00e5\3\2\2\2\u0606\u0607\bt\1"+
+		"\2\u0607\u0630\5\u0104\u0083\2\u0608\u0630\5t;\2\u0609\u0630\5j\66\2\u060a"+
+		"\u0630\5\u0110\u0089\2\u060b\u0630\5p9\2\u060c\u0630\5\u012e\u0098\2\u060d"+
+		"\u060f\7v\2\2\u060e\u060d\3\2\2\2\u060e\u060f\3\2\2\2\u060f\u0610\3\2"+
+		"\2\2\u0610\u0630\5\u00b6\\\2\u0611\u0630\5\u00c6d\2\u0612\u0630\5\34\17"+
+		"\2\u0613\u0630\5v<\2\u0614\u0630\5\u0136\u009c\2\u0615\u0616\7\u0092\2"+
+		"\2\u0616\u0619\5P)\2\u0617\u0618\7\177\2\2\u0618\u061a\5\u00be`\2\u0619"+
+		"\u0617\3\2\2\2\u0619\u061a\3\2\2\2\u061a\u061b\3\2\2\2\u061b\u061c\7\u0091"+
+		"\2\2\u061c\u061d\5\u00e6t\23\u061d\u0630\3\2\2\2\u061e\u061f\t\13\2\2"+
+		"\u061f\u0630\5\u00e6t\22\u0620\u0621\7\u0082\2\2\u0621\u0626\5\u00e6t"+
+		"\2\u0622\u0623\7\177\2\2\u0623\u0625\5\u00e6t\2\u0624\u0622\3\2\2\2\u0625"+
+		"\u0628\3\2\2\2\u0626\u0624\3\2\2\2\u0626\u0627\3\2\2\2\u0627\u0629\3\2"+
+		"\2\2\u0628\u0626\3\2\2\2\u0629\u062a\7\u0083\2\2\u062a\u0630\3\2\2\2\u062b"+
+		"\u0630\5\u00e8u\2\u062c\u062d\7y\2\2\u062d\u0630\5\u00e6t\5\u062e\u0630"+
+		"\5P)\2\u062f\u0606\3\2\2\2\u062f\u0608\3\2\2\2\u062f\u0609\3\2\2\2\u062f"+
+		"\u060a\3\2\2\2\u062f\u060b\3\2\2\2\u062f\u060c\3\2\2\2\u062f\u060e\3\2"+
+		"\2\2\u062f\u0611\3\2\2\2\u062f\u0612\3\2\2\2\u062f\u0613\3\2\2\2\u062f"+
+		"\u0614\3\2\2\2\u062f\u0615\3\2\2\2\u062f\u061e\3\2\2\2\u062f\u0620\3\2"+
+		"\2\2\u062f\u062b\3\2\2\2\u062f\u062c\3\2\2\2\u062f\u062e\3\2\2\2\u0630"+
+		"\u0656\3\2\2\2\u0631\u0632\f\20\2\2\u0632\u0633\7\u008c\2\2\u0633\u0655"+
+		"\5\u00e6t\21\u0634\u0635\f\17\2\2\u0635\u0636\t\f\2\2\u0636\u0655\5\u00e6"+
+		"t\20\u0637\u0638\f\16\2\2\u0638\u0639\t\r\2\2\u0639\u0655\5\u00e6t\17"+
+		"\u063a\u063b\f\r\2\2\u063b\u063c\t\16\2\2\u063c\u0655\5\u00e6t\16\u063d"+
+		"\u063e\f\f\2\2\u063e\u063f\t\17\2\2\u063f\u0655\5\u00e6t\r\u0640\u0641"+
+		"\f\13\2\2\u0641\u0642\7\u0095\2\2\u0642\u0655\5\u00e6t\f\u0643\u0644\f"+
+		"\n\2\2\u0644\u0645\7\u0096\2\2\u0645\u0655\5\u00e6t\13\u0646\u0647\f\t"+
+		"\2\2\u0647\u0648\t\20\2\2\u0648\u0655\5\u00e6t\n\u0649\u064a\f\b\2\2\u064a"+
+		"\u064b\7\u0086\2\2\u064b\u064c\5\u00e6t\2\u064c\u064d\7|\2\2\u064d\u064e"+
+		"\5\u00e6t\t\u064e\u0655\3\2\2\2\u064f\u0650\f\4\2\2\u0650\u0651\7\u009f"+
+		"\2\2\u0651\u0655\5\u00e6t\5\u0652\u0653\f\6\2\2\u0653\u0655\5\u00eav\2"+
+		"\u0654\u0631\3\2\2\2\u0654\u0634\3\2\2\2\u0654\u0637\3\2\2\2\u0654\u063a"+
+		"\3\2\2\2\u0654\u063d\3\2\2\2\u0654\u0640\3\2\2\2\u0654\u0643\3\2\2\2\u0654"+
+		"\u0646\3\2\2\2\u0654\u0649\3\2\2\2\u0654\u064f\3\2\2\2\u0654\u0652\3\2"+
+		"\2\2\u0655\u0658\3\2\2\2\u0656\u0654\3\2\2\2\u0656\u0657\3\2\2\2\u0657"+
+		"\u00e7\3\2\2\2\u0658\u0656\3\2\2\2\u0659\u065a\7w\2\2\u065a\u065b\5\u00e6"+
+		"t\2\u065b\u00e9\3\2\2\2\u065c\u065d\7x\2\2\u065d\u065e\7\u0080\2\2\u065e"+
+		"\u0663\5\u00ecw\2\u065f\u0660\7\177\2\2\u0660\u0662\5\u00ecw\2\u0661\u065f"+
+		"\3\2\2\2\u0662\u0665\3\2\2\2\u0663\u0661\3\2\2\2\u0663\u0664\3\2\2\2\u0664"+
+		"\u0666\3\2\2\2\u0665\u0663\3\2\2\2\u0666\u0667\7\u0081\2\2\u0667\u00eb"+
+		"\3\2\2\2\u0668\u066a\5P)\2\u0669\u066b\7\u00b1\2\2\u066a\u0669\3\2\2\2"+
+		"\u066a\u066b\3\2\2\2\u066b\u066c\3\2\2\2\u066c\u066d\7\u009e\2\2\u066d"+
+		"\u066e\5\u00e6t\2\u066e\u00ed\3\2\2\2\u066f\u0670\7\u00b1\2\2\u0670\u0672"+
+		"\7|\2\2\u0671\u066f\3\2\2\2\u0671\u0672\3\2\2\2\u0672\u0673\3\2\2\2\u0673"+
+		"\u0674\7\u00b1\2\2\u0674\u00ef\3\2\2\2\u0675\u0676\7\u00b1\2\2\u0676\u0678"+
+		"\7|\2\2\u0677\u0675\3\2\2\2\u0677\u0678\3\2\2\2\u0678\u0679\3\2\2\2\u0679"+
+		"\u067a\5\u0132\u009a\2\u067a\u00f1\3\2\2\2\u067b\u067f\7\24\2\2\u067c"+
+		"\u067e\5d\63\2\u067d\u067c\3\2\2\2\u067e\u0681\3\2\2\2\u067f\u067d\3\2"+
+		"\2\2\u067f\u0680\3\2\2\2\u0680\u0682\3\2\2\2\u0681\u067f\3\2\2\2\u0682"+
+		"\u0683\5P)\2\u0683\u00f3\3\2\2\2\u0684\u0686\5d\63\2\u0685\u0684\3\2\2"+
+		"\2\u0686\u0689\3\2\2\2\u0687\u0685\3\2\2\2\u0687\u0688\3\2\2\2\u0688\u068a"+
+		"\3\2\2\2\u0689\u0687\3\2\2\2\u068a\u068b\5P)\2\u068b\u00f5\3\2\2\2\u068c"+
+		"\u0691\5\u00f8}\2\u068d\u068e\7\177\2\2\u068e\u0690\5\u00f8}\2\u068f\u068d"+
+		"\3\2\2\2\u0690\u0693\3\2\2\2\u0691\u068f\3\2\2\2\u0691\u0692\3\2\2\2\u0692"+
+		"\u00f7\3\2\2\2\u0693\u0691\3\2\2\2\u0694\u0695\5P)\2\u0695\u00f9\3\2\2"+
+		"\2\u0696\u069b\5\u00fc\177\2\u0697\u0698\7\177\2\2\u0698\u069a\5\u00fc"+
+		"\177\2\u0699\u0697\3\2\2\2\u069a\u069d\3\2\2\2\u069b\u0699\3\2\2\2\u069b"+
+		"\u069c\3\2\2\2\u069c\u00fb\3\2\2\2\u069d\u069b\3\2\2\2\u069e\u06a0\5d"+
+		"\63\2\u069f\u069e\3\2\2\2\u06a0\u06a3\3\2\2\2\u06a1\u069f\3\2\2\2\u06a1"+
+		"\u06a2\3\2\2\2\u06a2\u06a4\3\2\2\2\u06a3\u06a1\3\2\2\2\u06a4\u06a5\5P"+
+		")\2\u06a5\u06a6\7\u00b1\2\2\u06a6\u06bc\3\2\2\2\u06a7\u06a9\5d\63\2\u06a8"+
+		"\u06a7\3\2\2\2\u06a9\u06ac\3\2\2\2\u06aa\u06a8\3\2\2\2\u06aa\u06ab\3\2"+
+		"\2\2\u06ab\u06ad\3\2\2\2\u06ac\u06aa\3\2\2\2\u06ad\u06ae\7\u0082\2\2\u06ae"+
+		"\u06af\5P)\2\u06af\u06b6\7\u00b1\2\2\u06b0\u06b1\7\177\2\2\u06b1\u06b2"+
+		"\5P)\2\u06b2\u06b3\7\u00b1\2\2\u06b3\u06b5\3\2\2\2\u06b4\u06b0\3\2\2\2"+
+		"\u06b5\u06b8\3\2\2\2\u06b6\u06b4\3\2\2\2\u06b6\u06b7\3\2\2\2\u06b7\u06b9"+
+		"\3\2\2\2\u06b8\u06b6\3\2\2\2\u06b9\u06ba\7\u0083\2\2\u06ba\u06bc\3\2\2"+
+		"\2\u06bb\u06a1\3\2\2\2\u06bb\u06aa\3\2\2\2\u06bc\u00fd\3\2\2\2\u06bd\u06be"+
+		"\5\u00fc\177\2\u06be\u06bf\7\u0087\2\2\u06bf\u06c0\5\u00e6t\2\u06c0\u00ff"+
+		"\3\2\2\2\u06c1\u06c3\5d\63\2\u06c2\u06c1\3\2\2\2\u06c3\u06c6\3\2\2\2\u06c4"+
+		"\u06c2\3\2\2\2\u06c4\u06c5\3\2\2\2\u06c5\u06c7\3\2\2\2\u06c6\u06c4\3\2"+
+		"\2\2\u06c7\u06c8\5P)\2\u06c8\u06c9\7\u009c\2\2\u06c9\u06ca\7\u00b1\2\2"+
+		"\u06ca\u0101\3\2\2\2\u06cb\u06ce\5\u00fc\177\2\u06cc\u06ce\5\u00fe\u0080"+
+		"\2\u06cd\u06cb\3\2\2\2\u06cd\u06cc\3\2\2\2\u06ce\u06d6\3\2\2\2\u06cf\u06d2"+
+		"\7\177\2\2\u06d0\u06d3\5\u00fc\177\2\u06d1\u06d3\5\u00fe\u0080\2\u06d2"+
+		"\u06d0\3\2\2\2\u06d2\u06d1\3\2\2\2\u06d3\u06d5\3\2\2\2\u06d4\u06cf\3\2"+
+		"\2\2\u06d5\u06d8\3\2\2\2\u06d6\u06d4\3\2\2\2\u06d6\u06d7\3\2\2\2\u06d7"+
+		"\u06db\3\2\2\2\u06d8\u06d6\3\2\2\2\u06d9\u06da\7\177\2\2\u06da\u06dc\5"+
+		"\u0100\u0081\2\u06db\u06d9\3\2\2\2\u06db\u06dc\3\2\2\2\u06dc\u06df\3\2"+
+		"\2\2\u06dd\u06df\5\u0100\u0081\2\u06de\u06cd\3\2\2\2\u06de\u06dd\3\2\2"+
+		"\2\u06df\u0103\3\2\2\2\u06e0\u06e2\7\u0089\2\2\u06e1\u06e0\3\2\2\2\u06e1"+
+		"\u06e2\3\2\2\2\u06e2\u06e3\3\2\2\2\u06e3\u06ee\5\u0106\u0084\2\u06e4\u06e6"+
+		"\7\u0089\2\2\u06e5\u06e4\3\2\2\2\u06e5\u06e6\3\2\2\2\u06e6\u06e7\3\2\2"+
+		"\2\u06e7\u06ee\7\u00ab\2\2\u06e8\u06ee\7\u00ad\2\2\u06e9\u06ee\7\u00ac"+
+		"\2\2\u06ea\u06ee\5\u0108\u0085\2\u06eb\u06ee\5\u010a\u0086\2\u06ec\u06ee"+
+		"\7\u00b0\2\2\u06ed\u06e1\3\2\2\2\u06ed\u06e5\3\2\2\2\u06ed\u06e8\3\2\2"+
+		"\2\u06ed\u06e9\3\2\2\2\u06ed\u06ea\3\2\2\2\u06ed\u06eb\3\2\2\2\u06ed\u06ec"+
+		"\3\2\2\2\u06ee\u0105\3\2\2\2\u06ef\u06f0\t\21\2\2\u06f0\u0107\3\2\2\2"+
+		"\u06f1\u06f2\7\u0082\2\2\u06f2\u06f3\7\u0083\2\2\u06f3\u0109\3\2\2\2\u06f4"+
+		"\u06f5\t\22\2\2\u06f5\u010b\3\2\2\2\u06f6\u06f7\7\u00b1\2\2\u06f7\u06f8"+
+		"\7\u0087\2\2\u06f8\u06f9\5\u00e6t\2\u06f9\u010d\3\2\2\2\u06fa\u06fb\7"+
+		"\u009c\2\2\u06fb\u06fc\5\u00e6t\2\u06fc\u010f\3\2\2\2\u06fd\u06fe\7\u00b2"+
+		"\2\2\u06fe\u06ff\5\u0112\u008a\2\u06ff\u0700\7\u00c3\2\2\u0700\u0111\3"+
+		"\2\2\2\u0701\u0707\5\u0118\u008d\2\u0702\u0707\5\u0120\u0091\2\u0703\u0707"+
+		"\5\u0116\u008c\2\u0704\u0707\5\u0124\u0093\2\u0705\u0707\7\u00bc\2\2\u0706"+
+		"\u0701\3\2\2\2\u0706\u0702\3\2\2\2\u0706\u0703\3\2\2\2\u0706\u0704\3\2"+
+		"\2\2\u0706\u0705\3\2\2\2\u0707\u0113\3\2\2\2\u0708\u070a\5\u0124\u0093"+
+		"\2\u0709\u0708\3\2\2\2\u0709\u070a\3\2\2\2\u070a\u0716\3\2\2\2\u070b\u0710"+
+		"\5\u0118\u008d\2\u070c\u0710\7\u00bc\2\2\u070d\u0710\5\u0120\u0091\2\u070e"+
+		"\u0710\5\u0116\u008c\2\u070f\u070b\3\2\2\2\u070f\u070c\3\2\2\2\u070f\u070d"+
+		"\3\2\2\2\u070f\u070e\3\2\2\2\u0710\u0712\3\2\2\2\u0711\u0713\5\u0124\u0093"+
+		"\2\u0712\u0711\3\2\2\2\u0712\u0713\3\2\2\2\u0713\u0715\3\2\2\2\u0714\u070f"+
+		"\3\2\2\2\u0715\u0718\3\2\2\2\u0716\u0714\3\2\2\2\u0716\u0717\3\2\2\2\u0717"+
+		"\u0115\3\2\2\2\u0718\u0716\3\2\2\2\u0719\u0720\7\u00bb\2\2\u071a\u071b"+
+		"\7\u00da\2\2\u071b\u071c\5\u00e6t\2\u071c\u071d\7\u00b6\2\2\u071d\u071f"+
+		"\3\2\2\2\u071e\u071a\3\2\2\2\u071f\u0722\3\2\2\2\u0720\u071e\3\2\2\2\u0720"+
+		"\u0721\3\2\2\2\u0721\u0723\3\2\2\2\u0722\u0720\3\2\2\2\u0723\u0724\7\u00d9"+
+		"\2\2\u0724\u0117\3\2\2\2\u0725\u0726\5\u011a\u008e\2\u0726\u0727\5\u0114"+
+		"\u008b\2\u0727\u0728\5\u011c\u008f\2\u0728\u072b\3\2\2\2\u0729\u072b\5"+
+		"\u011e\u0090\2\u072a\u0725\3\2\2\2\u072a\u0729\3\2\2\2\u072b\u0119\3\2"+
+		"\2\2\u072c\u072d\7\u00c0\2\2\u072d\u0731\5\u012c\u0097\2\u072e\u0730\5"+
+		"\u0122\u0092\2\u072f\u072e\3\2\2\2\u0730\u0733\3\2\2\2\u0731\u072f\3\2"+
+		"\2\2\u0731\u0732\3\2\2\2\u0732\u0734\3\2\2\2\u0733\u0731\3\2\2\2\u0734"+
+		"\u0735\7\u00c6\2\2\u0735\u011b\3\2\2\2\u0736\u0737\7\u00c1\2\2\u0737\u0738"+
+		"\5\u012c\u0097\2\u0738\u0739\7\u00c6\2\2\u0739\u011d\3\2\2\2\u073a\u073b"+
+		"\7\u00c0\2\2\u073b\u073f\5\u012c\u0097\2\u073c\u073e\5\u0122\u0092\2\u073d"+
+		"\u073c\3\2\2\2\u073e\u0741\3\2\2\2\u073f\u073d\3\2\2\2\u073f\u0740\3\2"+
+		"\2\2\u0740\u0742\3\2\2\2\u0741\u073f\3\2\2\2\u0742\u0743\7\u00c8\2\2\u0743"+
+		"\u011f\3\2\2\2\u0744\u074b\7\u00c2\2\2\u0745\u0746\7\u00d8\2\2\u0746\u0747"+
+		"\5\u00e6t\2\u0747\u0748\7\u00b6\2\2\u0748\u074a\3\2\2\2\u0749\u0745\3"+
+		"\2\2\2\u074a\u074d\3\2\2\2\u074b\u0749\3\2\2\2\u074b\u074c\3\2\2\2\u074c"+
+		"\u074e\3\2\2\2\u074d\u074b\3\2\2\2\u074e\u074f\7\u00d7\2\2\u074f\u0121"+
+		"\3\2\2\2\u0750\u0751\5\u012c\u0097\2\u0751\u0752\7\u00cb\2\2\u0752\u0753"+
+		"\5\u0126\u0094\2\u0753\u0123\3\2\2\2\u0754\u0755\7\u00c4\2\2\u0755\u0756"+
+		"\5\u00e6t\2\u0756\u0757\7\u00b6\2\2\u0757\u0759\3\2\2\2\u0758\u0754\3"+
+		"\2\2\2\u0759\u075a\3\2\2\2\u075a\u0758\3\2\2\2\u075a\u075b\3\2\2\2\u075b"+
+		"\u075d\3\2\2\2\u075c\u075e\7\u00c5\2\2\u075d\u075c\3\2\2\2\u075d\u075e"+
+		"\3\2\2\2\u075e\u0761\3\2\2\2\u075f\u0761\7\u00c5\2\2\u0760\u0758\3\2\2"+
+		"\2\u0760\u075f\3\2\2\2\u0761\u0125\3\2\2\2\u0762\u0765\5\u0128\u0095\2"+
+		"\u0763\u0765\5\u012a\u0096\2\u0764\u0762\3\2\2\2\u0764\u0763\3\2\2\2\u0765"+
+		"\u0127\3\2\2\2\u0766\u076d\7\u00cd\2\2\u0767\u0768\7\u00d5\2\2\u0768\u0769"+
+		"\5\u00e6t\2\u0769\u076a\7\u00b6\2\2\u076a\u076c\3\2\2\2\u076b\u0767\3"+
+		"\2\2\2\u076c\u076f\3\2\2\2\u076d\u076b\3\2\2\2\u076d\u076e\3\2\2\2\u076e"+
+		"\u0771\3\2\2\2\u076f\u076d\3\2\2\2\u0770\u0772\7\u00d6\2\2\u0771\u0770"+
+		"\3\2\2\2\u0771\u0772\3\2\2\2\u0772\u0773\3\2\2\2\u0773\u0774\7\u00d4\2"+
+		"\2\u0774\u0129\3\2\2\2\u0775\u077c\7\u00cc\2\2\u0776\u0777\7\u00d2\2\2"+
+		"\u0777\u0778\5\u00e6t\2\u0778\u0779\7\u00b6\2\2\u0779\u077b\3\2\2\2\u077a"+
+		"\u0776\3\2\2\2\u077b\u077e\3\2\2\2\u077c\u077a\3\2\2\2\u077c\u077d\3\2"+
+		"\2\2\u077d\u0780\3\2\2\2\u077e\u077c\3\2\2\2\u077f\u0781\7\u00d3\2\2\u0780"+
+		"\u077f\3\2\2\2\u0780\u0781\3\2\2\2\u0781\u0782\3\2\2\2\u0782\u0783\7\u00d1"+
+		"\2\2\u0783\u012b\3\2\2\2\u0784\u0785\7\u00ce\2\2\u0785\u0787\7\u00ca\2"+
+		"\2\u0786\u0784\3\2\2\2\u0786\u0787\3\2\2\2\u0787\u0788\3\2\2\2\u0788\u078e"+
+		"\7\u00ce\2\2\u0789\u078a\7\u00d0\2\2\u078a\u078b\5\u00e6t\2\u078b\u078c"+
+		"\7\u00b6\2\2\u078c\u078e\3\2\2\2\u078d\u0786\3\2\2\2\u078d\u0789\3\2\2"+
+		"\2\u078e\u012d\3\2\2\2\u078f\u0791\7\u00b3\2\2\u0790\u0792\5\u0130\u0099"+
+		"\2\u0791\u0790\3\2\2\2\u0791\u0792\3\2\2\2\u0792\u0793\3\2\2\2\u0793\u0794"+
+		"\7\u00ec\2\2\u0794\u012f\3\2\2\2\u0795\u0796\7\u00ed\2\2\u0796\u0797\5"+
+		"\u00e6t\2\u0797\u0798\7\u00b6\2\2\u0798\u079a\3\2\2\2\u0799\u0795\3\2"+
+		"\2\2\u079a\u079b\3\2\2\2\u079b\u0799\3\2\2\2\u079b\u079c\3\2\2\2\u079c"+
+		"\u079e\3\2\2\2\u079d\u079f\7\u00ee\2\2\u079e\u079d\3\2\2\2\u079e\u079f"+
+		"\3\2\2\2\u079f\u07a2\3\2\2\2\u07a0\u07a2\7\u00ee\2\2\u07a1\u0799\3\2\2"+
+		"\2\u07a1\u07a0\3\2\2\2\u07a2\u0131\3\2\2\2\u07a3\u07a6\7\u00b1\2\2\u07a4"+
+		"\u07a6\5\u0134\u009b\2\u07a5\u07a3\3\2\2\2\u07a5\u07a4\3\2\2\2\u07a6\u0133"+
+		"\3\2\2\2\u07a7\u07a8\t\23\2\2\u07a8\u0135\3\2\2\2\u07a9\u07aa\7\30\2\2"+
+		"\u07aa\u07ac\5\u0158\u00ad\2\u07ab\u07ad\5\u015a\u00ae\2\u07ac\u07ab\3"+
+		"\2\2\2\u07ac\u07ad\3\2\2\2\u07ad\u07af\3\2\2\2\u07ae\u07b0\5\u0148\u00a5"+
+		"\2\u07af\u07ae\3\2\2\2\u07af\u07b0\3\2\2\2\u07b0\u07b2\3\2\2\2\u07b1\u07b3"+
+		"\5\u0142\u00a2\2\u07b2\u07b1\3\2\2\2\u07b2\u07b3\3\2\2\2\u07b3\u07b5\3"+
+		"\2\2\2\u07b4\u07b6\5\u0146\u00a4\2\u07b5\u07b4\3\2\2\2\u07b5\u07b6\3\2"+
+		"\2\2\u07b6\u0137\3\2\2\2\u07b7\u07b8\7E\2\2\u07b8\u07ba\7\u0080\2\2\u07b9"+
+		"\u07bb\5\u013c\u009f\2\u07ba\u07b9\3\2\2\2\u07bb\u07bc\3\2\2\2\u07bc\u07ba"+
+		"\3\2\2\2\u07bc\u07bd\3\2\2\2\u07bd\u07be\3\2\2\2\u07be\u07bf\7\u0081\2"+
+		"\2\u07bf\u0139\3\2\2\2\u07c0\u07c1\7z\2\2\u07c1\u07c2\7{\2\2\u07c2\u013b"+
+		"\3\2\2\2\u07c3\u07c9\7\30\2\2\u07c4\u07c6\5\u0158\u00ad\2\u07c5\u07c7"+
+		"\5\u015a\u00ae\2\u07c6\u07c5\3\2\2\2\u07c6\u07c7\3\2\2\2\u07c7\u07ca\3"+
+		"\2\2\2\u07c8\u07ca\5\u013e\u00a0\2\u07c9\u07c4\3\2\2\2\u07c9\u07c8\3\2"+
+		"\2\2\u07ca\u07cc\3\2\2\2\u07cb\u07cd\5\u0148\u00a5\2\u07cc\u07cb\3\2\2"+
+		"\2\u07cc\u07cd\3\2\2\2\u07cd\u07cf\3\2\2\2\u07ce\u07d0\5\u0142\u00a2\2"+
+		"\u07cf\u07ce\3\2\2\2\u07cf\u07d0\3\2\2\2\u07d0\u07d2\3\2\2\2\u07d1\u07d3"+
+		"\5\u015c\u00af\2\u07d2\u07d1\3\2\2\2\u07d2\u07d3\3\2\2\2\u07d3\u07d4\3"+
+		"\2\2\2\u07d4\u07d5\5\u0152\u00aa\2\u07d5\u013d\3\2\2\2\u07d6\u07d8\7,"+
+		"\2\2\u07d7\u07d6\3\2\2\2\u07d7\u07d8\3\2\2\2\u07d8\u07d9\3\2\2\2\u07d9"+
+		"\u07db\5\u015e\u00b0\2\u07da\u07dc\5\u0140\u00a1\2\u07db\u07da\3\2\2\2"+
+		"\u07db\u07dc\3\2\2\2\u07dc\u013f\3\2\2\2\u07dd\u07de\7-\2\2\u07de\u07df"+
+		"\7\u00a7\2\2\u07df\u07e0\5\u016a\u00b6\2\u07e0\u0141\3\2\2\2\u07e1\u07e2"+
+		"\7\36\2\2\u07e2\u07e3\7\34\2\2\u07e3\u07e8\5\u0144\u00a3\2\u07e4\u07e5"+
+		"\7\177\2\2\u07e5\u07e7\5\u0144\u00a3\2\u07e6\u07e4\3\2\2\2\u07e7\u07ea"+
+		"\3\2\2\2\u07e8\u07e6\3\2\2\2\u07e8\u07e9\3\2\2\2\u07e9\u0143\3\2\2\2\u07ea"+
+		"\u07e8\3\2\2\2\u07eb\u07ed\5\u00b6\\\2\u07ec\u07ee\5\u0166\u00b4\2\u07ed"+
+		"\u07ec\3\2\2\2\u07ed\u07ee\3\2\2\2\u07ee\u0145\3\2\2\2\u07ef\u07f0\7F"+
+		"\2\2\u07f0\u07f1\7\u00a7\2\2\u07f1\u0147\3\2\2\2\u07f2\u07f5\7\32\2\2"+
+		"\u07f3\u07f6\7\u008a\2\2\u07f4\u07f6\5\u014a\u00a6\2\u07f5\u07f3\3\2\2"+
+		"\2\u07f5\u07f4\3\2\2\2\u07f6\u07f8\3\2\2\2\u07f7\u07f9\5\u014e\u00a8\2"+
+		"\u07f8\u07f7\3\2\2\2\u07f8\u07f9\3\2\2\2\u07f9\u07fb\3\2\2\2\u07fa\u07fc"+
+		"\5\u0150\u00a9\2\u07fb\u07fa\3\2\2\2\u07fb\u07fc\3\2\2\2\u07fc\u0149\3"+
+		"\2\2\2\u07fd\u0802\5\u014c\u00a7\2\u07fe\u07ff\7\177\2\2\u07ff\u0801\5"+
+		"\u014c\u00a7\2\u0800\u07fe\3\2\2\2\u0801\u0804\3\2\2\2\u0802\u0800\3\2"+
+		"\2\2\u0802\u0803\3\2\2\2\u0803\u014b\3\2\2\2\u0804\u0802\3\2\2\2\u0805"+
+		"\u0808\5\u00e6t\2\u0806\u0807\7\4\2\2\u0807\u0809\7\u00b1\2\2\u0808\u0806"+
+		"\3\2\2\2\u0808\u0809\3\2\2\2\u0809\u014d\3\2\2\2\u080a\u080b\7\33\2\2"+
+		"\u080b\u080c\7\34\2\2\u080c\u080d\5\u0084C\2\u080d\u014f\3\2\2\2\u080e"+
+		"\u080f\7\35\2\2\u080f\u0810\5\u00e6t\2\u0810\u0151\3\2\2\2\u0811\u0812"+
+		"\7\u009e\2\2\u0812\u0813\7\u0082\2\2\u0813\u0814\5\u00fc\177\2\u0814\u0815"+
+		"\7\u0083\2\2\u0815\u0819\7\u0080\2\2\u0816\u0818\5f\64\2\u0817\u0816\3"+
+		"\2\2\2\u0818\u081b\3\2\2\2\u0819\u0817\3\2\2\2\u0819\u081a\3\2\2\2\u081a"+
+		"\u081c\3\2\2\2\u081b\u0819\3\2\2\2\u081c\u081d\7\u0081\2\2\u081d\u0153"+
+		"\3\2\2\2\u081e\u081f\7%\2\2\u081f\u0824\5\u0156\u00ac\2\u0820\u0821\7"+
+		"\177\2\2\u0821\u0823\5\u0156\u00ac\2\u0822\u0820\3\2\2\2\u0823\u0826\3"+
+		"\2\2\2\u0824\u0822\3\2\2\2\u0824\u0825\3\2\2\2\u0825\u0155\3\2\2\2\u0826"+
+		"\u0824\3\2\2\2\u0827\u0828\5\u00b6\\\2\u0828\u0829\7\u0087\2\2\u0829\u082a"+
+		"\5\u00e6t\2\u082a\u0157\3\2\2\2\u082b\u082d\5\u00b6\\\2\u082c\u082e\5"+
+		"\u0162\u00b2\2\u082d\u082c\3\2\2\2\u082d\u082e\3\2\2\2\u082e\u0832\3\2"+
+		"\2\2\u082f\u0831\5\u00be`\2\u0830\u082f\3\2\2\2\u0831\u0834\3\2\2\2\u0832"+
+		"\u0830\3\2\2\2\u0832\u0833\3\2\2\2\u0833\u0836\3\2\2\2\u0834\u0832\3\2"+
+		"\2\2\u0835\u0837\5\u0164\u00b3\2\u0836\u0835\3\2\2\2\u0836\u0837\3\2\2"+
+		"\2\u0837\u083b\3\2\2\2\u0838\u083a\5\u00be`\2\u0839\u0838\3\2\2\2\u083a"+
+		"\u083d\3\2\2\2\u083b\u0839\3\2\2\2\u083b\u083c\3\2\2\2\u083c\u083f\3\2"+
+		"\2\2\u083d\u083b\3\2\2\2\u083e\u0840\5\u0162\u00b2\2\u083f\u083e\3\2\2"+
+		"\2\u083f\u0840\3\2\2\2\u0840\u0843\3\2\2\2\u0841\u0842\7\4\2\2\u0842\u0844"+
+		"\7\u00b1\2\2\u0843\u0841\3\2\2\2\u0843\u0844\3\2\2\2\u0844\u0159\3\2\2"+
+		"\2\u0845\u0846\7\67\2\2\u0846\u084c\5\u0168\u00b5\2\u0847\u0848\5\u0168"+
+		"\u00b5\2\u0848\u0849\7\67\2\2\u0849\u084c\3\2\2\2\u084a\u084c\5\u0168"+
+		"\u00b5\2\u084b\u0845\3\2\2\2\u084b\u0847\3\2\2\2\u084b\u084a\3\2\2\2\u084c"+
+		"\u084d\3\2\2\2\u084d\u084e\5\u0158\u00ad\2\u084e\u084f\7\31\2\2\u084f"+
+		"\u0850\5\u00e6t\2\u0850\u015b\3\2\2\2\u0851\u0852\7\61\2\2\u0852\u0853"+
+		"\t\24\2\2\u0853\u0858\7,\2\2\u0854\u0855\7\u00a7\2\2\u0855\u0859\5\u016a"+
+		"\u00b6\2\u0856\u0857\7\u00a7\2\2\u0857\u0859\7+\2\2\u0858\u0854\3\2\2"+
+		"\2\u0858\u0856\3\2\2\2\u0859\u0860\3\2\2\2\u085a\u085b\7\61\2\2\u085b"+
+		"\u085c\7\60\2\2\u085c\u085d\7,\2\2\u085d\u085e\7\u00a7\2\2\u085e\u0860"+
+		"\5\u016a\u00b6\2\u085f\u0851\3\2\2\2\u085f\u085a\3\2\2\2\u0860\u015d\3"+
+		"\2\2\2\u0861\u0865\5\u0160\u00b1\2\u0862\u0863\7 \2\2\u0863\u0866\7\34"+
+		"\2\2\u0864\u0866\7\177\2\2\u0865\u0862\3\2\2\2\u0865\u0864\3\2\2\2\u0866"+
+		"\u0867\3\2\2\2\u0867\u0868\5\u015e\u00b0\2\u0868\u087c\3\2\2\2\u0869\u086a"+
+		"\7\u0082\2\2\u086a\u086b\5\u015e\u00b0\2\u086b\u086c\7\u0083\2\2\u086c"+
+		"\u087c\3\2\2\2\u086d\u086e\7\u008e\2\2\u086e\u0874\5\u0160\u00b1\2\u086f"+
+		"\u0870\7\u0095\2\2\u0870\u0875\5\u0160\u00b1\2\u0871\u0872\7&\2\2\u0872"+
+		"\u0873\7\u00a7\2\2\u0873\u0875\5\u016a\u00b6\2\u0874\u086f\3\2\2\2\u0874"+
+		"\u0871\3\2\2\2\u0875\u087c\3\2\2\2\u0876\u0877\5\u0160\u00b1\2\u0877\u0878"+
+		"\t\25\2\2\u0878\u0879\5\u0160\u00b1\2\u0879\u087c\3\2\2\2\u087a\u087c"+
+		"\5\u0160\u00b1\2\u087b\u0861\3\2\2\2\u087b\u0869\3\2\2\2\u087b\u086d\3"+
+		"\2\2\2\u087b\u0876\3\2\2\2\u087b\u087a\3\2\2\2\u087c\u015f\3\2\2\2\u087d"+
+		"\u087f\5\u00b6\\\2\u087e\u0880\5\u0162\u00b2\2\u087f\u087e\3\2\2\2\u087f"+
+		"\u0880\3\2\2\2\u0880\u0882\3\2\2\2\u0881\u0883\5\u0094K\2\u0882\u0881"+
+		"\3\2\2\2\u0882\u0883\3\2\2\2\u0883\u0886\3\2\2\2\u0884\u0885\7\4\2\2\u0885"+
+		"\u0887\7\u00b1\2\2\u0886\u0884\3\2\2\2\u0886\u0887\3\2\2\2\u0887\u0161"+
+		"\3\2\2\2\u0888\u0889\7\37\2\2\u0889\u088a\5\u00e6t\2\u088a\u0163\3\2\2"+
+		"\2\u088b\u088c\7\'\2\2\u088c\u088d\5\u00be`\2\u088d\u0165\3\2\2\2\u088e"+
+		"\u088f\t\26\2\2\u088f\u0167\3\2\2\2\u0890\u0891\7\65\2\2\u0891\u0892\7"+
+		"\63\2\2\u0892\u08a0\7a\2\2\u0893\u0894\7\64\2\2\u0894\u0895\7\63\2\2\u0895"+
+		"\u08a0\7a\2\2\u0896\u0897\7\66\2\2\u0897\u0898\7\63\2\2\u0898\u08a0\7"+
+		"a\2\2\u0899\u089a\7\63\2\2\u089a\u08a0\7a\2\2\u089b\u089d\7\62\2\2\u089c"+
+		"\u089b\3\2\2\2\u089c\u089d\3\2\2\2\u089d\u089e\3\2\2\2\u089e\u08a0\7a"+
+		"\2\2\u089f\u0890\3\2\2\2\u089f\u0893\3\2\2\2\u089f\u0896\3\2\2\2\u089f"+
+		"\u0899\3\2\2\2\u089f\u089c\3\2\2\2\u08a0\u0169\3\2\2\2\u08a1\u08a2\t\27"+
+		"\2\2\u08a2\u016b\3\2\2\2\u08a3\u08a5\7\u00b5\2\2\u08a4\u08a6\5\u016e\u00b8"+
+		"\2\u08a5\u08a4\3\2\2\2\u08a5\u08a6\3\2\2\2\u08a6\u08a7\3\2\2\2\u08a7\u08a8"+
+		"\7\u00e7\2\2\u08a8\u016d\3\2\2\2\u08a9\u08ae\5\u0170\u00b9\2\u08aa\u08ad"+
+		"\7\u00eb\2\2\u08ab\u08ad\5\u0170\u00b9\2\u08ac\u08aa\3\2\2\2\u08ac\u08ab"+
+		"\3\2\2\2\u08ad\u08b0\3\2\2\2\u08ae\u08ac\3\2\2\2\u08ae\u08af\3\2\2\2\u08af"+
+		"\u08ba\3\2\2\2\u08b0\u08ae\3\2\2\2\u08b1\u08b6\7\u00eb\2\2\u08b2\u08b5"+
+		"\7\u00eb\2\2\u08b3\u08b5\5\u0170\u00b9\2\u08b4\u08b2\3\2\2\2\u08b4\u08b3"+
+		"\3\2\2\2\u08b5\u08b8\3\2\2\2\u08b6\u08b4\3\2\2\2\u08b6\u08b7\3\2\2\2\u08b7"+
+		"\u08ba\3\2\2\2\u08b8\u08b6\3\2\2\2\u08b9\u08a9\3\2\2\2\u08b9\u08b1\3\2"+
+		"\2\2\u08ba\u016f\3\2\2\2\u08bb\u08bf\5\u0172\u00ba\2\u08bc\u08bf\5\u0174"+
+		"\u00bb\2\u08bd\u08bf\5\u0176\u00bc\2\u08be\u08bb\3\2\2\2\u08be\u08bc\3"+
+		"\2\2\2\u08be\u08bd\3\2\2\2\u08bf\u0171\3\2\2\2\u08c0\u08c2\7\u00e8\2\2"+
+		"\u08c1\u08c3\7\u00e6\2\2\u08c2\u08c1\3\2\2\2\u08c2\u08c3\3\2\2\2\u08c3"+
+		"\u08c4\3\2\2\2\u08c4\u08c5\7\u00e5\2\2\u08c5\u0173\3\2\2\2\u08c6\u08c8"+
+		"\7\u00e9\2\2\u08c7\u08c9\7\u00e4\2\2\u08c8\u08c7\3\2\2\2\u08c8\u08c9\3"+
+		"\2\2\2\u08c9\u08ca\3\2\2\2\u08ca\u08cb\7\u00e3\2\2\u08cb\u0175\3\2\2\2"+
+		"\u08cc\u08ce\7\u00ea\2\2\u08cd\u08cf\7\u00e2\2\2\u08ce\u08cd\3\2\2\2\u08ce"+
+		"\u08cf\3\2\2\2\u08cf\u08d0\3\2\2\2\u08d0\u08d1\7\u00e1\2\2\u08d1\u0177"+
+		"\3\2\2\2\u08d2\u08d4\7\u00b4\2\2\u08d3\u08d5\5\u017a\u00be\2\u08d4\u08d3"+
+		"\3\2\2\2\u08d4\u08d5\3\2\2\2\u08d5\u08d6\3\2\2\2\u08d6\u08d7\7\u00db\2"+
+		"\2\u08d7\u0179\3\2\2\2\u08d8\u08da\5\u017e\u00c0\2\u08d9\u08d8\3\2\2\2"+
+		"\u08d9\u08da\3\2\2\2\u08da\u08dc\3\2\2\2\u08db\u08dd\5\u017c\u00bf\2\u08dc"+
+		"\u08db\3\2\2\2\u08dd\u08de\3\2\2\2\u08de\u08dc\3\2\2\2\u08de\u08df\3\2"+
+		"\2\2\u08df\u08e2\3\2\2\2\u08e0\u08e2\5\u017e\u00c0\2\u08e1\u08d9\3\2\2"+
+		"\2\u08e1\u08e0\3\2\2\2\u08e2\u017b\3\2\2\2\u08e3\u08e5\7\u00dc\2\2\u08e4"+
+		"\u08e6\7\u00b1\2\2\u08e5\u08e4\3\2\2\2\u08e5\u08e6\3\2\2\2\u08e6\u08e7"+
+		"\3\2\2\2\u08e7\u08e9\7\u00b7\2\2\u08e8\u08ea\5\u017e\u00c0\2\u08e9\u08e8"+
+		"\3\2\2\2\u08e9\u08ea\3\2\2\2\u08ea\u017d\3\2\2\2\u08eb\u08f0\5\u0180\u00c1"+
+		"\2\u08ec\u08ef\7\u00e0\2\2\u08ed\u08ef\5\u0180\u00c1\2\u08ee\u08ec\3\2"+
+		"\2\2\u08ee\u08ed\3\2\2\2\u08ef\u08f2\3\2\2\2\u08f0\u08ee\3\2\2\2\u08f0"+
+		"\u08f1\3\2\2\2\u08f1\u08fc\3\2\2\2\u08f2\u08f0\3\2\2\2\u08f3\u08f8\7\u00e0"+
+		"\2\2\u08f4\u08f7\7\u00e0\2\2\u08f5\u08f7\5\u0180\u00c1\2\u08f6\u08f4\3"+
+		"\2\2\2\u08f6\u08f5\3\2\2\2\u08f7\u08fa\3\2\2\2\u08f8\u08f6\3\2\2\2\u08f8"+
+		"\u08f9\3\2\2\2\u08f9\u08fc\3\2\2\2\u08fa\u08f8\3\2\2\2\u08fb\u08eb\3\2"+
+		"\2\2\u08fb\u08f3\3\2\2\2\u08fc\u017f\3\2\2\2\u08fd\u0901\5\u0182\u00c2"+
+		"\2\u08fe\u0901\5\u0184\u00c3\2\u08ff\u0901\5\u0186\u00c4\2\u0900\u08fd"+
+		"\3\2\2\2\u0900\u08fe\3\2\2\2\u0900\u08ff\3\2\2\2\u0901\u0181\3\2\2\2\u0902"+
+		"\u0904\7\u00dd\2\2\u0903\u0905\7\u00e6\2\2\u0904\u0903\3\2\2\2\u0904\u0905"+
+		"\3\2\2\2\u0905\u0906\3\2\2\2\u0906\u0907\7\u00e5\2\2\u0907\u0183\3\2\2"+
+		"\2\u0908\u090a\7\u00de\2\2\u0909\u090b\7\u00e4\2\2\u090a\u0909\3\2\2\2"+
+		"\u090a\u090b\3\2\2\2\u090b\u090c\3\2\2\2\u090c\u090d\7\u00e3\2\2\u090d"+
+		"\u0185\3\2\2\2\u090e\u0910\7\u00df\2\2\u090f\u0911\7\u00e2\2\2\u0910\u090f"+
+		"\3\2\2\2\u0910\u0911\3\2\2\2\u0911\u0912\3\2\2\2\u0912\u0913\7\u00e1\2"+
+		"\2\u0913\u0187\3\2\2\2\u011d\u018a\u018c\u0190\u0193\u0198\u019e\u01a8"+
 		"\u01ac\u01b5\u01ba\u01c6\u01cd\u01d1\u01db\u01e0\u01e6\u01eb\u01ed\u01f3"+
 		"\u01fb\u01ff\u0202\u0207\u0210\u0213\u0219\u021f\u0225\u0227\u022c\u022f"+
 		"\u0234\u0237\u023c\u0240\u0245\u024c\u0250\u0253\u025b\u025e\u0261\u0264"+
 		"\u026b\u0275\u027d\u0281\u0284\u028c\u0293\u0298\u029f\u02a5\u02aa\u02ae"+
 		"\u02b3\u02b6\u02bb\u02bf\u02ca\u02ce\u02d1\u02d4\u02d7\u02dd\u02e2\u02e6"+
 		"\u02e9\u02f2\u02f7\u02fb\u0300\u0306\u0311\u031a\u0321\u0328\u0331\u0338"+
-		"\u033d\u034b\u0356\u035c\u0363\u036a\u036e\u0370\u0376\u037e\u0382\u038d"+
-		"\u0394\u039c\u03a1\u03a8\u03af\u03b6\u03b9\u03bf\u03c3\u03cc\u03e7\u03ed"+
-		"\u03f7\u03fa\u0404\u040d\u0414\u0417\u041d\u0421\u0424\u042c\u043c\u0450"+
-		"\u0457\u045b\u0463\u046f\u0479\u0484\u048f\u0493\u049d\u04a1\u04a3\u04a7"+
-		"\u04ad\u04b3\u04bc\u04c6\u04d6\u04db\u04de\u04e5\u04ef\u04fb\u04fe\u0506"+
-		"\u0509\u050b\u0519\u0523\u052c\u052f\u0532\u053d\u0547\u0552\u0558\u0564"+
-		"\u056e\u0578\u057a\u0589\u058e\u0596\u059f\u05a5\u05a8\u05b3\u05bb\u05c0"+
-		"\u05c6\u05ce\u05d5\u05dd\u05e7\u0604\u0610\u061b\u0628\u0631\u0656\u0658"+
-		"\u0665\u066c\u0673\u0679\u0681\u0689\u0693\u069d\u06a3\u06ac\u06b8\u06bd"+
-		"\u06c6\u06cf\u06d4\u06d8\u06dd\u06e0\u06e3\u06e7\u06ef\u0708\u070b\u0711"+
-		"\u0714\u0718\u0722\u072c\u0733\u0741\u074d\u075c\u075f\u0762\u0766\u076f"+
-		"\u0773\u077e\u0782\u0788\u078f\u0793\u079d\u07a0\u07a3\u07a7\u07ae\u07b1"+
-		"\u07b4\u07b7\u07be\u07c8\u07cb\u07ce\u07d1\u07d4\u07d9\u07dd\u07ea\u07ef"+
-		"\u07f7\u07fa\u07fd\u0804\u080a\u081b\u0826\u082f\u0834\u0838\u083d\u0841"+
-		"\u0845\u084d\u085a\u0861\u0867\u0876\u087d\u0881\u0884\u0888\u089e\u08a1"+
-		"\u08a7\u08ae\u08b0\u08b6\u08b8\u08bb\u08c0\u08c4\u08ca\u08d0\u08d6\u08db"+
-		"\u08e0\u08e3\u08e7\u08eb\u08f0\u08f2\u08f8\u08fa\u08fd\u0902\u0906\u090c"+
-		"\u0912";
+		"\u033d\u034b\u035a\u0361\u0368\u036c\u036e\u0374\u037c\u0380\u038b\u0392"+
+		"\u039a\u039f\u03a6\u03ad\u03b4\u03b7\u03bd\u03c1\u03ca\u03e5\u03eb\u03f5"+
+		"\u03f8\u0402\u040b\u0412\u0415\u041b\u041f\u0422\u042a\u043a\u044e\u0455"+
+		"\u0459\u0461\u046d\u0477\u0482\u048d\u0491\u049b\u049f\u04a1\u04a5\u04ab"+
+		"\u04b1\u04ba\u04c4\u04d4\u04d9\u04dc\u04e3\u04ed\u04f9\u04fc\u0504\u0507"+
+		"\u0509\u0517\u0521\u052a\u052d\u0530\u053b\u0545\u0550\u0556\u0562\u056c"+
+		"\u0576\u0578\u0587\u058c\u0594\u059d\u05a3\u05a6\u05b1\u05b9\u05be\u05c4"+
+		"\u05cc\u05d3\u05db\u05e5\u0602\u060e\u0619\u0626\u062f\u0654\u0656\u0663"+
+		"\u066a\u0671\u0677\u067f\u0687\u0691\u069b\u06a1\u06aa\u06b6\u06bb\u06c4"+
+		"\u06cd\u06d2\u06d6\u06db\u06de\u06e1\u06e5\u06ed\u0706\u0709\u070f\u0712"+
+		"\u0716\u0720\u072a\u0731\u073f\u074b\u075a\u075d\u0760\u0764\u076d\u0771"+
+		"\u077c\u0780\u0786\u078d\u0791\u079b\u079e\u07a1\u07a5\u07ac\u07af\u07b2"+
+		"\u07b5\u07bc\u07c6\u07c9\u07cc\u07cf\u07d2\u07d7\u07db\u07e8\u07ed\u07f5"+
+		"\u07f8\u07fb\u0802\u0808\u0819\u0824\u082d\u0832\u0836\u083b\u083f\u0843"+
+		"\u084b\u0858\u085f\u0865\u0874\u087b\u087f\u0882\u0886\u089c\u089f\u08a5"+
+		"\u08ac\u08ae\u08b4\u08b6\u08b9\u08be\u08c2\u08c8\u08ce\u08d4\u08d9\u08de"+
+		"\u08e1\u08e5\u08e9\u08ee\u08f0\u08f6\u08f8\u08fb\u0900\u0904\u090a\u0910";
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {

--- a/compiler/ballerina-lang/src/main/resources/grammar/BallerinaParser.g4
+++ b/compiler/ballerina-lang/src/main/resources/grammar/BallerinaParser.g4
@@ -199,7 +199,7 @@ typeName
     |   LEFT_PARENTHESIS typeName RIGHT_PARENTHESIS                         # groupTypeNameLabel
     |   LEFT_PARENTHESIS typeName (COMMA typeName)* RIGHT_PARENTHESIS       # tupleTypeNameLabel
     |   OBJECT LEFT_BRACE objectBody RIGHT_BRACE                            # objectTypeNameLabel
-    |   RECORD? LEFT_BRACE fieldDefinitionList RIGHT_BRACE                  # recordTypeNameLabel
+    |   RECORD LEFT_BRACE fieldDefinitionList RIGHT_BRACE                  # recordTypeNameLabel
     ;
 
 fieldDefinitionList

--- a/language-server/modules/langserver-core/samples/hover/hover.bal
+++ b/language-server/modules/langserver-core/samples/hover/hover.bal
@@ -6,7 +6,7 @@ import ballerina/io;
 @Field{value:"name: string value name of the person"}
 @Field{value:"id: int value id of the person"}
 @Field{value:"age: int value age of the person"}
-type Person {
+type Person record {
     string name;
     int id;
     int age;

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/recordVarDef1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/recordVarDef1.bal
@@ -4,7 +4,7 @@ function helloWorld() {
     };
 }
 
-type Person {
+type Person record {
     int age;
     string name;
 };

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/recordVarDef2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/recordVarDef2.bal
@@ -5,7 +5,7 @@ function helloWorld() {
     };
 }
 
-type Person {
+type Person record {
     int age;
     string name;
 };

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/userDefinedRecordEmptyLine.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/userDefinedRecordEmptyLine.bal
@@ -2,10 +2,10 @@ function testFunction() {
     
 }
 
-type testRecord1 {
+type testRecord1 record {
     int test1A = 12;
 };
 
-type testRecord2 {
+type testRecord2 record {
     int test2A = 12;
 };

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/userDefinedRecordNonEmptyLine.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/userDefinedRecordNonEmptyLine.bal
@@ -2,10 +2,10 @@ function testFunction() {
     f
 }
 
-type testRecord1 {
+type testRecord1 record {
     int test1A = 12;
 };
 
-type testRecord2 {
+type testRecord2 record {
     int test2A = 12;
 };

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/source/userDefinedRecordEmptyLine.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/source/userDefinedRecordEmptyLine.bal
@@ -6,10 +6,10 @@ service<http:Service> hello {
     }
 }
 
-type testRecord1 {
+type testRecord1 record {
     int test1A = 12;
 };
 
-type testRecord2 {
+type testRecord2 record {
     int test2A = 12;
 };

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/source/userDefinedRecordNonEmptyLine.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/source/userDefinedRecordNonEmptyLine.bal
@@ -6,10 +6,10 @@ service<http:Service> hello {
     }
 }
 
-type testRecord1 {
+type testRecord1 record {
     int test1A = 12;
 };
 
-type testRecord2 {
+type testRecord2 record {
     int test2A = 12;
 };

--- a/language-server/modules/langserver-core/src/test/resources/definition/test.definition.pkg/definition1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/test.definition.pkg/definition1.bal
@@ -4,7 +4,7 @@ import ballerina/io;
 
 @readonly string lastName;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;

--- a/language-server/modules/langserver-core/src/test/resources/definition/test.definition.pkg/definition2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/test.definition.pkg/definition2.bal
@@ -2,7 +2,7 @@
 
 import ballerina/io;
 
-type Person {
+type Person record {
     string name;
     int id;
     int age;

--- a/language-server/modules/langserver-core/src/test/resources/hover/hover.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/hover.bal
@@ -6,7 +6,7 @@ import ballerina/io;
 @Field{value:"name: string value name of the person"}
 @Field{value:"id: int value id of the person"}
 @Field{value:"age: int value age of the person"}
-type Person {
+type Person record {
     string name;
     int id;
     int age;

--- a/language-server/modules/langserver-core/src/test/resources/references/project/references1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/references/project/references1.bal
@@ -3,7 +3,7 @@ import pkg1;
 @readonly string READ_ONLY_VAR;
 @final string FINAL_VAR = "Final variable";
 
-type Info {
+type Info record {
     int id;
     string name;
 };

--- a/misc/docerina/src/main/resources/docerina-templates/html/page.hbs
+++ b/misc/docerina/src/main/resources/docerina-templates/html/page.hbs
@@ -741,7 +741,7 @@
                                                 <!-- Records -->
                                                 {{#if isRecord}}
                                                     <h2 id="{{name}}">
-                                                        <span class="{{icon}} sm-icon"></span> public type {{name}}
+                                                        <span class="{{icon}} sm-icon"></span> public type {{name}} record
                                                     </h2>
                                                     {{#if description}}
                                                         <p>

--- a/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
+++ b/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
@@ -158,7 +158,8 @@ public class HtmlDocTest {
 
     @Test(description = "Connectors in a package should be shown in the constructs with new docerina syntax")
     public void testConnectorsWithNewSyntax() throws Exception {
-        BLangPackage bLangPackage = createPackage("import ballerina/http;\n public type GitHubClientConfig {\n" + " "
+        BLangPackage bLangPackage = createPackage(
+                "import ballerina/http;\n public type GitHubClientConfig record {\n" + " "
                 + "   " + "    " + "http:ClientEndpointConfig clientEndpointConfiguration = {};\n" + "};\n" + "\n" +
                 "documentation { " + "GitHub client\n" + "    E{{}}\n" + "    F{{githubClientConfiguration}} - GitHub" +
                 " client " + "configurations (Access token, Client endpoint configurations)\n" + "    " +
@@ -366,7 +367,7 @@ public class HtmlDocTest {
 
     @Test(description = "Structs in a package should be shown in the constructs")
     public void testStructs() throws Exception {
-        BLangPackage bLangPackage = createPackage("public type Message {string message; error? cause;};");
+        BLangPackage bLangPackage = createPackage("public type Message record {string message; error? cause;};");
         Page page = generatePage(bLangPackage);
         Assert.assertEquals(page.constructs.size(), 1);
         Assert.assertEquals(page.constructs.get(0).name, "Message");

--- a/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/resources/templates/client/client.mustache
+++ b/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/resources/templates/client/client.mustache
@@ -4,7 +4,7 @@ import ballerina/http;
 //=====================================
 //============Client Config============
 //=====================================
-public type {{name}}ClientConfig {
+public type {{name}}ClientConfig record {
     string serviceUrl;
 };
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/client/client-ep.mustache
@@ -5,7 +5,7 @@ import ballerina/http;
 //=====================================
 //============Client Config============
 //=====================================
-public type {{cut info.title " "}}ClientConfig {
+public type {{cut info.title " "}}ClientConfig record {
     string serviceUrl,
     http:ClientEndpointConfig clientConfig,
 };

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/model/schemas.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/model/schemas.mustache
@@ -1,5 +1,5 @@
 {{#schemas}}{{#value}}
 {{#isArraySchema}}public type {{key}} {};{{/isArraySchema}}{{^isArraySchema}}
-public type {{key}} { {{#properties}}
+public type {{key}} record { {{#properties}}
     {{#value}}{{#equals ../../key type}}{{type}}?{{else}}{{type}}{{/equals}}{{/value}} {{key}},{{/properties}}
 };{{/isArraySchema}}{{/value}}{{/schemas}}

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/test/annotations.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/test/annotations.bal
@@ -6,7 +6,7 @@
 @Field {value:"before: Name of the function to be run before the test is run"}
 @Field {value:"after: Name of the function to be run after the test is run"}
 @Field {value:"dependsOn: A list of function names the test function depends on, and will be run before the test"}
-public type TestConfig {
+public type TestConfig record {
     boolean enable = true;
     string[] groups;
     string dataProvider;
@@ -18,7 +18,7 @@ public type TestConfig {
 @Description { value:"Configuration of the function to be mocked."}
 @Field {value:"packageName: Name of the package that the function to be mocked resides in"}
 @Field {value:"functionName: Name of the function to be mocked"}
-public type MockConfig {
+public type MockConfig record {
     string packageName = ".";
     string functionName;
 };

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/test/assert.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/test/assert.bal
@@ -8,7 +8,7 @@ import ballerina/reflect;
 @Field{value:"The assertion error message"}
 @Field{value:"The error which caused the assertion error"}
 @Field{value:"The assert error category"}
-type AssertError {
+type AssertError record {
     string message;
     error? cause;
     string category;

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/ServiceSkeletonTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/ServiceSkeletonTest.java
@@ -41,17 +41,18 @@ public class ServiceSkeletonTest {
 
     @BeforeClass
     public void setup() {
+        sourceRoot = getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
         System.setProperty("java.util.logging.manager", "org.ballerinalang.logging.BLogManager");
         System.setProperty("java.util.logging.config.file", "logging.properties");
-        System.setProperty(TesterinaConstants.BALLERINA_SOURCE_ROOT, System.getProperty("user.dir")
-                                                                     + "/src/test/resources");
+        System.setProperty(TesterinaConstants.BALLERINA_SOURCE_ROOT, sourceRoot);
     }
 
     @Test
     public void testBefore() {
         cleanup();
         BTestRunner bTestRunner = new BTestRunner();
-        bTestRunner.runTest(sourceRoot + "service.skeleton", new Path[]{Paths.get("service-skeleton-test.bal")}, new
+        bTestRunner.runTest(Paths.get(sourceRoot, "service.skeleton").toString(),
+                            new Path[]{Paths.get("service-skeleton-test.bal")}, new
                 ArrayList<>());
         Assert.assertEquals(bTestRunner.getTesterinaReport().getTestSummary(".", "passed"), 1);
     }

--- a/stdlib/ballerina-builtin/src/main/ballerina/auth/jwt_auth_provider.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/auth/jwt_auth_provider.bal
@@ -125,7 +125,7 @@ public type JWTAuthProvider object {
 documentation {
     Represents JWT validator configurations
 }
-public type JWTAuthProviderConfig {
+public type JWTAuthProviderConfig record {
     string issuer,
     string audience,
     int clockSkew,
@@ -134,7 +134,7 @@ public type JWTAuthProviderConfig {
     string trustStorePassword,
 };
 
-type CachedJWTAuthContext {
+type CachedJWTAuthContext record {
     internal:JwtPayload jwtPayload,
     int expiryTime;
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/auth/jwt_supported_config_auth_provider.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/auth/jwt_supported_config_auth_provider.bal
@@ -91,7 +91,7 @@ function createJWTIssueConfig(ConfigJwtAuthProviderConfig authConfig) returns (i
     return config;
 }
 
-public type ConfigJwtAuthProviderConfig {
+public type ConfigJwtAuthProviderConfig record {
     string issuer,
     string audience,
     int expTime,

--- a/stdlib/ballerina-builtin/src/main/ballerina/builtin/docs.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/builtin/docs.bal
@@ -18,7 +18,7 @@ deprecated {}
 public annotation Description docData;
 
 deprecated {}
-type docData {
+type docData record {
     string value;
 };
 

--- a/stdlib/ballerina-builtin/src/main/ballerina/builtin/errors.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/builtin/errors.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type error {
+public type error record {
     string message;
     error? cause;
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/builtin/jsonlib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/builtin/jsonlib.bal
@@ -41,7 +41,7 @@ documentation {
     P{{options}} jsonOptions struct for JSON to XML conversion properties
     R{{}} The XML representation of the JSON
 }
-public native function json::toXML({
-                                         string attributePrefix = "@";
-                                         string arrayEntryTag = "item";
+public native function json::toXML(record {
+                                         string attributePrefix = "@",
+                                         string arrayEntryTag = "item",
                                      } options) returns (xml|error);

--- a/stdlib/ballerina-builtin/src/main/ballerina/builtin/tablelib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/builtin/tablelib.bal
@@ -81,7 +81,7 @@ documentation {
     F{{index}} An array of index columns
     F{{data}} An array of record data
 }
-type TableConfig {
+type TableConfig record {
     string[] primaryKey;
     string[] index;
     any[] data;

--- a/stdlib/ballerina-builtin/src/main/ballerina/builtin/xmllib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/builtin/xmllib.bal
@@ -110,9 +110,9 @@ documentation {
     P{{options}} xmlOptions struct for XML to JSON conversion properties
     R{{}} JSON representation of the given XML
 }
-public native function xml::toJSON({
-                                         string attributePrefix = "@";
-                                         boolean preserveNamespaces = true;
+public native function xml::toJSON(record {
+                                         string attributePrefix = "@",
+                                         boolean preserveNamespaces = true,
                                      } options) returns (json);
 
 documentation {

--- a/stdlib/ballerina-builtin/src/main/ballerina/cache/cache.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/cache/cache.bal
@@ -36,7 +36,7 @@ documentation {
     F{{value}} cache value
     F{{lastAccessedTime}} last accessed time in ms of this value which is used to remove LRU cached values
 }
-type CacheEntry {
+type CacheEntry record {
     any value;
     int lastAccessedTime;
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/file/service.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/file/service.bal
@@ -21,7 +21,7 @@ documentation {
     F{{name}} Absolute file URI for triggerd event
     F{{operation}} Triggered event action. This can be create, delete or modify
 }
-public type FileEvent {
+public type FileEvent record {
     string name,
     string operation,
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/file/service_endpoint.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/file/service_endpoint.bal
@@ -48,7 +48,7 @@ documentation {
     F{{path}}  Directory path which need to listen
     F{{recursive}} Recursively monitor all sub folders or not in the given direcotry path
 }
-public type ListenerEndpointConfiguration {
+public type ListenerEndpointConfiguration record {
     string path,
     boolean recursive = false,
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/internal/compression.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/internal/compression.bal
@@ -22,7 +22,7 @@ documentation {
     F{{message}} The error message
     F{{cause}} The error which caused the compression error
 }
-public type CompressionError  {
+public type CompressionError record {
     string message,
     error? cause,
 };

--- a/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_common.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_common.bal
@@ -32,7 +32,7 @@
 documentation {
     Represents a JWT header.
 }
-public type JwtHeader {
+public type JwtHeader record {
     string alg;
     string typ;
     string cty;
@@ -43,7 +43,7 @@ public type JwtHeader {
 documentation {
     Represents a JWT payload.
 }
-public type JwtPayload {
+public type JwtPayload record {
     string iss;
     string sub;
     string[] aud;

--- a/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_issuer.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_issuer.bal
@@ -19,7 +19,7 @@ import ballerina/io;
 documentation {
     Represents JWT issuer configurations.
 }
-public type JWTIssuerConfig {
+public type JWTIssuerConfig record {
     string keyAlias,
     string keyPassword,
     string keyStoreFilePath,

--- a/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_native.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_native.bal
@@ -25,7 +25,7 @@ documentation {
 }
 native function verifySignature(string data, string signature, string algorithm, TrustStore trustStore)
     returns (boolean);
-type TrustStore {
+type TrustStore record {
     string certificateAlias,
     string trustStoreFilePath,
     string trustStorePassword,
@@ -41,7 +41,7 @@ documentation {
 }
 native function sign(string data, string algorithm, KeyStore keyStore) returns (string);
 
-type KeyStore {
+type KeyStore record {
     string keyAlias,
     string keyPassword,
     string keyStoreFilePath,

--- a/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_validator.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/internal/jwt_validator.bal
@@ -20,7 +20,7 @@ import ballerina/time;
 documentation {
     Represents JWT validator configurations.
 }
-public type JWTValidatorConfig {
+public type JWTValidatorConfig record {
     string issuer,
     string audience,
     int clockSkew,

--- a/stdlib/ballerina-builtin/src/main/ballerina/io/Package.md
+++ b/stdlib/ballerina-builtin/src/main/ballerina/io/Package.md
@@ -113,7 +113,7 @@ Records of the `.CSV` file can read directly into a table of a matching type.
 
  ```ballerina
 // First let’s define a type that matches a record in the CSV file.
-type Employee {
+type Employee record {
     string id;
     string name;
     float salary;

--- a/stdlib/ballerina-builtin/src/main/ballerina/io/socket.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/io/socket.bal
@@ -69,7 +69,7 @@ documentation {
     F{{ciphers}} Encrypt/decrypt algorithms (i.e RSA, SHA-256)
     F{{sslProtocol}} Supported SSL protocols (i.e SSL, TLS)
 }
-public type SocketProperties {
+public type SocketProperties record {
     int localPort;
     string keyStoreFile;
     string keyStorePassword;

--- a/stdlib/ballerina-builtin/src/main/ballerina/reflect/reflect.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/reflect/reflect.bal
@@ -24,9 +24,9 @@ documentation {
 }
 public native function equals(any value1, any value2) returns (boolean);
 
-public type anyStruct {};
+public type anyStruct record {};
 
-public type annotationData {
+public type annotationData record {
     string name,
     string pkgName,
     anyStruct value,

--- a/stdlib/ballerina-builtin/src/main/ballerina/runtime/errors.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/runtime/errors.bal
@@ -20,7 +20,7 @@ documentation {
     F{{message}} error message
     F{{cause}} optional error cause
 }
-public type NullReferenceException {
+public type NullReferenceException record {
     string message;
     error? cause;
 };
@@ -31,7 +31,7 @@ documentation {
     F{{message}} error message
     F{{cause}} optional error cause
 }
-public type IllegalStateException {
+public type IllegalStateException record {
     string message;
     error? cause;
 };
@@ -44,7 +44,7 @@ documentation {
     F{{fileName}} File name
     F{{lineNumber}} Line number
 }
-public type CallStackElement {
+public type CallStackElement record {
     string callableName;
     string packageName;
     string fileName;
@@ -73,7 +73,7 @@ documentation {
     F{{cause}} optional `error` instance
     F{{causes}} optional array of `error` instances
 }
-public type CallFailedException {
+public type CallFailedException record {
     string message;
     error? cause;
     error[]? causes;

--- a/stdlib/ballerina-builtin/src/main/ballerina/runtime/invocation-context.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/runtime/invocation-context.bal
@@ -17,7 +17,7 @@
 documentation {
     Represents the InvocationContext.
 }
-public type InvocationContext {
+public type InvocationContext record {
     string id;
     UserPrincipal userPrincipal;
     AuthContext authContext;
@@ -27,7 +27,7 @@ public type InvocationContext {
 documentation {
     Represents the AuthenticationContext, populated with authenticated information.
 }
-public type AuthContext {
+public type AuthContext record {
     string scheme;
     string authToken;
 };
@@ -35,7 +35,7 @@ public type AuthContext {
 documentation {
     Represents the UserPrincipal, populated with authenticated user information.
 }
-public type UserPrincipal {
+public type UserPrincipal record {
     string userId;
     string username;
     map claims;

--- a/stdlib/ballerina-builtin/src/main/ballerina/time/timelib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/time/timelib.bal
@@ -23,7 +23,7 @@ documentation {
     F{{zoneId}} Zone short ID or offset string
     F{{zoneOffset}} The offset in seconds
 }
-public type Timezone {
+public type Timezone record {
     string zoneId,
     int zoneOffset,
 };

--- a/stdlib/ballerina-database/src/main/ballerina/h2/endpoint.bal
+++ b/stdlib/ballerina-database/src/main/ballerina/h2/endpoint.bal
@@ -28,7 +28,7 @@ documentation {
     F{{poolOptions}} Properties for the connection pool configuration. Refer `sql:PoolOptions` for more details
     F{{dbOptions}} A map of DB specific properties
 }
-public type ClientEndpointConfiguration {
+public type ClientEndpointConfiguration record {
     string host,
     string path,
     int port = 9092,

--- a/stdlib/ballerina-database/src/main/ballerina/jdbc/endpoint.bal
+++ b/stdlib/ballerina-database/src/main/ballerina/jdbc/endpoint.bal
@@ -25,7 +25,7 @@ documentation {
     F{{poolOptions}} Properties for the connection pool configuration. Refer `sql:PoolOptions` for more details
     F{{dbOptions}} A map of DB specific properties. These properties will have an effect only if the dataSourceClassName is provided in poolOptions
 }
-public type ClientEndpointConfiguration {
+public type ClientEndpointConfiguration record {
     string url,
     string username,
     string password,

--- a/stdlib/ballerina-database/src/main/ballerina/mysql/endpoint.bal
+++ b/stdlib/ballerina-database/src/main/ballerina/mysql/endpoint.bal
@@ -27,7 +27,7 @@ documentation {
     F{{poolOptions}} Properties for the connection pool configuration. Refer `sql:PoolOptions` for more details
     F{{dbOptions}} A map of DB specific properties
 }
-public type ClientEndpointConfiguration {
+public type ClientEndpointConfiguration record {
     string host,
     int port = 3306,
     string name,

--- a/stdlib/ballerina-database/src/main/ballerina/sql/types.bal
+++ b/stdlib/ballerina-database/src/main/ballerina/sql/types.bal
@@ -31,7 +31,7 @@ documentation {
     F{{maxLifetime}} Maximum lifetime of a connection in the pool. Default is 30 minutes
     F{{validationTimeout}} Maximum amount of time that a connection will be tested for aliveness. Default 5 seconds
 }
-public type PoolOptions {
+public type PoolOptions record {
     string connectionInitSql,
     string dataSourceClassName,
     boolean autoCommit = true,
@@ -142,7 +142,7 @@ documentation {
     F{{recordType}} In case of OUT direction, if the sqlType is REFCURSOR, this represents the record type to map a
                       result row
 }
-public type Parameter {
+public type Parameter record {
     SQLType sqlType,
     any value,
     Direction direction,

--- a/stdlib/ballerina-grpc/src/main/ballerina/grpc/annotation.bal
+++ b/stdlib/ballerina-grpc/src/main/ballerina/grpc/annotation.bal
@@ -25,7 +25,7 @@ documentation {
     F{{serverStreaming}} - Server streaming flag. This applies only for bidirectional streaming. Flag
     sets to true, if the service defines as bidirectional streaming.
 }
-public type GrpcServiceConfig {
+public type GrpcServiceConfig record {
     string name;
     boolean clientStreaming;
     boolean serverStreaming;
@@ -42,7 +42,7 @@ documentation {
     F{{streaming}} - Server streaming flag. This flag sets to true to specify that the resource is capable of sending
      multiple responses per request.
 }
-public type GrpcResourceConfig {
+public type GrpcResourceConfig record {
     boolean streaming;
 };
 
@@ -56,7 +56,7 @@ documentation {
 
     F{{descriptor}} - Service descriptor sets at compile time.
 }
-public type ServiceDescriptorData {
+public type ServiceDescriptorData record {
     string descriptor;
 };
 

--- a/stdlib/ballerina-grpc/src/main/ballerina/grpc/client_endpoint.bal
+++ b/stdlib/ballerina-grpc/src/main/ballerina/grpc/client_endpoint.bal
@@ -60,7 +60,7 @@ documentation {
     F{{url}} - The server url.
     F{{secureSocket}} - The SSL configurations for the client endpoint.
 }
-public type ClientEndpointConfig {
+public type ClientEndpointConfig record {
     string url,
     SecureSocket? secureSocket,
 };
@@ -78,7 +78,7 @@ documentation {
     F{{shareSession}} - Enable/disable new ssl session creation.
     F{{ocspStapling}} - Enable/disable ocsp stapling.
 }
-public type SecureSocket {
+public type SecureSocket record {
     TrustStore? trustStore,
     KeyStore? keyStore,
     Protocols? protocol,

--- a/stdlib/ballerina-grpc/src/main/ballerina/grpc/grpc_commons.bal
+++ b/stdlib/ballerina-grpc/src/main/ballerina/grpc/grpc_commons.bal
@@ -20,7 +20,7 @@ documentation {
     F{{path}} File path to trust store file
     F{{password}} Trust store password
 }
-public type TrustStore {
+public type TrustStore record {
     string path,
     string password,
 };
@@ -31,7 +31,7 @@ documentation {
     F{{path}} File path to key store file
     F{{password}} Key store password
 }
-public type KeyStore {
+public type KeyStore record {
     string path,
     string password,
 };
@@ -42,7 +42,7 @@ documentation {
     F{{name}} SSL Protocol to be used. eg TLS1.2
     F{{versions}} SSL/TLS protocols to be enabled. eg TLSv1,TLSv1.1,TLSv1.2
 }
-public type Protocols {
+public type Protocols record {
     string name,
     string[] versions,
 };
@@ -54,7 +54,7 @@ documentation {
     F{{cacheSize}} Maximum size of the cache
     F{{cacheValidityPeriod}} Time duration of cache validity period
 }
-public type ValidateCert {
+public type ValidateCert record {
     boolean enable,
     int cacheSize,
     int cacheValidityPeriod,
@@ -67,7 +67,7 @@ documentation {
     F{{cacheSize}} Maximum size of the cache
     F{{cacheValidityPeriod}} Time duration of cache validity period
 }
-public type ServiceOcspStapling {
+public type ServiceOcspStapling record {
     boolean enable,
     int cacheSize,
     int cacheValidityPeriod,

--- a/stdlib/ballerina-grpc/src/main/ballerina/grpc/service_endpoint.bal
+++ b/stdlib/ballerina-grpc/src/main/ballerina/grpc/service_endpoint.bal
@@ -68,7 +68,7 @@ documentation {
     F{{port}} - The server port.
     F{{secureSocket}} - The SSL configurations for the client endpoint.
 }
-public type ServiceEndpointConfiguration {
+public type ServiceEndpointConfiguration record {
     string host,
     int port,
     ServiceSecureSocket? secureSocket,
@@ -87,7 +87,7 @@ documentation {
     F{{shareSession}} - Enable/disable new ssl session creation.
     F{{ocspStapling}} - Enable/disable ocsp stapling.
 }
-public type ServiceSecureSocket {
+public type ServiceSecureSocket record {
     TrustStore? trustStore,
     KeyStore? keyStore,
     Protocols? protocol,

--- a/stdlib/ballerina-grpc/src/main/resources/templates/skeleton/clientStub.mustache
+++ b/stdlib/ballerina-grpc/src/main/resources/templates/skeleton/clientStub.mustache
@@ -73,7 +73,7 @@ public type {{connectorId}}{{stubTypeName}}{{stubType}}Client object {
 };
 {{/client}}
 {{#structs}}
-type {{structId}} {
+type {{structId}} record {
     {{#attribute}}{{type}}{{label}} {{name}};
     {{/attribute}}
 };

--- a/stdlib/ballerina-http/src/main/ballerina/http/annotation.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/annotation.bal
@@ -31,7 +31,7 @@ documentation {
     F{{versioning}} The version of the service to be used
     F{{authConfig}} Authentication configurations for securing the service
 }
-public type HttpServiceConfig {
+public type HttpServiceConfig record {
     Listener[] endpoints,
     string host = "b7a.default",
     string basePath,
@@ -52,7 +52,7 @@ documentation {
     F{{allowCredentials}} Specifies whether credentials are required to access the service
     F{{maxAge}} The maximum duration to cache the preflight from client side
 }
-public type CorsConfig {
+public type CorsConfig record {
     string[] allowHeaders,
     string[] allowMethods,
     string[] allowOrigins,
@@ -69,7 +69,7 @@ documentation {
     F{{allowNoVersion}} Allow requests with missing version path segment in the URL to be dispatched
     F{{matchMajorVersion}} Allow requests with only the major version specified in the URL to be dispatched
 }
-public type Versioning {
+public type Versioning record {
     string pattern = "v{major}.{minor}",
     boolean allowNoVersion = false,
     boolean matchMajorVersion = false,
@@ -86,7 +86,7 @@ documentation {
                               an `onIdleTimeout` resource in the WebSocket service.
     F{{maxFrameSize}} The maximum payload size of a WebSocket frame in bytes
 }
-public type WSServiceConfig {
+public type WSServiceConfig record {
     Listener[] endpoints,
     WebSocketListener[] webSocketEndpoints,
     string path,
@@ -124,7 +124,7 @@ documentation {
     F{{webSocketUpgrade}} Annotation to define HTTP to WebSocket upgrade
     F{{authConfig}} Authentication Configs to secure the resource
 }
-public type HttpResourceConfig {
+public type HttpResourceConfig record {
     string[] methods,
     string path,
     string body,
@@ -142,7 +142,7 @@ documentation {
     F{{upgradePath}} Path which is used to upgrade from HTTP to WebSocket
     F{{upgradeService}} WebSocket service which should be used after a successful upgrade
 }
-public type WebSocketUpgradeConfig {
+public type WebSocketUpgradeConfig record {
     string upgradePath,
     typedesc upgradeService,
 };
@@ -154,7 +154,7 @@ documentation {
     F{{authProviders}} Array of authentication provider IDs
     F{{scopes}} Array of scopes
 }
-public type ListenerAuthConfig {
+public type ListenerAuthConfig record {
     Authentication? authentication,
     string[]? authProviders,
     string[]? scopes,
@@ -165,7 +165,7 @@ documentation {
 
     F{{enabled}} Specifies whether authentication is enabled
 }
-public type Authentication {
+public type Authentication record {
     boolean enabled,
 };
 

--- a/stdlib/ballerina-http/src/main/ballerina/http/caching/http_caching_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/caching/http_caching_client.bal
@@ -67,7 +67,7 @@ documentation {
                 `CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`
                 header and either the `etag` or `last-modified` header are present.
 }
-public type CacheConfig {
+public type CacheConfig record {
     boolean enabled = true,
     boolean isShared = false,
     int expiryTimeMillis = 86400,

--- a/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/client_endpoint.bal
@@ -62,7 +62,7 @@ documentation {
     F{{url}} URL of the target service
     F{{secureSocket}} Configurations for secure communication with the remote HTTP endpoint
 }
-public type TargetService {
+public type TargetService record {
     string url,
     SecureSocket? secureSocket,
 };
@@ -86,7 +86,7 @@ documentation {
     F{{compression}} Specifies the way of handling compression (`accept-encoding`) header
     F{{auth}} HTTP authentication releated configurations
 }
-public type ClientEndpointConfig {
+public type ClientEndpointConfig record {
     string url,
     CircuitBreakerConfig? circuitBreaker,
     int timeoutMillis = 60000,
@@ -116,7 +116,7 @@ documentation {
     F{{backOffFactor}} Multiplier of the retry interval to exponentailly increase retry interval
     F{{maxWaitInterval}} Maximum time of the retry interval in milliseconds
 }
-public type RetryConfig {
+public type RetryConfig record {
     int count,
     int interval,
     float backOffFactor,
@@ -136,7 +136,7 @@ documentation {
     F{{shareSession}} Enable/disable new SSL session creation
     F{{ocspStapling}} Enable/disable OCSP stapling
 }
-public type SecureSocket {
+public type SecureSocket record {
     TrustStore? trustStore,
     KeyStore? keyStore,
     Protocols? protocol,
@@ -153,7 +153,7 @@ documentation {
     F{{enabled}} Enable/disable redirection
     F{{maxCount}} Maximum number of redirects to follow
 }
-public type FollowRedirects {
+public type FollowRedirects record {
     boolean enabled = false,
     int maxCount = 5,
 };
@@ -166,7 +166,7 @@ documentation {
     F{{userName}} Proxy server username
     F{{password}} proxy server password
 }
-public type ProxyConfig {
+public type ProxyConfig record {
     string host,
     int port,
     string userName,
@@ -181,7 +181,7 @@ documentation {
     F{{waitTime}} Maximum waiting time for a request to grab an idle connection from the client
     F{{maxActiveStreamsPerConnection}} Maximum number of active streams allowed per an HTTP/2 connection
 }
-public type ConnectionThrottling {
+public type ConnectionThrottling record {
     int maxActiveConnections = -1,
     int waitTime = 60000,
     int maxActiveStreamsPerConnection = -1,
@@ -202,7 +202,7 @@ documentation {
     F{{clientId}} Clietnt ID for OAuth2 authentication
     F{{clientSecret}} Client secret for OAuth2 authentication
 }
-public type AuthConfig {
+public type AuthConfig record {
     AuthScheme scheme,
     string username,
     string password,

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_client.bal
@@ -218,7 +218,7 @@ documentation {
     F{{cause}} The error which caused the `HttpTimeoutError`
     F{{statusCode}} HTTP status code
 }
-public type HttpTimeoutError {
+public type HttpTimeoutError record {
     string message,
     error? cause,
     int statusCode,

--- a/stdlib/ballerina-http/src/main/ballerina/http/http_commons.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/http_commons.bal
@@ -60,7 +60,7 @@ documentation {
     F{{path}} Path to the trust store file
     F{{password}} Trust store password
 }
-public type TrustStore {
+public type TrustStore record {
     string path,
     string password,
 };
@@ -71,7 +71,7 @@ documentation {
     F{{path}} Path to the key store file
     F{{password}} Key store password
 }
-public type KeyStore {
+public type KeyStore record {
     string path,
     string password,
 };
@@ -82,7 +82,7 @@ documentation {
     F{{name}} SSL Protocol to be used (e.g.: TLS1.2)
     F{{versions}} SSL/TLS protocols to be enabled (e.g.: TLSv1,TLSv1.1,TLSv1.2)
 }
-public type Protocols {
+public type Protocols record {
     string name,
     string[] versions,
 };
@@ -94,7 +94,7 @@ documentation {
     F{{cacheSize}} Maximum size of the cache
     F{{cacheValidityPeriod}} The time period for which a cache entry is valid
 }
-public type ValidateCert {
+public type ValidateCert record {
     boolean enable,
     int cacheSize,
     int cacheValidityPeriod,
@@ -107,7 +107,7 @@ documentation {
     F{{cacheSize}} Maximum size of the cache
     F{{cacheValidityPeriod}} The time period for which a cache entry is valid
 }
-public type ServiceOcspStapling {
+public type ServiceOcspStapling record {
     boolean enable,
     int cacheSize,
     int cacheValidityPeriod,

--- a/stdlib/ballerina-http/src/main/ballerina/http/resiliency/failover_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/resiliency/failover_client_endpoint.bal
@@ -70,7 +70,7 @@ documentation {
     F{{failoverCodes}} Array of HTTP response status codes for which the failover behaviour should be triggered
     F{{intervalMillis}} Failover delay interval in milliseconds
 }
-public type FailoverClientEndpointConfiguration {
+public type FailoverClientEndpointConfiguration record {
     CircuitBreakerConfig? circuitBreaker,
     int timeoutMillis = 60000,
     string httpVersion = "1.1",

--- a/stdlib/ballerina-http/src/main/ballerina/http/resiliency/failover_connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/resiliency/failover_connector.bal
@@ -25,7 +25,7 @@ documentation {
     F{{failoverCodes}} Array of HTTP response status codes for which the failover mechanism triggers
     F{{interval}} Failover delay interval in milliseconds
 }
-public type FailoverConfig {
+public type FailoverConfig record {
     int[] failoverCodes,
     int interval,
 };
@@ -38,7 +38,7 @@ documentation {
     F{{statusCode}} HTTP status code to be sent to the caller
     F{{httpActionErr}} Errors which occurred at each endpoint during the failover
 }
-public type FailoverActionError {
+public type FailoverActionError record {
     string message,
     error? cause,
     int statusCode,
@@ -54,7 +54,7 @@ documentation {
     F{{failoverCodesIndex}} An indexed array of HTTP response status codes for which the failover mechanism triggers
     F{{failoverInterval}} Failover delay interval in milliseconds
 }
-public type FailoverInferredConfig {
+public type FailoverInferredConfig record {
     CallerActions[] failoverClientsArray,
     boolean[] failoverCodesIndex,
     int failoverInterval,

--- a/stdlib/ballerina-http/src/main/ballerina/http/resiliency/http_circuit_breaker.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/resiliency/http_circuit_breaker.bal
@@ -58,7 +58,7 @@ documentation {
     F{{totalBuckets}} The discrete time buckets into which the time window is divided
     F{{lastUsedBucketId}} ID of the last bucket used in Circuit Breaker calculations
 }
-public type CircuitHealth {
+public type CircuitHealth record {
    time:Time startTime,
    int requestCount,
    int errorCount,
@@ -78,7 +78,7 @@ documentation {
                          the upstream service
     F{{statusCodes}} Array of HTTP response status codes which are considered as failures
 }
-public type CircuitBreakerConfig {
+public type CircuitBreakerConfig record {
     RollingWindow rollingWindow,
     float failureThreshold,
     int resetTimeMillis,
@@ -91,7 +91,7 @@ documentation {
     F{{timeWindowMillis}} Time period in milliseconds for which the failure threshold is calculated
     F{{bucketSizeMillis}} The granularity at which the time window slides. This is measured in milliseconds.
 }
-public type RollingWindow {
+public type RollingWindow record {
     int timeWindowMillis = 60000,
     int bucketSizeMillis = 10000,
 };
@@ -102,7 +102,7 @@ documentation {
     F{{successCount}} Number of successful requests during the sub-window time frame
     F{{failureCount}} Number of failed requests during the sub-window time frame
 }
-public type Bucket {
+public type Bucket record {
     int successCount,
     int failureCount,
 };
@@ -118,7 +118,7 @@ documentation {
     F{{noOfBuckets}} Number of buckets derived from the `RollingWindow`
     F{{rollingWindow}} `RollingWindow` options provided in the `CircuitBreakerConfig`
 }
-public type CircuitBreakerInferredConfig {
+public type CircuitBreakerInferredConfig record {
    float failureThreshold,
    int resetTimeMillis,
    boolean[] statusCodes,

--- a/stdlib/ballerina-http/src/main/ballerina/http/resiliency/http_load_balancer.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/resiliency/http_load_balancer.bal
@@ -211,7 +211,7 @@ documentation {
     F{{statusCode}} HTTP status code of the LoadBalanceActionError
     F{{httpActionErr}} Array of errors occurred at each endpoint
 }
-public type LoadBalanceActionError {
+public type LoadBalanceActionError record {
     string message,
     error? cause,
     int statusCode,

--- a/stdlib/ballerina-http/src/main/ballerina/http/resiliency/load_balance_client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/resiliency/load_balance_client_endpoint.bal
@@ -68,7 +68,7 @@ documentation {
     F{{algorithm}} The algorithm to be used for load balancing. The HTTP package provides 'roundRobin()' by default
     F{{failover}} Configuration for load balancer whether to fail over in case of a failure
 }
-public type LoadBalanceClientEndpointConfiguration {
+public type LoadBalanceClientEndpointConfiguration record {
     CircuitBreakerConfig? circuitBreaker,
     int timeoutMillis = 60000,
     string httpVersion = "1.1",

--- a/stdlib/ballerina-http/src/main/ballerina/http/secure_listener.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/secure_listener.bal
@@ -82,7 +82,7 @@ documentation {
     F{{filters}} Filters to be applied to the request before being dispatched to the actual `resource`
     F{{authProviders}} The array of authentication providers which are used to authenticate the users
 }
-public type SecureEndpointConfiguration {
+public type SecureEndpointConfiguration record {
     string host,
     int port = 9090,
     KeepAlive keepAlive = KEEPALIVE_AUTO,
@@ -111,7 +111,7 @@ documentation {
     F{{signingAlg}} The signing algorithm which is used to sign the JWT token
     F{{propagateToken}} `true` if propagating authentication info as JWT
 }
-public type AuthProvider {
+public type AuthProvider record {
     string scheme,
     string id,
     string authStoreProvider,

--- a/stdlib/ballerina-http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/service_endpoint.bal
@@ -80,7 +80,7 @@ documentation {
     F{{host}} The remote host name/IP
     F{{port}} The remote port
 }
-public type Remote {
+public type Remote record {
     @readonly string host;
     @readonly int port;
 };
@@ -91,7 +91,7 @@ documentation {
     F{{host}} The local host name/IP
     F{{port}} The local port
 }
-public type Local {
+public type Local record {
     @readonly string host;
     @readonly int port;
 };
@@ -106,7 +106,7 @@ documentation {
     F{{maxEntityBodySize}} Maximum allowed size for the entity body. Exceeding this limit will result in a
                            `413 - Payload Too Large` response.
 }
-public type RequestLimits {
+public type RequestLimits record {
     int maxUriLength = -1;
     int maxHeaderSize = -1;
     int maxEntityBodySize = -1;
@@ -126,7 +126,7 @@ documentation {
     F{{filters}} If any pre-processing needs to be done to the request before dispatching the request to the
                  resource, filters can applied
 }
-public type ServiceEndpointConfiguration {
+public type ServiceEndpointConfiguration record {
     string host,
     int port,
     KeepAlive keepAlive = KEEPALIVE_AUTO,
@@ -149,7 +149,7 @@ documentation {
     F{{shareSession}} Enable/disable new SSL session creation
     F{{ocspStapling}} Enable/disable OCSP stapling
 }
-public type ServiceSecureSocket {
+public type ServiceSecureSocket record {
     TrustStore? trustStore,
     KeyStore? keyStore,
     Protocols? protocol,

--- a/stdlib/ballerina-http/src/main/ballerina/http/websocket/websocket_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/websocket/websocket_client.bal
@@ -87,7 +87,7 @@ documentation {
  true if the client is ready to recieve messages as soon as the connection is established. This is true by default. If changed to false the function ready() of the
 `WebSocketClient`needs to be called once to start receiving messages.
 }
-public type WebSocketClientEndpointConfig {
+public type WebSocketClientEndpointConfig record {
     string url,
     typedesc? callbackService,
     string[] subProtocols,

--- a/stdlib/ballerina-http/src/main/ballerina/swagger/annotation.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/swagger/annotation.bal
@@ -27,7 +27,7 @@ documentation {
     F{{tags}} A list of tags used by the specification with additional metadata
     F{{security}} Security requirements for this service
 }
-public type ServiceInformation {
+public type ServiceInformation record {
     string title,
     string serviceVersion,
     string description,
@@ -46,7 +46,7 @@ documentation {
     F{{email}} Contact email
     F{{url}} Contact web address/page
 }
-public type Contact {
+public type Contact record {
     string name,
     string email,
     string url,
@@ -58,7 +58,7 @@ documentation {
     F{{name}} License name
     F{{url}} License url
 }
-public type License {
+public type License record {
     string name,
     string url,
 };
@@ -69,7 +69,7 @@ documentation {
     F{{description}} Documentation description
     F{{url}} External documentation url
 }
-public type DocumentationInformation {
+public type DocumentationInformation record {
     string description,
     string url,
 };
@@ -81,7 +81,7 @@ documentation {
     F{{description}} Tag decription
     F{{externalDocs}} Optional documentation on the tag
 }
-public type Tag {
+public type Tag record {
     string name,
     string description,
     DocumentationInformation externalDocs,
@@ -93,7 +93,7 @@ documentation {
     F{{name}} Security scheme name
     F{{requirements}} Array of security requirements
 }
-public type SecurityRequirement {
+public type SecurityRequirement record {
     string name,
     string[] requirements,
 };
@@ -109,7 +109,7 @@ documentation {
     F{{allowEmptyValue}} Is an empty value allowed for this parameter. Valid only for query parameters
     F{{schema}} Parameter data type
 }
-public type ParameterInformation {
+public type ParameterInformation record {
     string inInfo,
     string name,
     string description,
@@ -126,7 +126,7 @@ documentation {
     F{{isArray}} Is this an array type schema
     F{{ref}} Schema reference if this schema definition is a reference type definition
 }
-public type Schema {
+public type Schema record {
     string format,
     boolean isArray,
     string ref,
@@ -141,7 +141,7 @@ documentation {
     F{{externalDocs}} Additional documentation for this operation
     F{{parameters}} A list of parameters that are applicable for this operation
 }
-public type ResourceInformation {
+public type ResourceInformation record {
     string[] tags,
     string summary,
     string description,
@@ -158,7 +158,7 @@ documentation {
     F{{headers}} Response headers
     F{{examples}} Examples for this response
 }
-public type Response {
+public type Response record {
     string code,
     string description,
     string response,
@@ -173,7 +173,7 @@ documentation {
     F{{discontinued}} Is this header deprecated
     F{{description}} Header description
 }
-public type Header {
+public type Header record {
     boolean required,
     boolean discontinued,
     string description,
@@ -187,7 +187,7 @@ documentation {
     F{{value}} Any example value
     F{{externalValue}} A URL that points to the literal example
 }
-public type Example {
+public type Example record {
     string summary,
     string description,
     any value,
@@ -204,7 +204,7 @@ documentation {
     F{{schema}} The schema defining the type used for the request body
     F{{encoding}} Encoding and content type details
 }
-public type requestBody {
+public type requestBody record {
     string description,
     boolean required,
     string example,
@@ -222,7 +222,7 @@ documentation {
     F{{explode}} Should property values of array or object generate separate parameters for each value of the array
     F{{allowReserved}} Determines whether the parameter value SHOULD allow reserved characters
 }
-public type Encoding {
+public type Encoding record {
     ParameterInformation[] headers,
     string contentType,
     string style,
@@ -235,7 +235,7 @@ documentation {
 
     F{{generate}} generates client code if set to true
 }
-public type ClientInformation {
+public type ClientInformation record {
     boolean generate = true,
 };
 

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/connection.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/connection.bal
@@ -48,7 +48,7 @@ documentation { Configurations related to a JMS connection
     F{{connectionFactoryName}} JMS connection factory to be used in creating JMS connections
     F{{properties}} Additional properties use in initializing the initial context
 }
-public type ConnectionConfiguration {
+public type ConnectionConfiguration record {
     string initialContextFactory = "wso2mbInitialContextFactory";
     string providerUrl = "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'";
     string connectionFactoryName = "ConnectionFactory";

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/consumer.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/consumer.bal
@@ -87,7 +87,7 @@ documentation { Configurations related to a JMS consumer object
     F{{session}} JMS session used to create the consumer
     F{{identifier}} Unique identifier of the consumer
 }
-public type ConsumerEndpointConfiguration {
+public type ConsumerEndpointConfiguration record {
     Session? session;
     string identifier;
 };

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/durable_topic_subscriber.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/durable_topic_subscriber.bal
@@ -80,7 +80,7 @@ documentation { Configurations related to the durable topic subscriber endpoint
     F{{messageSelector}} JMS selector statement
     F{{identifier}} unique identifier for the subscription
 }
-public type DurableTopicSubscriberEndpointConfiguration {
+public type DurableTopicSubscriberEndpointConfiguration record {
     Session? session;
     string topicPattern;
     string messageSelector;

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/queue_receiver.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/queue_receiver.bal
@@ -80,7 +80,7 @@ documentation { Configurations related to the QueueReceiver endpoint
     F{{messageSelector}} JMS selector statement
     F{{identifier}} unique identifier for the subscription
 }
-public type QueueReceiverEndpointConfiguration {
+public type QueueReceiverEndpointConfiguration record {
     Session? session;
     string queueName;
     string messageSelector;

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/queue_sender.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/queue_sender.bal
@@ -74,7 +74,7 @@ documentation { Configurations related to a QueueSender object
     F{{session}} JMS session object used to create the consumer
     F{{queueName}} name of the target queue
 }
-public type QueueSenderEndpointConfiguration {
+public type QueueSenderEndpointConfiguration record {
     Session? session;
     string queueName;
 };

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/session.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/session.bal
@@ -56,6 +56,6 @@ documentation { Configurations related to a JMS session
     F{{acknowledgementMode}}  specifies the session mode that will be used. Legal values are "AUTO_ACKNOWLEDGE",
     "CLIENT_ACKNOWLEDGE", "SESSION_TRANSACTED" and "DUPS_OK_ACKNOWLEDGE"
 }
-public type SessionConfiguration {
+public type SessionConfiguration record {
     string acknowledgementMode = "AUTO_ACKNOWLEDGE";
 };

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/simple_durable_topic_subscriber.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/simple_durable_topic_subscriber.bal
@@ -130,7 +130,7 @@ documentation { Configurations of the simple durable topic subscriber endpoint
     F{{messageSelector}} JMS selector statement
     F{{topicPattern}} Name or the pattern of the topic subscription
 }
-public type SimpleDurableTopicSubscriberEndpointConfiguration {
+public type SimpleDurableTopicSubscriberEndpointConfiguration record {
     string initialContextFactory = "bmbInitialContextFactory";
     string providerUrl = "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'";
     string connectionFactoryName = "ConnectionFactory";

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/simple_queue_receiver.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/simple_queue_receiver.bal
@@ -125,7 +125,7 @@ documentation { Configurations related to the SimpleQueueReceiver endpoint
     F{{properties}} Additional properties use in initializing the initial context
     F{{queueName}} Name of the target queue
 }
-public type SimpleQueueReceiverEndpointConfiguration {
+public type SimpleQueueReceiverEndpointConfiguration record {
     string initialContextFactory = "bmbInitialContextFactory";
     string providerUrl = "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'";
     string connectionFactoryName = "ConnectionFactory";

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/simple_queue_sender.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/simple_queue_sender.bal
@@ -113,7 +113,7 @@ documentation { Configurations related to the SimpleQueueSender endpoint
     F{{properties}} Additional properties use in initializing the initial context
     F{{queueName}} Name of the target queue
 }
-public type SimpleQueueSenderEndpointConfiguration {
+public type SimpleQueueSenderEndpointConfiguration record {
     string initialContextFactory = "bmbInitialContextFactory";
     string providerUrl = "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'";
     string connectionFactoryName = "ConnectionFactory";

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/simple_topic_publisher.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/simple_topic_publisher.bal
@@ -121,7 +121,7 @@ documentation { Configuration related to simple topic publisher endpoint
     F{{properties}} JMS message properties
     F{{topicPattern}} name of the target topic
 }
-public type SimpleTopicPublisherEndpointConfiguration {
+public type SimpleTopicPublisherEndpointConfiguration record {
     string initialContextFactory = "bmbInitialContextFactory";
     string providerUrl = "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'";
     string connectionFactoryName = "ConnectionFactory";

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/simple_topic_subscriber.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/simple_topic_subscriber.bal
@@ -132,7 +132,7 @@ documentation { Configuration related to simple topic subscriber endpoint
     F{{properties}} JMS message properties
     F{{topicPattern}} Topic name pattern
 }
-public type SimpleTopicSubscriberEndpointConfiguration {
+public type SimpleTopicSubscriberEndpointConfiguration record {
     string initialContextFactory = "bmbInitialContextFactory";
     string providerUrl = "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'";
     string connectionFactoryName = "ConnectionFactory";

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/topic_publisher.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/topic_publisher.bal
@@ -72,7 +72,7 @@ documentation { Configuration related to the topic publisher endpoint
     F{{session}} Session object used to create topic publisher
     F{{topicPattern}} Topic name pattern
 }
-public type TopicPublisherEndpointConfiguration {
+public type TopicPublisherEndpointConfiguration record {
     Session? session;
     string topicPattern;
 };

--- a/stdlib/ballerina-jms/src/main/ballerina/jms/topic_subscriber.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/jms/topic_subscriber.bal
@@ -77,7 +77,7 @@ documentation { Configuration related to topic subscriber endpoint
     F{{messageSelector}} Message selector condition to filter messages
     F{{identifier}} Identifier of topic subscriber endpoint
 }
-public type TopicSubscriberEndpointConfiguration {
+public type TopicSubscriberEndpointConfiguration record {
     Session? session;
     string topicPattern;
     string messageSelector;

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/common.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/common.bal
@@ -23,7 +23,7 @@ documentation { Configurations related to Ballerina message broker URL
     F{{virtualHost}} target virtualhost
     F{{secureSocket}} TLS configurations
 }
-public type BrokerURLConfig {
+public type BrokerURLConfig record {
     string username = "admin",
     string password = "admin",
     string host = "localhost",
@@ -38,7 +38,7 @@ documentation { Configurations related to TLS
     F{{keyStore}} Keystore configuration
     F{{sslCertAlias}} name of the ssl cert alias
 }
-public type ServiceSecureSocket {
+public type ServiceSecureSocket record {
     Store? trustStore,
     Store? keyStore,
     string sslCertAlias,
@@ -48,7 +48,7 @@ documentation {
     F{{path}} file path to key store
     F{{password}} password used to protect the key store
 }
-public type Store {
+public type Store record {
     string path,
     string password,
 };

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/consumer.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/consumer.bal
@@ -59,7 +59,7 @@ public type ConsumerActions object {
     }
 };
 
-public type ConsumerEndpointConfiguration {
+public type ConsumerEndpointConfiguration record {
     jms:Session? session;
     string identifier;
 };

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/simple_durable_topic_subscriber.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/simple_durable_topic_subscriber.bal
@@ -106,7 +106,7 @@ documentation { Configuration related to simple topic subscriber endpoint
     F{{properties}} JMS message properties
     F{{topicPattern}} Topic name pattern
 }
-public type SimpleDurableTopicSubscriberEndpointConfiguration {
+public type SimpleDurableTopicSubscriberEndpointConfiguration record {
     string username = "admin",
     string password = "admin",
     string host = "localhost",

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/simple_queue_receiver.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/simple_queue_receiver.bal
@@ -108,7 +108,7 @@ documentation { Configurations related to SimpleQueueReceiver endpoint
     F{{queueName}} Name of the target queue
 
 }
-public type SimpleQueueListenerEndpointConfiguration {
+public type SimpleQueueListenerEndpointConfiguration record {
     string username = "admin",
     string password = "admin",
     string host = "localhost",

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/simple_queue_sender.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/simple_queue_sender.bal
@@ -130,7 +130,7 @@ documentation { Configurations related to SimpleQueueSender endpoint
     F{{properties}} Additional properties use in initializing the initial context
     F{{queueName}} Name of the target queue
 }
-public type SimpleQueueSenderEndpointConfiguration {
+public type SimpleQueueSenderEndpointConfiguration record {
     string username = "admin",
     string password = "admin",
     string host = "localhost",

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/simple_topic_publisher.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/simple_topic_publisher.bal
@@ -131,7 +131,7 @@ documentation { Configurations related to SimpleQueueSender endpoint
     F{{properties}} Additional properties use in initializing the initial context
     F{{topicPattern}} name of the target topic
 }
-public type SimpleTopicPublisherEndpointConfiguration {
+public type SimpleTopicPublisherEndpointConfiguration record {
     string username = "admin",
     string password = "admin",
     string host = "localhost",

--- a/stdlib/ballerina-jms/src/main/ballerina/mb/simple_topic_subscriber.bal
+++ b/stdlib/ballerina-jms/src/main/ballerina/mb/simple_topic_subscriber.bal
@@ -103,7 +103,7 @@ documentation { Configuration related to simple topic subscriber endpoint
     F{{properties}} JMS message properties
     F{{topicPattern}} Topic name pattern
 }
-public type SimpleTopicSubscriberEndpointConfiguration {
+public type SimpleTopicSubscriberEndpointConfiguration record {
     string username = "admin",
     string password = "admin",
     string host = "localhost",

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/annotation.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/annotation.bal
@@ -37,7 +37,7 @@ documentation {
     F{{followRedirects}} The HTTP redirect related configuration specifying if subscription requests should be sent
                             to redirected hubs/topics
 }
-public type SubscriberServiceConfiguration {
+public type SubscriberServiceConfiguration record {
     Listener[] endpoints,
     string path,
     boolean subscribeOnStartUp,

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/commons.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/commons.bal
@@ -446,7 +446,7 @@ documentation {
     F{{leaseSeconds}} The lease period for which the subscription is expected to be active
     F{{secret}} The secret to be used for authenticated content distribution with this subscription
 }
-public type SubscriptionChangeRequest {
+public type SubscriptionChangeRequest record {
     string topic,
     string callback,
     int leaseSeconds,
@@ -460,7 +460,7 @@ documentation {
     F{{topic}} The topic for which the subscription/unsubscription was successful
     F{{response}} The response from the hub to the subscription/unsubscription requests
 }
-public type SubscriptionChangeResponse {
+public type SubscriptionChangeResponse record {
     string hub,
     string topic,
     http:Response response,
@@ -627,7 +627,7 @@ documentation {
     F{{leaseSeconds}} The lease second period specified for the particular subscription
     F{{createdAt}} The time at which the subscription was created
 }
-type SubscriptionDetails {
+type SubscriptionDetails record {
     string topic,
     string callback,
     string secret,
@@ -653,7 +653,7 @@ documentation {
     F{{payload}} The payload to be sent
     F{{contentType}} The content-type of the payload
 }
-type WebSubContent {
+type WebSubContent record {
     string|xml|json|blob|io:ByteChannel payload,
     string contentType,
 };

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/hub_client_endpoint.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/hub_client_endpoint.bal
@@ -74,7 +74,7 @@ documentation {
     F{{auth}} Authentication mechanism for the underlying HTTP Client
     F{{followRedirects}} HTTP redirect related configuration
 }
-public type HubClientEndpointConfig {
+public type HubClientEndpointConfig record {
     string url,
     http:SecureSocket? clientSecureSocket,
     http:AuthConfig? auth,

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/hub_service.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/hub_service.bal
@@ -697,7 +697,7 @@ documentation {
     F{{topic}} The topic for which notification would happen
     F{{secret}} The secret if specified by the topic's publisher
 }
-type TopicRegistration {
+type TopicRegistration record {
     string topic,
     string secret,
 };

--- a/stdlib/ballerina-websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
+++ b/stdlib/ballerina-websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
@@ -205,7 +205,7 @@ documentation {
     F{{topicPayloadKeys}} The payload keys to consider if required with dispatching for custom services
     F{{topicResourceMap}} The mapping between topics and resources if required for custom services
 }
-public type SubscriberServiceEndpointConfiguration {
+public type SubscriberServiceEndpointConfiguration record {
     string host;
     int port;
     http:ServiceSecureSocket? httpServiceSecureSocket;

--- a/stdlib/transactions/src/main/ballerina/transactions/2pc_participant.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/2pc_participant.bal
@@ -21,7 +21,7 @@ documentation {
 
     F{{name}} - protocol name
 }
-type Protocol {
+type Protocol record {
     @readonly string name;
 };
 
@@ -30,7 +30,7 @@ documentation {
 
     F{{name}} - protocol name
 }
-type LocalProtocol {
+type LocalProtocol record {
     @readonly string name;
 };
 
@@ -41,7 +41,7 @@ documentation {
     F{{url}}  - protocol URL. This URL will have a value only if the participant is remote. If the participant is local,
                 the `protocolFn` will be called
 }
-public type RemoteProtocol {
+public type RemoteProtocol record {
     @readonly string name;
     @readonly string url;
 };

--- a/stdlib/transactions/src/main/ballerina/transactions/connector_initiator.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/connector_initiator.bal
@@ -16,10 +16,10 @@
 
 import ballerina/http;
 
-type InitiatorClientConfig {
+type InitiatorClientConfig record {
     string registerAtURL;
     int timeoutMillis;
-    {
+    record {
         int count;
         int interval;
     } retryConfig;

--- a/stdlib/transactions/src/main/ballerina/transactions/connector_participant_2pc.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/connector_participant_2pc.bal
@@ -16,10 +16,10 @@
 
 import ballerina/http;
 
-public type Participant2pcClientConfig {
+public type Participant2pcClientConfig record {
     string participantURL;
     int timeoutMillis;
-    {
+    record {
         int count;
         int interval;
     } retryConfig;

--- a/stdlib/transactions/src/main/ballerina/transactions/data.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/data.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type TransactionContext {
+public type TransactionContext record {
     @readonly string contextVersion = "1.0";
     @readonly string transactionId;
     @readonly int transactionBlockId;
@@ -22,13 +22,13 @@ public type TransactionContext {
     @readonly string registerAtURL;
 };
 
-type RegistrationRequest {
+type RegistrationRequest record {
     string transactionId;
     string participantId;
     RemoteProtocol[] participantProtocols;
 };
 
-type RegistrationResponse {
+type RegistrationResponse record {
     string transactionId;
     RemoteProtocol[] coordinatorProtocols;
 };
@@ -42,23 +42,23 @@ function toProtocolArray(RemoteProtocol[] remoteProtocols) returns Protocol[] {
     return protocols;
 }
 
-public type RequestError {
+public type RequestError record {
     string errorMessage;
 };
 
-public type PrepareRequest {
+public type PrepareRequest record {
     string transactionId;
 };
 
-public type PrepareResponse {
+public type PrepareResponse record {
     string message;
 };
 
-public type NotifyRequest {
+public type NotifyRequest record {
     string transactionId;
     string message;
 };
 
-public type NotifyResponse {
+public type NotifyResponse record {
     string message;
 };

--- a/tests/ballerina-test-integration/src/test/resources/filter/multiple-filters-attribute-share-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/multiple-filters-attribute-share-test.bal
@@ -99,7 +99,7 @@ service<http:Service> echo bind echoEP {
     }
 }
 
-public type FilterDto {
+public type FilterDto record {
     boolean authenticated;
     string username;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/advanced_type_client.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/advanced_type_client.bal
@@ -331,25 +331,25 @@ public type HelloWorldClient object {
 };
 
 
-type Person {
+type Person record {
     string name;
     Address address;
 
 };
 
-type Address {
+type Address record {
     int postalCode;
     string state;
     string country;
 
 };
 
-type StockRequest {
+type StockRequest record {
     string name;
 
 };
 
-type StockQuote {
+type StockQuote record {
     string symbol;
     string name;
     float last;
@@ -358,16 +358,16 @@ type StockQuote {
 
 };
 
-type StockQuotes {
+type StockQuotes record {
     StockQuote[] stock;
 };
 
-type StockNames {
+type StockNames record {
     string[] names;
 
 };
 
-type Empty {
+type Empty record {
 
 };
 

--- a/tests/ballerina-test-integration/src/test/resources/grpc/advanced_type_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/advanced_type_service.bal
@@ -80,18 +80,18 @@ service HelloWorld bind ep {
     }
 }
 
-type Person {
+type Person record {
     string name;
     Address address;
 };
 
-type Address {
+type Address record {
     int postalCode;
     string state;
     string country;
 };
 
-type StockQuote {
+type StockQuote record {
     string symbol;
     string name;
     float last;
@@ -99,14 +99,14 @@ type StockQuote {
     float high;
 };
 
-type StockRequest {
+type StockRequest record {
     string name;
 };
 
-type StockQuotes {
+type StockQuotes record {
     StockQuote[] stock;
 };
 
-type StockNames {
+type StockNames record {
     string[] names;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/array_field_type_client.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/array_field_type_client.bal
@@ -493,37 +493,37 @@ public type HelloWorldClient object {
 };
 
 
-type TestInt {
+type TestInt record {
     int[] values;
 
 };
 
-type TestString {
+type TestString record {
     string[] values;
 
 };
 
-type TestFloat {
+type TestFloat record {
     float[] values;
 
 };
 
-type TestBoolean {
+type TestBoolean record {
     boolean[] values;
 
 };
 
-type TestStruct {
+type TestStruct record {
     A[] values;
 
 };
 
-type A {
+type A record {
     string name;
 
 };
 
-type Empty {
+type Empty record {
 
 };
 

--- a/tests/ballerina-test-integration/src/test/resources/grpc/array_field_type_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/array_field_type_service.bal
@@ -126,26 +126,26 @@ service HelloWorld bind ep {
     }
 }
 
-type TestInt {
+type TestInt record {
     int[] values;
 };
 
-type TestString {
+type TestString record {
     string[] values;
 };
 
-type TestFloat {
+type TestFloat record {
     float[] values;
 };
 
-type TestBoolean {
+type TestBoolean record {
     boolean[] values;
 };
 
-type TestStruct {
+type TestStruct record {
     A[] values;
 };
 
-type A {
+type A record {
     string name;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/bidirectional_streaming_client.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/bidirectional_streaming_client.bal
@@ -115,7 +115,7 @@ public type ChatClient object {
     }
 };
 
-type ChatMessage {
+type ChatMessage record {
     string name;
     string message;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/bidirectional_streaming_service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/bidirectional_streaming_service.bal
@@ -71,7 +71,7 @@ service<grpc:Listener> Chat bind ep {
     }
 }
 
-type ChatMessage {
+type ChatMessage record {
     string name;
     string message;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/unary1_blocking_client.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/unary1_blocking_client.bal
@@ -290,12 +290,12 @@ map descriptorMap =
 
 };
 
-type Request {
+type Request record {
     string name;
     string message;
     int age;
 };
 
-type Response {
+type Response record {
     string resp;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/unary1_nonblocking_client.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/unary1_nonblocking_client.bal
@@ -259,12 +259,12 @@ map descriptorMap =
 
 };
 
-type Request {
+type Request record {
     string name;
     string message;
     int age;
 };
 
-type Response {
+type Response record {
     string resp;
 };

--- a/tests/ballerina-test-integration/src/test/resources/grpc/unary_server1.bal
+++ b/tests/ballerina-test-integration/src/test/resources/grpc/unary_server1.bal
@@ -79,12 +79,12 @@ service HelloWorld bind ep {
     }
 }
 
-type Request {
+type Request record {
     string name;
     string message;
     int age;
 };
 
-type Response {
+type Response record {
     string resp;
 };

--- a/tests/ballerina-test-integration/src/test/resources/streaming/streams-within-services.bal
+++ b/tests/ballerina-test-integration/src/test/resources/streaming/streams-within-services.bal
@@ -4,11 +4,11 @@ import ballerina/io;
 
 string alertedHostName = "NotAssigned";
 
-type ClientRequest {
+type ClientRequest record {
     string host;
 };
 
-type RequestCount {
+type RequestCount record {
     string host;
     int count;
 };

--- a/tests/ballerina-test-integration/src/test/resources/transaction/participant2.bal
+++ b/tests/ballerina-test-integration/src/test/resources/transaction/participant2.bal
@@ -116,7 +116,7 @@ service<http:Service> participant2 bind participant2EP {
     }
 }
 
-type Registration {
+type Registration record {
     string REGISTRATIONID;
 };
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
@@ -62,8 +62,9 @@ public class InvalidSyntaxParserTest {
     @Test
     public void testServiceWithoutResourceName() {
         CompileResult result = BCompileUtil.compile("test-src/parser/service-without-resource-name-negative.bal");
-        BAssertUtil.validateError(result, 0, "invalid token 'endpoint'", 6, 6);
-        BAssertUtil.validateError(result, 3, "extraneous input ';'", 8, 7);
+        BAssertUtil.validateError(result, 0, "invalid token 'endpoint'", 6, 4);
+        BAssertUtil.validateError(result, 1, "mismatched input ','. expecting ';'", 6, 19);
+        BAssertUtil.validateError(result, 2, "mismatched input ')'. expecting ';'", 6, 41);
     }
 
     @Test
@@ -80,8 +81,7 @@ public class InvalidSyntaxParserTest {
     @Test
     public void testServiceWithoutResourceParams() {
         CompileResult result = BCompileUtil.compile("test-src/parser/service-without-resource-params-negative.bal");
-        BAssertUtil.validateError(result, 0, "missing token '(' before '{'", 9, 11);
-        BAssertUtil.validateError(result, 1, "extraneous input 'return'", 11, 9);
+        BAssertUtil.validateError(result, 0, "mismatched input '{'. expecting '('", 9, 11);
     }
 
     @Test

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarErrorTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarErrorTest.java
@@ -32,6 +32,6 @@ public class GlobalVarErrorTest {
     public void testStructFieldWithChildPackagePaths() {
         CompileResult resultNegative = BCompileUtil.compile(
                 "test-src/statements/variabledef/global-var-function-negative.bal");
-        BAssertUtil.validateError(resultNegative, 6, "extraneous input ':'", 7, 20);
+        BAssertUtil.validateError(resultNegative, 0, "extraneous input ':'", 7, 20);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/access/private_access_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/access/private_access_negative.bal
@@ -4,7 +4,7 @@ type Foo object {
     }
 };
 
-type Bar {
+type Bar record {
     string s;
 };
 
@@ -113,23 +113,23 @@ function test4() returns string {
     return m.s;
 }
 
-type FooRecord {
+type FooRecord record {
     string s;
     BarRecord br;
 };
 
-type BarRecord {
+type BarRecord record {
     string s;
 };
 
-{
+record {
      string s;
      Baz z = 1;
      Foo foo1;
      BarRecord br;
 } anonRecord;
 
-public type ParentRecord {
+public type ParentRecord record {
     int i;
     ChildFoo c;
     ChildRecord r;
@@ -137,12 +137,12 @@ public type ParentRecord {
     Baz z = 1;
 };
 
-type ChildRecord {
+type ChildRecord record {
     string name;
 };
 
 function test5() returns string {
-    {
+    record {
          string s;
          Baz z = 1;
          Foo foo1;
@@ -152,7 +152,7 @@ function test5() returns string {
     return m.s;
 }
 
-public function test6({
+public function test6(record {
                           string s;
                           Baz z = 1;
                           Foo foo1;
@@ -161,13 +161,13 @@ public function test6({
     return "K";
 }
 
-public function test7() returns {
+public function test7() returns record {
                                     string s;
                                     Baz z = 1;
                                     Foo foo1;
                                     BarRecord br;
                                 }{
-    {
+    record {
           string s;
           Baz z = 1;
           Foo foo1;
@@ -183,7 +183,7 @@ type FooTypeObj object {
     }
 };
 
-type BarTypeRecord {
+type BarTypeRecord record {
     string s;
 };
 
@@ -202,7 +202,7 @@ public type FooTypePublicObj object {
     }
 };
 
-public type BarTypePublicRecord {
+public type BarTypePublicRecord record {
     string s;
 };
 
@@ -214,7 +214,7 @@ public type TypeE BarTypePublicRecord;
 
 public type TypeF BazTypePublicFinite;
 
-public type Person {
+public type Person record {
    string name;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/balo/test_projects/finite_type_project/foo/finite_type_definitions.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/balo/test_projects/finite_type_project/foo/finite_type_definitions.bal
@@ -8,7 +8,7 @@ public type Int int;
 
 public type POrInt Person|int;
 
-public type Person {
+public type Person record {
    string name;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/balo/test_projects/test_project/foo/different_function_signatures.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/balo/test_projects/test_project/foo/different_function_signatures.bal
@@ -52,7 +52,7 @@ public function funcWithNilDefaultParamExpr_1(string? s = null) returns string? 
     return s;
 }
 
-public type Student {
+public type Student record {
     int a;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/balo/test_projects/test_project/foo/object_definitions.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/balo/test_projects/test_project/foo/object_definitions.bal
@@ -224,7 +224,7 @@ public type Dog object {
     }
 };
 
-public type Lion {
+public type Lion record {
     int barVal,
     string name,
     Tiger? person,

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/h2/h2_actions_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/h2/h2_actions_test.bal
@@ -2,7 +2,7 @@ import ballerina/h2;
 import ballerina/sql;
 import ballerina/io;
 
-public type Customer {
+public type Customer record {
     int customerId,
     string name,
     float creditLimit,

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_negative_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_negative_test.bal
@@ -2,16 +2,16 @@ import ballerina/sql;
 import ballerina/jdbc;
 import ballerina/io;
 
-type ResultCustomers {
+type ResultCustomers record {
     string FIRSTNAME,
 };
 
-type Person {
+type Person record {
     int id,
     string name,
 };
 
-type ResultCustomers2 {
+type ResultCustomers2 record {
     string FIRSTNAME,
     string LASTNAME,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_actions_test.bal
@@ -3,35 +3,35 @@ import ballerina/jdbc;
 import ballerina/time;
 import ballerina/io;
 
-type ResultCustomers {
+type ResultCustomers record {
     string FIRSTNAME,
 };
 
-type ResultCustomers2 {
+type ResultCustomers2 record {
     string FIRSTNAME,
     string LASTNAME,
 };
 
-type ResultIntType {
+type ResultIntType record {
     int INT_TYPE,
 };
 
-type ResultBlob {
+type ResultBlob record {
     blob BLOB_TYPE,
 };
 
-type ResultDataType {
+type ResultDataType record {
     int INT_TYPE,
     int LONG_TYPE,
     float FLOAT_TYPE,
     float DOUBLE_TYPE,
 };
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 
-type ResultArrayType {
+type ResultArrayType record {
     int[] INT_ARRAY,
     int[] LONG_ARRAY,
     float[] DOUBLE_ARRAY,
@@ -40,14 +40,14 @@ type ResultArrayType {
     float[] FLOAT_ARRAY,
 };
 
-type ResultDates {
+type ResultDates record {
     string DATE_TYPE,
     string TIME_TYPE,
     string TIMESTAMP_TYPE,
     string DATETIME_TYPE,
 };
 
-type ResultBalTypes {
+type ResultBalTypes record {
     int INT_TYPE,
     int LONG_TYPE,
     float FLOAT_TYPE,
@@ -59,7 +59,7 @@ type ResultBalTypes {
     float REAL_TYPE,
 };
 
-type Employee {
+type Employee record {
     int id,
     string name,
     string address,

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_mirror_table_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql_mirror_table_test.bal
@@ -1,7 +1,7 @@
 import ballerina/sql;
 import ballerina/jdbc;
 
-type Employee {
+type Employee record {
     int id,
     string name,
     string address,

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/mirror_table_transaction_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/mirror_table_transaction_test.bal
@@ -2,11 +2,11 @@ import ballerina/jdbc;
 import ballerina/io;
 import ballerina/runtime;
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 
-type CustomersTrx {
+type CustomersTrx record {
     string firstName,
     string lastName,
     int registrationID,
@@ -14,7 +14,7 @@ type CustomersTrx {
     string country,
 };
 
-type CustomersTrx2 {
+type CustomersTrx2 record {
     int customerId,
     string firstName,
     string lastName,

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/mirror_table_xa_transaction_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/mirror_table_xa_transaction_test.bal
@@ -1,17 +1,17 @@
 import ballerina/jdbc;
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 
-type CustomersTrx {
+type CustomersTrx record {
     int customerId,
     string name,
     float creditLimit,
     string country,
 };
 
-type SalaryTrx {
+type SalaryTrx record {
     int id,
     float value,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/sql_transaction_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/sql_transaction_test.bal
@@ -2,7 +2,7 @@ import ballerina/jdbc;
 import ballerina/io;
 import ballerina/runtime;
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/sql_xa_transaction_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/transaction/sql_xa_transaction_test.bal
@@ -1,7 +1,7 @@
 import ballerina/jdbc;
 import ballerina/h2;
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/debugger/test_object_and_match.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/debugger/test_object_and_match.bal
@@ -68,7 +68,7 @@ function Person::attachInterface(int add) returns int {
     return count;
 }
 
-type Foo {
+type Foo record {
     int count,
     string last,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/debugger/try-catch-finally.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/debugger/try-catch-finally.bal
@@ -1,15 +1,15 @@
-public type testError {
+public type testError record {
     string message;
     error? cause;
     string code;
 };
 
-public type testDataError {
+public type testDataError record {
     string message;
     error? cause;
     string data;
 };
-public type testInputError {
+public type testInputError record {
     string message;
     error? cause;
     string input;

--- a/tests/ballerina-test/src/test/resources/test-src/documentation/deprecated_transformer.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/documentation/deprecated_transformer.bal
@@ -1,11 +1,11 @@
-type Person {
+type Person record {
     string firstName;
     string lastName;
     int age;
     string city;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/documentation/multiple.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/documentation/multiple.bal
@@ -4,7 +4,7 @@ documentation { Documentation for Tst struct
 F{{a}} annotation `field a` documentation
 F{{b}} annotation `field b` documentation
 F{{c}} annotation `field c` documentation}
-type Tst {
+type Tst record {
     string a;
     string b;
     string c;
@@ -18,20 +18,20 @@ documentation { Documentation for Test struct
 F{{a}} struct `field a` documentation
 F{{b}} struct `field b` documentation
 F{{c}} struct `field c` documentation}
-type Test {
+type Test record {
     int a;
     int b;
     int c;
 };
 
-type Person {
+type Person record {
     string firstName;
     string lastName;
     int age;
     string city;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/documentation/negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/documentation/negative.bal
@@ -5,7 +5,7 @@ F{{a}} annotation `field a` documentation
 F{{a}} annotation `field a` documentation
 F{{b}} annotation `field b` documentation
 F{{c}} annotation `field c` documentation}
-type Tst {
+type Tst record {
     string a;
     string b;
     string cd;
@@ -22,7 +22,7 @@ F{{a}} struct `field a` documentation
 F{{a}} struct `field a` documentation
 F{{b}} struct `field b` documentation
 F{{c}} struct `field c` documentation}
-type Test {
+type Test record {
     int a;
     int b;
     int cdd;
@@ -63,14 +63,14 @@ public type File object {
 //    e.name = p.firstName;
 //}
 
-type Person {
+type Person record {
     string firstName;
     string lastName;
     int age;
     string city;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;
@@ -82,7 +82,7 @@ Test Connector
 F{{url}} url for endpoint
 F{{url}} url for endpoint
 P{{urls}} urls for endpoint}
-type TestConnector {
+type TestConnector record {
   string url;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/documentation/struct.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/documentation/struct.bal
@@ -2,7 +2,7 @@ documentation { Documentation for Test type
 F{{a}} type `field a` documentation
 F{{b}} type `field b` documentation
 F{{c}} type `field c` documentation}
-type Test {
+type Test record {
     int a;
     int b;
     int c;

--- a/tests/ballerina-test/src/test/resources/test-src/documentation/transformer.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/documentation/transformer.bal
@@ -1,11 +1,11 @@
-type Person {
+type Person record {
     string firstName;
     string lastName;
     int age;
     string city;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointInFunction.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointInFunction.bal
@@ -38,7 +38,7 @@ type DummyEndpoint object {
     }
 };
 
-public type DummyEndpointConfig {
+public type DummyEndpointConfig record {
     string conf1;
     boolean conf2;
     int conf3;

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointWithService.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointWithService.bal
@@ -30,7 +30,7 @@ type DummyEndpoint object {
     }
 };
 
-public type DummyEndpointConfig {
+public type DummyEndpointConfig record {
     string conf1;
     boolean conf2;
     int conf3;

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_action_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_action_negative.bal
@@ -1,6 +1,6 @@
 
 type DummyEndpoint object {
-    public function init ({} conf) {
+    public function init (record {} conf) {
     }
 
     public function getCallerActions () returns (DummyClient) {

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_action_positive.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_action_positive.bal
@@ -1,6 +1,6 @@
 
 type DummyEndpoint object {
-    public function init ({} conf) {
+    public function init (record {} conf) {
     }
 
     public function getCallerActions () returns (DummyClient) {

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint.bal
@@ -30,7 +30,7 @@ type DummyEndpoint object {
     }
 };
 
-public type DummyEndpointConfig {
+public type DummyEndpointConfig record {
     string conf1;
     boolean conf2;
     int conf3;

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint_negative.bal
@@ -30,7 +30,7 @@ type DummyEndpoint object {
     }
 };
 
-public type DummyEndpointConfig {
+public type DummyEndpointConfig record {
     string conf1;
     boolean conf2;
     int conf3;

--- a/tests/ballerina-test/src/test/resources/test-src/enums/enums.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/enums/enums.bal
@@ -25,7 +25,7 @@ function testEnumAsParameter(state st) returns (boolean) {
     }
 }
 
-type person {
+type person record {
         string name;
         int age;
         state st;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions.typecast.foo.bar/bar.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions.typecast.foo.bar/bar.bal
@@ -1,5 +1,5 @@
 
-public type Student {
+public type Student record {
     string name,
     int age,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/expressions.typecast.foo/cast-to-struct-in-different-pkg.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions.typecast.foo/cast-to-struct-in-different-pkg.bal
@@ -1,7 +1,7 @@
 
 import expressions.typecast.foo.bar;
 
-public type Person {
+public type Person record {
     string name,
     int age,
     Person? parent,

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_negative.bal
@@ -17,13 +17,13 @@ function testCheckedExprSemanticErrors2() {
     string line = check readLineError();
 }
 
-public type myerror {
+public type myerror record {
     string message;
     error? cause;
     int code;
 };
 
-public type customError {
+public type customError record {
     string message;
     error? cause;
     int code;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
@@ -48,7 +48,7 @@ function testSafeAssignOpInAssignmentStatement3 () returns (boolean|error) {
     return fos.status;
 }
 
-type FileOpenStatus {
+type FileOpenStatus record {
     boolean status = false;
 };
 
@@ -71,17 +71,17 @@ function testSafeAssignOpInAssignmentStatement6 () returns boolean {
     return statusFailure;
 }
 
-type person {
+type person record {
     string name;
 };
 
-public type myerror {
+public type myerror record {
     string message;
     error? cause;
     int code;
 };
 
-public type customError {
+public type customError record {
     string message;
     error? cause;
     int code;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/c.d/structs.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/c.d/structs.bal
@@ -1,7 +1,7 @@
 
 import e.f;
 
-public type Person {
+public type Person record {
     string name;
     int age;
     f:Address adrs;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/e.f/structs.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/e.f/structs.bal
@@ -1,5 +1,5 @@
 
-public type Address {
+public type Address record {
     string street;
     string city;
     string country;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string name;
     int age;
     Person? parent;
@@ -10,7 +10,7 @@ type Person {
     boolean alive;
 };
 
-type Student {
+type Student record {
     string name;
     int age;
 };
@@ -27,7 +27,7 @@ function testStructToStruct () returns (Student) {
     return s;
 }
 
-type Info {
+type Info record {
     blob infoBlob;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string name;
     int age;
     Person | () parent;
@@ -11,18 +11,18 @@ type Person {
     Person[]|() children;
 };
 
-type Person2 {
+type Person2 record {
     string name;
     int age;
 };
 
-type Person3 {
+type Person3 record {
     string name;
     int age;
     string gender;
 };
 
-type Student {
+type Student record {
     string name;
     int age;
 };
@@ -194,7 +194,7 @@ function testMapWithIncompatibleArrayToStruct () returns (Person) {
     return p;
 }
 
-type Employee {
+type Employee record {
     string name;
     int age;
     Person partner;
@@ -314,7 +314,7 @@ function testJsonArrayToStruct () returns (Person) {
     return p;
 }
 
-type Info {
+type Info record {
     map foo;
 };
 
@@ -368,12 +368,12 @@ function testIncompatibleJsonToBoolean () returns (boolean) {
     return value;
 }
 
-type Address {
+type Address record {
     string city;
     string country;
 };
 
-type AnyArray {
+type AnyArray record {
     any[] a;
 };
 
@@ -383,7 +383,7 @@ function testJsonToAnyArray () returns (AnyArray) {
     return value;
 }
 
-type IntArray {
+type IntArray record {
     int[] a;
 };
 
@@ -394,7 +394,7 @@ function testJsonToIntArray () returns (IntArray) {
 }
 
 
-type StringArray {
+type StringArray record {
     string[]? a;
 };
 
@@ -410,7 +410,7 @@ function testJsonIntArrayToStringArray () returns (StringArray) {
     return a;
 }
 
-type XmlArray {
+type XmlArray record {
     xml[] a;
 };
 
@@ -470,7 +470,7 @@ function testIncompatibleJsonToStructWithErrors () returns (Person | error) {
     return p;
 }
 
-type PersonA {
+type PersonA record {
     string name;
     int age;
 };
@@ -483,7 +483,7 @@ function JsonToStructWithErrors () returns (PersonA | error) {
     return pA;
 }
 
-type PhoneBook {
+type PhoneBook record {
     string[] names;
 };
 
@@ -493,13 +493,13 @@ function testStructWithStringArrayToJSON () returns (json) {
     return phonebookJson;
 }
 
-type person {
+type person record {
     string fname;
     string lname;
     int age;
 };
 
-type movie {
+type movie record {
     string title;
     int year;
     string released;
@@ -525,7 +525,7 @@ function testStructToMapWithRefTypeArray () returns (map, int) {
     return (m, writers[0].age);
 }
 
-type StructWithDefaults {
+type StructWithDefaults record {
     string s = "string value";
     int a = 45;
     float f = 5.3;
@@ -541,7 +541,7 @@ function testEmptyJSONtoStructWithDefaults () returns (StructWithDefaults | erro
     return testStruct;
 }
 
-type StructWithoutDefaults {
+type StructWithoutDefaults record {
     string s;
     int a;
     float f;
@@ -608,7 +608,7 @@ function structWithComplexMapToJson() returns (json | error) {
     return js;
 }
 
-type ComplexArrayStruct{
+type ComplexArrayStruct record {
     int[] a;
     float[] b;
     boolean[] c;
@@ -660,7 +660,7 @@ function testJsonToMapConstrained1() returns map {
     return check <map<string>> j;
 }
 
-type T1 {
+type T1 record {
     int x;
     int y;
 };
@@ -687,7 +687,7 @@ function testJsonToMapConstrainedFail() returns map {
     return m;
 }
 
-type T2 {
+type T2 record {
   int x;
   int y;
   int z;
@@ -716,7 +716,7 @@ function testStructArrayConversion2() returns T2 {
     return b[0];
 }
 
-public type T3 {
+public type T3 record {
   int x,
   int y,
 };
@@ -811,7 +811,7 @@ function testArrayToJson2() returns json {
     return j;
 }
 
-public type TX {
+public type TX record {
   int x,
   int y,
   blob b,
@@ -858,7 +858,7 @@ function anyToFloat() returns float {
     return check <float> a;
 }
 
-type A {
+type A record {
     float f;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -52,7 +52,7 @@ function testElvisRefTypeNestedCaseTwo () returns (int|string) {
     return b;
 }
 
-public type Person {
+public type Person record {
     string name;
     int age;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/fieldaccess/safe_navigation.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/fieldaccess/safe_navigation.bal
@@ -1,6 +1,6 @@
 import ballerina/io;
 
-type Person {
+type Person record {
     int a;
     string fname = "John";
     string lname;
@@ -8,12 +8,12 @@ type Person {
     Info|() info2;
 };
 
-type Info {
+type Info record {
     Address|error address1;
     Address|() address2;
 };
 
-type Address {
+type Address record {
     string street;
     string city;
     string country = "Sri Lanka";

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/fieldaccess/safe_navigation_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/fieldaccess/safe_navigation_negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     int a;
     string fname = "John";
     string lname;
@@ -6,12 +6,12 @@ type Person {
     Info|() info2;
 };
 
-type Info {
+type Info record {
     Address|error address1;
     Address|() address2;
 };
 
-type Address {
+type Address record {
     string street;
     string city;
     string country = "Sri Lanka";
@@ -64,7 +64,7 @@ function testUpdatingNullableStructField () returns any {
     return p;
 }
 
-type Student {
+type Student record {
     json info;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-success.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-success.bal
@@ -25,7 +25,7 @@ function useILWithinStruct() returns (string, string, int) {
     return (person.^"first name", person.^"last name", person.^"current age");
 }
 
-type Person {
+type Person record {
     string ^"first name";
     string ^"last name";
     int ^"current age";
@@ -112,7 +112,7 @@ function useILInStructName() returns (string, string, int, string) {
     return (^"person one".^"first name", ^"person one".^"last name", ^"person one".^"current age", ^"person one"["first name"]);
 }
 
-type ^"family person" {
+type ^"family person" record {
     string ^"first name";
     string ^"last name";
     int ^"current age";

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/pkg.variable/variable-def.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/pkg.variable/variable-def.bal
@@ -5,7 +5,7 @@ public float ^"Variable Float" = 99.34323;
 public any ^"Variable Any" = 88343;
 public Person ^"person 1" = {^"first name": "Harry", ^"last name":"potter", ^"current age": 25};
 
-public type Person {
+public type Person record {
     string ^"first name";
     string ^"last name";
     int ^"current age";

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
@@ -168,7 +168,7 @@ function xmlTest() returns (int, int, map) {
     return (nodeCount, elementCount, m);
 }
 
-type person {
+type person record {
     string name;
     int age;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/negative/fp-struct-incorrect-arg-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/negative/fp-struct-incorrect-arg-negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string fname;
     string lname;
     function (string, string) returns (string) getName;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/negative/fp-struct-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/negative/fp-struct-negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string fname;
     string lname;
     function (string, string) returns (string) getName;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/struct-function-pointers.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/lambda/struct-function-pointers.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string fname;
     string lname;
     function (string, string) returns (string) getName;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -30,7 +30,7 @@ function foo (int a, string b, boolean c) returns (string) {
     return a + b + c;
 }
 
-type Person {
+type Person record {
     string name;
     string location;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/incompatible-struct-cast-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/incompatible-struct-cast-negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string name;
     int age;
     Person? parent;
@@ -8,7 +8,7 @@ type Person {
 };
 
 
-type Student {
+type Student record {
     string name;
     int age;
     map address;

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -129,7 +129,7 @@ function testStringToJson(string s) returns (json) {
     return s;
 }
 
-type Person {
+type Person record {
     string name;
     int age;
     map address;
@@ -141,7 +141,7 @@ type Person {
     boolean alive;
 };
 
-type Student {
+type Student record {
     string name;
     int age;
     map address;
@@ -252,7 +252,7 @@ function testIncompatibleJsonToBoolean() returns (boolean) {
     return value;
 }
 
-type Address {
+type Address record {
     string city;
     string country;
 };
@@ -368,12 +368,12 @@ function testAnyNullToXml() returns (xml) {
     return value;
 }
 
-type A {
+type A record {
     string x;
     int y;
 };
 
-type B {
+type B record {
     string x;
 };
 
@@ -545,7 +545,7 @@ function testAnyToTableWithErrors() returns (table | error) {
     return casted;
 }
 
-type Employee {
+type Employee record {
     int id;
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/unaryoperations/lengthof-operation.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/unaryoperations/lengthof-operation.bal
@@ -119,7 +119,7 @@ function arrayLengthAccessTestStructFieldAccessCase (int x, int y) returns (int)
     }
 }
 
-type Person {
+type Person record {
     string name;
     int[] days;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/functions/different-function-signatures.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/functions/different-function-signatures.bal
@@ -126,7 +126,7 @@ function funcWithNilDefaultParamExpr_1(string? s = null) returns string? {
     return s;
 }
 
-type Student {
+type Student record {
     int a;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/csv_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/csv_io.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 
 io:CSVChannel? csvChannel;
 
-type Employee {
+type Employee record {
     string id;
     string name;
     float salary;

--- a/tests/ballerina-test/src/test/resources/test-src/lang/annotations/invalid-child-annotation.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/lang/annotations/invalid-child-annotation.bal
@@ -3,12 +3,12 @@ function foo (string args) {
     // do nothing
 }
 
-type Arguments {
+type Arguments record {
     string value;
     Property prop;
 };
 
-type Property {
+type Property record {
     string name;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/lock/locks-in-services.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/lock/locks-in-services.bal
@@ -98,13 +98,13 @@ service<http:Service> sample1 bind echoEP {
     }
 }
 
-type Person {
+type Person record {
     int age,
     string name,
     Address address,
 };
 
-type Address {
+type Address record {
     int no,
     string line1,
     string line2,

--- a/tests/ballerina-test/src/test/resources/test-src/net/grpc/negative_json_message_type.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/grpc/negative_json_message_type.bal
@@ -42,6 +42,6 @@ service UnsupportedJsonType bind ep {
     }
 }
 
-type JsonMessage {
+type JsonMessage record {
     json payload;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/net/grpc/negative_map_message_type.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/grpc/negative_map_message_type.bal
@@ -42,7 +42,7 @@ service UnsupportedMapType bind ep {
     }
 }
 
-type MapMessage {
+type MapMessage record {
     map payload;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/object/anon_object.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/object/anon_object.bal
@@ -107,7 +107,7 @@ function testObjectEquivalencyBetweenAnonAndNormalObject() returns (int, string,
 }
 
 function testAnonObjectWithRecordLiteral() returns (int, string) {
-    object { public { {int age; string name;} details;} private { int length; string kind; }
+    object { public { record {int age; string name;} details;} private { int length; string kind; }
     new (details, kind) {
     }
     function getName () returns string { return details.name; }} value = new ({age:8, name:"sanjiva"}, "passed kind");
@@ -117,7 +117,7 @@ function testAnonObjectWithRecordLiteral() returns (int, string) {
 
 type Foo object {
     public {
-        {int age; string name;} details;
+        record {int age; string name;} details;
     }
     private {
         int length;

--- a/tests/ballerina-test/src/test/resources/test-src/object/object_cyclic_self_reference.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/object/object_cyclic_self_reference.bal
@@ -26,7 +26,7 @@ type Foo object {
     }
 };
 
-type Bar {
+type Bar record {
     int barVal,
     string name,
     Person person,

--- a/tests/ballerina-test/src/test/resources/test-src/object/object_cyclic_self_reference_with_default.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/object/object_cyclic_self_reference_with_default.bal
@@ -29,7 +29,7 @@ type Foo object {
     }
 };
 
-type Bar {
+type Bar record {
     int barVal,
     string name,
     Person? person,

--- a/tests/ballerina-test/src/test/resources/test-src/object/object_un_initializable_field.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/object/object_un_initializable_field.bal
@@ -36,7 +36,7 @@ type Foo object {
     }
 };
 
-type Bar {
+type Bar record {
     int barVal,
     string name,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/parser/service-without-resource-name-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/parser/service-without-resource-name-negative.bal
@@ -3,8 +3,6 @@ import ballerina/http;
 service<http:Service> HelloService {
 
 
-    (endpoint caller, http:Request request) {
-      int b;
-      ;
+  (endpoint caller, http:Request request) {
   }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/parser/service-without-resource-params-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/parser/service-without-resource-params-negative.bal
@@ -8,6 +8,5 @@ service<http:Service> HelloService {
     }
     tweet {
         int b;
-        return m;
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/record/anon_record.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/anon_record.bal
@@ -3,19 +3,19 @@ function testAnonStructAsFuncParam() returns (int) {
     return testAnonStructFunc(10, {k:14, s:"sameera"});
 }
 
-function testAnonStructFunc(int i, {int k = 10; string s;} anonSt) returns (int) {
+function testAnonStructFunc(int i, record {int k = 10; string s;} anonSt) returns (int) {
     return anonSt.k + i;
 }
 
 
 function testAnonStructAsLocalVar() returns (int) {
-    {int k = 11; string s;} anonSt = {};
+    record {int k = 11; string s;} anonSt = {};
 
     return anonSt.k;
 }
 
 
-{string fname; string lname; int age;} person;
+record {string fname; string lname; int age;} person;
 
 function testAnonStructAsPkgVar() returns (string) {
 
@@ -25,18 +25,18 @@ function testAnonStructAsPkgVar() returns (string) {
     return person.fname + ":" + person.lname + ":" + person.age;
 }
 
-type employee {
+type employee record {
     string fname;
     string lname;
     int age;
-    { string line01;
+    record { string line01;
              string line02;
              string city;
              string state;
              string zipcode;
     } address;
 
-    {
+    record {
         string month = "JAN";
         string day = "01";
         string year = "1970";

--- a/tests/ballerina-test/src/test/resources/test-src/record/eq/eq1.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/eq/eq1.bal
@@ -1,5 +1,5 @@
 
-public type person {
+public type person record {
     int age;
     string name;
     string address;
@@ -8,7 +8,7 @@ public type person {
     int id;
 };
 
-public type employee {
+public type employee record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/record/eq2/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/eq2/eq2.bal
@@ -1,5 +1,5 @@
 
-public type employee {
+public type employee record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/record/nested_record_inline_init.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/nested_record_inline_init.bal
@@ -1,6 +1,6 @@
 string child = "Bob";
 
-type Person {
+type Person record {
     string name = "default first name";
     string fname;
     string lname;
@@ -10,7 +10,7 @@ type Person {
     Family family = {spouse : "Jane"};
 };
 
-type Family {
+type Family record {
     string spouse;
     int noOfChildren;
     string[] children = ["Alex", child];

--- a/tests/ballerina-test/src/test/resources/test-src/record/org.foo.baz/baz1.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/org.foo.baz/baz1.bal
@@ -1,14 +1,14 @@
 
-public type ParentFoo {
+public type ParentFoo record {
     int i;
     ChildFoo c;
 };
 
-type ChildFoo {
+type ChildFoo record {
     string name;
 };
 
-type privatePerson {
+type privatePerson record {
     int age;
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/record/org.foo.baz/baz2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/org.foo.baz/baz2.bal
@@ -1,10 +1,10 @@
 
-public type FooDepartment {
+public type FooDepartment record {
     string dptName;
     FooPerson[] employees;
 };
 
-public type FooPerson {
+public type FooPerson record {
     string name = "default first name";
     string lname;
     map adrs;
@@ -13,17 +13,17 @@ public type FooPerson {
     FooPerson? parent;
 };
 
-type FooFamily {
+type FooFamily record {
     string spouse;
     int noOfChildren;
     string[] children;
 };
 
-public type FooEmployee {
+public type FooEmployee record {
     string fname;
     string lname;
     int age;
-    {
+    record {
         string city;
         string state;
         string zipcode;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record.bal
@@ -1,9 +1,9 @@
-type Department {
+type Department record {
     string dptName;
     Person[] employees;
 };
 
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;
@@ -12,7 +12,7 @@ type Person {
     Person? parent;
 };
 
-type Family {
+type Family record {
     string spouse;
     int noOfChildren;
     string[] children;
@@ -99,7 +99,7 @@ function testNestedStructInit () returns (Person) {
     return p1;
 }
 
-type NegativeValTest {
+type NegativeValTest record {
     int negativeInt = -9;
     int negativeSpaceInt = -8;
     float negativeFloat = -88.234;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_access_dynamic_index_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_access_dynamic_index_negative.bal
@@ -1,11 +1,11 @@
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;
     int age = 999;
 };
 
-type StructField {
+type StructField record {
     string key;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_access_with_index.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_access_with_index.bal
@@ -1,9 +1,9 @@
-type Department {
+type Department record {
     string dptName;
     Person[] employees;
 };
 
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;
@@ -11,7 +11,7 @@ type Person {
     Family family;
 };
 
-type Family {
+type Family record {
     string spouse;
     int noOfChildren;
     string[] children;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_access_with_index_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_access_with_index_negative.bal
@@ -9,7 +9,7 @@ function testUndeclaredAttributeAccess() {
     dpt["id"] = "HR";       
 }
       
-type Department {
+type Department record {
     string dptName;     
     int count;      
 };

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_annotation.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_annotation.bal
@@ -2,7 +2,7 @@ documentation { Documentation for Test annotation
 F{{a}} annotation `field a` documentation
 F{{b}} annotation `field b` documentation
 F{{c}} annotation `field c` documentation}
-type Tst {
+type Tst record {
     string a;
     string b;
     string c;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_annotation_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_annotation_negative.bal
@@ -5,7 +5,7 @@ F{{a}} annotation `field a` documentation
 F{{a}} annotation `field a` documentation
 F{{b}} annotation `field b` documentation
 F{{c}} annotation `field c` documentation}
-type Tst {
+type Tst record {
     string a;
     string b;
     string cd;
@@ -31,7 +31,7 @@ F{{a}} struct `field a` documentation
 F{{a}} struct `field a` documentation
 F{{b}} struct `field b` documentation
 F{{c}} struct `field c` documentation}
-type Test {
+type Test record {
     int a;
     int b;
     int cdd;
@@ -72,14 +72,14 @@ public type File object {
 //    e.name = p.firstName;
 //}
 
-type Person {
+type Person record {
     string firstName;
     string lastName;
     int age;
     string city;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;
@@ -91,7 +91,7 @@ Test Connector
 F{{url}} url for endpoint
 F{{url}} url for endpoint
 P{{urls}} urls for endpoint}
-type TestConnector {
+type TestConnector record {
   string url;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_doc_annotation.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_doc_annotation.bal
@@ -2,7 +2,7 @@ documentation { Documentation for Test struct
 F{{a}} struct `field a` documentation
 F{{b}} struct `field b` documentation
 F{{c}} struct `field c` documentation}
-type Test {
+type Test record {
     int a;
     int b;
     int c;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_equivalency.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_equivalency.bal
@@ -3,7 +3,7 @@ import eq2;
 import req;
 import req2;
 
-public type person1 {
+public type person1 record {
     int age;
     string name;
     string address;
@@ -12,7 +12,7 @@ public type person1 {
     int id;
 };
 
-public type employee1 {
+public type employee1 record {
     int age;
     string name;
     string address;
@@ -31,7 +31,7 @@ function testEquivalenceOfPrivateStructsInSamePackage () returns (string) {
     return p.ssn;
 }
 
-public type person2 {
+public type person2 record {
     int age;
     string name;
     string address;
@@ -40,7 +40,7 @@ public type person2 {
     int id;
 };
 
-public type employee2 {
+public type employee2 record {
     int age;
     string name;
     string address;
@@ -70,7 +70,7 @@ function testEqOfPublicStructs () returns (string) {
 }
 
 
-public type employee3 {
+public type employee3 record {
     int age;
     string name;
     string address;
@@ -101,18 +101,18 @@ function testEqOfPublicStructs2 () returns (string) {
 
 
 
-type userA {
+type userA record {
     int age;
     string name;
 };
 
-type userB {
+type userB record {
     int age;
     string name;
     string address;
 };
 
-type userFoo {
+type userFoo record {
     int age;
     string name;
     string address;
@@ -132,19 +132,19 @@ function testRuntimeEqPrivateStructsInSamePackage () returns (string) {
 }
 
 
-public type userPA {
+public type userPA record {
     int age;
     string name;
 };
 
-public type userPB {
+public type userPB record {
     int age;
     string name;
     string address;
 };
 
 
-public type userPFoo {
+public type userPFoo record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_literal_with_attached_functions.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_literal_with_attached_functions.bal
@@ -1,5 +1,5 @@
 
-type Person {
+type Person record {
     int age = 9;
     string name = "default first name";
 };

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_literals.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_literals.bal
@@ -1,10 +1,10 @@
-type Department {
+type Department record {
     string dptName;
     Person[] employees;
     Person manager;
 };
 
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_simple_scenario.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_simple_scenario.bal
@@ -4,7 +4,7 @@ public function testSimpleRecord () returns (int, string) {
     return (p.age, p.name);
 }
 
-type Person {
+type Person record {
     int age,
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/record/record_with_attached_functions.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/record_with_attached_functions.bal
@@ -5,7 +5,7 @@ public function testObjectWithInterface () returns (int, string) {
 }
 
 
-type Person {
+type Person record {
     int age = 10,
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/record/req/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/req/eq2.bal
@@ -1,5 +1,5 @@
 
-public type userPFoo {
+public type userPFoo record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/record/req2/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/record/req2/eq2.bal
@@ -1,5 +1,5 @@
 
-public type userPB {
+public type userPB record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/reflect/equal-complex.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/reflect/equal-complex.bal
@@ -1,7 +1,7 @@
 import ballerina/reflect;
 
 // Start types
-type SimplePerson {
+type SimplePerson record {
     string name;
     int age = -1;
     boolean married;
@@ -23,7 +23,7 @@ function testPrimitiveTypes() returns (boolean) {
            !reflect:equals((),sp1);
 }
 
-public type ArrayedPerson {
+public type ArrayedPerson record {
     string name;
     int age = -1;
     boolean married;
@@ -44,16 +44,16 @@ function testTypesWithArrays() returns (boolean) {
            !reflect:equals((),ap1);
 }
 
-public type Wheel {
+public type Wheel record {
     int pressure;
 };
 
-public type Engine {
+public type Engine record {
     string model;
     float capacity;
 };
 
-public type Car {
+public type Car record {
     string name;
     Wheel[] wheels;
     Engine engine;

--- a/tests/ballerina-test/src/test/resources/test-src/services/dispatching/data-binding-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/dispatching/data-binding-test.bal
@@ -4,7 +4,7 @@ endpoint http:NonListener testEP {
     port:9090
 };
 
-type Person {
+type Person record {
     string name,
     int age,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/services/echo-service.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/echo-service.bal
@@ -4,7 +4,7 @@ import ballerina/io;
 
 @final string constPath = getConstPath();
 
-type Person {
+type Person record {
     string name,
     int age,
 };

--- a/tests/ballerina-test/src/test/resources/test-src/services/session/http-session-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/services/session/http-session-test.bal
@@ -2,7 +2,7 @@ import ballerina/http;
 import ballerina/mime;
 import ballerina/io;
 
-type Data {
+type Data record {
     string name,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/arrays/array-length-access-expr.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/arrays/array-length-access-expr.bal
@@ -129,7 +129,7 @@ function arrayLengthAccessNullArrayCase(int x, int y) returns (int) {
     return length;
 }
 
-type Person {
+type Person record {
     string name;
     int[] days;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/statements/arrays/arraysofarrays/arrays-of-arrays.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/arrays/arraysofarrays/arrays-of-arrays.bal
@@ -69,7 +69,7 @@ function arrayTest(int[][] yy) returns (int) {
     return yy[0][1];
 }
 
-type B {
+type B record {
     int x;
 };
 
@@ -195,6 +195,6 @@ function testRefArrayIterator() returns A {
     return a;
 }
 
-type A {
+type A record {
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/statements/block/block-stmt-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/block/block-stmt-negative.bal
@@ -94,7 +94,7 @@ function testUnreachableBreak() returns (string){
     return "done";
 }
 
-public type testError {
+public type testError record {
     string message;
     error? cause;
     string code;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/comment/comments.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/comment/comments.bal
@@ -32,7 +32,7 @@ function fooFunc(string a, // foo function
     return;
 }
 
-type Person { // Person type
+type Person record { // Person type
     // name field
     string name,
 
@@ -64,7 +64,7 @@ service<DummyService> FooService {
 
 // end of file
 
-type Config {
+type Config record {
     string name,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
@@ -64,7 +64,7 @@ function testCompoundAssignmentDivisionArrayElement() returns (int){
      return x[0];
 }
 
-type Company {
+type Company record {
    int count;
    int count2;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-arrays.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-arrays.bal
@@ -34,7 +34,7 @@ function concatJSON(int index, json value){
     output = output + index + ":" + stringValue + " ";
 }
 
-type person {
+type person record {
     string name;
     int age;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-complex.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-complex.bal
@@ -16,7 +16,7 @@ function concatTwoInts (int i, int j) {
     output = output + i + ":" + j + " ";
 }
 
-type Week {
+type Week record {
     string[] days;
 };
 
@@ -62,7 +62,7 @@ function testIntRangeSimpleArity2(int a, int b) returns (string){
 
 int gx = 0;
 
-type data {
+type data record {
     int sx;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-json.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-json.bal
@@ -71,12 +71,12 @@ function testJSONNull () returns (string) {
     return output;
 }
 
-type Protocols {
+type Protocols record {
     string data;
     Protocol[] plist;
 };
 
-type Protocol {
+type Protocol record {
     string name;
     string url;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/foreach/foreach-negative.bal
@@ -31,7 +31,7 @@ function test4(){
     }
 }
 
-type person {
+type person record {
     int id;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/matchstmt/match_stmt_basic.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/matchstmt/match_stmt_basic.bal
@@ -48,12 +48,12 @@ function openFileSuccess(string path) returns (File | error) {
     return f;
 }
 
-type File {
+type File record {
     string path;
 };
 
 
-type MyFile {
+type MyFile record {
     string path;
     int bytes;
 };
@@ -155,12 +155,12 @@ function testMatchStatementBasics14(json a) returns (string | int | boolean) {
 }
 
 
-type Human {
+type Human record {
     string name;
     function (int, string) returns string | () foo;
 };
 
-type Man {
+type Man record {
     string name;
     function (int, string) returns string | () foo;
     int age;
@@ -176,7 +176,7 @@ function testMatchStatementBasics16() returns (string | int | boolean) {
     }
 }
 
-type Woman {
+type Woman record {
     string fname;
     (function (int, string) returns string) | Human foo;
     int age;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/returnstmt/return-in-resource.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/returnstmt/return-in-resource.bal
@@ -4,7 +4,7 @@ service<DummyService> helloWorld {
     }
 }
 
-type Config {
+type Config record {
 };
 
 type DummyEndpoint object {

--- a/tests/ballerina-test/src/test/resources/test-src/statements/transaction/transaction_handler_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/transaction/transaction_handler_test.bal
@@ -1,6 +1,6 @@
 import ballerina/transactions;
 
-public type TrxError {
+public type TrxError record {
     string message;
     error? cause;
     string data;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/transaction/transaction_stmt.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/transaction/transaction_stmt.bal
@@ -1,4 +1,4 @@
-public type TrxError {
+public type TrxError record {
     string message;
     error? cause;
     string data;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/transform/transform-stmt.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/transform/transform-stmt.bal
@@ -1,11 +1,11 @@
-type Person {
+type Person record {
     string firstName;
     string lastName;
     int age;
     string city;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/trycatch/finally-stmt.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/trycatch/finally-stmt.bal
@@ -45,7 +45,7 @@ function test3() returns (string){
     }
 }
 
-type Test4Val {
+type Test4Val record {
     string value;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/trycatch/try-catch-finally-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/trycatch/try-catch-finally-negative.bal
@@ -21,7 +21,7 @@ function funcReturnInt() returns (int){
     return a;
 }
 
-public type TestError {
+public type TestError record {
     string message;
     error? cause;
     string code;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/trycatch/try-catch-stmt.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/trycatch/try-catch-stmt.bal
@@ -1,18 +1,18 @@
 import ballerina/runtime;
 
-public type testError {
+public type testError record {
     string message;
     error? cause;
     string code;
 };
 
-public type testDataError {
+public type testDataError record {
     string message;
     error? cause;
     string data;
 };
 
-public type testInputError {
+public type testInputError record {
     string message;
     error? cause;
     string input;

--- a/tests/ballerina-test/src/test/resources/test-src/statements/variabledef/global-var-function-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/variabledef/global-var-function-negative.bal
@@ -1,8 +1,9 @@
-struct s1 {
+type s1 record {
   float x;
-}
+};
 
-function getGlobalVars() returns (float) {
+function getGlobalVars() returns float {
     s1 v = {};
     float f = v.foo:x;
+    return f;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/statements/variabledef/variable-scope-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/variabledef/variable-scope-negative.bal
@@ -49,7 +49,7 @@ service<DummyService> myService {
 }
 
 type DummyEndpoint object {
-    function init ({} conf)  {
+    function init(record {} conf)  {
     }
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/aggregation-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/aggregation-streaming-test.bal
@@ -17,12 +17,12 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type StatusCount {
+type StatusCount record {
     string status;
     int totalCount;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/boolean-type-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/boolean-type-test.bal
@@ -17,11 +17,11 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type ClientRequest {
+type ClientRequest record {
     string host;
 };
 
-type RequestCount {
+type RequestCount record {
     string host;
     int count;
     boolean test;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/filter-streaming-test-v2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/filter-streaming-test-v2.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/filter-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/filter-streaming-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/filter-streaming-with-reference-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/filter-streaming-with-reference-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/join-streaming-negative-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/join-streaming-negative-test.bal
@@ -17,19 +17,19 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Stock {
+type Stock record {
     string symbol;
     float price;
     int volume;
 };
 
-type Twitter {
+type Twitter record {
     string user;
     string tweet;
     string company;
 };
 
-type StockWithPrice {
+type StockWithPrice record {
     string symbol;
     string tweet;
     float price;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/join-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/join-streaming-test.bal
@@ -17,19 +17,19 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Stock {
+type Stock record {
     string symbol;
     float price;
     int volume;
 };
 
-type Twitter {
+type Twitter record {
     string user;
     string tweet;
     string company;
 };
 
-type StockWithPrice {
+type StockWithPrice record {
     string symbol;
     string tweet;
     float price;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/orderby-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/orderby-streaming-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/output-rate-limiting-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/output-rate-limiting-test.bal
@@ -17,13 +17,13 @@
 import ballerina/io;
 import ballerina/runtime;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/output-rate-limiting-time-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/output-rate-limiting-time-test.bal
@@ -17,13 +17,13 @@
 import ballerina/io;
 import ballerina/runtime;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/passthrough-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/passthrough-streaming-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/pattern-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/pattern-streaming-test.bal
@@ -17,20 +17,20 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type RoomTempInfo {
+type RoomTempInfo record {
     int deviceID;
     int roomNo;
     float temp;
 };
 
-type RegulatorInfo {
+type RegulatorInfo record {
     int deviceID;
     int roomNo;
     float tempSet;
     boolean isOn;
 };
 
-type TempDiffInfo {
+type TempDiffInfo record {
     int roomNo;
     float tempDifference;
 };
@@ -94,14 +94,14 @@ function runPatternQuery1() returns (TempDiffInfo[]) {
     return tempDiffInfoArray;
 }
 
-type RegulatorState {
+type RegulatorState record {
     int deviceId;
     int roomNo;
     float tempSet;
     string userAction;
 };
 
-type RoomKeyAction {
+type RoomKeyAction record {
     int roomNo;
     string userAction;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/pipeline-streaming-test-v2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/pipeline-streaming-test-v2.bal
@@ -17,12 +17,12 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type StatusCount {
+type StatusCount record {
     string status;
     int totalCount;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/pipeline-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/pipeline-streaming-test.bal
@@ -17,12 +17,12 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type StatusCount {
+type StatusCount record {
     string status;
     int totalCount;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/projection-streaming-negative-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/projection-streaming-negative-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/projection-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/projection-streaming-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/sequence-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/sequence-streaming-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type DeviceTempInfo {
+type DeviceTempInfo record {
     int deviceID;
     int roomNo;
     float temp;
 };
 
-type TempDiffInfo {
+type TempDiffInfo record {
     float initialTemp;
     float peakTemp;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/stream-functions-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/stream-functions-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/streaming-action-negative-test-v1.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/streaming-action-negative-test-v1.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/streaming-action-negative-test-v2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/streaming-action-negative-test-v2.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/streaming-inline-operations-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/streaming-inline-operations-test.bal
@@ -17,13 +17,13 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type Employee {
+type Employee record {
     string name;
     int age;
     string status;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/streaming/window-streaming-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/streaming/window-streaming-test.bal
@@ -17,12 +17,12 @@
 import ballerina/runtime;
 import ballerina/io;
 
-type StatusCount {
+type StatusCount record {
     string status;
     int totalCount;
 };
 
-type Teacher {
+type Teacher record {
     string name;
     int age;
     string status;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/anon-struct.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/anon-struct.bal
@@ -3,19 +3,19 @@ function testAnonStructAsFuncParam() returns (int) {
     return testAnonStructFunc(10, {k:14, s:"sameera"});
 }
 
-function testAnonStructFunc(int i, {int k = 10; string s;} anonSt) returns (int) {
+function testAnonStructFunc(int i, record {int k = 10; string s;} anonSt) returns (int) {
     return anonSt.k + i;
 }
 
 
 function testAnonStructAsLocalVar() returns (int) {
-    {int k = 11; string s;} anonSt = {};
+    record {int k = 11; string s;} anonSt = {};
 
     return anonSt.k;
 }
 
 
-{string fname; string lname; int age;} person;
+record {string fname; string lname; int age;} person;
 
 function testAnonStructAsPkgVar() returns (string) {
 
@@ -25,11 +25,11 @@ function testAnonStructAsPkgVar() returns (string) {
     return person.fname + ":" + person.lname + ":" + person.age;
 }
 
-type employee {
+type employee record {
     string fname;
     string lname;
     int age;
-    {
+    record {
         string line01;
         string line02;
         string city;
@@ -37,7 +37,7 @@ type employee {
         string zipcode;
     } address;
 
-    {
+    record {
         string month = "JAN";
         string day = "01";
         string year = "1970";

--- a/tests/ballerina-test/src/test/resources/test-src/structs/constants/struct-constants.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/constants/struct-constants.bal
@@ -5,7 +5,7 @@ function main (string... i) {
     return;
 }
 
-type Person {
+type Person record {
     string name;
     map adrs;
     int age;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/eq/eq1.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/eq/eq1.bal
@@ -1,5 +1,5 @@
 
-public type person {
+public type person record {
     int age;
     string name;
     string address;
@@ -25,7 +25,7 @@ public function <person p> setSSN(string ssn) {
     p.ssn = ssn;
 }
 
-public type employee {
+public type employee record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/eq2/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/eq2/eq2.bal
@@ -1,5 +1,5 @@
 
-public type employee {
+public type employee record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/expression-as-struct-literal-key-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/expression-as-struct-literal-key-negative.bal
@@ -1,4 +1,4 @@
-type Department {
+type Department record {
     string dptName;
     boolean y;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/structs/invalid-struct-literal-key-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/invalid-struct-literal-key-negative.bal
@@ -1,9 +1,9 @@
-type Department {
+type Department record {
     string dptName;
     boolean y;
 };
 
-type person {
+type person record {
     string a;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/structs/nested-struct-inline-init.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/nested-struct-inline-init.bal
@@ -1,6 +1,6 @@
 string child = "Bob";
 
-type Person {
+type Person record {
     string name = "default first name";
     string fname;
     string lname;
@@ -10,7 +10,7 @@ type Person {
     Family family = {spouse : "Jane"};
 };
 
-type Family {
+type Family record {
     string spouse;
     int noOfChildren;
     string[] children = ["Alex", child];

--- a/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.attached_funcs/funcs.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.attached_funcs/funcs.bal
@@ -1,6 +1,6 @@
 
 
-public type user {
+public type user record {
     int age;
     string name;
     string address;
@@ -17,7 +17,7 @@ function <user u> getAge() returns (int) {
 
 
 
-public type person {
+public type person record {
     int age;
     string name;
     string address;
@@ -44,7 +44,7 @@ public function <person p> setSSN(string ssn) {
     p.ssn = ssn;
 }
 
-public type employee {
+public type employee record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.bar/bar.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.bar/bar.bal
@@ -1,5 +1,5 @@
 
-public type officer {
+public type officer record {
     int age;
     string name = "hidden, private";
     string address;
@@ -7,7 +7,7 @@ public type officer {
     int ssn;
 };
 
-public type userBar {
+public type userBar record {
     int age;
     string name = "hidden, private";
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.baz/private-fields-negative-01.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.baz/private-fields-negative-01.bal
@@ -1,14 +1,14 @@
 
-public type ParentFoo {
+public type ParentFoo record {
     int i;
     ChildFoo c;
 };
 
-type ChildFoo {
+type ChildFoo record {
     string name;
 };
 
-type privatePerson {
+type privatePerson record {
     int age;
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.baz/private-fields-negative-02.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/org.foo.baz/private-fields-negative-02.bal
@@ -1,10 +1,10 @@
 
-public type FooDepartment {
+public type FooDepartment record {
     string dptName;
     FooPerson[] employees;
 };
 
-public type FooPerson {
+public type FooPerson record {
     string name = "default first name";
     string lname;
     map adrs;
@@ -13,18 +13,18 @@ public type FooPerson {
     FooPerson parent;
 };
 
-type FooFamily {
+type FooFamily record {
     string spouse;
     int noOfChildren;
     string[] children;
 };
 
-public type FooEmployee {
+public type FooEmployee record {
     string fname;
     string lname;
     int age;
     private :
-        type {
+       type  record {
             string city;
             string state;
             string zipcode;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/org.foo/private-fields.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/org.foo/private-fields.bal
@@ -1,5 +1,5 @@
 
-public type userFoo {
+public type userFoo record {
     int age;
     string name;
     string address;
@@ -7,21 +7,21 @@ public type userFoo {
     string ssn;
 };
 
-public type user {
+public type user record {
     int age;
     string name;
     string address;
     string zipcode = "23468";
 };
 
-public type person  {
+public type person record {
     int age;
     string name;
     string ssn;
     int id;
 };
 
-type student {
+type student record {
     int age;
     string name;
     string ssn;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/req/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/req/eq2.bal
@@ -1,5 +1,5 @@
 
-public type userPFoo {
+public type userPFoo record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/req2/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/req2/eq2.bal
@@ -1,5 +1,5 @@
 
-public type userPB {
+public type userPB record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-access-dynamic-index-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-access-dynamic-index-negative.bal
@@ -1,11 +1,11 @@
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;
     int age = 999;
 };
 
-type StructField {
+type StructField record {
     string key;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-access-with-index-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-access-with-index-negative.bal
@@ -9,7 +9,7 @@ function testUndeclaredAttributeAccess() {
     dpt["id"] = "HR";       
 }     
       
-type Department {
+type Department record {
     string dptName;     
     int count;      
 };

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-access-with-index.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-access-with-index.bal
@@ -1,9 +1,9 @@
-type Department {
+type Department record {
     string dptName;
     Person[] employees;
 };
 
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;
@@ -11,7 +11,7 @@ type Person {
     Family family;
 };
 
-type Family {
+type Family record {
     string spouse;
     int noOfChildren;
     string[] children;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-equivalency-01-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-equivalency-01-negative.bal
@@ -1,11 +1,11 @@
 
-public type person01 {
+public type person01 record {
     int age;
     string name;
     string address;
 };
 
-public type employee01 {
+public type employee01 record {
     int age;
     string name;
     string zipcode = "95134";
@@ -18,13 +18,13 @@ function testEqOfStructsInSamePackage01() returns (string) {
     return p.name;
 }
 
-public type person02 {
+public type person02 record {
     int age;
     string name;
     string address;
 };
 
-public type employee02 {
+public type employee02 record {
     int age;
     string name;
     int address;
@@ -37,13 +37,13 @@ function testEqOfStructsInSamePackage02() returns (string) {
     return p.name;
 }
 
-public type person03 {
+public type person03 record {
     int age;
     string name;
     string address;
 };
 
-public type employee03 {
+public type employee03 record {
     int age;
     string name;
 };
@@ -55,14 +55,14 @@ function testEqOfStructsInSamePackage03() returns (string) {
     return p.name;
 }
 
-type person06 {
+type person06 record {
     int age;
     string name;
     int address;
     string id;
 };
 
-type employee06 {
+type employee06 record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-equivalency.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-equivalency.bal
@@ -3,7 +3,7 @@ import eq2;
 import req;
 import req2;
 
-public type person1 {
+public type person1 record {
     int age;
     string name;
     string address;
@@ -31,7 +31,7 @@ public function <person1 p> setSSN (string ssn) {
     p.ssn = ssn;
 }
 
-public type employee1 {
+public type employee1 record {
     int age;
     string name;
     string address;
@@ -74,7 +74,7 @@ function testEquivalenceOfPrivateStructsInSamePackage () returns (string) {
     return p.getSSN();
 }
 
-public type person2 {
+public type person2 record {
     int age;
     string name;
     string address;
@@ -99,7 +99,7 @@ public function <person2 p> setSSN (string ssn) {
     p.ssn = ssn;
 }
 
-public type employee2 {
+public type employee2 record {
     int age;
     string name;
     string address;
@@ -149,7 +149,7 @@ function testEqOfPublicStructs () returns (string) {
 }
 
 
-public type employee3 {
+public type employee3 record {
     int age;
     string name;
     string address;
@@ -200,7 +200,7 @@ function testEqOfPublicStructs2 () returns (string) {
 
 
 
-type userA {
+type userA record {
     int age;
     string name;
 };
@@ -213,7 +213,7 @@ function <userA ua> getAge () returns (int) {
     return ua.age;
 }
 
-type userB {
+type userB record {
     int age;
     string name;
     string address;
@@ -227,7 +227,7 @@ function <userB ub> getAge () returns (int) {
     return ub.age;
 }
 
-type userFoo {
+type userFoo record {
     int age;
     string name;
     string address;
@@ -255,7 +255,7 @@ function testRuntimeEqPrivateStructsInSamePackage () returns (string) {
 }
 
 
-public type userPA {
+public type userPA record {
     int age;
     string name;
 };
@@ -268,7 +268,7 @@ public function <userPA ua> getAge () returns (int) {
     return ua.age;
 }
 
-public type userPB {
+public type userPB record {
     int age;
     string name;
     string address;
@@ -282,7 +282,7 @@ public function <userPB ub> getAge () returns (int) {
     return ub.age;
 }
 
-public type userPFoo {
+public type userPFoo record {
     int age;
     string name;
     string address;
@@ -340,7 +340,7 @@ function testRuntimeEqPublicStructs1 () returns (string) {
     }
 }
 
-type personC {
+type personC record {
     string name;
     addressStruct address;
 };
@@ -353,7 +353,7 @@ function <personC p> getAddress() returns (string){
     return p.address.toString();
 }
 
-type addressStruct {
+type addressStruct record {
     int no;
     string city;
 };
@@ -362,7 +362,7 @@ function <addressStruct ad> toString() returns (string){
     return ad.no + ad.city;
 }
 
-type officeAddressStruct {
+type officeAddressStruct record {
     int no;
     string city;
     string department;
@@ -404,7 +404,7 @@ function testStructEquivalencyWithFunctionType () returns (string, string) {
     return (s1,s2);
 }
 
-type AnyStruct {
+type AnyStruct record {
 };
 
 function <AnyStruct a> shout (AnotherAnyStruct aa) returns (string) {
@@ -420,7 +420,7 @@ function <AnyStruct a> call () returns (AnotherAnyStruct) {
     return {} ;
 }
 
-type SomeStruct {
+type SomeStruct record {
     string s;
 };
 
@@ -437,9 +437,9 @@ function <SomeStruct b> call () returns (SomeOtherStruct) {
     return { s : "return"};
 }
 
-type SomeOtherStruct {
+type SomeOtherStruct record {
     string s;
 };
 
-type AnotherAnyStruct {
+type AnotherAnyStruct record {
 };

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-literals.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-literals.bal
@@ -1,10 +1,10 @@
-type Department {
+type Department record {
     string dptName;
     Person[] employees;
     Person manager;
 };
 
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-private-fields-01-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-private-fields-01-negative.bal
@@ -1,12 +1,12 @@
 
 import org.foo;
 
-public type userA {
+public type userA record {
     int age;
     string name;
 };
 
-public type userB {
+public type userB record {
     int age;
     string name;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-private-fields-02-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-private-fields-02-negative.bal
@@ -10,7 +10,7 @@ public function testPrivateFieldAccess() {
 
 }
 
-public type personFoo {
+public type personFoo record {
     int age;
     string name;
     string ssn;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct.bal
@@ -1,9 +1,9 @@
-type Department {
+type Department record {
     string dptName;
     Person[] employees;
 };
 
-type Person {
+type Person record {
     string name = "default first name";
     string lname;
     map adrs;
@@ -12,7 +12,7 @@ type Person {
     Person|() parent;
 };
 
-type Family {
+type Family record {
     string spouse;
     int noOfChildren;
     string[] children;
@@ -95,7 +95,7 @@ function testNestedStructInit () returns (Person) {
     return p1;
 }
 
-type NegativeValTest {
+type NegativeValTest record {
     int negativeInt = -9;
     int negativeSpaceInt = -8;
     float negativeFloat = -88.234;

--- a/tests/ballerina-test/src/test/resources/test-src/structs/structs-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/structs-negative.bal
@@ -1,14 +1,14 @@
-type Department {
+type Department record {
     string dptName;
     boolean y;
 };
 
-type Department {
+type Department record {
     string name;
     int[] a1;
 };
 
-type Department2 {
+type Department2 record {
     string dptName;
     int id;
     string id;

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return-negative.bal
@@ -1,6 +1,6 @@
 import ballerina/mysql;
 
-type Employee {
+type Employee record {
     int id;
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return.bal
@@ -1,6 +1,6 @@
 import ballerina/mysql;
 
-type Employee {
+type Employee record {
     int id;
     string name;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/record-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/record-negative.bal
@@ -1,4 +1,4 @@
-type Student {
+type Student record {
     string name;
     string address;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/record.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/propagation/record.bal
@@ -1,4 +1,4 @@
-type Student {
+type Student record {
     string name;
     string address;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/any/any-type-success.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/any/any-type-success.bal
@@ -36,7 +36,7 @@ function tableReturnFunction () returns (table) {
     return tb;
 }
 
-type Employee {
+type Employee record {
     int id;
     string name;
 };
@@ -59,7 +59,7 @@ function anyInStructTest() returns (any) {
   return sample.val;
 }
 
-type Sample {
+type Sample record {
   int i;
   any val;
   string msg;

--- a/tests/ballerina-test/src/test/resources/test-src/types/blob/blob-value.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/blob/blob-value.bal
@@ -5,11 +5,11 @@ blob glbVarBlob;
 blob gA = base16 `aeeecdefabcd12345567888822`;
 blob gB = base64 `aGVsbG8gYmFsbGVyaW5hICEhIQ==`;
 
-type BinaryData {
+type BinaryData record {
     blob blobField;
 };
 
-type TestRec {
+type TestRec record {
     blob a = base16 `aa ab`;
     blob b = base64 `aGVsbG8gYmFsbGVyaW5hICEhIQ==`;
     blob c;

--- a/tests/ballerina-test/src/test/resources/test-src/types/errors/error-return.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/errors/error-return.bal
@@ -1,4 +1,4 @@
-public type InvalidNameError {
+public type InvalidNameError record {
     string message;
     error? cause;
     string companyName;

--- a/tests/ballerina-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -83,7 +83,7 @@ function finiteAssignmentStateSameTypeComparisonCaseTwo() returns State {
 
 type POrInt Person|int;
 
-type Person {
+type Person record {
    string name;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/constrained-json-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/constrained-json-negative.bal
@@ -1,10 +1,10 @@
-type Person {
+type Person record {
     string name;
     int age;
     string address;
 };
 
-type Student {
+type Student record {
     string name;
     int age;
     string address;
@@ -34,21 +34,21 @@ function testConstraintJSONIndexing() returns (json){
     return j["bus"];
 }
 
-type Employee {
+type Employee record {
     string first_name;
     string last_name;
     int age;
     Address address;
 };
 
-type Address {
+type Address record {
     string number;
     string street;
     string city;
     PhoneNumber phoneNumber;
 };
 
-type PhoneNumber {
+type PhoneNumber record {
     string areaCode;
     string number;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/constrained-json.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/constrained-json.bal
@@ -1,10 +1,10 @@
-type Person  {
+type Person record {
     string name;
     int age;
     string address;
 };
 
-type Student {
+type Student record {
     string name;
     int age;
     string address;
@@ -62,21 +62,21 @@ function getStudent() returns (json<Student>){
     return j;
 }
 
-type Employee {
+type Employee record {
     string first_name;
     string last_name;
     int age;
     Address address;
 };
 
-type Address {
+type Address record {
     string number;
     string street;
     string city;
     PhoneNumber phoneNumber;
 };
 
-type PhoneNumber {
+type PhoneNumber record {
     string areaCode;
     string number;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/pkg/structdef/struct-defs.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/pkg/structdef/struct-defs.bal
@@ -1,5 +1,5 @@
 
-public type Person {
+public type Person record {
     string name;
     int age;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/pkginvalid/structdef/struct-defs.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/pkginvalid/structdef/struct-defs.bal
@@ -1,5 +1,5 @@
 
-public type Person {
+public type Person record {
     string name;
     int age;
     string address;

--- a/tests/ballerina-test/src/test/resources/test-src/types/map-struct-json-unified.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/map-struct-json-unified.bal
@@ -1,6 +1,6 @@
 import ballerina/io;
 
-type Person {
+type Person record {
     string name;
     int age;
     Person | () parent;

--- a/tests/ballerina-test/src/test/resources/test-src/types/map/constrained-map-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/map/constrained-map-negative.bal
@@ -19,13 +19,13 @@ function testConstrainedMapAssignDifferentConstraintsNegative() returns (map<int
     return testMap;
 }
 
-type Person {
+type Person record {
     string name;
     int age;
     string address;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
 };
@@ -61,7 +61,7 @@ function testInvalidCastAnyToConstrainedMap() returns (map<Employee>) {
     return castMap;
 }
 
-type Student {
+type Student record {
     int index;
     int age;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/map/constrained-map.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/map/constrained-map.bal
@@ -261,13 +261,13 @@ function updateGenericMapWithNullValue (map m) returns (map) {
     return m;
 }
 
-type Person {
+type Person record {
      string name,
     int age,
     string address;
 };
 
-type Employee {
+type Employee record {
      string name,
     int age;
 };
@@ -381,7 +381,7 @@ function testAnyMapToRefTypeRuntimeCast () returns (map<Employee>|error) {
     }
 }
 
-type Student {
+type Student record {
      int index,
     int age;
 };
@@ -450,7 +450,7 @@ function testMapOfElementTypeRefArray () returns ((string, int)) {
     return (jackR.name, jackR.age);
 }
 
-type PersonComplex {
+type PersonComplex record {
      string name,
     int age,
     PersonComplex? parent,
@@ -488,7 +488,7 @@ function testJsonToStructConversionStructWithConstrainedMap () returns (string, 
     return (ms["city"], ms["country"]);
 }
 
-type PersonComplexTwo {
+type PersonComplexTwo record {
     string name,
     int age,
     PersonComplexTwo? parent,
@@ -583,19 +583,19 @@ function testMapConstrainedEquivalentMapInsert () returns (string, int) {
     return (emp["jack"].name, emp["jack"].age);
 }
 
-type Transaction {
+type Transaction record {
     string transactionId,
     string coordinationType,
     map<Participant> participants,
     Protocol[] coordinatorProtocols;
 };
 
-type Participant {
+type Participant record {
     string participantId,
     Protocol[] participantProtocols;
 };
 
-type Protocol {
+type Protocol record {
     string name,
     string url,
     int transactionBlockId,
@@ -604,7 +604,7 @@ type Protocol {
                string protocolAction) returns boolean)|() protocolFn;
 };
 
-type TwoPhaseCommitTransaction {
+type TwoPhaseCommitTransaction record {
     string transactionId,
     string coordinationType,
     map<Participant> participants,

--- a/tests/ballerina-test/src/test/resources/test-src/types/null/null-value.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/null/null-value.bal
@@ -32,7 +32,7 @@ function testStructNull () returns (Person|(), Person|(), int) {
     return (p1, p2, a);
 }
 
-type Person {
+type Person record {
     string name;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/stream/stream-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/stream/stream-negative.bal
@@ -1,10 +1,10 @@
-type Person {
+type Person record {
     string name;
     int age;
     string address;
 };
 
-type Employee {
+type Employee record {
     string name;
     int age;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/stream/stream-value.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/stream/stream-value.bal
@@ -3,12 +3,12 @@ import ballerina/time;
 
 stream<Employee> globalEmployeeStream;
 
-type Employee {
+type Employee record {
     int id,
     string name,
 };
 
-type Job {
+type Job record {
     string description,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_iteration.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_iteration.bal
@@ -1,34 +1,34 @@
 import ballerina/jdbc;
 
-type Person {
+type Person record {
     int id;
     int age;
     float salary;
     string name;
 };
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL;
 };
 
-type Employee {
+type Employee record {
     int id;
     string name;
     float salary;
 };
 
-type EmployeeCompatible {
+type EmployeeCompatible record {
     int id;
     string name;
     float salary;
 };
 
-type EmployeeSalary {
+type EmployeeSalary record {
     int id;
     float salary;
 };
 
-type EmployeeSalaryCompatible {
+type EmployeeSalaryCompatible record {
     int id;
     float salary;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_iteration_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_iteration_negative.bal
@@ -1,21 +1,21 @@
-type Employee {
+type Employee record {
     int id;
     string name;
     float salary;
 };
 
-type EmployeeIncompatible {
+type EmployeeIncompatible record {
     float id;
     string name;
     float salary;
 };
 
-type EmployeeSalary {
+type EmployeeSalary record {
     int id;
     float salary;
 };
 
-type EmployeeSalaryIncompatible {
+type EmployeeSalaryIncompatible record {
     float id;
     float salary;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_literal.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_literal.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 import ballerina/jdbc;
 import ballerina/sql;
 
-type Person {
+type Person record {
     int id,
     int age,
     float salary,
@@ -10,28 +10,28 @@ type Person {
     boolean married,
 };
 
-type Company {
+type Company record {
     int id,
     string name,
 };
 
-type TypeTest {
+type TypeTest record {
     int id,
     json jsonData,
     xml xmlData,
 };
 
-type BlobTypeTest {
+type BlobTypeTest record {
     int id,
     blob blobData,
 };
 
-type AnyTypeTest {
+type AnyTypeTest record {
     int id,
     any anyData,
 };
 
-type ArraTypeTest {
+type ArraTypeTest record {
     int id,
     int[] intArrData,
     float[] floatArrData,
@@ -39,7 +39,7 @@ type ArraTypeTest {
     boolean[] booleanArrData,
 };
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_literal_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_literal_negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     int id,
     int age,
     float salary,

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_literal_syntax.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_literal_syntax.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     int id,
     int age,
     float salary,

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
@@ -18,42 +18,42 @@ import ballerina/jdbc;
 import ballerina/sql;
 import ballerina/time;
 
-type ResultDatesWithNillableStringType {
+type ResultDatesWithNillableStringType record {
     string? DATE_TYPE,
     string? TIME_TYPE,
     string? TIMESTAMP_TYPE,
     string? DATETIME_TYPE,
 };
 
-type ResultDatesWithTimeType {
+type ResultDatesWithTimeType record {
     time:Time DATE_TYPE,
     time:Time TIME_TYPE,
     time:Time TIMESTAMP_TYPE,
     time:Time DATETIME_TYPE,
 };
 
-type ResultDatesWithNillableTimeType {
+type ResultDatesWithNillableTimeType record {
     time:Time? DATE_TYPE;
     time:Time? TIME_TYPE;
     time:Time? TIMESTAMP_TYPE;
     time:Time? DATETIME_TYPE;
 };
 
-type ResultDatesWithIntType {
+type ResultDatesWithIntType record {
     int DATE_TYPE,
     int TIME_TYPE,
     int TIMESTAMP_TYPE,
     int DATETIME_TYPE,
 };
 
-type ResultDatesWithNillableIntType {
+type ResultDatesWithNillableIntType record {
     int? DATE_TYPE,
     int? TIME_TYPE,
     int? TIMESTAMP_TYPE,
     int? DATETIME_TYPE,
 };
 
-type NillableDataTypes {
+type NillableDataTypes record {
     int? int_type,
     int? long_type,
     float? float_type,
@@ -74,7 +74,7 @@ type NillableDataTypes {
     time:Time? timestamp_type,
 };
 
-type ResultMapNonNillableTypeNillableElements {
+type ResultMapNonNillableTypeNillableElements record {
     int?[] INT_ARRAY;
     int?[] LONG_ARRAY;
     float?[] FLOAT_ARRAY;
@@ -82,7 +82,7 @@ type ResultMapNonNillableTypeNillableElements {
     string?[] STRING_ARRAY;
 };
 
-type ResultMapNillable {
+type ResultMapNillable record {
     int?[]? INT_ARRAY;
     int?[]? LONG_ARRAY;
     float?[]? FLOAT_ARRAY;
@@ -90,7 +90,7 @@ type ResultMapNillable {
     string?[]? STRING_ARRAY;
 };
 
-type ResultMapNillableTypeNonNillableElements {
+type ResultMapNillableTypeNonNillableElements record {
     int[]? INT_ARRAY;
     int[]? LONG_ARRAY;
     float[]? FLOAT_ARRAY;

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_nillable_mapping_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_nillable_mapping_negative.bal
@@ -17,95 +17,95 @@
 import ballerina/jdbc;
 import ballerina/time;
 
-type NonNillableInt {
+type NonNillableInt record {
     int val;
 };
 
-type NonNillableLong {
+type NonNillableLong record {
     int val;
 };
 
-type NonNillableFloat {
+type NonNillableFloat record {
     float val;
 };
 
-type NonNillableDouble {
+type NonNillableDouble record {
     float val;
 };
 
-type NonNillableBoolean {
+type NonNillableBoolean record {
     boolean val;
 };
 
-type NonNillableString {
+type NonNillableString record {
     string val;
 };
 
-type NonNillableNumeric {
+type NonNillableNumeric record {
     float val;
 };
 
-type NonNillableTinyInt {
+type NonNillableTinyInt record {
     int val;
 };
 
-type NonNillableSmallInt {
+type NonNillableSmallInt record {
     int val;
 };
 
-type NonNillableDecimal {
+type NonNillableDecimal record {
     float val;
 };
 
-type NonNillableReal {
+type NonNillableReal record {
     float val;
 };
 
-type NonNillableClob {
+type NonNillableClob record {
     string val;
 };
 
-type NonNillableBlob {
+type NonNillableBlob record {
     blob val;
 };
 
-type NonNillableBinary {
+type NonNillableBinary record {
     blob val;
 };
 
-type NonNillableDate {
+type NonNillableDate record {
     time:Time val;
 };
 
-type NonNillableTime {
+type NonNillableTime record {
     time:Time val;
 };
 
-type NonNillableDateTime {
+type NonNillableDateTime record {
     time:Time val;
 };
 
-type NonNillableTimeStamp {
+type NonNillableTimeStamp record {
     time:Time val;
 };
 
-type InvalidUnion {
+type InvalidUnion record {
     (int|string) val;
 };
 
-type InvalidUnionArrayElement {
+type InvalidUnionArrayElement record {
     (int|string)[] val,
 };
 
-type InvalidUnionArray {
+type InvalidUnionArray record {
     int[]|string val,
 };
 
-type InvalidUnionArray2 {
+type InvalidUnionArray2 record {
     string?[] val,
 };
 
-type ResultMap {
+type ResultMap record {
     int[] INT_ARRAY,
     int[] LONG_ARRAY,
     float[] FLOAT_ARRAY,
@@ -113,7 +113,7 @@ type ResultMap {
     string[] STRING_ARRAY,
 };
 
-type ResultMapNonNillableTypeNillableElements {
+type ResultMapNonNillableTypeNillableElements record {
     int?[] INT_ARRAY,
     int?[] LONG_ARRAY,
     float?[] FLOAT_ARRAY,
@@ -121,7 +121,7 @@ type ResultMapNonNillableTypeNillableElements {
     string?[] STRING_ARRAY,
 };
 
-type ResultMapNillable {
+type ResultMapNillable record {
     int?[]? INT_ARRAY,
     int?[]? LONG_ARRAY,
     float?[]? FLOAT_ARRAY,
@@ -129,7 +129,7 @@ type ResultMapNillable {
     string?[]? STRING_ARRAY,
 };
 
-type ResultMapNillableTypeNonNillableElements {
+type ResultMapNillableTypeNonNillableElements record {
     int[]? INT_ARRAY;
     int[]? LONG_ARRAY;
     float[]? FLOAT_ARRAY;

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_sql.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_sql.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     int id,
     int age = -1,
     float salary,
@@ -6,21 +6,21 @@ type Person {
     boolean married,
 };
 
-type Order {
+type Order record {
     int personId,
     int orderId,
     string items,
     float amount,
 };
 
-type OrderDetails {
+type OrderDetails record {
     int orderId,
     string personName,
     string items,
     float amount,
 };
 
-type Student {
+type Student record {
     string name,
     int index,
     int age = -1,

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_test_helper.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_test_helper.bal
@@ -1,7 +1,7 @@
 import ballerina/sql;
 import ballerina/jdbc;
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table_type.bal
@@ -3,7 +3,7 @@ import ballerina/jdbc;
 import ballerina/io;
 import ballerina/time;
 
-type ResultPrimitive {
+type ResultPrimitive record {
     int INT_TYPE;
     int LONG_TYPE;
     float FLOAT_TYPE;
@@ -12,7 +12,7 @@ type ResultPrimitive {
     string STRING_TYPE;
 };
 
-type ResultSetTestAlias {
+type ResultSetTestAlias record {
     int INT_TYPE;
     int LONG_TYPE;
     float FLOAT_TYPE;
@@ -22,13 +22,13 @@ type ResultSetTestAlias {
     int DT2INT_TYPE;
 };
 
-type ResultObject {
+type ResultObject record {
     blob BLOB_TYPE;
     string CLOB_TYPE;
     blob BINARY_TYPE;
 };
 
-type ResultMap {
+type ResultMap record {
     int[] INT_ARRAY;
     int[] LONG_ARRAY;
     float[] FLOAT_ARRAY;
@@ -36,54 +36,54 @@ type ResultMap {
     string[] STRING_ARRAY;
 };
 
-type ResultBlob {
+type ResultBlob record {
     blob BLOB_TYPE;
 };
 
-type ResultDates {
+type ResultDates record {
     string DATE_TYPE;
     string TIME_TYPE;
     string TIMESTAMP_TYPE;
     string DATETIME_TYPE;
 };
 
-type ResultDatesStruct {
+type ResultDatesStruct record {
     time:Time DATE_TYPE;
     time:Time TIME_TYPE;
     time:Time TIMESTAMP_TYPE;
     time:Time DATETIME_TYPE;
 };
 
-type ResultDatesInt {
+type ResultDatesInt record {
     int DATE_TYPE;
     int TIME_TYPE;
     int TIMESTAMP_TYPE;
     int DATETIME_TYPE;
 };
 
-type ResultSetFloat {
+type ResultSetFloat record {
     float FLOAT_TYPE;
     float DOUBLE_TYPE;
     float NUMERIC_TYPE;
     float DECIMAL_TYPE;
 };
 
-type ResultPrimitiveInt {
+type ResultPrimitiveInt record {
     int INT_TYPE;
 };
 
-type ResultCount {
+type ResultCount record {
     int COUNTVAL;
 };
 
-type ResultTest {
+type ResultTest record {
     int t1Row;
     int t1Int;
     int t2Row;
     int t2Int;
 };
 
-type ResultSignedInt {
+type ResultSignedInt record {
     int ID;
     int? TINYINTDATA;
     int? SMALLINTDATA;
@@ -91,14 +91,14 @@ type ResultSignedInt {
     int? BIGINTDATA;
 };
 
-type ResultComplexTypes {
+type ResultComplexTypes record {
     int ROW_ID;
     blob? BLOB_TYPE;
     string? CLOB_TYPE;
     blob? BINARY_TYPE;
 };
 
-type TestTypeData {
+type TestTypeData record {
     int i;
     int[] iA;
     int l;

--- a/tests/ballerina-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -42,7 +42,7 @@ function basicTupleTest () returns (string) {
     return exFlow;
 }
 
-type FooStruct {
+type FooStruct record {
     string x;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -43,11 +43,11 @@ function testArrayTypes() returns (typedesc, typedesc) {
 
 function testRecordTypes() returns (typedesc, typedesc) {
     typedesc a = RecordA;
-    typedesc b = {string c, int d,};
+    typedesc b = record {string c, int d,};
     return (a,b);
 }
 
-type RecordA {
+type RecordA record {
     string a;
     int b;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
@@ -62,7 +62,7 @@ function testNullableTypeBasics2() returns (int|boolean|()) {
 
 }
 
-public type ParamAny {
+public type ParamAny record {
     any value,
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/var/var-invalid-usage-struct-field-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/var/var-invalid-usage-struct-field-negative.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string name;
     int age;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/types/var/var-type-assign-stmt.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/var/var-type-assign-stmt.bal
@@ -1,4 +1,4 @@
-type Person {
+type Person record {
     string name;
     int age;
     Person? parent;
@@ -150,7 +150,7 @@ function testIncompatibleJsonToStructWithErrors() returns (Person | error) {
     return p;
 }
 
-type PersonA {
+type PersonA record {
     string name;
     int age;
 };
@@ -163,12 +163,12 @@ function testJsonToStructWithErrors() returns (PersonA | error) {
     return p;
 }
 
-type A {
+type A record {
     string x;
     int y;
 };
 
-type B {
+type B record {
     string x;
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/workers/not-so-basic-worker-actions.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/workers/not-so-basic-worker-actions.bal
@@ -434,7 +434,7 @@ function forkJoinWithStruct () returns string {
     return result;
 }
 
-type foo {
+type foo record {
     int x;
     string y;
 };

--- a/tests/ballerina-test/src/test/resources/test-src/workers/worker-in-action.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/workers/worker-in-action.bal
@@ -1,4 +1,4 @@
-type ClientEndpointConfiguration {
+type ClientEndpointConfiguration record {
 
 };
 

--- a/tests/ballerina-test/src/test/resources/test-src/workers/worker-in-function-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/workers/worker-in-function-test.bal
@@ -2,7 +2,7 @@ function testSimpleWorker (string msg) returns string {
     return testSimpleWorkerVM(msg);
 }
 
-type TStruct {
+type TStruct record {
     string msg;
 };
 


### PR DESCRIPTION
## Purpose
> This PR will make the `record` keyword mandatory when defining records. The usage will be as follows:
```ballerina
type Person record {
     string name,
     int age,
};
```