### PR TITLE
Convert I/O APIs to read/write byte[]

### DIFF
--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -195,10 +195,10 @@ documentation {
 
     P{{channel}} Byte channel
     P{{numberOfBytes}} Number of bytes to be read
-    R{{}} Bytes read as a blob along with the number of bytes read.
+    R{{}} Bytes read as a byte[] along with the number of bytes read.
 }
-function readBytes (io:ByteChannel channel, int numberOfBytes) returns (blob, int) {
-    blob bytes;
+function readBytes (io:ByteChannel channel, int numberOfBytes) returns (byte[], int) {
+    byte[] bytes;
     int numberOfBytesRead;
     (bytes, numberOfBytesRead) = check (channel.read(numberOfBytes));
     return (bytes, numberOfBytesRead);
@@ -208,11 +208,11 @@ documentation {
     This function will write the bytes from the byte channel.
 
     P{{channel}} Byte channel
-    P{{content}} Content to be written as a blob
+    P{{content}} Content to be written as a byte[]
     P{{startOffset}} Offset
     R{{}} number of bytes written.
 }
-function writeBytes (io:ByteChannel channel, blob content, int startOffset) returns (int) {
+function writeBytes (io:ByteChannel channel, byte[] content, int startOffset) returns (int) {
     int numberOfBytesWritten = check (channel.write(content, startOffset));
     return numberOfBytesWritten;
 }
@@ -235,7 +235,7 @@ function copy (int pkgSize, io:ByteChannel src, io:ByteChannel dest, string full
         terminalWidth = terminalWidth - tabLength;
     }
     int bytesChunk = 8;
-    blob readContent;
+    byte[] readContent;
     int readCount = -1;
     float totalCount = 0.0;
     int numberOfBytesWritten = 0;

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -195,7 +195,7 @@ documentation {
 
     P{{channel}} Byte channel
     P{{numberOfBytes}} Number of bytes to be read
-    R{{}} Bytes read as a byte[] along with the number of bytes read.
+    R{{}} Read content as byte[] along with the number of bytes read.
 }
 function readBytes (io:ByteChannel channel, int numberOfBytes) returns (byte[], int) {
     byte[] bytes;

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -212,7 +212,7 @@ documentation {
     P{{startOffset}} Offset
     R{{}} number of bytes written.
 }
-function writeBytes (io:ByteChannel channel, byte[] content, int startOffset) returns (int) {
+function writeBytes (io:ByteChannel channel, byte[] content, int startOffset) returns int {
     int numberOfBytesWritten = check (channel.write(content, startOffset));
     return numberOfBytesWritten;
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/completionBeforeUnderscore1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/completionBeforeUnderscore1.json
@@ -22,7 +22,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "createMemoryChannel(blob content)(ballerina/io:ByteChannel)",
+      "label": "createMemoryChannel(byte[] content)(ballerina/io:ByteChannel)",
       "kind": "Function",
       "detail": "Function",
       "sortText": "121",

--- a/stdlib/io/src/main/ballerina/io/byte_channel.bal
+++ b/stdlib/io/src/main/ballerina/io/byte_channel.bal
@@ -30,7 +30,7 @@ public type ByteChannel object {
         P{{nBytes}} Positive integer. Represents the number of bytes which should be read
         R{{}} Content, the number of bytes read or an error
     }
-    public native function read(@sensitive int nBytes) returns @tainted (blob, int)|error;
+    public native function read(@sensitive int nBytes) returns @tainted (byte[], int)|error;
 
     documentation {
         Sink bytes from a given input/output resource.
@@ -41,7 +41,7 @@ public type ByteChannel object {
         R{{offset}} Offset which should be kept when writing bytes
         R{{}} Number of bytes written or an error
     }
-    public native function write(blob content, int offset) returns int|error;
+    public native function write(byte[] content, int offset) returns int|error;
 
     documentation {
         Closes a given byte channel.

--- a/stdlib/io/src/main/ballerina/io/open.bal
+++ b/stdlib/io/src/main/ballerina/io/open.bal
@@ -55,7 +55,7 @@ documentation {
     P{{content}} Content which should be exposed as channel
     R{{}} ByteChannel represenation to read the memory content
 }
-public native function createMemoryChannel(blob content) returns ByteChannel;
+public native function createMemoryChannel(byte[] content) returns ByteChannel;
 
 documentation {
     Retrieves a CSV channel from a give file path.
@@ -71,8 +71,8 @@ public function openCsvFile(@sensitive string path,
                             @sensitive Mode mode = "r",
                             @sensitive Separator fieldSeparator = ",",
                             @sensitive string charset = "UTF-8",
-                            @sensitive int skipHeaders=0) returns @tainted CSVChannel {
+                            @sensitive int skipHeaders = 0) returns @tainted CSVChannel {
     ByteChannel channel = openFile(path, mode);
     CharacterChannel charChannel = new(channel, charset);
-    return new CSVChannel(charChannel, fs = fieldSeparator,nHeaders = skipHeaders);
+    return new CSVChannel(charChannel, fs = fieldSeparator, nHeaders = skipHeaders);
 }

--- a/stdlib/io/src/main/ballerina/io/strings.bal
+++ b/stdlib/io/src/main/ballerina/io/strings.bal
@@ -29,7 +29,7 @@ public type StringReader object {
       P{{encoding}} encoding of the characters of the content
     }
     public new(string content, string encoding = "UTF-8") {
-        blob contentBytes = content.toBlob(encoding);
+        byte[] contentBytes = content.toByteArray(encoding);
         ByteChannel byteChannel = createMemoryChannel(contentBytes);
         channel = new CharacterChannel(byteChannel, encoding);
     }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CreateMemoryChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CreateMemoryChannel.java
@@ -52,12 +52,25 @@ public class CreateMemoryChannel extends AbstractNativeChannel {
     private static final int MESSAGE_CONTENT_INDEX = 0;
 
     /**
+     * Shrink the byte array to fit with the given content.
+     *
+     * @param array byte array with elements initialized.
+     * @return byte array which is shrunk.
+     */
+    private byte[] shrink(BByteArray array) {
+        int contentLength = (int) array.size();
+        byte[] content = new byte[contentLength];
+        System.arraycopy(array.getBytes(), 0, content, 0, contentLength);
+        return content;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public Channel inFlow(Context context) throws BallerinaException {
         try {
-            byte[] content = ((BByteArray) context.getRefArgument(MESSAGE_CONTENT_INDEX)).getValues();
+            byte[] content = shrink(((BByteArray) context.getRefArgument(MESSAGE_CONTENT_INDEX)));
             ByteArrayInputStream contentStream = new ByteArrayInputStream(content);
             ReadableByteChannel readableByteChannel = Channels.newChannel(contentStream);
             return new BlobIOChannel(new BlobChannel(readableByteChannel));

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CreateMemoryChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CreateMemoryChannel.java
@@ -20,6 +20,7 @@ package org.ballerinalang.stdlib.io.nativeimpl;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.stdlib.io.channels.AbstractNativeChannel;
@@ -41,7 +42,7 @@ import java.nio.channels.ReadableByteChannel;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "io",
         functionName = "createMemoryChannel",
-        args = {@Argument(name = "content", type = TypeKind.BLOB)},
+        args = {@Argument(name = "content", type = TypeKind.ARRAY, elementType = TypeKind.BYTE)},
         isPublic = true
 )
 public class CreateMemoryChannel extends AbstractNativeChannel {
@@ -56,7 +57,7 @@ public class CreateMemoryChannel extends AbstractNativeChannel {
     @Override
     public Channel inFlow(Context context) throws BallerinaException {
         try {
-            byte[] content = context.getBlobArgument(MESSAGE_CONTENT_INDEX);
+            byte[] content = ((BByteArray) context.getRefArgument(MESSAGE_CONTENT_INDEX)).getValues();
             ByteArrayInputStream contentStream = new ByteArrayInputStream(content);
             ReadableByteChannel readableByteChannel = Channels.newChannel(contentStream);
             return new BlobIOChannel(new BlobChannel(readableByteChannel));

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ReadBytes.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ReadBytes.java
@@ -24,7 +24,7 @@ import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.BTupleType;
 import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BRefValueArray;
@@ -52,7 +52,7 @@ import java.util.Arrays;
         functionName = "read",
         receiver = @Receiver(type = TypeKind.OBJECT, structType = "ByteChannel", structPackage = "ballerina/io"),
         args = {@Argument(name = "nBytes", type = TypeKind.INT)},
-        returnType = {@ReturnType(type = TypeKind.BLOB),
+        returnType = {@ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.BYTE),
                 @ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.RECORD, structType = "IOError", structPackage = "ballerina/io")},
         isPublic = true
@@ -88,7 +88,7 @@ public class ReadBytes implements NativeCallableUnit {
             context.setReturnValues(errorStruct);
         } else {
             Integer numberOfBytes = result.getResponse();
-            contentTuple.add(0, new BBlob(content));
+            contentTuple.add(0, new BByteArray(content));
             contentTuple.add(1, new BInteger(numberOfBytes));
             context.setReturnValues(contentTuple);
         }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/WriteBytes.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/WriteBytes.java
@@ -99,7 +99,7 @@ public class WriteBytes implements NativeCallableUnit {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         BMap<String, BValue> channel = (BMap<String, BValue>) context.getRefArgument(BYTE_CHANNEL_INDEX);
-        byte[] content = ((BByteArray) context.getRefArgument(CONTENT_INDEX)).getValues();
+        byte[] content = ((BByteArray) context.getRefArgument(CONTENT_INDEX)).getBytes();
         int offset = (int) context.getIntArgument(START_OFFSET_INDEX);
         Channel byteChannel = (Channel) channel.getNativeData(IOConstants.BYTE_CHANNEL_NAME);
         EventContext eventContext = new EventContext(context, callback);

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/WriteBytes.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/WriteBytes.java
@@ -22,6 +22,7 @@ import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
 import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
@@ -44,7 +45,7 @@ import org.ballerinalang.stdlib.io.utils.IOUtils;
         orgName = "ballerina", packageName = "io",
         functionName = "write",
         receiver = @Receiver(type = TypeKind.OBJECT, structType = "ByteChannel", structPackage = "ballerina/io"),
-        args = {@Argument(name = "content", type = TypeKind.BLOB),
+        args = {@Argument(name = "content", type = TypeKind.ARRAY, elementType = TypeKind.BYTE),
                 @Argument(name = "offset", type = TypeKind.INT)},
         returnType = {@ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.RECORD, structType = "IOError", structPackage = "ballerina/io")},
@@ -60,7 +61,7 @@ public class WriteBytes implements NativeCallableUnit {
     /**
      * Index which holds the content in ballerina/io#writeBytes.
      */
-    private static final int CONTENT_INDEX = 0;
+    private static final int CONTENT_INDEX = 1;
 
     /*
      * Index which holds the start offset in ballerina/io#writeBytes.
@@ -98,7 +99,7 @@ public class WriteBytes implements NativeCallableUnit {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         BMap<String, BValue> channel = (BMap<String, BValue>) context.getRefArgument(BYTE_CHANNEL_INDEX);
-        byte[] content = context.getBlobArgument(CONTENT_INDEX);
+        byte[] content = ((BByteArray) context.getRefArgument(CONTENT_INDEX)).getValues();
         int offset = (int) context.getIntArgument(START_OFFSET_INDEX);
         Channel byteChannel = (Channel) channel.getNativeData(IOConstants.BYTE_CHANNEL_NAME);
         EventContext eventContext = new EventContext(context, callback);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
@@ -102,21 +102,21 @@ public class IOTest {
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         BValue[] returns = BRunUtil.invokeStateful(bytesInputOutputProgramFile, "readBytes", args);
         readBytes = (BByteArray) returns[0];
-        Assert.assertEquals(expectedBytes, readBytes.getValues());
+        Assert.assertEquals(expectedBytes, readBytes.getBytes());
 
         //Reads the next three bytes "456"
         expectedBytes = "456".getBytes();
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         returns = BRunUtil.invokeStateful(bytesInputOutputProgramFile, "readBytes", args);
         readBytes = (BByteArray) returns[0];
-        Assert.assertEquals(expectedBytes, readBytes.getValues());
+        Assert.assertEquals(expectedBytes, readBytes.getBytes());
 
         //Request for a get, the bytes will be empty
         expectedBytes = new byte[0];
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         returns = BRunUtil.invokeStateful(bytesInputOutputProgramFile, "readBytes", args);
         readBytes = (BByteArray) returns[0];
-        Assert.assertEquals(expectedBytes, readBytes.getValues());
+        Assert.assertEquals(expectedBytes, readBytes.getBytes());
 
         BRunUtil.invokeStateful(bytesInputOutputProgramFile, "close");
     }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
@@ -22,8 +22,8 @@ import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
-import org.ballerinalang.model.values.BBlob;
 import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BMap;
@@ -91,7 +91,7 @@ public class IOTest {
     public void testReadBytes() throws URISyntaxException {
         int numberOfBytesToRead = 3;
         String resourceToRead = "datafiles/io/text/6charfile.txt";
-        BBlob readBytes;
+        BByteArray readBytes;
 
         //Will initialize the channel
         BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead)), new BString("r")};
@@ -101,22 +101,22 @@ public class IOTest {
         byte[] expectedBytes = "123".getBytes();
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         BValue[] returns = BRunUtil.invokeStateful(bytesInputOutputProgramFile, "readBytes", args);
-        readBytes = (BBlob) returns[0];
-        Assert.assertEquals(expectedBytes, readBytes.blobValue());
+        readBytes = (BByteArray) returns[0];
+        Assert.assertEquals(expectedBytes, readBytes.getValues());
 
         //Reads the next three bytes "456"
         expectedBytes = "456".getBytes();
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         returns = BRunUtil.invokeStateful(bytesInputOutputProgramFile, "readBytes", args);
-        readBytes = (BBlob) returns[0];
-        Assert.assertEquals(expectedBytes, readBytes.blobValue());
+        readBytes = (BByteArray) returns[0];
+        Assert.assertEquals(expectedBytes, readBytes.getValues());
 
         //Request for a get, the bytes will be empty
         expectedBytes = new byte[0];
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         returns = BRunUtil.invokeStateful(bytesInputOutputProgramFile, "readBytes", args);
-        readBytes = (BBlob) returns[0];
-        Assert.assertEquals(expectedBytes, readBytes.blobValue());
+        readBytes = (BByteArray) returns[0];
+        Assert.assertEquals(expectedBytes, readBytes.getValues());
 
         BRunUtil.invokeStateful(bytesInputOutputProgramFile, "close");
     }
@@ -296,7 +296,7 @@ public class IOTest {
         BValue[] args = {new BString(sourceToWrite), new BString("w")};
         BRunUtil.invokeStateful(bytesInputOutputProgramFile, "initFileChannel", args);
 
-        args = new BValue[]{new BBlob(content), new BInteger(0)};
+        args = new BValue[]{new BByteArray(content), new BInteger(0)};
         BRunUtil.invokeStateful(bytesInputOutputProgramFile, "writeBytes", args);
 
         BRunUtil.invokeStateful(bytesInputOutputProgramFile, "close");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
@@ -21,7 +21,7 @@ package org.ballerinalang.test.nativeimpl.functions.io.socket;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
@@ -135,16 +135,16 @@ public class ClientSocketTest {
     public void testWriteReadContent() {
         String content = "Hello World\n";
         byte[] contentBytes = content.getBytes();
-        BValue[] args = { new BBlob(contentBytes)};
+        BValue[] args = {new BByteArray(contentBytes)};
         final BValue[] writeReturns = BRunUtil.invokeStateful(socketClient, "write", args);
         BInteger returnedSize = (BInteger) writeReturns[0];
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
-        args = new BValue[] { new BInteger(content.length()) };
+        args = new BValue[]{new BInteger(content.length())};
         final BValue[] readReturns = BRunUtil.invokeStateful(socketClient, "read", args);
-        final BBlob readContent = (BBlob) readReturns[0];
+//        final BByteArray readContent = (BByteArray) readReturns[0];
         returnedSize = (BInteger) readReturns[1];
 
-        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
+//        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Read size not match with the request size");
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
@@ -141,10 +141,8 @@ public class ClientSocketTest {
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
         args = new BValue[]{new BInteger(content.length())};
         final BValue[] readReturns = BRunUtil.invokeStateful(socketClient, "read", args);
-//        final BByteArray readContent = (BByteArray) readReturns[0];
         returnedSize = (BInteger) readReturns[1];
 
-//        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Read size not match with the request size");
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
@@ -159,9 +159,7 @@ public class SecureClientSocketTest {
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
         args = new BValue[] { new BInteger(content.length()) };
         final BValue[] readReturns = BRunUtil.invokeStateful(socketClient, "read", args);
-//        final BByteArray readContent = (BByteArray) readReturns[0];
         returnedSize = (BInteger) readReturns[1];
-//        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Read size not match with the request size");
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
@@ -22,7 +22,7 @@ import org.ballerinalang.bre.bvm.BLangVMStructs;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
@@ -153,15 +153,15 @@ public class SecureClientSocketTest {
         final String newline = System.lineSeparator();
         String content = "Hello World" + newline;
         final byte[] contentBytes = content.getBytes();
-        BValue[] args = { new BBlob(contentBytes)};
+        BValue[] args = { new BByteArray(contentBytes)};
         final BValue[] writeReturns = BRunUtil.invokeStateful(socketClient, "write", args);
         BInteger returnedSize = (BInteger) writeReturns[0];
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
         args = new BValue[] { new BInteger(content.length()) };
         final BValue[] readReturns = BRunUtil.invokeStateful(socketClient, "read", args);
-        final BBlob readContent = (BBlob) readReturns[0];
+//        final BByteArray readContent = (BByteArray) readReturns[0];
         returnedSize = (BInteger) readReturns[1];
-        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
+//        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Read size not match with the request size");
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/file.internal/file-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/file.internal/file-test.bal
@@ -152,7 +152,7 @@ function testWriteFile(string pathValue) returns error? {
     internal:Path filePath = new(pathValue);
     string absolutePath = filePath.getPathValue();
     io:ByteChannel channel = io:openFile(absolutePath, "rw");
-    var result = channel.write(TEST_CONTENT.toBlob("UTF-8"), 0);
+    var result = channel.write(TEST_CONTENT.toByteArray("UTF-8"), 0);
     return channel.close();
 }
 
@@ -161,9 +161,10 @@ function testReadFile(string pathValue) returns boolean {
     var readResult = channel.read(100);
     _ = channel.close();
     match readResult {
-        (blob, int) byteContent => {
+        (byte[], int) byteContent => {
             var (bytes, numberOfBytes) = byteContent;
-            return bytes.toString("UTF-8") == TEST_CONTENT;
+            return lengthof bytes == lengthof TEST_CONTENT.toByteArray("UTF-8");
+            //return bytes.toString("UTF-8") == TEST_CONTENT;
         }
         error err => {
             log:printError("Error occurred while reading content: " + pathValue, err = err);

--- a/tests/ballerina-test/src/test/resources/test-src/file.internal/file-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/file.internal/file-test.bal
@@ -164,7 +164,6 @@ function testReadFile(string pathValue) returns boolean {
         (byte[], int) byteContent => {
             var (bytes, numberOfBytes) = byteContent;
             return lengthof bytes == lengthof TEST_CONTENT.toByteArray("UTF-8");
-            //return bytes.toString("UTF-8") == TEST_CONTENT;
         }
         error err => {
             log:printError("Error occurred while reading content: " + pathValue, err = err);

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytes_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytes_io.bal
@@ -6,11 +6,11 @@ function initFileChannel (string filePath, io:Mode permission) {
     channel = io:openFile(filePath, permission);
 }
 
-function readBytes (int numberOfBytes) returns (blob|error) {
-    blob empty;
+function readBytes (int numberOfBytes) returns (byte[]|error) {
+    byte[] empty;
     var result = channel.read(numberOfBytes);
     match result {
-        (blob,int) content =>{
+        (byte[],int) content =>{
             var (bytes, _) = content;
             return bytes;
         }
@@ -20,7 +20,7 @@ function readBytes (int numberOfBytes) returns (blob|error) {
     }
 }
 
-function writeBytes (blob content, int startOffset) returns (int|error) {
+function writeBytes (byte[] content, int startOffset) returns (int|error) {
     int empty = -1;
     var result = channel.write(content, startOffset);
     match result {

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytes_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytes_io.bal
@@ -6,7 +6,7 @@ function initFileChannel (string filePath, io:Mode permission) {
     channel = io:openFile(filePath, permission);
 }
 
-function readBytes (int numberOfBytes) returns (byte[]|error) {
+function readBytes (int numberOfBytes) returns byte[]|error {
     byte[] empty;
     var result = channel.read(numberOfBytes);
     match result {
@@ -20,7 +20,7 @@ function readBytes (int numberOfBytes) returns (byte[]|error) {
     }
 }
 
-function writeBytes (byte[] content, int startOffset) returns (int|error) {
+function writeBytes (byte[] content, int startOffset) returns int|error {
     int empty = -1;
     var result = channel.write(content, startOffset);
     match result {
@@ -37,10 +37,10 @@ function close () {
     var result = channel.close();
 }
 
-function testBase64EncodeByteChannel(io:ByteChannel contentToBeEncoded) returns (io:ByteChannel|error) {
+function testBase64EncodeByteChannel(io:ByteChannel contentToBeEncoded) returns io:ByteChannel|error {
     return contentToBeEncoded.base64Encode();
 }
 
-function testBase64DecodeByteChannel(io:ByteChannel contentToBeDecoded) returns (io:ByteChannel|error) {
+function testBase64DecodeByteChannel(io:ByteChannel contentToBeDecoded) returns io:ByteChannel|error {
     return contentToBeDecoded.base64Decode();
 }

--- a/tests/ballerina-test/src/test/resources/test-src/io/client_socket_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/client_socket_io.bal
@@ -19,7 +19,7 @@ function closeSocket () {
     error? err = socket.close();
 }
 
-function write (byte[] content) returns (int | error) {
+function write (byte[] content) returns int|error {
     io:ByteChannel channel = socket.channel;
     var result = channel.write(content, 0);
     match result {
@@ -32,7 +32,7 @@ function write (byte[] content) returns (int | error) {
     }
 }
 
-function read (int size) returns (byte[], int) | error {
+function read (int size) returns (byte[], int)|error {
     io:ByteChannel channel = socket.channel;
     var result = channel.read(size);
     match result{

--- a/tests/ballerina-test/src/test/resources/test-src/io/client_socket_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/client_socket_io.bal
@@ -19,7 +19,7 @@ function closeSocket () {
     error? err = socket.close();
 }
 
-function write (blob content) returns (int | error) {
+function write (byte[] content) returns (int | error) {
     io:ByteChannel channel = socket.channel;
     var result = channel.write(content, 0);
     match result {
@@ -32,11 +32,11 @@ function write (blob content) returns (int | error) {
     }
 }
 
-function read (int size) returns (blob, int) | error {
+function read (int size) returns (byte[], int) | error {
     io:ByteChannel channel = socket.channel;
     var result = channel.read(size);
     match result{
-        (blob , int)  content => {
+        (byte[] , int)  content => {
             var (bytes, numberOfBytes) = content;
             return (bytes, numberOfBytes);
         }

--- a/tests/ballerina-test/src/test/resources/test-src/io/secure_client_socket_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/secure_client_socket_io.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 
 io:Socket socket;
 
-function openSocketConnection (string host, int port, io:SocketProperties prop) {
+function openSocketConnection(string host, int port, io:SocketProperties prop) {
     var result = io:openSecureSocket(host, port, prop);
     match result {
         io:Socket s => {
@@ -14,11 +14,11 @@ function openSocketConnection (string host, int port, io:SocketProperties prop) 
     }
 }
 
-function closeSocket () {
+function closeSocket() {
     error? err = socket.close();
 }
 
-function write (blob content) returns (int | error) {
+function write(byte[] content) returns (int|error) {
     io:ByteChannel channel = socket.channel;
     var result = channel.write(content, 0);
     match result {
@@ -31,11 +31,11 @@ function write (blob content) returns (int | error) {
     }
 }
 
-function read (int size) returns (blob, int) | error {
+function read(int size) returns (byte[], int)|error {
     io:ByteChannel channel = socket.channel;
     var result = channel.read(size);
-    match result{
-        (blob , int)  content => {
+    match result {
+        (byte[], int) content => {
             var (bytes, numberOfBytes) = content;
             return (bytes, numberOfBytes);
         }

--- a/tests/ballerina-test/src/test/resources/test-src/io/secure_client_socket_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/secure_client_socket_io.bal
@@ -18,7 +18,7 @@ function closeSocket() {
     error? err = socket.close();
 }
 
-function write(byte[] content) returns (int|error) {
+function write(byte[] content) returns int|error {
     io:ByteChannel channel = socket.channel;
     var result = channel.write(content, 0);
     match result {


### PR DESCRIPTION
## Purpose
I/O APIs were based on blob type. With the introduction of byte[] it would be more applicable for I/O APIs to allow read/write content as bytes. 

## Goals
- Convert the existing I/O APIs to read/write content as byte[]
- Add the relevant test cases

## Approach
With the introduction of byte[] the following I/O APIs will be changed

```
public native function read(@sensitive int nBytes) returns @tainted (byte[], int)|error;
public native function write(byte[] content, int offset) returns int|error;
public native function createMemoryChannel(byte[] content) returns ByteChannel;
```
## Release note
Introduces the capability to read/write content via byte io apis as byte[]

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8