### PR TITLE
Handle programs with no entry point

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -98,7 +98,8 @@ public class LauncherUtils {
 
         // If there is no main or service entry point, throw an error
         if (!programFile.isMainEPAvailable() && !programFile.isServiceEPAvailable()) {
-            throw new RuntimeException("main function not found in '" + programFile.getProgramFilePath() + "'");
+            throw LauncherUtils.createLauncherException(
+                    "error: '" + programFile.getProgramFilePath() + "' does not contain a main function or a service");
         }
 
         boolean runServicesOrNoMainEP = runServices || !programFile.isMainEPAvailable();


### PR DESCRIPTION
## Purpose
> Fix #9387. With this fix, programs with neither a main() nor a service will give a proper error message to the user, instead of crashing and logging it to the crash log. For example,

```
$ ballerina run test.bal 
error: 'test.bal' does not contain a main function or a service
```