### PR TITLE
Add source generation for new syntax of object fields

### DIFF
--- a/composer/modules/integration-tests/src/test/js/test.js
+++ b/composer/modules/integration-tests/src/test/js/test.js
@@ -43,7 +43,6 @@ describe('Ballerina Composer Test Suite', () => {
     
     before(function (beforeAllDone) {
         this.timeout(10000);
-        console.log(sourceGenSkip)
         const targetPath = path.join(global.targetPath, 'lib', `composer-server.jar`);
         backEndProcess = spawn('java', [`-Dballerina.home=${global.targetPath}`, '-jar', targetPath]);
         backEndProcess.stderr.pipe(process.stderr);
@@ -65,17 +64,18 @@ describe('Ballerina Composer Test Suite', () => {
             let model;
             let content;
             
-            beforeEach(done => {
+            before(done => {
                 model = undefined;
                 content = undefined;
                 fs.readFile(testFile, 'utf8', (err, fileContent) => {
                     parse(fileContent, testFile, parsedModel => {
                         content = fileContent;
                         model = parsedModel;
+                        let error;
                         if (!model) {
-                            done(new Error('could not parse'));
+                            error = new Error('Could not parse!');
                         }
-                        done();
+                        done(error);
                     });
                 })
             });

--- a/composer/modules/integration-tests/src/test/resources/config.json
+++ b/composer/modules/integration-tests/src/test/resources/config.json
@@ -6,7 +6,9 @@
             "identify_trends.bal",
             "join_multiple_streams.bal",
             "table_queries.bal",
-            "temporal_aggregations_and_windows.bal"
+            "temporal_aggregations_and_windows.bal",
+            "table.bal",
+            "csv_io.bal"
         ]
     }
 }

--- a/composer/modules/web/source-gen/tree.g
+++ b/composer/modules/web/source-gen/tree.g
@@ -489,10 +489,7 @@ TypeDefinition
    ;
 
 ObjectType
-   : <noFieldsAvailable?>                                                                <initFunction.source> <functions>*
-   | <noPrivateFieldsAvailable?> public { <publicFields>* }                              <initFunction.source> <functions>*
-   | <noPublicFieldAvailable?>                              private { <privateFields>* } <initFunction.source> <functions>*
-   |                             public { <publicFields>* } private { <privateFields>* } <initFunction.source> <functions>*
+   : <fields>* <initFunction.source> <functions>*
    ;
 
 RecordType
@@ -546,28 +543,32 @@ ValueType
    ;
 
 Variable
-   : <isAnonType?> <endWithSemicolon?> <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                 <const?const>       record { <typeNode.source> }          <name.value>                                ;
-   | <isAnonType?> <endWithComma?>     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                 <const?const>       record { <typeNode.source> }          <name.value>                                ,
-   | <isAnonType?>                     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                 <const?const>       record { <typeNode.source> }          <name.value>
-   | <noVisibleName?>                                                                                                                                           <typeNode.source>
-   | <endpoint?>                                                                                                                                       endpoint <typeNode.source>            <name.value> {   <initialExpression.source> ; }
-   | <endpoint?>                                                                                                                                       endpoint <typeNode.source>            <name.value> {                                }
-   | <serviceEndpoint?>                                                                                                                                endpoint                              <name.value>
-   | <defaultable?>      <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                          <typeNode.source>            <name.value> =   <initialExpression.source>
-   | <defaultable?>      <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                                                       <name.value> =   <initialExpression.source>
-   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <const?const> <safeAssignment?>          <typeNode.source>            <name.value> =?  <initialExpression.source> ;
-   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <const?const>                            <typeNode.source>            <name.value> =   <initialExpression.source> ;
-   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <const?const>                            <typeNode.source>            <name.value>                                ;
-   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                          <typeNode.source>            <name.value>                                ;
-   | <endWithSemicolon?>                                                                                                             <safeAssignment?>          <typeNode.source>            <name.value> =? <initialExpression.source>  ;
-   | <endWithComma?>                                                                                                                 <safeAssignment?>          <typeNode.source>            <name.value> =? <initialExpression.source>  ,
-   | <endWithSemicolon?>                                                                                                                                        <typeNode.source>            <name.value> =  <initialExpression.source>  ;
-   | <endWithComma?>                                                                                                                                            <typeNode.source>            <name.value> =  <initialExpression.source>  ,
-   | <endWithSemicolon?> <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                          <typeNode.source> <rest?...> <name.value>                                ;
-   | <endWithComma?>     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                          <typeNode.source> <rest?...> <name.value>                                ,
-   |                                                                                                                                 <safeAssignment?>          <typeNode.source>            <name.value> =? <initialExpression.source>
-   |                                                                                                                                                            <typeNode.source>            <name.value> =  <initialExpression.source>
-   |                     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                          <typeNode.source> <rest?...> <name.value>
+   : <isAnonType?> <endWithSemicolon?> <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                     <const?const>     record    { <typeNode.source> }          <name.value>                                ;
+   | <isAnonType?> <endWithComma?>     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                     <const?const>     record    { <typeNode.source> }          <name.value>                                ,
+   | <isAnonType?>                     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                     <const?const>     record    { <typeNode.source> }          <name.value>
+   | <noVisibleName?>                                                                                                                                                  <typeNode.source>
+   | <endpoint?>                                                                                                                                           endpoint    <typeNode.source>            <name.value> {  <initialExpression.source> ; }
+   | <endpoint?>                                                                                                                                           endpoint    <typeNode.source>            <name.value> {                               }
+   | <serviceEndpoint?>                                                                                                                                    endpoint                                 <name.value>
+   | <defaultable?>      <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                                 <typeNode.source>            <name.value> =  <initialExpression.source>
+   | <defaultable?>      <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                                                              <name.value> =  <initialExpression.source>
+   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <const?const>     <safeAssignment?>             <typeNode.source>            <name.value> =? <initialExpression.source> ;
+   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <const?const>                                   <typeNode.source>            <name.value> =  <initialExpression.source> ;
+   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <const?const>                                   <typeNode.source>            <name.value>                                ;
+   | <global?>           <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                                 <typeNode.source>            <name.value>                                ;
+   | <endWithSemicolon?>                                                                                                                 <safeAssignment?>             <typeNode.source>            <name.value> =? <initialExpression.source>  ;
+   | <endWithComma?>                                                                                                                     <safeAssignment?>             <typeNode.source>            <name.value> =? <initialExpression.source>  ,
+   | <endWithSemicolon?> <inObject?>                                                                   <public?public> <private?private>                               <typeNode.source>            <name.value> =  <initialExpression.source>  ;
+   | <endWithComma?>     <inObject?>                                                                   <public?public> <private?private>                               <typeNode.source>            <name.value> =  <initialExpression.source>  ,
+   | <endWithSemicolon?> <inObject?> <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <private?private>                   <typeNode.source> <rest?...> <name.value>                                ;
+   | <endWithComma?>     <inObject?> <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public> <private?private>                   <typeNode.source> <rest?...> <name.value>                                ,
+   | <endWithSemicolon?>                                                                                                                                               <typeNode.source>            <name.value> =  <initialExpression.source>  ;
+   | <endWithComma?>                                                                                                                                                   <typeNode.source>            <name.value> =  <initialExpression.source>  ,
+   | <endWithSemicolon?> <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                                 <typeNode.source> <rest?...> <name.value>                                ;
+   | <endWithComma?>     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>*                                                                 <typeNode.source> <rest?...> <name.value>                                ,
+   |                                                                                                                                     <safeAssignment?>             <typeNode.source>            <name.value> =? <initialExpression.source>
+   |                                                                                                                                                                   <typeNode.source>            <name.value> =  <initialExpression.source>
+   |                     <annotationAttachments>* <documentationAttachments>* <deprecatedAttachments>* <public?public>                                                 <typeNode.source> <rest?...> <name.value>
    ;
 
 VariableDef

--- a/composer/modules/web/src/plugins/ballerina/model/source-gen.js
+++ b/composer/modules/web/src/plugins/ballerina/model/source-gen.js
@@ -1652,29 +1652,9 @@ export default function getSourceOf(node, pretty = false, l = 0, replaceLambda) 
                  + join(node.valueSet, pretty, replaceLambda, l, w, '', '|') + w() + ';';
             }
         case 'ObjectType':
-            if (node.noFieldsAvailable && node.initFunction && node.functions) {
-                return getSourceOf(node.initFunction, pretty, l, replaceLambda)
-                 + join(node.functions, pretty, replaceLambda, l, w, '');
-            } else if (node.noPrivateFieldsAvailable && node.publicFields
-                         && node.initFunction && node.functions) {
-                return dent() + w() + 'public' + w() + '{' + indent()
-                 + join(node.publicFields, pretty, replaceLambda, l, w, '') + outdent() + w() + '}'
+            return join(node.fields, pretty, replaceLambda, l, w, '')
                  + getSourceOf(node.initFunction, pretty, l, replaceLambda)
                  + join(node.functions, pretty, replaceLambda, l, w, '');
-            } else if (node.noPublicFieldAvailable && node.privateFields
-                         && node.initFunction && node.functions) {
-                return dent() + w() + 'private' + w() + '{' + indent()
-                 + join(node.privateFields, pretty, replaceLambda, l, w, '') + outdent() + w()
-                 + '}' + getSourceOf(node.initFunction, pretty, l, replaceLambda)
-                 + join(node.functions, pretty, replaceLambda, l, w, '');
-            } else {
-                return dent() + dent() + w() + 'public' + w() + '{' + indent()
-                 + join(node.publicFields, pretty, replaceLambda, l, w, '') + outdent()
-                 + w() + '}' + w() + 'private' + w() + '{' + indent()
-                 + join(node.privateFields, pretty, replaceLambda, l, w, '') + outdent() + w()
-                 + '}' + getSourceOf(node.initFunction, pretty, l, replaceLambda)
-                 + join(node.functions, pretty, replaceLambda, l, w, '');
-            }
         case 'RecordType':
             return join(node.fields, pretty, replaceLambda, l, w, '');
         case 'TypedescExpression':
@@ -1866,6 +1846,39 @@ export default function getSourceOf(node, pretty = false, l = 0, replaceLambda) 
                 return getSourceOf(node.typeNode, pretty, l, replaceLambda) + w(' ')
                  + node.name.valueWithBar + a(' ') + w() + '=?'
                  + getSourceOf(node.initialExpression, pretty, l, replaceLambda) + w() + ',';
+            } else if (node.endWithSemicolon && node.inObject && node.typeNode
+                         && node.name.valueWithBar && node.initialExpression) {
+                return dent() + (node.public ? w() + 'public' + a(' ') : '')
+                 + (node.private ? w() + 'private' : '')
+                 + getSourceOf(node.typeNode, pretty, l, replaceLambda) + w(' ') + node.name.valueWithBar + a(' ')
+                 + w(' ') + '=' + a(' ')
+                 + getSourceOf(node.initialExpression, pretty, l, replaceLambda) + w() + ';';
+            } else if (node.endWithComma && node.inObject && node.typeNode
+                         && node.name.valueWithBar && node.initialExpression) {
+                return (node.public ? w() + 'public' + a(' ') : '')
+                 + (node.private ? w() + 'private' : '')
+                 + getSourceOf(node.typeNode, pretty, l, replaceLambda) + w(' ') + node.name.valueWithBar + a(' ') + w(' ')
+                 + '=' + a(' ')
+                 + getSourceOf(node.initialExpression, pretty, l, replaceLambda) + w() + ',';
+            } else if (node.endWithSemicolon && node.inObject
+                         && node.annotationAttachments && node.documentationAttachments
+                         && node.deprecatedAttachments && node.typeNode && node.name.valueWithBar) {
+                return dent()
+                 + join(node.annotationAttachments, pretty, replaceLambda, l, w, '')
+                 + join(node.documentationAttachments, pretty, replaceLambda, l, w, '')
+                 + join(node.deprecatedAttachments, pretty, replaceLambda, l, w, '') + (node.public ? w() + 'public' + a(' ') : '')
+                 + (node.private ? w() + 'private' : '')
+                 + getSourceOf(node.typeNode, pretty, l, replaceLambda) + (node.rest ? w() + '...' : '')
+                 + w(' ') + node.name.valueWithBar + a(' ') + w() + ';';
+            } else if (node.endWithComma && node.inObject && node.annotationAttachments
+                         && node.documentationAttachments && node.deprecatedAttachments
+                         && node.typeNode && node.name.valueWithBar) {
+                return join(node.annotationAttachments, pretty, replaceLambda, l, w, '')
+                 + join(node.documentationAttachments, pretty, replaceLambda, l, w, '')
+                 + join(node.deprecatedAttachments, pretty, replaceLambda, l, w, '') + (node.public ? w() + 'public' + a(' ') : '')
+                 + (node.private ? w() + 'private' : '')
+                 + getSourceOf(node.typeNode, pretty, l, replaceLambda) + (node.rest ? w() + '...' : '') + w(' ')
+                 + node.name.valueWithBar + a(' ') + w() + ',';
             } else if (node.endWithSemicolon && node.typeNode && node.name.valueWithBar
                          && node.initialExpression) {
                 return dent() + getSourceOf(node.typeNode, pretty, l, replaceLambda)
@@ -1908,9 +1921,9 @@ export default function getSourceOf(node, pretty = false, l = 0, replaceLambda) 
             } else {
                 return join(node.annotationAttachments, pretty, replaceLambda, l, w, '')
                  + join(node.documentationAttachments, pretty, replaceLambda, l, w, '')
-                 + join(node.deprecatedAttachments, pretty, replaceLambda, l, w, '') + getSourceOf(node.typeNode, pretty, l, replaceLambda)
-                 + (node.rest ? w() + '...' : '') + w(' ')
-                 + node.name.valueWithBar + a(' ');
+                 + join(node.deprecatedAttachments, pretty, replaceLambda, l, w, '') + (node.public ? w() + 'public' + a(' ') : '')
+                 + getSourceOf(node.typeNode, pretty, l, replaceLambda) + (node.rest ? w()
+                 + '...' : '') + w(' ') + node.name.valueWithBar + a(' ');
             }
         case 'VariableDef':
             if (node.endpoint && node.variable) {

--- a/composer/modules/web/src/plugins/ballerina/model/tree-builder.js
+++ b/composer/modules/web/src/plugins/ballerina/model/tree-builder.js
@@ -205,6 +205,9 @@ class TreeBuilder {
         }
 
         if (node.kind === 'Variable') {
+            if (parentKind === 'ObjectType') {
+                node.inObject = true;
+            }
 
             if (node.typeNode && node.typeNode.isAnonType) {
                 node.isAnonType = true;
@@ -390,44 +393,6 @@ class TreeBuilder {
         }
 
         if (node.kind === 'ObjectType') {
-            node.publicFields = [];
-            node.privateFields = [];
-            let fields = node.fields;
-            let privateFieldBlockVisible = false;
-            let publicFieldBlockVisible = false;
-
-            for (let i = 0; i < fields.length; i++) {
-                if (fields[i].public) {
-                    node.publicFields.push(fields[i]);
-                } else {
-                    node.privateFields.push(fields[i]);
-                }
-            }
-
-            if (node.ws) {
-                for (let i = 0; i < node.ws.length; i++) {
-                    if (node.ws[i].text === 'public' && node.ws[i + 1].text === '{') {
-                        publicFieldBlockVisible = true;
-                    }
-
-                    if (node.ws[i].text === 'private' && node.ws[i + 1].text === '{') {
-                        privateFieldBlockVisible = true;
-                    }
-                }
-            }
-
-            if (node.privateFields.length <= 0 && !privateFieldBlockVisible) {
-                node.noPrivateFieldsAvailable = true;
-            }
-
-            if (node.publicFields.length <= 0 && !publicFieldBlockVisible) {
-                node.noPublicFieldAvailable = true;
-            }
-
-            if (fields.length <= 0 && node.noPrivateFieldsAvailable && node.noPublicFieldAvailable) {
-                node.noFieldsAvailable = true;
-            }
-
             if (node.initFunction) {
                 if (!node.initFunction.ws) {
                     node.initFunction.defaultConstructor = true;


### PR DESCRIPTION
## Purpose
* Update ballerina examples submodule inside composer integration tests so that we are using examples updated for new syntax
* Update source gen for the new syntax
