### PR TITLE
Support equals check for int and byte in reflect pkg

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -2188,7 +2188,7 @@ public class CPU {
             case InstructionCodes.I2BI:
                 i = operands[0];
                 j = operands[1];
-                if (isByteLiteral((int) sf.longRegs[i])) {
+                if (isByteLiteral(sf.longRegs[i])) {
                     sf.refRegs[j] = new BByte((byte) sf.longRegs[i]);
                 } else {
                     handleTypeConversionError(ctx, sf, j, TypeConstants.INT_TNAME, TypeConstants.BYTE_TNAME);
@@ -2400,7 +2400,7 @@ public class CPU {
         }
     }
 
-    private static boolean isByteLiteral(int longValue) {
+    private static boolean isByteLiteral(long longValue) {
         return (longValue >= BBYTE_MIN_VALUE && longValue <= BBYTE_MAX_VALUE);
     }
 
@@ -3039,11 +3039,15 @@ public class CPU {
         }
 
         BType rhsType = rhsValue.getType();
+
+        if (rhsType.getTag() == TypeTags.INT_TAG && lhsType.getTag() == TypeTags.BYTE_TAG) {
+            return isByteLiteral(((BInteger) rhsValue).intValue());
+        }
+
         if (rhsType.equals(lhsType)) {
             return true;
         } else if (rhsType.getTag() == TypeTags.INT_TAG &&
-                (lhsType.getTag() == TypeTags.JSON_TAG || lhsType.getTag() == TypeTags.FLOAT_TAG ||
-                        lhsType.getTag() == TypeTags.BYTE_TAG)) {
+                (lhsType.getTag() == TypeTags.JSON_TAG || lhsType.getTag() == TypeTags.FLOAT_TAG)) {
             return true;
         } else if (rhsType.getTag() == TypeTags.FLOAT_TAG && lhsType.getTag() == TypeTags.JSON_TAG) {
             return true;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BByte.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BByte.java
@@ -41,7 +41,7 @@ public final class BByte extends BValueType implements BRefType<Byte> {
 
     @Override
     public long intValue() {
-        return this.value;
+        return Byte.toUnsignedInt(value);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -221,6 +221,10 @@ public class Types {
             return isAssignable(((BStreamType) source).constraint, ((BStreamType) target).constraint);
         }
 
+        if (target.tag == TypeTags.INT && source.tag == TypeTags.BYTE) {
+            return true;
+        }
+
         BSymbol symbol = symResolver.resolveImplicitConversionOp(source, target);
         if (symbol != symTable.notFoundSymbol) {
             return true;

--- a/stdlib/reflect/src/main/java/org/ballerinalang/stdlib/reflect/nativeimpl/Equals.java
+++ b/stdlib/reflect/src/main/java/org/ballerinalang/stdlib/reflect/nativeimpl/Equals.java
@@ -26,6 +26,8 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.util.JsonNode;
 import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BByte;
+import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BNewArray;
@@ -76,6 +78,18 @@ public class Equals extends BlockingNativeCallableUnit {
         
         if (null == lhsValue || null == rhsValue) {
             return false;
+        }
+
+        if (TypeTags.INT_TAG == lhsValue.getType().getTag() && TypeTags.BYTE_TAG == rhsValue.getType().getTag()) {
+            BInteger bInteger = (BInteger) lhsValue;
+            BByte bByte = (BByte) rhsValue;
+            return bInteger.intValue() == bByte.intValue();
+        }
+
+        if (TypeTags.BYTE_TAG == lhsValue.getType().getTag() && TypeTags.INT_TAG == rhsValue.getType().getTag()) {
+            BByte bByte = (BByte) lhsValue;
+            BInteger bInteger = (BInteger) rhsValue;
+            return bInteger.intValue() == bByte.intValue();
         }
         
         // Required for any == any.

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -42,11 +42,13 @@ public class BByteValueNegativeTest {
     @Test(description = "Test byte value negative")
     public void testBlobValueNegative() {
         CompileResult result = BCompileUtil.compile("test-src/types/byte/byte-value-negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 21);
+        Assert.assertEquals(result.getErrorCount(), 23);
         String msg1 = "incompatible types: expected 'byte', found 'int'";
         String msg2 = "incompatible types: expected 'byte', found 'float'";
         String msg3 = "incompatible types: expected 'byte', found 'string'";
         String msg4 = "incompatible types: expected 'byte', found 'byte|error'";
+        String msg5 = "pattern will not be matched";
+        String msg6 = "unreachable pattern: preceding patterns are too general or the pattern ordering is not correct";
         BAssertUtil.validateError(result, 0, msg1 , 2, 15);
         BAssertUtil.validateError(result, 1, msg1 , 3, 15);
         BAssertUtil.validateError(result, 2, msg1 , 4, 15);
@@ -68,6 +70,8 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 18, msg4 , 24, 15);
         BAssertUtil.validateError(result, 19, msg4 , 27, 15);
         BAssertUtil.validateError(result, 20, msg4 , 30, 15);
+        BAssertUtil.validateError(result, 21, msg5, 38, 9);
+        BAssertUtil.validateError(result, 22, msg6, 55, 9);
     }
 
     @Test(description = "Test byte shift operators negative")

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -42,7 +42,7 @@ public class BByteValueNegativeTest {
     @Test(description = "Test byte value negative")
     public void testBlobValueNegative() {
         CompileResult result = BCompileUtil.compile("test-src/types/byte/byte-value-negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 23);
+        Assert.assertEquals(result.getErrorCount(), 25);
         String msg1 = "incompatible types: expected 'byte', found 'int'";
         String msg2 = "incompatible types: expected 'byte', found 'float'";
         String msg3 = "incompatible types: expected 'byte', found 'string'";
@@ -72,6 +72,8 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 20, msg4 , 30, 15);
         BAssertUtil.validateError(result, 21, msg5, 38, 9);
         BAssertUtil.validateError(result, 22, msg6, 55, 9);
+        BAssertUtil.validateError(result, 23, msg5, 63, 29);
+        BAssertUtil.validateError(result, 24, msg6, 71, 29);
     }
 
     @Test(description = "Test byte shift operators negative")

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -295,6 +295,26 @@ public class BByteValueTest {
         Assert.assertEquals(bInteger.intValue(), 266, "Invalid integer value returned.");
     }
 
+    @Test(description = "Test byte to int safe conversion")
+    public void testByteOrIntMatch3() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(result, "testByteOrIntMatch3", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BInteger.class);
+        BInteger bInteger = (BInteger) returns[0];
+        Assert.assertEquals(bInteger.intValue(), 456, "Invalid byte value returned.");
+    }
+
+    @Test(description = "Test byte to int safe conversion")
+    public void testByteOrIntMatch4() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(result, "testByteOrIntMatch4", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BInteger.class);
+        BInteger bInteger = (BInteger) returns[0];
+        Assert.assertEquals(bInteger.intValue(), -123, "Invalid integer value returned.");
+    }
+
 
     @Test(description = "Test bitwise and operator")
     public void testBitwiseAndOperator() {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -275,6 +275,27 @@ public class BByteValueTest {
         BRunUtil.invoke(result, "testWorkerWithByteVariable", new BValue[0]);
     }
 
+    @Test(description = "Test byte to int safe conversion")
+    public void testByteOrIntMatch1() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(result, "testByteOrIntMatch1", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BByte.class);
+        BByte bByte = (BByte) returns[0];
+        Assert.assertEquals(bByte.byteValue(), 12, "Invalid byte value returned.");
+    }
+
+    @Test(description = "Test byte to int safe conversion")
+    public void testByteOrIntMatch2() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(result, "testByteOrIntMatch2", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BInteger.class);
+        BInteger bInteger = (BInteger) returns[0];
+        Assert.assertEquals(bInteger.intValue(), 266, "Invalid integer value returned.");
+    }
+
+
     @Test(description = "Test bitwise and operator")
     public void testBitwiseAndOperator() {
         byte a = 12;

--- a/tests/ballerina-test/src/test/resources/test-src/reflect/equal.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/reflect/equal.bal
@@ -85,6 +85,54 @@ function testIntFalsePositive() returns (boolean) {
 
 // End Int
 
+// Start Byte
+
+function testByteTruePositive1() returns boolean {
+    byte b1 = 5;
+    byte b2 = 5;
+    return reflect:equals(b1, b2);
+}
+
+function testByteTruePositive2() returns boolean {
+    byte b1 = 5;
+    return reflect:equals(b1, 5);
+}
+
+function testByteTrueNegative1() returns boolean {
+    byte b1 = 5;
+    byte b2 = 10;
+    return reflect:equals(b1, b2);
+}
+
+function testByteTrueNegative2() returns boolean {
+    byte b1 = 5;
+    return reflect:equals(b1, 10);
+}
+
+function testByteFalseNegative1() returns boolean {
+    byte b1 = 5;
+    byte b2 = 5;
+    return !reflect:equals(b1, b2);
+}
+
+function testByteFalseNegative2() returns boolean {
+    byte b1 = 5;
+    return !reflect:equals(b1, 5);
+}
+
+function testByteFalsePositive1() returns boolean {
+    byte b1 = 5;
+    byte b2 = 10;
+    return !reflect:equals(b1, b2);
+}
+
+function testByteFalsePositive2() returns boolean {
+    byte b1 = 5;
+    return !reflect:equals(b1, 10);
+}
+
+// End Byte
+
 // Start Float
 
 function testFloatTruePositive() returns (boolean) {

--- a/tests/ballerina-test/src/test/resources/test-src/reflect/equal.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/reflect/equal.bal
@@ -98,6 +98,11 @@ function testByteTruePositive2() returns boolean {
     return reflect:equals(b1, 5);
 }
 
+function testByteTruePositive3() returns boolean {
+    byte b1 = 245;
+    return reflect:equals(b1, 245);
+}
+
 function testByteTrueNegative1() returns boolean {
     byte b1 = 5;
     byte b2 = 10;

--- a/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value-negative.bal
@@ -58,6 +58,20 @@ function testUnreachableByteMatchStmt2() {
     }
 }
 
+function testUnreachableByteMatchStmt3() {
+    int a = foo(2) but {    int => 333,
+                            byte => 777,
+                            string[] => 666
+                        };
+}
+
+function testUnreachableByteMatchStmt4() {
+    int a = foo(2) but {    int => 333,
+                            string[] => 666,
+                            byte => 777
+                        };
+}
+
 function foo (int a) returns (byte|int|string[]) {
     if (a == 1) {
         return check <byte>12;

--- a/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value-negative.bal
@@ -29,3 +29,40 @@ function invalidByteLiteral() {
     int x5 = 12345;
     byte x6 = <byte> x5;
 }
+
+function testUnreachableByteMatchStmt1() {
+    match foo(2) {
+        int b => {
+            // do nothing
+        }
+        byte c => {
+            // do nothing
+        }
+        string[] s => {
+            // do nothing
+        }
+    }
+}
+
+function testUnreachableByteMatchStmt2() {
+    match foo(2) {
+        int b => {
+            // do nothing
+        }
+        string[] s => {
+            // do nothing
+        }
+        byte c => {
+            // do nothing
+        }
+    }
+}
+
+function foo (int a) returns (byte|int|string[]) {
+    if (a == 1) {
+        return check <byte>12;
+    } else if (a == 3) {
+        return 267;
+    }
+    return ["ba", "le"];
+}

--- a/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -116,34 +116,77 @@ function testByteBinaryNotEqualOperation(byte a, byte b, byte c) returns (boolea
     return (b1, b2);
 }
 
-function testByteOrIntMatch1() returns byte|int {
-    match byteOrInt(true) {
+function testByteOrIntMatch1() returns byte|int|string[]|Foo {
+    match byteOrInt(1) {
+        byte c => {
+            return c;
+        }
+
+        int b => {
+            return b;
+        }
+
+        string[] s => {
+            return s;
+        }
+
+        Foo foo => {
+            return foo;
+        }
+    }
+}
+
+function testByteOrIntMatch2() returns byte|int|string[]|Foo  {
+    match byteOrInt(2) {
         byte c => {
             return c;
         }
         int b => {
             return b;
         }
-    }
-}
-
-function testByteOrIntMatch2() returns byte|int {
-    match byteOrInt(false) {
-        byte c => {
-            return c;
+        string[] s => {
+            return s;
         }
-        int b => {
-            return b;
+
+        Foo foo => {
+            return foo;
         }
     }
 }
 
-function byteOrInt(boolean boo) returns (int|byte) {
-    if (boo) {
+function testByteOrIntMatch3() returns int {
+    int x = byteOrInt(1) but {  byte => 456,
+                                int => -123,
+                                string[] => 789,
+                                Foo => 8765
+                             };
+    return x;
+}
+
+function testByteOrIntMatch4() returns int {
+    int x = byteOrInt(2) but {  byte => 456,
+                                int => -123,
+                                string[] => 789,
+                                Foo => 8765
+                             };
+    return x;
+}
+
+function byteOrInt(int a) returns byte|int|string[]|Foo {
+    if (a == 1) {
         return check <byte>12;
+    } else if (a == 2) {
+        return 266;
+    } else if (a == 3) {
+        return ["DD", "GG"];
     }
-    return 266;
+    Foo foo = {};
+    return foo;
 }
+
+type Foo record {
+    string name;
+};
 
 function testWorkerWithByteVariable() {
   worker w1 {

--- a/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -116,6 +116,35 @@ function testByteBinaryNotEqualOperation(byte a, byte b, byte c) returns (boolea
     return (b1, b2);
 }
 
+function testByteOrIntMatch1() returns byte|int {
+    match byteOrInt(true) {
+        byte c => {
+            return c;
+        }
+        int b => {
+            return b;
+        }
+    }
+}
+
+function testByteOrIntMatch2() returns byte|int {
+    match byteOrInt(false) {
+        byte c => {
+            return c;
+        }
+        int b => {
+            return b;
+        }
+    }
+}
+
+function byteOrInt(boolean boo) returns (int|byte) {
+    if (boo) {
+        return check <byte>12;
+    }
+    return 266;
+}
+
 function testWorkerWithByteVariable() {
   worker w1 {
     byte a = 10;


### PR DESCRIPTION
## Purpose
```ballerina
function testByteTruePositive() returns boolean {
    byte b1 = 5;
    byte b2 = 5;
    return reflect:equals(b1, b2);
}
```

This also adds checks for byte|int match case scenarios