### PR TITLE
Fix issue in not getting project root correctly in Windows

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
@@ -15,7 +15,6 @@
  */
 package org.ballerinalang.langserver.compiler;
 
-import com.google.common.io.Files;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.langserver.compiler.common.CustomErrorStrategyFactory;
@@ -47,6 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -79,7 +79,7 @@ public class LSCompiler {
 
     static {
         // Here we will create a tmp directory as the untitled project repo.
-        File untitledDir = Files.createTempDir();
+        File untitledDir = com.google.common.io.Files.createTempDir();
         untitledProjectPath = untitledDir.toPath();
         // Now lets create a empty untitled.bal to fool compiler.
         File untitledBal = new File(Paths.get(untitledProjectPath.toString(), UNTITLED_BAL).toString());
@@ -354,17 +354,47 @@ public class LSCompiler {
     }
 
     @CheckForNull
-    public static String findProjectRoot(String parentDir, Path homePath) {
-        Path path = Paths.get(parentDir, ProjectDirConstants.DOT_BALLERINA_DIR_NAME);
-        if (!path.equals(homePath) && java.nio.file.Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+    public static String findProjectRoot(String parentDir, Path balHomePath) {
+        if (parentDir == null) {
+            return null;
+        }
+        String tmpParentDir = parentDir;
+
+        Path pathWithDotBal = null;
+        boolean pathWithDotBalExists = false;
+
+        // Go to top till you find a project directory or ballerina home
+        while (!pathWithDotBalExists && tmpParentDir != null) {
+            pathWithDotBal = Paths.get(tmpParentDir, ProjectDirConstants.DOT_BALLERINA_DIR_NAME);
+            pathWithDotBalExists = Files.exists(pathWithDotBal, LinkOption.NOFOLLOW_LINKS);
+            if (!pathWithDotBalExists) {
+                Path parentsParent = Paths.get(tmpParentDir).getParent();
+                tmpParentDir = (parentsParent != null) ? parentsParent.toString() : null;
+            }
+        }
+
+        boolean balHomeExists = Files.exists(balHomePath, LinkOption.NOFOLLOW_LINKS);
+
+        // Check if you find ballerina home if so return parent.
+        if (pathWithDotBalExists && balHomeExists && isSameFile(pathWithDotBal, balHomePath)) {
             return parentDir;
         }
-        Path parent = Paths.get(parentDir);
-        Path parentsParent = parent.getParent();
-        if (null != parentsParent) {
-            return findProjectRoot(parentsParent.toString(), homePath);
+
+        // Else return the project directory.
+        if (pathWithDotBalExists) {
+            return tmpParentDir;
+        } else {
+            // If no directory found return parent.
+            return parentDir;
         }
-        return null;
+    }
+
+    private static boolean isSameFile(Path path1, Path path2) {
+        try {
+            return path1.equals(path2) || Files.isSameFile(path1, path2);
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
>  When comparing the paths in windows; `path1.equals(path2)` does only a string comparision. However; there might be shortened paths (still physical equal) in Windows.
> 
> **For example;**
> * C:\Users\ImeshChandrasiri\AppData\temp\123\untitled.bal
> * C:\Users\IMESHC~1\AppData\temp\123\untitled.bal
>
> This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/9321