### PR TITLE
Filter public functions from the package list for completions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -718,9 +718,9 @@ public class CommonUtil {
         BType getClientFuncType = bEndpointVarSymbol.getClientFunction.type;
         BType boundType = ((BInvokableType) getClientFuncType).retType;
         boundType.tsymbol.scope.entries.forEach((name, scopeEntry) -> {
+            String[] nameComponents = name.toString().split("\\.");
             if (scopeEntry.symbol instanceof BInvokableSymbol
-                    && !scopeEntry.symbol.getName().getValue().equals(UtilSymbolKeys.NEW_KEYWORD_KEY)) {
-                String[] nameComponents = name.toString().split("\\.");
+                    && !nameComponents[nameComponents.length - 1].equals(UtilSymbolKeys.NEW_KEYWORD_KEY)) {
                 SymbolInfo actionFunctionSymbol =
                         new SymbolInfo(nameComponents[nameComponents.length - 1], scopeEntry);
                 endpointActions.add(actionFunctionSymbol);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/index/DAOUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/index/DAOUtil.java
@@ -57,8 +57,10 @@ public class DAOUtil {
                 String pkgOrgName = resultSet.getString(2);
                 String funcName = resultSet.getString(4);
                 String completionItem = resultSet.getString(3);
-                PackageFunctionDAO packageFunctionDAO =
-                        new PackageFunctionDAO(pkgName, pkgOrgName, funcName, jsonToCompletionItem(completionItem));
+                boolean isPrivate = resultSet.getBoolean(5);
+                boolean isAttached = resultSet.getBoolean(6);
+                PackageFunctionDAO packageFunctionDAO = new PackageFunctionDAO(pkgName, pkgOrgName, funcName,
+                        jsonToCompletionItem(completionItem), isPrivate, isAttached);
                 packageFunctionDAOs.add(packageFunctionDAO);
             }
         } catch (SQLException e) {
@@ -81,8 +83,9 @@ public class DAOUtil {
                 String pkgOrgName = resultSet.getString(2);
                 String recordName = resultSet.getString(4);
                 String completionItem = resultSet.getString(3);
+                boolean isPrivate = resultSet.getBoolean(5);
                 RecordDAO recordDAO =
-                        new RecordDAO(pkgName, pkgOrgName, recordName, jsonToCompletionItem(completionItem));
+                        new RecordDAO(pkgName, pkgOrgName, recordName, isPrivate, jsonToCompletionItem(completionItem));
                 recordDAOs.add(recordDAO);
             }
         } catch (SQLException e) {
@@ -128,9 +131,10 @@ public class DAOUtil {
                 String pkgName = resultSet.getString(1);
                 String pkgOrgName = resultSet.getString(2);
                 String recordName = resultSet.getString(4);
+                boolean isPrivate = resultSet.getBoolean(5);
                 String completionItem = resultSet.getString(3);
                 ObjectDAO recordDAO =
-                        new ObjectDAO(pkgName, pkgOrgName, recordName, jsonToCompletionItem(completionItem));
+                        new ObjectDAO(pkgName, pkgOrgName, recordName, isPrivate, jsonToCompletionItem(completionItem));
                 objectDAOs.add(recordDAO);
             }
         } catch (SQLException e) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/index/DTOUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/index/DTOUtil.java
@@ -47,6 +47,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -177,7 +178,10 @@ public class DTOUtil {
      */
     public static BFunctionDTO getFunctionDTO(int pkgEntryId, int objectId, BInvokableSymbol bInvokableSymbol) {
         CompletionItem completionItem = BInvokableSymbolUtil.getFunctionCompletionItem(bInvokableSymbol);
-        return new BFunctionDTO(pkgEntryId, objectId, bInvokableSymbol.getName().getValue(), completionItem);
+        boolean isPrivate = !((bInvokableSymbol.flags & Flags.PUBLIC) == Flags.PUBLIC);
+        boolean isAttached = (bInvokableSymbol.flags & Flags.ATTACHED) == Flags.ATTACHED;
+        return new BFunctionDTO(pkgEntryId, objectId, bInvokableSymbol.getName().getValue(), completionItem, isPrivate,
+                isAttached);
     }
 
     /**
@@ -190,11 +194,13 @@ public class DTOUtil {
     public static BObjectTypeSymbolDTO getObjectTypeSymbolDTO(int pkgEntryId, BObjectTypeSymbol bObjectTypeSymbol,
                                                      ObjectType type) {
         CompletionItem completionItem = null;
+        boolean isPrivate = !((bObjectTypeSymbol.flags & Flags.PUBLIC) == Flags.PUBLIC);
         if (type == ObjectType.OBJECT) {
             completionItem = BPackageSymbolUtil.getBTypeCompletionItem(bObjectTypeSymbol.getName().getValue());
         }
 
-        return new BObjectTypeSymbolDTO(pkgEntryId, bObjectTypeSymbol.getName().getValue(), null, type, completionItem);
+        return new BObjectTypeSymbolDTO(pkgEntryId, bObjectTypeSymbol.getName().getValue(), null, type, isPrivate,
+                completionItem);
     }
 
     /**
@@ -206,7 +212,9 @@ public class DTOUtil {
     public static BRecordTypeSymbolDTO getRecordTypeSymbolDTO(int pkgEntryId, BRecordTypeSymbol recordTypeSymbol) {
         CompletionItem completionItem = BPackageSymbolUtil
                 .getBTypeCompletionItem(recordTypeSymbol.getName().getValue());
-        return new BRecordTypeSymbolDTO(pkgEntryId, recordTypeSymbol.getName().getValue(), null, completionItem);
+        boolean isPrivate = !((recordTypeSymbol.flags & Flags.PUBLIC) == Flags.PUBLIC);
+        return new BRecordTypeSymbolDTO(pkgEntryId, recordTypeSymbol.getName().getValue(), null, isPrivate,
+                completionItem);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/PackageActionFunctionAndTypesFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/PackageActionFunctionAndTypesFilter.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -116,13 +117,16 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
 
             try {
                 List<PackageFunctionDAO> packageFunctionDAOs = LSIndexImpl.getInstance().getQueryProcessor()
-                        .getFunctionsFromPackage(packageID.getName().getValue(), packageID.getOrgName().getValue());
+                        .getFilteredFunctionsFromPackage(packageID.getName().getValue(),
+                                packageID.getOrgName().getValue(), false, false);
                 List<RecordDAO> recordDAOs = LSIndexImpl.getInstance().getQueryProcessor()
-                        .getRecordsFromPackage(packageID.getName().getValue(), packageID.getOrgName().getValue());
+                        .getRecordsFromPackageOnAccessType(packageID.getName().getValue(),
+                                packageID.getOrgName().getValue(), false);
                 List<OtherTypeDAO> otherTypeDAOs = LSIndexImpl.getInstance().getQueryProcessor()
                         .getOtherTypesFromPackage(packageID.getName().getValue(), packageID.getOrgName().getValue());
                 List<ObjectDAO> objectDAOs = LSIndexImpl.getInstance().getQueryProcessor()
-                        .getObjectsFromPackage(packageID.getName().getValue(), packageID.getOrgName().getValue());
+                        .getObjectsFromPackageOnAccessType(packageID.getName().getValue(),
+                                packageID.getOrgName().getValue(), false);
                 if (packageFunctionDAOs.isEmpty() && recordDAOs.isEmpty() && objectDAOs.isEmpty()) {
                     return Either.forRight(this.loadActionsFunctionsAndTypesFromScope(scopeEntryMap));
                 }
@@ -158,14 +162,14 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
         List<SymbolInfo> actionFunctionList = new ArrayList<>();
         entryMap.forEach((name, value) -> {
             BSymbol symbol = value.symbol;
-            if ((symbol instanceof BInvokableSymbol && ((BInvokableSymbol) symbol).receiverSymbol == null)
+            if (((symbol instanceof BInvokableSymbol && ((BInvokableSymbol) symbol).receiverSymbol == null)
                     || (symbol instanceof BTypeSymbol && !(symbol instanceof BPackageSymbol))
-                    || symbol instanceof BVarSymbol) {
+                    || symbol instanceof BVarSymbol) && (symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
                 SymbolInfo entry = new SymbolInfo(name.toString(), value);
                 actionFunctionList.add(entry);
             }
         });
-        
+
         return actionFunctionList;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/Constants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/Constants.java
@@ -38,36 +38,52 @@ public class Constants {
             "INSERT INTO bLangResource (serviceId, name) values (?, ?)";
 
     static final String INSERT_BLANG_FUNCTION =
-            "INSERT INTO bLangFunction (packageId, objectId, name, completionItem) values (?, ?, ?, ?)";
+            "INSERT INTO bLangFunction (packageId, objectId, name, completionItem, private, attached)" +
+                    " values (?, ?, ?, ?, ?, ?)";
 
     static final String INSERT_BLANG_RECORD =
-            "INSERT INTO bLangRecord (packageId, name, fields, completionItem) values (?, ?, ?, ?)";
+            "INSERT INTO bLangRecord (packageId, name, fields, private, completionItem) values (?, ?, ?, ?, ?)";
 
     static final String INSERT_OTHER_TYPE =
             "INSERT INTO bLangType (packageId, name, fields, completionItem) values (?, ?, ?, ?)";
 
     static final String INSERT_BLANG_OBJECT = 
-            "INSERT INTO bLangObject (packageId, name, fields, type, completionItem) values (?, ?, ?, ?, ?)";
+            "INSERT INTO bLangObject (packageId, name, fields, type, private, completionItem)" +
+                    "values (?, ?, ?, ?, ?, ?)";
     
     // UPDATE Statements
     static final String UPDATE_ENDPOINT_ACTION_HOLDER_ID = 
             "UPDATE bLangObject SET actionHolderId = ? WHERE id = ?";
     
     // GET Statements
-    static final String GET_FUNCTIONS_FROM_PACKAGE = "SELECT p.name, p.orgName, f.completionItem, f.name " +
-            "FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) AS p " +
-            "INNER JOIN bLangFunction AS f WHERE p.id=f.packageId AND f.objectId=-1 AND f.name NOT LIKE '%<init>%' " +
-            "AND " + "f.name NOT LIKE '%<start>%' AND f.name NOT LIKE '%<stop>%'";
+    static final String GET_ALL_FUNCTIONS_FROM_PACKAGE = "SELECT p.name, p.orgName, f.completionItem, f.name, " +
+            "f.private, f.attached FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?)" +
+            "AS p INNER JOIN bLangFunction AS f WHERE p.id=f.packageId AND f.objectId=-1 AND f.name " +
+            "NOT LIKE '%<init>%' AND " + "f.name NOT LIKE '%<start>%' AND f.name NOT LIKE '%<stop>%'";
+
+    static final String GET_FILTERED_FUNCTIONS_FROM_PACKAGE = "SELECT p.name, p.orgName, f.completionItem, f.name, " +
+            "f.private, f.attached FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?)" +
+            "AS p INNER JOIN bLangFunction AS f WHERE p.id=f.packageId AND f.objectId=-1 AND f.private=? " +
+            "AND f.attached=? AND f.name NOT LIKE '%<init>%' AND " + "f.name NOT LIKE '%<start>%' " +
+            "AND f.name NOT LIKE '%<stop>%'";
     
-    static final String GET_RECORDS_FROM_PACKAGE = "SELECT p.name, p.orgName, r.completionItem, r.name " +
-            "FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) AS p " +
+    static final String GET_ALL_RECORDS_FROM_PACKAGE = "SELECT p.name, p.orgName, r.completionItem, r.name, " +
+            "r.private FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) AS p " +
             "INNER JOIN bLangRecord AS r WHERE p.id = r.packageId";
+    
+    static final String GET_RECORDS_ON_ACCESS_TYPE_FROM_PACKAGE = "SELECT p.name, p.orgName, r.completionItem, " +
+            "r.name, r.private FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) AS p " +
+            "INNER JOIN bLangRecord AS r WHERE p.id = r.packageId AND r.private=?";
     
     static final String GET_OTHER_TYPES_FROM_PACKAGE = "SELECT p.name, p.orgName, t.completionItem, t.name " +
             "FROM (SELECT id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) AS p " +
             "INNER JOIN bLangType AS t WHERE p.id = t.packageId";
     
-    static final String GET_OBJECT_FROM_PACKAGE = "SELECT p.name, p.orgName, o.completionItem, o.name " +
+    static final String GET_OBJECTS_ON_ACCESS_TYPE_FROM_PACKAGE = "SELECT p.name, p.orgName, o.completionItem," +
+            " o.name, o.private FROM (select id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) " +
+            "AS p INNER JOIN bLangObject AS o WHERE p.id = o.packageId AND o.type = 3 AND o.private=?";
+    
+    static final String GET_ALL_OBJECT_FROM_PACKAGE = "SELECT p.name, p.orgName, o.completionItem, o.name, o.private " +
             "FROM (select id, name, orgName FROM bLangPackage WHERE name = ? AND orgName = ?) AS p " +
             "INNER JOIN bLangObject AS o WHERE p.id = o.packageId AND o.type = 3";
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/LSIndexQueryProcessor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/LSIndexQueryProcessor.java
@@ -66,13 +66,19 @@ public class LSIndexQueryProcessor {
  
     private PreparedStatement updateActionHolderId;
 
-    private PreparedStatement getFunctionsFromPackage;
+    private PreparedStatement getAllFunctionsFromPackage;
+
+    private PreparedStatement getFilteredFunctionsFromPackage;
     
     private PreparedStatement getRecordsFromPackage;
+    
+    private PreparedStatement getRecordsOnAccessType;
     
     private PreparedStatement getOtherTypesFromPackage;
     
     private PreparedStatement getObjectsFromPackage;
+    
+    private PreparedStatement getObjectsOnAccessType;
 
     private Connection connection;
 
@@ -101,10 +107,20 @@ public class LSIndexQueryProcessor {
                     Statement.RETURN_GENERATED_KEYS);
 
             // Select Statements
-            getFunctionsFromPackage = connection.prepareStatement(Constants.GET_FUNCTIONS_FROM_PACKAGE);
-            getRecordsFromPackage = connection.prepareStatement(Constants.GET_RECORDS_FROM_PACKAGE);
-            getOtherTypesFromPackage = connection.prepareStatement(Constants.GET_OTHER_TYPES_FROM_PACKAGE);
-            getObjectsFromPackage = connection.prepareStatement(Constants.GET_OBJECT_FROM_PACKAGE);
+            getAllFunctionsFromPackage =
+                    connection.prepareStatement(Constants.GET_ALL_FUNCTIONS_FROM_PACKAGE);
+            getFilteredFunctionsFromPackage =
+                    connection.prepareStatement(Constants.GET_FILTERED_FUNCTIONS_FROM_PACKAGE);
+            getRecordsFromPackage =
+                    connection.prepareStatement(Constants.GET_ALL_RECORDS_FROM_PACKAGE);
+            getRecordsOnAccessType =
+                    connection.prepareStatement(Constants.GET_RECORDS_ON_ACCESS_TYPE_FROM_PACKAGE);
+            getOtherTypesFromPackage =
+                    connection.prepareStatement(Constants.GET_OTHER_TYPES_FROM_PACKAGE);
+            getObjectsFromPackage =
+                    connection.prepareStatement(Constants.GET_ALL_OBJECT_FROM_PACKAGE);
+            getObjectsOnAccessType =
+                    connection.prepareStatement(Constants.GET_OBJECTS_ON_ACCESS_TYPE_FROM_PACKAGE);
         } catch (SQLException e) {
             logger.error("Error in Creating Prepared Statement.");
         }
@@ -180,6 +196,8 @@ public class LSIndexQueryProcessor {
             insertBLangFunction.setInt(2, bFunctionDTO.getObjectId());
             insertBLangFunction.setString(3, bFunctionDTO.getName());
             insertBLangFunction.setString(4, DTOUtil.completionItemToJSON(bFunctionDTO.getCompletionItem()));
+            insertBLangFunction.setBoolean(5, bFunctionDTO.isPrivate());
+            insertBLangFunction.setBoolean(6, bFunctionDTO.isAttached());
             insertBLangFunction.addBatch();
         }
         insertBLangFunction.executeBatch();
@@ -201,7 +219,8 @@ public class LSIndexQueryProcessor {
             insertBLangRecord.setString(2, recordDTO.getName());
             // TODO: Currently null
             insertBLangRecord.setString(3, "");
-            insertBLangRecord.setString(4, DTOUtil.completionItemToJSON(recordDTO.getCompletionItem()));
+            insertBLangRecord.setBoolean(4, recordDTO.isPrivate());
+            insertBLangRecord.setString(5, DTOUtil.completionItemToJSON(recordDTO.getCompletionItem()));
             insertBLangRecord.addBatch();
         }
 
@@ -235,7 +254,7 @@ public class LSIndexQueryProcessor {
 
     /**
      * Batch Insert List of ObjectTypeSymbols.
-     * @param objectDTOs        List of BFunctionDTOs
+     * @param objectDTOs        List of BObjectDTOs
      * @return {@link List}     List of Generated Keys
      * @throws SQLException     Exception While Insert
      */
@@ -248,7 +267,8 @@ public class LSIndexQueryProcessor {
             // TODO: still null. handle properly
             insertBLangObject.setString(3, "");
             insertBLangObject.setInt(4, objectDTO.getType().getValue());
-            insertBLangObject.setString(5, DTOUtil.completionItemToJSON(objectDTO.getCompletionItem()));
+            insertBLangObject.setBoolean(5, objectDTO.isPrivate());
+            insertBLangObject.setString(6, DTOUtil.completionItemToJSON(objectDTO.getCompletionItem()));
             insertBLangObject.addBatch();
         }
 
@@ -286,13 +306,34 @@ public class LSIndexQueryProcessor {
      * @return {@link PackageFunctionDAO}   List of FunctionDAOs
      * @throws SQLException                 Exception While Insert
      */
-    public List<PackageFunctionDAO> getFunctionsFromPackage(String name, String orgName)
+    public List<PackageFunctionDAO> getAllFunctionsFromPackage(String name, String orgName)
             throws SQLException {
-        getFunctionsFromPackage.clearParameters();
-        getFunctionsFromPackage.setString(1, name);
-        getFunctionsFromPackage.setString(2, orgName);
+        getAllFunctionsFromPackage.clearParameters();
+        getAllFunctionsFromPackage.setString(1, name);
+        getAllFunctionsFromPackage.setString(2, orgName);
         
-        return DAOUtil.getPackageFunctionDAO(getFunctionsFromPackage.executeQuery());
+        return DAOUtil.getPackageFunctionDAO(getAllFunctionsFromPackage.executeQuery());
+    }
+
+    /**
+     * Get a List of PackageFunctionDAOs based on selection criteria over access type and attached or not.
+     * @param name                          Package Name
+     * @param orgName                       Org Name
+     * @param isPrivate                     Access Type
+     * @param isAttached                    Attached or not
+     * @return {@link PackageFunctionDAO}   List of FunctionDAOs
+     * @throws SQLException                 Exception While Insert
+     */
+    public List<PackageFunctionDAO> getFilteredFunctionsFromPackage(String name, String orgName,
+                                                                           boolean isPrivate, boolean isAttached)
+            throws SQLException {
+        getFilteredFunctionsFromPackage.clearParameters();
+        getFilteredFunctionsFromPackage.setString(1, name);
+        getFilteredFunctionsFromPackage.setString(2, orgName);
+        getFilteredFunctionsFromPackage.setBoolean(3, isPrivate);
+        getFilteredFunctionsFromPackage.setBoolean(4, isAttached);
+
+        return DAOUtil.getPackageFunctionDAO(getFilteredFunctionsFromPackage.executeQuery());
     }
 
     /**
@@ -308,6 +349,23 @@ public class LSIndexQueryProcessor {
         getRecordsFromPackage.setString(2, orgName);
         
         return DAOUtil.getRecordDAO(getRecordsFromPackage.executeQuery());
+    }
+
+    /**
+     * Get a List of RecordDAOs based on the access type either private or public.
+     * @param name                  Package Name
+     * @param orgName               Org Name
+     * @return {@link RecordDAO}    List of RecordDAOs
+     * @throws SQLException         Exception While Insert
+     */
+    public List<RecordDAO> getRecordsFromPackageOnAccessType(String name, String orgName,
+                                                             boolean isPrivate) throws SQLException {
+        getRecordsOnAccessType.clearParameters();
+        getRecordsOnAccessType.setString(1, name);
+        getRecordsOnAccessType.setString(2, orgName);
+        getRecordsOnAccessType.setBoolean(3, isPrivate);
+        
+        return DAOUtil.getRecordDAO(getRecordsOnAccessType.executeQuery());
     }
 
     /**
@@ -338,6 +396,23 @@ public class LSIndexQueryProcessor {
         getObjectsFromPackage.setString(2, orgName);
         
         return DAOUtil.getObjectDAO(getObjectsFromPackage.executeQuery());
+    }
+
+    /**
+     * Get a List of ObjectDAOs based on the access type either private or public.
+     * @param name                  Package Name
+     * @param orgName               Org Name
+     * @return {@link ObjectDAO}    List of FunctionDAOs
+     * @throws SQLException         Exception While Insert
+     */
+    public List<ObjectDAO> getObjectsFromPackageOnAccessType(String name, String orgName,
+                                                             boolean isPrivate) throws SQLException {
+        getObjectsOnAccessType.clearParameters();
+        getObjectsOnAccessType.setString(1, name);
+        getObjectsOnAccessType.setString(2, orgName);
+        getObjectsOnAccessType.setBoolean(3, isPrivate);
+        
+        return DAOUtil.getObjectDAO(getObjectsOnAccessType.executeQuery());
     }
 
     /**
@@ -387,7 +462,8 @@ public class LSIndexQueryProcessor {
                 packages.add(new BObjectTypeSymbolDTO(
                         Integer.parseInt(resultSet.getString(2)),
                         resultSet.getString(3),
-                        resultSet.getString(4)
+                        resultSet.getString(4),
+                        resultSet.getBoolean(7)
                 ));
             }
         } finally {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dao/ObjectDAO.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dao/ObjectDAO.java
@@ -23,19 +23,23 @@ import org.eclipse.lsp4j.CompletionItem;
  * DAO for ObjectTypeSymbol.
  */
 public class ObjectDAO {
+
     private String packageName;
 
     private String packageOrgName;
 
     private String objectName;
 
+    private boolean isPrivate;
+
     private CompletionItem completionItem;
 
-    public ObjectDAO(String packageName, String packageOrgName, String objectName,
+    public ObjectDAO(String packageName, String packageOrgName, String objectName, boolean isPrivate,
                      CompletionItem completionItem) {
         this.packageName = packageName;
         this.packageOrgName = packageOrgName;
         this.objectName = objectName;
+        this.isPrivate = isPrivate;
         this.completionItem = completionItem;
     }
 
@@ -49,6 +53,10 @@ public class ObjectDAO {
 
     public String getObjectName() {
         return objectName;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
     }
 
     public CompletionItem getCompletionItem() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dao/PackageFunctionDAO.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dao/PackageFunctionDAO.java
@@ -31,13 +31,19 @@ public class PackageFunctionDAO {
     private String functionName;
     
     private CompletionItem completionItem;
+    
+    private boolean isPrivate;
+    
+    private boolean isAttached;
 
     public PackageFunctionDAO(String packageName, String packageOrgName, String functionName,
-                              CompletionItem completionItem) {
+                              CompletionItem completionItem, boolean isPrivate, boolean isAttached) {
         this.packageName = packageName;
         this.packageOrgName = packageOrgName;
         this.functionName = functionName;
         this.completionItem = completionItem;
+        this.isPrivate = isPrivate;
+        this.isAttached = isAttached;
     }
 
     public String getPackageName() {
@@ -54,5 +60,13 @@ public class PackageFunctionDAO {
 
     public CompletionItem getCompletionItem() {
         return completionItem;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public boolean isAttached() {
+        return isAttached;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dao/RecordDAO.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dao/RecordDAO.java
@@ -23,19 +23,23 @@ import org.eclipse.lsp4j.CompletionItem;
  * DAO for BRecordTypeSymbol.
  */
 public class RecordDAO {
+
     private String packageName;
 
     private String packageOrgName;
 
     private String recordName;
 
+    private boolean isPrivate;
+
     private CompletionItem completionItem;
 
-    public RecordDAO(String packageName, String packageOrgName, String recordName,
+    public RecordDAO(String packageName, String packageOrgName, String recordName, boolean isPrivate,
                               CompletionItem completionItem) {
         this.packageName = packageName;
         this.packageOrgName = packageOrgName;
         this.recordName = recordName;
+        this.isPrivate = isPrivate;
         this.completionItem = completionItem;
     }
 
@@ -49,6 +53,10 @@ public class RecordDAO {
 
     public String getRecordName() {
         return recordName;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
     }
 
     public CompletionItem getCompletionItem() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dto/BFunctionDTO.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dto/BFunctionDTO.java
@@ -31,11 +31,18 @@ public class BFunctionDTO {
     private String name;
     
     private CompletionItem completionItem;
+    
+    private boolean isPrivate;
+    
+    private boolean isAttached;
 
-    public BFunctionDTO(int packageId, int objectId, String name, CompletionItem completionItem) {
+    public BFunctionDTO(int packageId, int objectId, String name, CompletionItem completionItem, boolean isPrivate,
+                        boolean isAttached) {
         this.packageId = packageId;
         this.objectId = objectId;
         this.name = name;
+        this.isPrivate = isPrivate;
+        this.isAttached = isAttached;
         this.completionItem = completionItem;
     }
 
@@ -53,5 +60,13 @@ public class BFunctionDTO {
 
     public CompletionItem getCompletionItem() {
         return completionItem;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public boolean isAttached() {
+        return isAttached;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dto/BObjectTypeSymbolDTO.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dto/BObjectTypeSymbolDTO.java
@@ -31,22 +31,26 @@ public class BObjectTypeSymbolDTO {
     private String fields;
     
     private ObjectType type;
+
+    private boolean isPrivate;
     
     private CompletionItem completionItem;
 
-    public BObjectTypeSymbolDTO(int packageId, String name, String fields, ObjectType type,
+    public BObjectTypeSymbolDTO(int packageId, String name, String fields, ObjectType type, boolean isPrivate,
                                 CompletionItem completionItem) {
         this.packageId = packageId;
         this.name = name;
         this.fields = fields;
         this.type = type;
+        this.isPrivate = isPrivate;
         this.completionItem = completionItem;
     }
 
-    public BObjectTypeSymbolDTO(int packageId, String name, String fields) {
+    public BObjectTypeSymbolDTO(int packageId, String name, String fields, boolean isPrivate) {
         this.packageId = packageId;
         this.name = name;
         this.fields = fields;
+        this.isPrivate = isPrivate;
     }
 
     public int getPackageId() {
@@ -63,6 +67,10 @@ public class BObjectTypeSymbolDTO {
 
     public ObjectType getType() {
         return type;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
     }
 
     public CompletionItem getCompletionItem() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dto/BRecordTypeSymbolDTO.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/index/dto/BRecordTypeSymbolDTO.java
@@ -30,12 +30,16 @@ public class BRecordTypeSymbolDTO {
     
     private String fields;
 
+    private boolean isPrivate;
+
     private CompletionItem completionItem;
 
-    public BRecordTypeSymbolDTO(int packageId, String name, String fields, CompletionItem completionItem) {
+    public BRecordTypeSymbolDTO(int packageId, String name, String fields, boolean isPrivate,
+                                CompletionItem completionItem) {
         this.packageId = packageId;
         this.name = name;
         this.fields = fields;
+        this.isPrivate = isPrivate;
         this.completionItem = completionItem;
     }
 
@@ -49,6 +53,10 @@ public class BRecordTypeSymbolDTO {
 
     public String getFields() {
         return fields;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
     }
 
     public CompletionItem getCompletionItem() {

--- a/language-server/modules/langserver-core/src/main/resources/lang-server-index.sql
+++ b/language-server/modules/langserver-core/src/main/resources/lang-server-index.sql
@@ -12,6 +12,8 @@ CREATE TABLE bLangFunction (
   packageId int(11) NOT NULL,
   objectId int(11) NOT NULL DEFAULT '-1',
   name varchar(256) NOT NULL,
+  private BIT NOT NULL DEFAULT 1,
+  attached BIT NOT NULL DEFAULT 0,
   completionItem varchar(MAX) NOT NULL
 );
 
@@ -22,6 +24,7 @@ CREATE TABLE bLangObject (
   fields varchar(256),
   type int(2) NOT NULL DEFAULT '3',
   actionHolderId int(11) DEFAULT '-1',
+  private BIT NOT NULL DEFAULT 1,
   completionItem varchar(MAX) DEFAULT NULL
 );
 
@@ -37,6 +40,7 @@ CREATE TABLE bLangRecord (
   packageId int(11) NOT NULL,
   name varchar(256) NOT NULL,
   fields varchar(MAX) NOT NULL,
+  private BIT NOT NULL DEFAULT 1,
   completionItem varchar(MAX) DEFAULT NULL
 );
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/actionInvocationSuggestion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/actionInvocationSuggestion1.json
@@ -6,14 +6,6 @@
   "source": "function/source/actionInvocationSuggestion1.bal",
   "items": [
     {
-      "label":"new()",
-      "kind":"Function",
-      "detail":"Function",
-      "sortText":"120",
-      "insertText":"new()",
-      "insertTextFormat":"Snippet"
-    },
-    {
       "label":"post(string path, ballerina/http:Request|string|xml|json|byte[]|ballerina/io:ByteChannel|ballerina/mime:Entity[]? message)(ballerina/http:Response|error)",
       "kind":"Function",
       "detail":"Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/actionInvocationSuggestion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/actionInvocationSuggestion2.json
@@ -6,14 +6,6 @@
   "source": "function/source/actionInvocationSuggestion2.bal",
   "items": [
     {
-      "label":"new()",
-      "kind":"Function",
-      "detail":"Function",
-      "sortText":"119",
-      "insertText":"new()",
-      "insertTextFormat":"Snippet"
-    },
-    {
       "label":"post(string path, ballerina/http:Request|string|xml|json|byte[]|ballerina/io:ByteChannel|ballerina/mime:Entity[]? message)(ballerina/http:Response|error)",
       "kind":"Function",
       "detail":"Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion1.json
@@ -22,14 +22,6 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"new()",
-      "kind":"Function",
-      "detail":"Function",
-      "sortText":"121",
-      "insertText":"new()",
-      "insertTextFormat":"Snippet"
-    },
-    {
       "label":"respond(ballerina/http:Response|string|xml|json|byte[]|ballerina/io:ByteChannel|ballerina/mime:Entity[]? message)(error?)",
       "kind":"Function",
       "detail":"Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion2.json
@@ -22,14 +22,6 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"new()",
-      "kind":"Function",
-      "detail":"Function",
-      "sortText":"121",
-      "insertText":"new()",
-      "insertTextFormat":"Snippet"
-    },
-    {
       "label":"respond(ballerina/http:Response|string|xml|json|byte[]|ballerina/io:ByteChannel|ballerina/mime:Entity[]? message)(error?)",
       "kind":"Function",
       "detail":"Function",


### PR DESCRIPTION
## Purpose
> With this added support for filtering the public functions, objects, and records from the package content. Also, fix the issue of not suggesting the imports under a particular org name where the package repo exists in the ballerina home.
Resolves #9288, Resolves #9359