### PR TITLE
Support unsigned right shift operators for byte and int types

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -349,6 +349,7 @@ public class CPU {
                     case InstructionCodes.BIXOR:
                     case InstructionCodes.BISHL:
                     case InstructionCodes.BISHR:
+                    case InstructionCodes.BIUSHR:
                         execBinaryOpCodes(ctx, sf, opcode, operands);
                         break;
     
@@ -1751,6 +1752,12 @@ public class CPU {
                 j = operands[1];
                 k = operands[2];
                 sf.longRegs[k] = sf.longRegs[i] >> sf.longRegs[j];
+                break;
+            case InstructionCodes.BIUSHR:
+                i = operands[0];
+                j = operands[1];
+                k = operands[2];
+                sf.longRegs[k] = sf.longRegs[i] >>> sf.longRegs[j];
                 break;
             default:
                 throw new UnsupportedOperationException();

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -176,11 +176,12 @@ public interface InstructionCodes {
     int MAP2T = 154;
     int JSON2T = 155;
 
-    int BISHL = 156;
-    int BISHR = 157;
+    int S2XML = 156;
+    int XML2S = 157;
 
-    int S2XML = 158;
-    int XML2S = 159;
+    int BISHL = 158;
+    int BISHR = 159;
+    int BIUSHR = 160;
 
     // Type cast
     int I2ANY = 162;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -92,6 +92,7 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIXOR] = "bixor";
         mnemonics[InstructionCodes.BISHL] = "bishl";
         mnemonics[InstructionCodes.BISHR] = "bishr";
+        mnemonics[InstructionCodes.BIUSHR] = "biushr";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1299,6 +1299,7 @@ public class PackageInfoReader {
                 case InstructionCodes.BIXOR:
                 case InstructionCodes.BISHL:
                 case InstructionCodes.BISHR:
+                case InstructionCodes.BIUSHR:
                 case InstructionCodes.XMLATTRLOAD:
                 case InstructionCodes.XMLATTRSTORE:
                 case InstructionCodes.S2QNAME:

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/OperatorKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/OperatorKind.java
@@ -50,6 +50,7 @@ public enum OperatorKind {
     BITWISE_XOR("^"),
     BITWISE_LEFT_SHIFT("<<"),
     BITWISE_RIGHT_SHIFT(">>"),
+    BITWISE_UNSIGNED_RIGHT_SHIFT(">>>"),
     CLOSED_RANGE("..."),
     HALF_OPEN_RANGE("..<");
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1349,7 +1349,8 @@ public class Desugar extends BLangNodeVisitor {
      */
     private boolean isBitwiseShiftOperation(BLangBinaryExpr binaryExpr) {
         return binaryExpr.opKind == OperatorKind.BITWISE_LEFT_SHIFT ||
-                binaryExpr.opKind == OperatorKind.BITWISE_RIGHT_SHIFT;
+                binaryExpr.opKind == OperatorKind.BITWISE_RIGHT_SHIFT ||
+                binaryExpr.opKind == OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT;
     }
 
     public void visit(BLangElvisExpr elvisExpr) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -252,6 +252,14 @@ public class SymbolTable {
         defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, byteType, intType, InstructionCodes.BISHR);
         defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, byteType, intType, InstructionCodes.BISHR);
         defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, intType, intType, InstructionCodes.BISHR);
+        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, intType, intType,
+                InstructionCodes.BIUSHR);
+        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, byteType, intType,
+                InstructionCodes.BIUSHR);
+        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, byteType, intType,
+                InstructionCodes.BIUSHR);
+        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, intType, intType,
+                InstructionCodes.BIUSHR);
 
         // Binary equality operators ==, !=
         defineBinaryOperator(OperatorKind.EQUAL, intType, intType, booleanType, InstructionCodes.IEQ);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -176,11 +176,12 @@ public interface InstructionCodes {
     int MAP2T = 154;
     int JSON2T = 155;
 
-    int BISHL = 156;
-    int BISHR = 157;
+    int S2XML = 156;
+    int XML2S = 157;
 
-    int S2XML = 158;
-    int XML2S = 159;
+    int BISHL = 158;
+    int BISHR = 159;
+    int BIUSHR = 160;
 
     // Type cast
     int I2ANY = 162;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -92,6 +92,7 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIXOR] = "bior";
         mnemonics[InstructionCodes.BISHL] = "bishl";
         mnemonics[InstructionCodes.BISHR] = "bishr";
+        mnemonics[InstructionCodes.BIUSHR] = "biushr";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/stdlib/internal/src/main/ballerina/internal/string_conversion.bal
+++ b/stdlib/internal/src/main/ballerina/internal/string_conversion.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.package internal;
+
+documentation {
+    Converts given byte array to a string.
+
+    P{{content}} Byte array content to be converted
+    P{{encoding}} Encoding to used in byte array conversion to string
+    R{{}} String representation of the given byte array
+}
+public native function byteArrayToString(byte[] content, string encoding) returns string;

--- a/stdlib/internal/src/main/java/org/ballerinalang/stdlib/internal/conversion/ByteArrayToString.java
+++ b/stdlib/internal/src/main/java/org/ballerinalang/stdlib/internal/conversion/ByteArrayToString.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.internal.conversion;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BByteArray;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Convert byte array to string.
+ *
+ * @since 0.980
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "internal",
+        functionName = "byteArrayToString",
+        args = {@Argument(name = "content", type = TypeKind.ARRAY, elementType = TypeKind.BYTE),
+                @Argument(name = "encoding", type = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.STRING)},
+        isPublic = true
+)
+public class ByteArrayToString extends BlockingNativeCallableUnit {
+
+    @Override
+    public void execute(Context context) {
+        try {
+            byte[] bytes = ((BByteArray) context.getRefArgument(0)).getBytes();
+            String encoding = context.getStringArgument(0);
+            String value = new String(bytes, encoding);
+            context.setReturnValues(new BString(value));
+        } catch (UnsupportedEncodingException e) {
+            throw new BallerinaException("Unsupported encoding of byte array", e);
+        }
+    }
+}

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteArrayValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteArrayValueTest.java
@@ -28,12 +28,16 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.io.UnsupportedEncodingException;
+
 /**
  * This test class will test byte array values.
  */
 public class BByteArrayValueTest {
 
     private CompileResult result;
+
+    private static final String content = "This is a sample string";
 
     @BeforeClass
     public void setup() {
@@ -242,5 +246,32 @@ public class BByteArrayValueTest {
         ByteArrayUtils.assertJBytesWithBBytes(bytes2, byteArray2.getBytes());
         Assert.assertEquals(bytes3.length, byteArray3.size());
         ByteArrayUtils.assertJBytesWithBBytes(bytes3, byteArray3.getBytes());
+    }
+
+    @Test(description = "Get string representation of byte array 1")
+    public void testByteArrayToString1() throws UnsupportedEncodingException {
+
+        BValue[] args = {new BByteArray(content.getBytes("UTF-8"))};
+        BValue[] returns = BRunUtil.invoke(result, "testByteArrayToString1", args);
+
+        Assert.assertEquals(returns[0].stringValue(), content);
+    }
+
+    @Test(description = "Get string representation of byte array 2")
+    public void testByteArrayToString2() throws UnsupportedEncodingException {
+
+        BValue[] args = {new BByteArray(content.getBytes("UTF-8")), new BString("UTF-8")};
+        BValue[] returns = BRunUtil.invoke(result, "testByteArrayToString2", args);
+
+        Assert.assertEquals(returns[0].stringValue(), content);
+    }
+
+    @Test(description = "Get string representation of byte array 3")
+    public void testByteArrayToString3() throws UnsupportedEncodingException {
+
+        BValue[] args = {new BByteArray(content.getBytes("UTF-16")), new BString("UTF-16")};
+        BValue[] returns = BRunUtil.invoke(result, "testByteArrayToString2", args);
+
+        Assert.assertEquals(returns[0].stringValue(), content);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -316,12 +316,35 @@ public class BByteValueTest {
     }
 
 
-    @Test(description = "Test bitwise and operator")
-    public void testBitwiseAndOperator() {
+    @Test(description = "Test bitwise and operator 1")
+    public void testBitwiseAndOperator1() {
         byte a = 12;
         byte b = 34;
         int i = 234;
         int j = -456;
+        invokeBitwiseAndTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise and operator 2")
+    public void testBitwiseAndOperator2() {
+        byte a = -97;
+        byte b = 12;
+        int i = -456832;
+        int j = 34;
+        invokeBitwiseAndTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise and operator 3")
+    public void testBitwiseAndOperator3() {
+        byte a = -97;
+        byte b = -23;
+        int i = -456832;
+        int j = -3456;
+        invokeBitwiseAndTestFunction(a, b, i, j);
+    }
+
+
+    private void invokeBitwiseAndTestFunction(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
         BValue[] returns = BRunUtil.invoke(result, "testBitwiseAndOperator", args);
         Assert.assertEquals(returns.length, 5);
@@ -337,12 +360,34 @@ public class BByteValueTest {
         Assert.assertEquals(bInteger4.intValue(), a & i & b & j, "Invalid result");
     }
 
-    @Test(description = "Test bitwise and operator")
-    public void testBitwiseOrOperator() {
+    @Test(description = "Test bitwise and operator 1")
+    public void testBitwiseOrOperator1() {
         byte a = 12;
         byte b = 34;
         int i = 234;
         int j = -456;
+        testBitwiseOrTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise and operator 2")
+    public void testBitwiseOrOperator2() {
+        byte a = -97;
+        byte b = 12;
+        int i = -456832;
+        int j = 34;
+        testBitwiseOrTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise and operator 3")
+    public void testBitwiseOrOperator3() {
+        byte a = -97;
+        byte b = -23;
+        int i = -456832;
+        int j = -3456;
+        testBitwiseOrTestFunction(a, b, i, j);
+    }
+
+    private void testBitwiseOrTestFunction(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
         BValue[] returns = BRunUtil.invoke(result, "testBitwiseOrOperator", args);
         Assert.assertEquals(returns.length, 5);
@@ -358,12 +403,35 @@ public class BByteValueTest {
         Assert.assertEquals(bInteger4.intValue(), a | i | b | j, "Invalid result");
     }
 
-    @Test(description = "Test bitwise and operator")
-    public void testBitwiseXorOperator() {
+    @Test(description = "Test bitwise and operator 1")
+    public void testBitwiseXorOperator1() {
         byte a = 12;
         byte b = 34;
         int i = 234;
         int j = -456;
+        testBitwiseXorTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise and operator 2")
+    public void testBitwiseXorOperator2() {
+        byte a = -97;
+        byte b = 12;
+        int i = -456832;
+        int j = 34;
+        testBitwiseXorTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise and operator 3")
+    public void testBitwiseXorOperator3() {
+        byte a = -97;
+        byte b = -23;
+        int i = -456832;
+        int j = -3456;
+        testBitwiseXorTestFunction(a, b, i, j);
+    }
+
+
+    private void testBitwiseXorTestFunction(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
         BValue[] returns = BRunUtil.invoke(result, "testBitwiseXorOperator", args);
         Assert.assertEquals(returns.length, 5);
@@ -379,34 +447,94 @@ public class BByteValueTest {
         Assert.assertEquals(bInteger4.intValue(), a ^ i ^ b ^ j, "Invalid result");
     }
 
-    @Test(description = "Test bitwise and operator")
-    public void testBitwiseRightShiftOperator() {
+    @Test(description = "Test bitwise right shift operator")
+    public void testBitwiseRightShiftOperator1() {
         byte a = 123;
         byte b = 4;
         int i = 234;
         int j = 3;
-        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseRightShiftOperator", args);
-        Assert.assertEquals(returns.length, 2);
-        BInteger bInteger1 = (BInteger) returns[0];
-        BInteger bInteger2 = (BInteger) returns[1];
-        Assert.assertEquals(bInteger1.intValue(), a >> b, "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), i >> j, "Invalid result");
+        invokeRightShiftOperatorTestFunction(a, b, i, j);
     }
 
-    @Test(description = "Test bitwise and operator")
-    public void testBitwiseLeftShiftOperator() {
+    @Test(description = "Test bitwise right shift operator")
+    public void testBitwiseRightShiftOperator2() {
+        byte a = -27;
+        byte b = 6;
+        int i = -45678776;
+        int j = 4;
+        invokeRightShiftOperatorTestFunction(a, b, i, j);
+    }
+
+    private void invokeRightShiftOperatorTestFunction(byte a, byte b, int i, int j) {
+        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseRightShiftOperator", args);
+        Assert.assertEquals(returns.length, 3);
+        BInteger bInteger1 = (BInteger) returns[0];
+        BInteger bInteger2 = (BInteger) returns[1];
+        BInteger bInteger3 = (BInteger) returns[2];
+        Assert.assertEquals(bInteger1.intValue(), a >> b, "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), i >> j, "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), a >> j, "Invalid result");
+    }
+
+    @Test(description = "Test bitwise left shift operator 1")
+    public void testBitwiseLeftShiftOperator1() {
         byte a = 23;
         byte b = 6;
         int i = 4567;
         int j = 7;
-        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseLeftShiftOperator", args);
-        Assert.assertEquals(returns.length, 2);
-        BInteger bInteger1 = (BInteger) returns[0];
-        BInteger bInteger2 = (BInteger) returns[1];
-        Assert.assertEquals(bInteger1.intValue(), a << b, "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), i << j, "Invalid result");
+        invokeLeftShiftOperatorTestFunction(a, b, i, j);
     }
 
+
+    @Test(description = "Test bitwise left shift operator 2")
+    public void testBitwiseLeftShiftOperator2() {
+        byte a = -27;
+        byte b = 6;
+        int i = -45678776;
+        int j = 4;
+        invokeLeftShiftOperatorTestFunction(a, b, i, j);
+    }
+
+    private void invokeLeftShiftOperatorTestFunction(byte a, byte b, int i, int j) {
+        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseLeftShiftOperator", args);
+        Assert.assertEquals(returns.length, 3);
+        BInteger bInteger1 = (BInteger) returns[0];
+        BInteger bInteger2 = (BInteger) returns[1];
+        BInteger bInteger3 = (BInteger) returns[2];
+        Assert.assertEquals(bInteger1.intValue(), a << b, "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), i << j, "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), a << j, "Invalid result");
+    }
+
+    @Test(description = "Test bitwise unsigned right shift operator 1")
+    public void testBitwiseUnsignedRightShiftOperator1() {
+        byte a = 127;
+        byte b = 3;
+        int i = 45677654;
+        int j = 5;
+        invokeUnsignedRightShiftTestFunction(a, b, i, j);
+    }
+
+    @Test(description = "Test bitwise unsigned right shift operator 2")
+    public void testBitwiseUnsignedRightShiftOperator2() {
+        byte a = -12; // equal to 244 in ballerina
+        byte b = 4;
+        int i = -1236754;
+        int j = 3;
+        invokeUnsignedRightShiftTestFunction(a, b, i, j);
+    }
+
+    private void invokeUnsignedRightShiftTestFunction(byte a, byte b, int i, int j) {
+        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOperator", args);
+        Assert.assertEquals(returns.length, 3);
+        BInteger bInteger1 = (BInteger) returns[0];
+        BInteger bInteger2 = (BInteger) returns[1];
+        BInteger bInteger3 = (BInteger) returns[2];
+        Assert.assertEquals(bInteger1.intValue(), (long) a >>> (long) b, "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), (long) i >>> (long) j, "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), (long) a >>> (long) j, "Invalid result");
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-array-value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-array-value.bal
@@ -1,4 +1,5 @@
 import ballerina/io;
+import ballerina/internal;
 
 byte[] glbVarBlob;
 
@@ -146,4 +147,12 @@ function testByteArrayReturn() returns (byte[], byte[], byte[]) {
     byte[] b = base64 `aGVsbG8gYmFsbGVyaW5hICEhIQ==`;
     byte[] c = [3,4,5,6,7,8,9];
     return (a, b, c);
+}
+
+function testByteArrayToString1(byte[] b) returns string {
+    return internal:byteArrayToString(b, "UTF-8");
+}
+
+function testByteArrayToString2(byte[] b, string encoding) returns string {
+    return internal:byteArrayToString(b, encoding);
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -230,14 +230,23 @@ function testBitwiseXorOperator(byte a, byte b, int i, int j) returns (byte, int
     return (b1, r1, r2, r3, r4);
 }
 
-function testBitwiseRightShiftOperator(byte a, byte b, int i, int j) returns (int, int){
+function testBitwiseRightShiftOperator(byte a, byte b, int i, int j) returns (int, int, int){
     int r1 = a >> b;
     int r2 = i >> j;
-    return (r1, r2);
+    int r3 = a >> j;
+    return (r1, r2, r3);
 }
 
-function testBitwiseLeftShiftOperator(byte a, byte b, int i, int j) returns (int, int){
+function testBitwiseLeftShiftOperator(byte a, byte b, int i, int j) returns (int, int, int){
     int r1 = a << b;
     int r2 = i << j;
-    return (r1, r2);
+    int r3 = a << j;
+    return (r1, r2, r3);
+}
+
+function testBitwiseUnsignedRightShiftOperator(byte a, byte b, int i, int j) returns (int, int, int){
+    int r1 = a >>> b;
+    int r2 = i >>> j;
+    int r3 = a >>> j;
+    return (r1, r2, r3);
 }


### PR DESCRIPTION
## Purpose
This PR ads support for bitwise unsigned right shift operator for byte and int types as below.

```ballerina
function testUnsignedRightShiftOperator() returns (int, int, int){
    byte a = 127;
    byte b = 3;
    int i = 45677654;
    int j = 5;

    int r1 = a >>> b;
    int r2 = i >>> j;
    int r3 = a >>> j;
    
    returns (r1, r2, r3);
}
```

This also adds a native method for byte array to string conversion.