### PR TITLE
Remove accepting little endian byte order from io api

### DIFF
--- a/stdlib/io/src/main/ballerina/io/data_channel.bal
+++ b/stdlib/io/src/main/ballerina/io/data_channel.bal
@@ -21,16 +21,15 @@ documentation {
 
     LITTLE_ENDIAN - specifies the byte order to be the least significant byte first
 }
-public type ByteOrder "BI"|"LI";
-@final public ByteOrder BIG_ENDIAN = "BI";
-@final public ByteOrder LITTLE_ENDIAN = "LI";
+public type ByteOrder "BE";
+@final public ByteOrder BIG_ENDIAN = "BE";
 
 documentation {
     Represents a data channel for reading/writing data.
 }
 public type DataChannel object {
 
-    public new(ByteChannel byteChannel, ByteOrder bOrder = "BI") {
+    public new(ByteChannel byteChannel, ByteOrder bOrder = "BE") {
         init(byteChannel, bOrder);
     }
 

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CreateDataChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CreateDataChannel.java
@@ -77,9 +77,9 @@ public class CreateDataChannel extends BlockingNativeCallableUnit {
      */
     private ByteOrder getByteOrder(String byteOrder) {
         switch (byteOrder) {
-            case "BI":
+            case "BE":
                 return ByteOrder.BIG_ENDIAN;
-            case "LI":
+            case "LE":
                 return ByteOrder.LITTLE_ENDIAN;
             default:
                 return ByteOrder.nativeOrder();


### PR DESCRIPTION
## Purpose
Currently data io supports only big endian. However it's made extensible to support little endian byte order. Introducing little endian support will be tracked in #9337

## Goals
- Remove accepting little endian as the network byte order