### PR TITLE
Clear standard output cache after back end completes starting up

### DIFF
--- a/composer/modules/integration-tests/src/test/js/test.js
+++ b/composer/modules/integration-tests/src/test/js/test.js
@@ -49,6 +49,7 @@ describe('Ballerina Composer Test Suite', () => {
             if (stdIndata.indexOf("Composer started successfully") < 0) {
                 return;
             }
+            stdIndata = '';
             console.log(stdIndata);
             testEnv.initialize();
             beforeAllDone();


### PR DESCRIPTION
## Purpose
Fixes the possible composer integration test fail due to before all hook being called multiple times