### PR TITLE
Change module name in some poms

### DIFF
--- a/composer/integration-tests/pom.xml
+++ b/composer/integration-tests/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration-tests</artifactId>
     <packaging>pom</packaging>
-    <name>Ballerina - Composer integration tests</name>
+    <name>Ballerina - Composer - Integration tests</name>
     <modules>
          <!--<module>ui-integration-tests</module>-->
     </modules>

--- a/composer/modules/distribution/pom.xml
+++ b/composer/modules/distribution/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <artifactId>ballerina-composer-electron-sources</artifactId>
     <packaging>pom</packaging>
-    <name>Ballerina Composer - Electron Sources</name>
+    <name>Ballerina - Composer - Electron Sources</name>
 
     <build>
         <plugins>


### PR DESCRIPTION
Change module names in electron and composer integration test poms to match the convention.