### PR TITLE
Add syntax highlighting for object and record fields in composer editor

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/utils/monarch-tokenizer.json
+++ b/composer/modules/web/src/plugins/ballerina/utils/monarch-tokenizer.json
@@ -19,6 +19,9 @@
             "include": "objectDec"
         },
         {
+            "include": "record"
+        },
+        {
             "include": "annotationDec"
         },
         {
@@ -166,7 +169,7 @@
     ],
     "continuedTupleType__b__0": [
         [
-            "(?=\\))",
+            "(?=\\)|;)",
             {
                 "next": "@pop",
                 "token": ""
@@ -1131,13 +1134,6 @@
             }
         ],
         {
-            "include": "objectDec"
-        },
-        [
-            "(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\")",
-            "entity.name.function.ballerina"
-        ],
-        {
             "include": "comment"
         }
     ],
@@ -1195,6 +1191,12 @@
             "include": "functionDec"
         },
         {
+            "include": "annotationDec"
+        },
+        {
+            "include": "variableDef"
+        },
+        {
             "include": "comment"
         },
         {
@@ -1212,38 +1214,86 @@
     ],
     "varDefBlock__b__0": [
         [
-            "\\}|;",
+            "\\}|;|,",
             {
                 "next": "@pop",
                 "token": ""
             }
         ],
         {
-            "include": "varDefBlockBody"
+            "include": "objectMemberFunctionDec"
         },
         {
-            "include": "functionDec"
+            "include": "variableDef"
+        },
+        {
+            "include": "code"
         }
     ],
-    "varDefBlockBody": [
+    "objectMemberFunctionDec": [
         [
-            "\\{",
+            "\\bfunction\\b",
             {
-                "next": "varDefBlockBody__b__0",
-                "token": "punctuation.definition.block.ballerina.documentation"
+                "next": "objectMemberFunctionDec__b__0",
+                "token": "keyword.ballerina"
             }
         ]
     ],
-    "varDefBlockBody__b__0": [
+    "objectMemberFunctionDec__b__0": [
         [
-            "(?=\\})",
+            "(?=(?:\\}|;))",
             {
                 "next": "@pop",
-                "token": "punctuation.definition.block.ballerina.documentation"
+                "token": "punctuation.definition.block.ballerina"
             }
         ],
         {
-            "include": "code"
+            "include": "functionReceiver"
+        },
+        {
+            "include": "functionParameters"
+        },
+        {
+            "include": "functionReturns"
+        },
+        {
+            "include": "functionName"
+        },
+        {
+            "include": "callableUnitBody"
+        },
+        {
+            "include": "comment"
+        }
+    ],
+    "variableDef": [
+        [
+            "\\b(?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))\\b|(?=\\()",
+            {
+                "next": "variableDef__b__0",
+                "token": "type.ballerina"
+            }
+        ]
+    ],
+    "variableDef__b__0": [
+        [
+            "\\b(?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))\\b|(?=\\,)|(?=;)",
+            {
+                "next": "@pop",
+                "token": "variable.ballerina"
+            }
+        ],
+        {
+            "include": "continuedTupleType"
+        },
+        {
+            "include": "continuedType"
+        },
+        {
+            "include": "constrainType"
+        },
+        {
+            "include": "comment"
         }
     ],
     "objectInitDec": [
@@ -1312,6 +1362,60 @@
                 "token": "punctuation.definition.block.ballerina"
             }
         ],
+        {
+            "include": "comment"
+        },
+        {
+            "include": "code"
+        }
+    ],
+    "record": [
+        [
+            "\\brecord\\b",
+            {
+                "next": "record__b__0",
+                "token": "keyword.ballerina"
+            }
+        ]
+    ],
+    "record__b__0": [
+        [
+            "\\}",
+            {
+                "next": "@pop",
+                "token": "delimiter.curly"
+            }
+        ],
+        {
+            "include": "recordBody"
+        },
+        {
+            "include": "comment"
+        }
+    ],
+    "recordBody": [
+        [
+            "\\{",
+            {
+                "next": "recordBody__b__0",
+                "token": "punctuation.definition.block.ballerina"
+            }
+        ]
+    ],
+    "recordBody__b__0": [
+        [
+            "(?=\\})",
+            {
+                "next": "@pop",
+                "token": "punctuation.definition.block.ballerina"
+            }
+        ],
+        {
+            "include": "annotationDec"
+        },
+        {
+            "include": "variableDef"
+        },
         {
             "include": "comment"
         },

--- a/composer/modules/web/src/plugins/ballerina/utils/monarch-tokenizer.json
+++ b/composer/modules/web/src/plugins/ballerina/utils/monarch-tokenizer.json
@@ -1130,7 +1130,7 @@
             "\\b(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\")\\b",
             {
                 "next": "@pop",
-                "token": "entity.name.function.ballerina"
+                "token": "source.ballerina"
             }
         ],
         {
@@ -1280,7 +1280,7 @@
             "\\b(?:(?:[a-zA-Z_][a-zA-Z0-9_]*)|(?:\\^\"([^|\"\\\\\\f\\n\\r\\t]|\\\\\\\\[btnfr]|\\\\[|\"\\\\/])+\"))\\b|(?=\\,)|(?=;)",
             {
                 "next": "@pop",
-                "token": "variable.ballerina"
+                "token": "source.ballerina"
             }
         ],
         {


### PR DESCRIPTION
## Purpose
Add syntax highlighting for object and record fields in composer editor

Fixes #9351 Fixes #9038 

![image](https://user-images.githubusercontent.com/3872221/42273712-993b4b24-7fa7-11e8-9deb-239143d7651c.png)

