### PR TITLE
Improve XML parser security to prevent XXE by default

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/XMLUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/XMLUtils.java
@@ -30,9 +30,11 @@ import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMProcessingInstruction;
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.OMXMLBuilderFactory;
+import org.apache.axiom.om.OMXMLParserWrapper;
 import org.apache.axiom.om.impl.dom.TextImpl;
 import org.apache.axiom.om.impl.llom.OMSourcedElementImpl;
 import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axiom.om.util.StAXParserConfiguration;
 import org.ballerinalang.model.TableOMDataSource;
 import org.ballerinalang.model.util.JsonNode.Type;
 import org.ballerinalang.model.values.BJSON;
@@ -127,7 +129,7 @@ public class XMLUtils {
         BRefValueArray elementsSeq = new BRefValueArray();
         OMDocument doc;
         try {
-            doc = OMXMLBuilderFactory.createOMBuilder(xmlStream).getDocument();
+            doc = createOMBuilder(xmlStream).getDocument();
             Iterator<OMNode> docChildItr = doc.getChildren();
             int i = 0;
             while (docChildItr.hasNext()) {
@@ -153,7 +155,7 @@ public class XMLUtils {
         BRefValueArray elementsSeq = new BRefValueArray();
         OMDocument doc;
         try {
-            doc = OMXMLBuilderFactory.createOMBuilder(xmlStream, charset).getDocument();
+            doc = createOMBuilder(xmlStream, charset).getDocument();
             Iterator<OMNode> docChildItr = doc.getChildren();
             int index = 0;
             while (docChildItr.hasNext()) {
@@ -178,7 +180,7 @@ public class XMLUtils {
         BRefValueArray elementsSeq = new BRefValueArray();
         OMDocument doc;
         try {
-            doc = OMXMLBuilderFactory.createOMBuilder(reader).getDocument();
+            doc = createOMBuilder(reader).getDocument();
             Iterator<OMNode> docChildItr = doc.getChildren();
             int i = 0;
             while (docChildItr.hasNext()) {
@@ -654,5 +656,17 @@ public class XMLUtils {
             qname = new QName(namespaceUri, localName);
         }
         return qname;
+    }
+
+    public static OMXMLParserWrapper createOMBuilder(InputStream xmlStream) {
+        return createOMBuilder(xmlStream, null);
+    }
+
+    public static OMXMLParserWrapper createOMBuilder(InputStream xmlStream, String encoding) {
+        return OMXMLBuilderFactory.createOMBuilder(StAXParserConfiguration.STANDALONE, xmlStream, encoding);
+    }
+
+    public static OMXMLParserWrapper createOMBuilder(Reader in) {
+        return OMXMLBuilderFactory.createOMBuilder(StAXParserConfiguration.STANDALONE, in);
     }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
@@ -24,6 +24,7 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMProcessingInstruction;
 import org.apache.axiom.om.OMText;
+import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.om.impl.common.OMChildrenQNameIterator;
 import org.apache.axiom.om.impl.common.OMNamespaceImpl;
 import org.apache.axiom.om.impl.dom.CommentImpl;
@@ -32,7 +33,6 @@ import org.apache.axiom.om.impl.llom.OMAttributeImpl;
 import org.apache.axiom.om.impl.llom.OMDocumentImpl;
 import org.apache.axiom.om.impl.llom.OMElementImpl;
 import org.apache.axiom.om.impl.llom.OMProcessingInstructionImpl;
-import org.apache.axiom.om.util.AXIOMUtil;
 import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.model.util.XMLNodeType;
 import org.ballerinalang.model.util.XMLUtils;
@@ -87,7 +87,7 @@ public final class BXMLItem extends BXML<OMNode> {
         }
 
         try {
-            omNode = AXIOMUtil.stringToOM(xmlValue);
+            omNode = XMLUtils.stringToOM(xmlValue);
             setXMLNodeType();
         } catch (Throwable t) {
             handleXmlException("failed to create xml: ", t);
@@ -115,7 +115,8 @@ public final class BXMLItem extends BXML<OMNode> {
         }
 
         try {
-            omNode = XMLUtils.createOMBuilder(inputStream).getDocumentElement();
+            omNode = OMXMLBuilderFactory.createOMBuilder(XMLUtils.STAX_PARSER_CONFIGURATION,
+                    inputStream).getDocumentElement();
             setXMLNodeType();
         } catch (Throwable t) {
             handleXmlException("failed to create xml: ", t);

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
@@ -24,7 +24,6 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMProcessingInstruction;
 import org.apache.axiom.om.OMText;
-import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.om.impl.common.OMChildrenQNameIterator;
 import org.apache.axiom.om.impl.common.OMNamespaceImpl;
 import org.apache.axiom.om.impl.dom.CommentImpl;
@@ -36,6 +35,7 @@ import org.apache.axiom.om.impl.llom.OMProcessingInstructionImpl;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.model.util.XMLNodeType;
+import org.ballerinalang.model.util.XMLUtils;
 import org.ballerinalang.model.util.XMLValidationUtils;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -115,7 +115,7 @@ public final class BXMLItem extends BXML<OMNode> {
         }
 
         try {
-            omNode = OMXMLBuilderFactory.createOMBuilder(inputStream).getDocumentElement();
+            omNode = XMLUtils.createOMBuilder(inputStream).getDocumentElement();
             setXMLNodeType();
         } catch (Throwable t) {
             handleXmlException("failed to create xml: ", t);

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/TestConstant.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/TestConstant.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TestConstant {
     public static final String CONTENT_TYPE_JSON = "application/json";
+    public static final String CONTENT_TYPE_XML = "application/xml";
     public static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
     public static final String CONTENT_TYPE_FORM_URL_ENCODED = "application/x-www-form-urlencoded";
     public static final String CHARSET_NAME = "UTF-8";

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/xmlsecurity/HTTPResponseXMLSecurityTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/xmlsecurity/HTTPResponseXMLSecurityTestCase.java
@@ -33,6 +33,9 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Testing actual runtime behaviour of the XML parser from security point of view.
+ */
 public class HTTPResponseXMLSecurityTestCase  extends IntegrationTestCase {
 
     private ServerInstance ballerinaServer;
@@ -78,6 +81,7 @@ public class HTTPResponseXMLSecurityTestCase  extends IntegrationTestCase {
         HttpResponse response = sendXmlPayload(xmlString);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        //TODO: Introduce validation of error message once GitHub issue #4533 is fixed.
     }
 
     private HttpResponse sendXmlPayload(String requestMsg) throws Exception {

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/xmlsecurity/HTTPResponseXMLSecurityTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/xmlsecurity/HTTPResponseXMLSecurityTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.xmlsecurity;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.ballerinalang.test.IntegrationTestCase;
+import org.ballerinalang.test.context.ServerInstance;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.TestConstant;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HTTPResponseXMLSecurityTestCase  extends IntegrationTestCase {
+
+    private ServerInstance ballerinaServer;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        String balFilePath = new File("src" + File.separator + "test" + File.separator + "resources"
+                + File.separator + "xmlSecurity" + File.separator +
+                "xml-parsing-service.bal").getAbsolutePath();
+        ballerinaServer = ServerInstance.initBallerinaServer();
+        ballerinaServer.startBallerinaServer(balFilePath);
+    }
+
+    @Test(description = "Test the service for XML External Entity Injection attack")
+    public void testXMLExternalEntityInjection() throws Exception {
+        String xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<!DOCTYPE foo [" +
+                "<!ELEMENT foo ANY >" +
+                "<!ENTITY xxe SYSTEM \"https://www.w3schools.com/xml/note.xml\" >]>" +
+                "<foo>&xxe;</foo>";
+        HttpResponse response = sendXmlPayload(xmlString);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        String respMsg = "";
+        Assert.assertEquals(response.getData(), respMsg, "Message content mismatched");
+    }
+
+    @Test(description = "Test the service for XML Entity Expansion attack", timeOut = 10000)
+    public void testXMLEntityExpansion() throws Exception {
+        String xmlString = "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE lolz [\n" +
+                "<!ENTITY lol \"lol\">\n" +
+                "<!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n" +
+                "<!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n" +
+                "<!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n" +
+                "<!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n" +
+                "<!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n" +
+                "<!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n" +
+                "<!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n" +
+                "<!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n" +
+                "]>\n" +
+                "<lolz>&lol9;</lolz>";
+        HttpResponse response = sendXmlPayload(xmlString);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+    }
+
+    private HttpResponse sendXmlPayload(String requestMsg) throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_XML);
+        String serviceUrl = "http://localhost:9090/xmlparser";
+        HttpResponse response = HttpClientRequest.doPost(serviceUrl, requestMsg, headers);
+        if (response == null) {
+            //Retrying to avoid intermittent test failure
+            response = HttpClientRequest.doPost(serviceUrl, requestMsg, headers);
+        }
+        return response;
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        ballerinaServer.stopServer();
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/xmlSecurity/xml-parsing-service.bal
+++ b/tests/ballerina-test-integration/src/test/resources/xmlSecurity/xml-parsing-service.bal
@@ -1,0 +1,31 @@
+import ballerina/http;
+import ballerina/log;
+
+@http:ServiceConfig {
+    basePath: "/xmlparser"
+}
+service<http:Service> xmlParserService bind { port: 9090 } {
+    @http:ResourceConfig {
+        path: "/"
+    }
+    parse(endpoint caller, http:Request request) {
+        var payload = request.getXmlPayload();
+        http:Response res = new;
+        match (payload) {
+            xml xmlPayload => {
+                res.statusCode = 200;
+                res.setTextPayload(xmlPayload.getTextValue());
+                caller->respond(res) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+            error err => {
+                res.statusCode = 500;
+                res.setTextPayload(err.message);
+                caller->respond(res) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+        }
+    }
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLSecurityTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLSecurityTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.types.xml;
+
+import org.ballerinalang.model.util.XMLUtils;
+import org.ballerinalang.model.values.BXML;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for XML security.
+ */
+public class XMLSecurityTest {
+
+    @Test
+    public void testExternalEntityInjection() {
+        String xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<!DOCTYPE foo [" +
+                "<!ELEMENT foo ANY >" +
+                "<!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>" +
+                "<foo>&xxe;</foo>";
+        BXML xmlDocument = XMLUtils.parse(xmlString);
+        Assert.assertEquals(xmlDocument.toString(), "<foo></foo>");
+    }
+
+    @Test (timeOut = 10000, expectedExceptions = org.ballerinalang.util.exceptions.BallerinaException.class)
+    public void testEntityExpansion() {
+        String xmlString = "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE lolz [\n" +
+                "<!ENTITY lol \"lol\">\n" +
+                "<!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n" +
+                "<!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n" +
+                "<!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n" +
+                "<!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n" +
+                "<!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n" +
+                "<!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n" +
+                "<!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n" +
+                "<!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n" +
+                "]>\n" +
+                "<lolz>&lol9;</lolz>";
+        XMLUtils.parse(xmlString).toString();
+    }
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLSecurityTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/xml/XMLSecurityTest.java
@@ -32,7 +32,7 @@ public class XMLSecurityTest {
         String xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<!DOCTYPE foo [" +
                 "<!ELEMENT foo ANY >" +
-                "<!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>" +
+                "<!ENTITY xxe SYSTEM \"https://www.w3schools.com/xml/note.xml\" >]>" +
                 "<foo>&xxe;</foo>";
         BXML xmlDocument = XMLUtils.parse(xmlString);
         Assert.assertEquals(xmlDocument.toString(), "<foo></foo>");


### PR DESCRIPTION
_NOTE: **Unit tests will fail until** the PR #9163 get merged_

## Purpose
The XML parsing utility of Ballerina currently use the `StAXParserConfiguration.DEFAULT` which allows remote entity inclusion, allowing in security vulnerability XML External Entity (XXE) Processing.  This is number 4 threat in OWASP Top 10 2017 categorization.

[1] https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing

## Goals
Prevent possibility of XML External Entity (XXE) Processing by default. 

## Approach
Change the XML parser to use `StAXParserConfiguration.STANDALONE` to make sure the parser is secure by default, and add unit tests and integration tests for XML entity expansion and XML external entity injection attack patterns.

## Related PRs
This PR depends on PR #9163 and **unit tests will fail until** the PR #9163 get merged. 