### PR TITLE
Remove composer automatically assigning a port

### DIFF
--- a/composer/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
+++ b/composer/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
@@ -107,7 +107,10 @@ public class ServerLauncher {
         // give precedence to command line arg for port
         if (cmdLineArgs.port != null) {
             config.setPort(cmdLineArgs.port);
+        } else {
+            config.setPort(DEFAULT_PORT);
         }
+        
         // if no port is provided via cmd args or config file, try to grab an open port
         if (config.getPort() == 0) {
             config.setPort(getAvailablePort(DEFAULT_PORT));


### PR DESCRIPTION
Fix #8283

Use --port 0 if you want Composer to automatically start on a free port