### PR TITLE
Fix shift operators byte value space inconsistencies

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -349,12 +349,12 @@ public class CPU {
                     case InstructionCodes.BIOR:
                     case InstructionCodes.IXOR:
                     case InstructionCodes.BIXOR:
-                    case InstructionCodes.BISHL:
-                    case InstructionCodes.BISHR:
-                    case InstructionCodes.ISHR:
-                    case InstructionCodes.ISHL:
-                    case InstructionCodes.BIUSHR:
-                    case InstructionCodes.IUSHR:
+                    case InstructionCodes.BILSHIFT:
+                    case InstructionCodes.BIRSHIFT:
+                    case InstructionCodes.IRSHIFT:
+                    case InstructionCodes.ILSHIFT:
+                    case InstructionCodes.BIUNRSHIFT:
+                    case InstructionCodes.IUNRSHIFT:
                         execBinaryOpCodes(ctx, sf, opcode, operands);
                         break;
     
@@ -1831,37 +1831,37 @@ public class CPU {
                 k = operands[2];
                 sf.longRegs[k] = sf.longRegs[i] ^ sf.longRegs[j];
                 break;
-            case InstructionCodes.BISHL:
+            case InstructionCodes.BILSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
                 sf.intRegs[k] = sf.intRegs[i] << sf.longRegs[j];
                 break;
-            case InstructionCodes.BISHR:
+            case InstructionCodes.BIRSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
                 sf.intRegs[k] = sf.intRegs[i] >> sf.longRegs[j];
                 break;
-            case InstructionCodes.ISHR:
+            case InstructionCodes.IRSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
                 sf.longRegs[k] = sf.longRegs[i] >> sf.longRegs[j];
                 break;
-            case InstructionCodes.ISHL:
+            case InstructionCodes.ILSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
                 sf.longRegs[k] = sf.longRegs[i] << sf.longRegs[j];
                 break;
-            case InstructionCodes.BIUSHR:
+            case InstructionCodes.BIUNRSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
                 sf.intRegs[k] = sf.intRegs[i] >>> sf.longRegs[j];
                 break;
-            case InstructionCodes.IUSHR:
+            case InstructionCodes.IUNRSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -351,7 +351,10 @@ public class CPU {
                     case InstructionCodes.BIXOR:
                     case InstructionCodes.BISHL:
                     case InstructionCodes.BISHR:
+                    case InstructionCodes.ISHR:
+                    case InstructionCodes.ISHL:
                     case InstructionCodes.BIUSHR:
+                    case InstructionCodes.IUSHR:
                         execBinaryOpCodes(ctx, sf, opcode, operands);
                         break;
     
@@ -1832,15 +1835,33 @@ public class CPU {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.longRegs[k] = sf.longRegs[i] << sf.longRegs[j];
+                sf.intRegs[k] = sf.intRegs[i] << sf.longRegs[j];
                 break;
             case InstructionCodes.BISHR:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
+                sf.intRegs[k] = sf.intRegs[i] >> sf.longRegs[j];
+                break;
+            case InstructionCodes.ISHR:
+                i = operands[0];
+                j = operands[1];
+                k = operands[2];
                 sf.longRegs[k] = sf.longRegs[i] >> sf.longRegs[j];
                 break;
+            case InstructionCodes.ISHL:
+                i = operands[0];
+                j = operands[1];
+                k = operands[2];
+                sf.longRegs[k] = sf.longRegs[i] << sf.longRegs[j];
+                break;
             case InstructionCodes.BIUSHR:
+                i = operands[0];
+                j = operands[1];
+                k = operands[2];
+                sf.intRegs[k] = sf.intRegs[i] >>> sf.longRegs[j];
+                break;
+            case InstructionCodes.IUSHR:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
@@ -2199,7 +2220,7 @@ public class CPU {
             case InstructionCodes.BI2I:
                 i = operands[0];
                 j = operands[1];
-                sf.longRegs[j] = (long) sf.intRegs[i];
+                sf.longRegs[j] = Byte.toUnsignedInt((byte) sf.intRegs[i]);
                 break;
             case InstructionCodes.F2I:
                 i = operands[0];

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -353,8 +353,6 @@ public class CPU {
                     case InstructionCodes.BIRSHIFT:
                     case InstructionCodes.IRSHIFT:
                     case InstructionCodes.ILSHIFT:
-                    case InstructionCodes.BIUNRSHIFT:
-                    case InstructionCodes.IUNRSHIFT:
                         execBinaryOpCodes(ctx, sf, opcode, operands);
                         break;
     

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -1799,19 +1799,19 @@ public class CPU {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = (byte) (sf.intRegs[i] & sf.intRegs[j]);
+                sf.intRegs[k] = sf.intRegs[i] & sf.intRegs[j];
                 break;
             case InstructionCodes.BIOR:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = (byte) (sf.intRegs[i] | sf.intRegs[j]);
+                sf.intRegs[k] = sf.intRegs[i] | sf.intRegs[j];
                 break;
             case InstructionCodes.BIXOR:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = (byte) (sf.intRegs[i] ^ sf.intRegs[j]);
+                sf.intRegs[k] = sf.intRegs[i] ^ sf.intRegs[j];
                 break;
             case InstructionCodes.IAND:
                 i = operands[0];

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -1799,19 +1799,19 @@ public class CPU {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = sf.intRegs[i] & sf.intRegs[j];
+                sf.intRegs[k] = (byte) (sf.intRegs[i] & sf.intRegs[j]);
                 break;
             case InstructionCodes.BIOR:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = sf.intRegs[i] | sf.intRegs[j];
+                sf.intRegs[k] = (byte) (sf.intRegs[i] | sf.intRegs[j]);
                 break;
             case InstructionCodes.BIXOR:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = sf.intRegs[i] ^ sf.intRegs[j];
+                sf.intRegs[k] = (byte) (sf.intRegs[i] ^ sf.intRegs[j]);
                 break;
             case InstructionCodes.IAND:
                 i = operands[0];
@@ -1835,37 +1835,25 @@ public class CPU {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = sf.intRegs[i] << sf.longRegs[j];
+                sf.intRegs[k] = (byte) (sf.intRegs[i] << sf.longRegs[j]);
                 break;
             case InstructionCodes.BIRSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.intRegs[k] = sf.intRegs[i] >> sf.longRegs[j];
+                sf.intRegs[k] = (byte) (sf.intRegs[i] >>> sf.longRegs[j]);
                 break;
             case InstructionCodes.IRSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                sf.longRegs[k] = sf.longRegs[i] >> sf.longRegs[j];
+                sf.longRegs[k] = sf.longRegs[i] >>> sf.longRegs[j];
                 break;
             case InstructionCodes.ILSHIFT:
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
                 sf.longRegs[k] = sf.longRegs[i] << sf.longRegs[j];
-                break;
-            case InstructionCodes.BIUNRSHIFT:
-                i = operands[0];
-                j = operands[1];
-                k = operands[2];
-                sf.intRegs[k] = sf.intRegs[i] >>> sf.longRegs[j];
-                break;
-            case InstructionCodes.IUNRSHIFT:
-                i = operands[0];
-                j = operands[1];
-                k = operands[2];
-                sf.longRegs[k] = sf.longRegs[i] >>> sf.longRegs[j];
                 break;
             default:
                 throw new UnsupportedOperationException();

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -185,10 +185,10 @@ public interface InstructionCodes {
     int S2XML = 156;
     int XML2S = 157;
 
-    int BISHL = 158;
-    int BISHR = 159;
-    int ISHL = 160;
-    int ISHR = 161;
+    int BILSHIFT = 158;
+    int BIRSHIFT = 159;
+    int ILSHIFT = 160;
+    int IRSHIFT = 161;
 
     // Type cast
     int I2ANY = 162;
@@ -249,7 +249,7 @@ public interface InstructionCodes {
     int ARRAYLEN = 207;
     int LENGTHOF = 208;
 
-    int BIUSHR = 209;
+    int BIUNRSHIFT = 209;
 
     int NEWSTRUCT = 210;
     int NEWMAP = 212;
@@ -269,7 +269,7 @@ public interface InstructionCodes {
     int IXOR = 227;
     int BACONST = 228;
 
-    int IUSHR = 229;
+    int IUNRSHIFT = 229;
 
     int IRET = 230;
     int FRET = 231;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -187,7 +187,8 @@ public interface InstructionCodes {
 
     int BISHL = 158;
     int BISHR = 159;
-    int BIUSHR = 160;
+    int ISHL = 160;
+    int ISHR = 161;
 
     // Type cast
     int I2ANY = 162;
@@ -248,6 +249,8 @@ public interface InstructionCodes {
     int ARRAYLEN = 207;
     int LENGTHOF = 208;
 
+    int BIUSHR = 209;
+
     int NEWSTRUCT = 210;
     int NEWMAP = 212;
     int NEWJSON = 213;
@@ -265,6 +268,8 @@ public interface InstructionCodes {
     int BIXOR = 226;
     int IXOR = 227;
     int BACONST = 228;
+
+    int IUSHR = 229;
 
     int IRET = 230;
     int FRET = 231;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -249,8 +249,6 @@ public interface InstructionCodes {
     int ARRAYLEN = 207;
     int LENGTHOF = 208;
 
-    int BIUNRSHIFT = 209;
-
     int NEWSTRUCT = 210;
     int NEWMAP = 212;
     int NEWJSON = 213;
@@ -268,8 +266,6 @@ public interface InstructionCodes {
     int BIXOR = 226;
     int IXOR = 227;
     int BACONST = 228;
-
-    int IUNRSHIFT = 229;
 
     int IRET = 230;
     int FRET = 231;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -94,8 +94,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIRSHIFT] = "birshift";
         mnemonics[InstructionCodes.IRSHIFT] = "irshift";
         mnemonics[InstructionCodes.ILSHIFT] = "ilshift";
-        mnemonics[InstructionCodes.BIUNRSHIFT] = "biunrshift";
-        mnemonics[InstructionCodes.IUNRSHIFT] = "iunrshift";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -90,12 +90,12 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIOR] = "bior";
         mnemonics[InstructionCodes.IXOR] = "ixor";
         mnemonics[InstructionCodes.BIXOR] = "bixor";
-        mnemonics[InstructionCodes.BISHL] = "bishl";
-        mnemonics[InstructionCodes.BISHR] = "bishr";
-        mnemonics[InstructionCodes.ISHR] = "ishr";
-        mnemonics[InstructionCodes.ISHL] = "ishl";
-        mnemonics[InstructionCodes.BIUSHR] = "biushr";
-        mnemonics[InstructionCodes.IUSHR] = "iushr";
+        mnemonics[InstructionCodes.BILSHIFT] = "bilshift";
+        mnemonics[InstructionCodes.BIRSHIFT] = "birshift";
+        mnemonics[InstructionCodes.IRSHIFT] = "irshift";
+        mnemonics[InstructionCodes.ILSHIFT] = "ilshift";
+        mnemonics[InstructionCodes.BIUNRSHIFT] = "biunrshift";
+        mnemonics[InstructionCodes.IUNRSHIFT] = "iunrshift";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -92,7 +92,10 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIXOR] = "bixor";
         mnemonics[InstructionCodes.BISHL] = "bishl";
         mnemonics[InstructionCodes.BISHR] = "bishr";
+        mnemonics[InstructionCodes.ISHR] = "ishr";
+        mnemonics[InstructionCodes.ISHL] = "ishl";
         mnemonics[InstructionCodes.BIUSHR] = "biushr";
+        mnemonics[InstructionCodes.IUSHR] = "iushr";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1301,12 +1301,12 @@ public class PackageInfoReader {
                 case InstructionCodes.BIOR:
                 case InstructionCodes.IXOR:
                 case InstructionCodes.BIXOR:
-                case InstructionCodes.BISHL:
-                case InstructionCodes.BISHR:
-                case InstructionCodes.ISHR:
-                case InstructionCodes.ISHL:
-                case InstructionCodes.BIUSHR:
-                case InstructionCodes.IUSHR:
+                case InstructionCodes.BILSHIFT:
+                case InstructionCodes.BIRSHIFT:
+                case InstructionCodes.IRSHIFT:
+                case InstructionCodes.ILSHIFT:
+                case InstructionCodes.BIUNRSHIFT:
+                case InstructionCodes.IUNRSHIFT:
                 case InstructionCodes.XMLATTRLOAD:
                 case InstructionCodes.XMLATTRSTORE:
                 case InstructionCodes.S2QNAME:

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1305,8 +1305,6 @@ public class PackageInfoReader {
                 case InstructionCodes.BIRSHIFT:
                 case InstructionCodes.IRSHIFT:
                 case InstructionCodes.ILSHIFT:
-                case InstructionCodes.BIUNRSHIFT:
-                case InstructionCodes.IUNRSHIFT:
                 case InstructionCodes.XMLATTRLOAD:
                 case InstructionCodes.XMLATTRSTORE:
                 case InstructionCodes.S2QNAME:

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1303,7 +1303,10 @@ public class PackageInfoReader {
                 case InstructionCodes.BIXOR:
                 case InstructionCodes.BISHL:
                 case InstructionCodes.BISHR:
+                case InstructionCodes.ISHR:
+                case InstructionCodes.ISHL:
                 case InstructionCodes.BIUSHR:
+                case InstructionCodes.IUSHR:
                 case InstructionCodes.XMLATTRLOAD:
                 case InstructionCodes.XMLATTRSTORE:
                 case InstructionCodes.S2QNAME:

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/OperatorKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/OperatorKind.java
@@ -50,7 +50,6 @@ public enum OperatorKind {
     BITWISE_XOR("^"),
     BITWISE_LEFT_SHIFT("<<"),
     BITWISE_RIGHT_SHIFT(">>"),
-    BITWISE_UNSIGNED_RIGHT_SHIFT(">>>"),
     CLOSED_RANGE("..."),
     HALF_OPEN_RANGE("..<");
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1360,8 +1360,7 @@ public class Desugar extends BLangNodeVisitor {
      */
     private boolean isBitwiseShiftOperation(BLangBinaryExpr binaryExpr) {
         return binaryExpr.opKind == OperatorKind.BITWISE_LEFT_SHIFT ||
-                binaryExpr.opKind == OperatorKind.BITWISE_RIGHT_SHIFT ||
-                binaryExpr.opKind == OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT;
+                binaryExpr.opKind == OperatorKind.BITWISE_RIGHT_SHIFT;
     }
 
     public void visit(BLangElvisExpr elvisExpr) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1307,15 +1307,9 @@ public class Desugar extends BLangNodeVisitor {
         result = binaryExpr;
 
         // Check for bitwise shift operator and add type conversion to int
-        if (isBitwiseShiftOperation(binaryExpr)) {
-            if (TypeTags.BYTE == binaryExpr.rhsExpr.type.tag) {
-                binaryExpr.rhsExpr = createTypeConversionExpr(binaryExpr.rhsExpr, binaryExpr.rhsExpr.type,
-                        symTable.intType);
-            }
-            if (TypeTags.BYTE == binaryExpr.lhsExpr.type.tag) {
-                binaryExpr.lhsExpr = createTypeConversionExpr(binaryExpr.lhsExpr, binaryExpr.lhsExpr.type,
-                        symTable.intType);
-            }
+        if (isBitwiseShiftOperation(binaryExpr) && TypeTags.BYTE == binaryExpr.rhsExpr.type.tag) {
+            binaryExpr.rhsExpr = createTypeConversionExpr(binaryExpr.rhsExpr, binaryExpr.rhsExpr.type,
+                    symTable.intType);
         }
 
         // Check lhs and rhs type compatibility

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1310,6 +1310,7 @@ public class Desugar extends BLangNodeVisitor {
         if (isBitwiseShiftOperation(binaryExpr) && TypeTags.BYTE == binaryExpr.rhsExpr.type.tag) {
             binaryExpr.rhsExpr = createTypeConversionExpr(binaryExpr.rhsExpr, binaryExpr.rhsExpr.type,
                     symTable.intType);
+            return;
         }
 
         // Check lhs and rhs type compatibility

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -523,6 +523,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 } else if ((exprType.tag == TypeTags.OBJECT || exprType.tag == TypeTags.RECORD)
                         && this.types.isAssignable(patternType, exprType)) {
                     pattern.matchedTypesIndirect.add(exprType);
+                } else if (exprType.tag == TypeTags.BYTE && patternType.tag == TypeTags.INT) {
+                    pattern.matchedTypesDirect.add(exprType);
+                    break;
                 } else {
                     // TODO Support other assignable types
                 }
@@ -1111,6 +1114,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 } else if ((exprType.tag == TypeTags.OBJECT || exprType.tag == TypeTags.RECORD)
                         && this.types.isAssignable(patternType, exprType)) {
                     pattern.matchedTypesIndirect.add(exprType);
+                } else if (exprType.tag == TypeTags.BYTE && patternType.tag == TypeTags.INT) {
+                    pattern.matchedTypesDirect.add(exprType);
+                    break;
                 } else {
                     // TODO Support other assignable types
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -222,10 +222,6 @@ public class Types {
             return isAssignable(((BStreamType) source).constraint, ((BStreamType) target).constraint);
         }
 
-        if (target.tag == TypeTags.INT && source.tag == TypeTags.BYTE) {
-            return true;
-        }
-
         BSymbol symbol = symResolver.resolveImplicitConversionOp(source, target);
         if (symbol != symTable.notFoundSymbol) {
             return true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -244,21 +244,21 @@ public class SymbolTable {
         defineBinaryOperator(OperatorKind.BITWISE_OR, intType, intType, intType, InstructionCodes.IOR);
         defineBinaryOperator(OperatorKind.BITWISE_XOR, byteType, byteType, byteType, InstructionCodes.BIXOR);
         defineBinaryOperator(OperatorKind.BITWISE_XOR, intType, intType, intType, InstructionCodes.IXOR);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, intType, intType, InstructionCodes.BISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, byteType, intType, InstructionCodes.BISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, byteType, intType, InstructionCodes.BISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, intType, intType, InstructionCodes.BISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, intType, intType, InstructionCodes.BISHR);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, byteType, intType, InstructionCodes.BISHR);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, byteType, intType, InstructionCodes.BISHR);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, intType, intType, InstructionCodes.BISHR);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, intType, intType, InstructionCodes.ISHL);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, byteType, intType, InstructionCodes.ISHL);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, byteType, byteType, InstructionCodes.BISHL);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, intType, byteType, InstructionCodes.BISHL);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, intType, intType, InstructionCodes.ISHR);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, byteType, intType, InstructionCodes.ISHR);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, byteType, byteType, InstructionCodes.BISHR);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, intType, byteType, InstructionCodes.BISHR);
         defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, intType, intType,
-                InstructionCodes.BIUSHR);
-        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, byteType, intType,
-                InstructionCodes.BIUSHR);
+                InstructionCodes.IUSHR);
         defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, byteType, intType,
+                InstructionCodes.IUSHR);
+        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, byteType, byteType,
                 InstructionCodes.BIUSHR);
-        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, intType, intType,
+        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, intType, byteType,
                 InstructionCodes.BIUSHR);
 
         // Binary equality operators ==, !=

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -244,22 +244,22 @@ public class SymbolTable {
         defineBinaryOperator(OperatorKind.BITWISE_OR, intType, intType, intType, InstructionCodes.IOR);
         defineBinaryOperator(OperatorKind.BITWISE_XOR, byteType, byteType, byteType, InstructionCodes.BIXOR);
         defineBinaryOperator(OperatorKind.BITWISE_XOR, intType, intType, intType, InstructionCodes.IXOR);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, intType, intType, InstructionCodes.ISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, byteType, intType, InstructionCodes.ISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, byteType, byteType, InstructionCodes.BISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, intType, byteType, InstructionCodes.BISHL);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, intType, intType, InstructionCodes.ISHR);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, byteType, intType, InstructionCodes.ISHR);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, byteType, byteType, InstructionCodes.BISHR);
-        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, intType, byteType, InstructionCodes.BISHR);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, intType, intType, InstructionCodes.ILSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, intType, byteType, intType, InstructionCodes.ILSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, byteType, byteType, InstructionCodes.BILSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_LEFT_SHIFT, byteType, intType, byteType, InstructionCodes.BILSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, intType, intType, InstructionCodes.IRSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, byteType, intType, InstructionCodes.IRSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, byteType, byteType, InstructionCodes.BIRSHIFT);
+        defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, intType, byteType, InstructionCodes.BIRSHIFT);
         defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, intType, intType,
-                InstructionCodes.IUSHR);
+                InstructionCodes.IUNRSHIFT);
         defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, byteType, intType,
-                InstructionCodes.IUSHR);
+                InstructionCodes.IUNRSHIFT);
         defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, byteType, byteType,
-                InstructionCodes.BIUSHR);
+                InstructionCodes.BIUNRSHIFT);
         defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, intType, byteType,
-                InstructionCodes.BIUSHR);
+                InstructionCodes.BIUNRSHIFT);
 
         // Binary equality operators ==, !=
         defineBinaryOperator(OperatorKind.EQUAL, intType, intType, booleanType, InstructionCodes.IEQ);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -252,14 +252,6 @@ public class SymbolTable {
         defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, intType, byteType, intType, InstructionCodes.IRSHIFT);
         defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, byteType, byteType, InstructionCodes.BIRSHIFT);
         defineBinaryOperator(OperatorKind.BITWISE_RIGHT_SHIFT, byteType, intType, byteType, InstructionCodes.BIRSHIFT);
-        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, intType, intType,
-                InstructionCodes.IUNRSHIFT);
-        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, intType, byteType, intType,
-                InstructionCodes.IUNRSHIFT);
-        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, byteType, byteType,
-                InstructionCodes.BIUNRSHIFT);
-        defineBinaryOperator(OperatorKind.BITWISE_UNSIGNED_RIGHT_SHIFT, byteType, intType, byteType,
-                InstructionCodes.BIUNRSHIFT);
 
         // Binary equality operators ==, !=
         defineBinaryOperator(OperatorKind.EQUAL, intType, intType, booleanType, InstructionCodes.IEQ);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -185,10 +185,10 @@ public interface InstructionCodes {
     int S2XML = 156;
     int XML2S = 157;
 
-    int BISHL = 158;
-    int BISHR = 159;
-    int ISHL = 160;
-    int ISHR = 161;
+    int BILSHIFT = 158;
+    int BIRSHIFT = 159;
+    int ILSHIFT = 160;
+    int IRSHIFT = 161;
 
     // Type cast
     int I2ANY = 162;
@@ -249,7 +249,7 @@ public interface InstructionCodes {
     int ARRAYLEN = 207;
     int LENGTHOF = 208;
 
-    int BIUSHR = 209;
+    int BIUNRSHIFT = 209;
 
     int NEWSTRUCT = 210;
     int NEWMAP = 212;
@@ -269,7 +269,7 @@ public interface InstructionCodes {
     int IXOR = 227;
     int BACONST = 228;
 
-    int IUSHR = 229;
+    int IUNRSHIFT = 229;
 
     int IRET = 230;
     int FRET = 231;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -187,7 +187,8 @@ public interface InstructionCodes {
 
     int BISHL = 158;
     int BISHR = 159;
-    int BIUSHR = 160;
+    int ISHL = 160;
+    int ISHR = 161;
 
     // Type cast
     int I2ANY = 162;
@@ -248,6 +249,8 @@ public interface InstructionCodes {
     int ARRAYLEN = 207;
     int LENGTHOF = 208;
 
+    int BIUSHR = 209;
+
     int NEWSTRUCT = 210;
     int NEWMAP = 212;
     int NEWJSON = 213;
@@ -265,6 +268,8 @@ public interface InstructionCodes {
     int BIXOR = 226;
     int IXOR = 227;
     int BACONST = 228;
+
+    int IUSHR = 229;
 
     int IRET = 230;
     int FRET = 231;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -249,8 +249,6 @@ public interface InstructionCodes {
     int ARRAYLEN = 207;
     int LENGTHOF = 208;
 
-    int BIUNRSHIFT = 209;
-
     int NEWSTRUCT = 210;
     int NEWMAP = 212;
     int NEWJSON = 213;
@@ -268,8 +266,6 @@ public interface InstructionCodes {
     int BIXOR = 226;
     int IXOR = 227;
     int BACONST = 228;
-
-    int IUNRSHIFT = 229;
 
     int IRET = 230;
     int FRET = 231;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -92,7 +92,10 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIXOR] = "bior";
         mnemonics[InstructionCodes.BISHL] = "bishl";
         mnemonics[InstructionCodes.BISHR] = "bishr";
+        mnemonics[InstructionCodes.ISHR] = "ishr";
+        mnemonics[InstructionCodes.ISHL] = "ishl";
         mnemonics[InstructionCodes.BIUSHR] = "biushr";
+        mnemonics[InstructionCodes.IUSHR] = "iushr";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -90,12 +90,12 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIOR] = "bior";
         mnemonics[InstructionCodes.IXOR] = "ior";
         mnemonics[InstructionCodes.BIXOR] = "bior";
-        mnemonics[InstructionCodes.BISHL] = "bishl";
-        mnemonics[InstructionCodes.BISHR] = "bishr";
-        mnemonics[InstructionCodes.ISHR] = "ishr";
-        mnemonics[InstructionCodes.ISHL] = "ishl";
-        mnemonics[InstructionCodes.BIUSHR] = "biushr";
-        mnemonics[InstructionCodes.IUSHR] = "iushr";
+        mnemonics[InstructionCodes.BILSHIFT] = "bilshift";
+        mnemonics[InstructionCodes.BIRSHIFT] = "birshift";
+        mnemonics[InstructionCodes.IRSHIFT] = "irshift";
+        mnemonics[InstructionCodes.ILSHIFT] = "ilshift";
+        mnemonics[InstructionCodes.BIUNRSHIFT] = "biunrshift";
+        mnemonics[InstructionCodes.IUNRSHIFT] = "iunrshift";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -94,8 +94,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.BIRSHIFT] = "birshift";
         mnemonics[InstructionCodes.IRSHIFT] = "irshift";
         mnemonics[InstructionCodes.ILSHIFT] = "ilshift";
-        mnemonics[InstructionCodes.BIUNRSHIFT] = "biunrshift";
-        mnemonics[InstructionCodes.IUNRSHIFT] = "iunrshift";
         mnemonics[InstructionCodes.BACONST] = "baconst";
 
         mnemonics[InstructionCodes.ISUB] = "isub";

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -40,9 +40,9 @@ public class BByteValueNegativeTest {
     }
 
     @Test(description = "Test byte value negative")
-    public void testBlobValueNegative() {
+    public void testByteValueNegative() {
         CompileResult result = BCompileUtil.compile("test-src/types/byte/byte-value-negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 25);
+        Assert.assertEquals(result.getErrorCount(), 29);
         String msg1 = "incompatible types: expected 'byte', found 'int'";
         String msg2 = "incompatible types: expected 'byte', found 'float'";
         String msg3 = "incompatible types: expected 'byte', found 'string'";
@@ -70,10 +70,10 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 18, msg4 , 24, 15);
         BAssertUtil.validateError(result, 19, msg4 , 27, 15);
         BAssertUtil.validateError(result, 20, msg4 , 30, 15);
-        BAssertUtil.validateError(result, 21, msg5, 38, 9);
-        BAssertUtil.validateError(result, 22, msg6, 55, 9);
-        BAssertUtil.validateError(result, 23, msg5, 63, 29);
-        BAssertUtil.validateError(result, 24, msg6, 71, 29);
+        BAssertUtil.validateError(result, 22, msg5, 38, 9);
+        BAssertUtil.validateError(result, 24, msg6, 55, 9);
+        BAssertUtil.validateError(result, 26, msg5, 63, 29);
+        BAssertUtil.validateError(result, 28, msg6, 71, 29);
     }
 
     @Test(description = "Test byte shift operators negative")

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -477,10 +477,10 @@ public class BByteValueTest {
         BByte bByte1 = (BByte) returns[0];
         BInteger bInteger2 = (BInteger) returns[1];
         BByte bByte2 = (BByte) returns[2];
-        Assert.assertEquals(bByte1.byteValue(), (byte) (a >> b), "Invalid result");
-        Assert.assertEquals(bByte1.intValue(), Byte.toUnsignedInt((byte) (a >> b)), "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), i >> j, "Invalid result");
-        Assert.assertEquals(bByte2.intValue(), Byte.toUnsignedInt((byte) (a >> j)), "Invalid result");
+        Assert.assertEquals(bByte1.byteValue(), (byte) (a >>> b), "Invalid result");
+        Assert.assertEquals(bByte1.intValue(), Byte.toUnsignedInt((byte) (a >>> b)), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), ((long) i >>> (long) j), "Invalid result");
+        Assert.assertEquals(bByte2.intValue(), Byte.toUnsignedInt((byte) (a >>> j)), "Invalid result");
     }
 
     private void invokeRightShiftOperatorTestFunction2(byte a, byte b, int i, int j) {
@@ -490,9 +490,9 @@ public class BByteValueTest {
         BInteger bInteger1 = (BInteger) returns[0];
         BInteger bInteger2 = (BInteger) returns[1];
         BInteger bInteger3 = (BInteger) returns[2];
-        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt((byte) (a >> b)), "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), i >> j, "Invalid result");
-        Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a >> j)), "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt((byte) (a >>> b)), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), ((long) i >>> (long) j), "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a >>> j)), "Invalid result");
     }
 
     @Test(description = "Test bitwise left shift operator 1")
@@ -541,48 +541,16 @@ public class BByteValueTest {
         Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a << j)), "Invalid result");
     }
 
-    @Test(description = "Test bitwise unsigned right shift operator 1")
-    public void testBitwiseUnsignedRightShiftOperator1() {
-        byte a = 127;
-        byte b = 3;
-        int i = 45677654;
-        int j = 5;
-        invokeUnsignedRightShiftTestFunction1(a, b, i, j);
-        invokeUnsignedRightShiftTestFunction2(a, b, i, j);
-    }
-
-    @Test(description = "Test bitwise unsigned right shift operator 2")
-    public void testBitwiseUnsignedRightShiftOperator2() {
-        byte a = -12;
-        byte b = 4;
-        int i = -1236754;
-        int j = 3;
-        invokeUnsignedRightShiftTestFunction1(a, b, i, j);
-        invokeUnsignedRightShiftTestFunction2(a, b, i, j);
-    }
-
-    private void invokeUnsignedRightShiftTestFunction1(byte a, byte b, int i, int j) {
-        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOperator1", args);
-        Assert.assertEquals(returns.length, 3);
-        BByte bByte1 = (BByte) returns[0];
-        BInteger bInteger2 = (BInteger) returns[1];
-        BByte bByte2 = (BByte) returns[2];
-        Assert.assertEquals(bByte1.byteValue(), (byte) (a >>> b), "Invalid result");
-        Assert.assertEquals(bByte1.intValue(), Byte.toUnsignedInt((byte) (a >>> b)), "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), (long) i >>> (long) j, "Invalid result");
-        Assert.assertEquals(bByte2.intValue(), Byte.toUnsignedInt((byte) (a >>> j)), "Invalid result");
-    }
-
-    private void invokeUnsignedRightShiftTestFunction2(byte a, byte b, int i, int j) {
-        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOperator2", args);
-        Assert.assertEquals(returns.length, 3);
-        BInteger bInteger1 = (BInteger) returns[0];
-        BInteger bInteger2 = (BInteger) returns[1];
-        BInteger bInteger3 = (BInteger) returns[2];
-        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt((byte) (a >>> b)), "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), (long) i >>> (long) j, "Invalid result");
-        Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a >>> j)), "Invalid result");
+    @Test(description = "Test byte shift")
+    public void testByteShift() {
+        byte a = (byte) 129;
+        byte c = (byte) (a << 1);
+        byte d = (byte) (c >> 1);
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(result, "testByteShift", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BByte.class);
+        BByte bByte = (BByte) returns[0];
+        Assert.assertEquals(bByte.byteValue(), d, "Invalid byte value returned.");
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -354,10 +354,11 @@ public class BByteValueTest {
         BInteger bInteger3 = (BInteger) returns[3];
         BInteger bInteger4 = (BInteger) returns[4];
         Assert.assertEquals(bByte.byteValue(), a & b, "Invalid result");
-        Assert.assertEquals(bInteger1.intValue(), a & b, "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), a & i, "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt(a) & Byte.toUnsignedInt(b), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), Byte.toUnsignedInt(a) & i, "Invalid result");
         Assert.assertEquals(bInteger3.intValue(), i & j, "Invalid result");
-        Assert.assertEquals(bInteger4.intValue(), a & i & b & j, "Invalid result");
+        Assert.assertEquals(bInteger4.intValue(), Byte.toUnsignedInt(a) & i & Byte.toUnsignedInt(b) & j,
+                "Invalid result");
     }
 
     @Test(description = "Test bitwise and operator 1")
@@ -397,10 +398,11 @@ public class BByteValueTest {
         BInteger bInteger3 = (BInteger) returns[3];
         BInteger bInteger4 = (BInteger) returns[4];
         Assert.assertEquals(bByte.byteValue(), a | b, "Invalid result");
-        Assert.assertEquals(bInteger1.intValue(), a | b, "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), a | i, "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt(a) | Byte.toUnsignedInt(b), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), Byte.toUnsignedInt(a) | i, "Invalid result");
         Assert.assertEquals(bInteger3.intValue(), i | j, "Invalid result");
-        Assert.assertEquals(bInteger4.intValue(), a | i | b | j, "Invalid result");
+        Assert.assertEquals(bInteger4.intValue(), Byte.toUnsignedInt(a) | i | Byte.toUnsignedInt(b) | j,
+                "Invalid result");
     }
 
     @Test(description = "Test bitwise and operator 1")
@@ -441,10 +443,11 @@ public class BByteValueTest {
         BInteger bInteger3 = (BInteger) returns[3];
         BInteger bInteger4 = (BInteger) returns[4];
         Assert.assertEquals(bByte.byteValue(), a ^ b, "Invalid result");
-        Assert.assertEquals(bInteger1.intValue(), a ^ b, "Invalid result");
-        Assert.assertEquals(bInteger2.intValue(), a ^ i, "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt(a) ^ Byte.toUnsignedInt(b), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), Byte.toUnsignedInt(a) ^ i, "Invalid result");
         Assert.assertEquals(bInteger3.intValue(), i ^ j, "Invalid result");
-        Assert.assertEquals(bInteger4.intValue(), a ^ i ^ b ^ j, "Invalid result");
+        Assert.assertEquals(bInteger4.intValue(), Byte.toUnsignedInt(a) ^ i ^ Byte.toUnsignedInt(b) ^ j,
+                "Invalid result");
     }
 
     @Test(description = "Test bitwise right shift operator")
@@ -453,7 +456,8 @@ public class BByteValueTest {
         byte b = 4;
         int i = 234;
         int j = 3;
-        invokeRightShiftOperatorTestFunction(a, b, i, j);
+        invokeRightShiftOperatorTestFunction1(a, b, i, j);
+        invokeRightShiftOperatorTestFunction2(a, b, i, j);
     }
 
     @Test(description = "Test bitwise right shift operator")
@@ -462,19 +466,33 @@ public class BByteValueTest {
         byte b = 6;
         int i = -45678776;
         int j = 4;
-        invokeRightShiftOperatorTestFunction(a, b, i, j);
+        invokeRightShiftOperatorTestFunction1(a, b, i, j);
+        invokeRightShiftOperatorTestFunction2(a, b, i, j);
     }
 
-    private void invokeRightShiftOperatorTestFunction(byte a, byte b, int i, int j) {
+    private void invokeRightShiftOperatorTestFunction1(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseRightShiftOperator", args);
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseRightShiftOperator1", args);
+        Assert.assertEquals(returns.length, 3);
+        BByte bByte1 = (BByte) returns[0];
+        BInteger bInteger2 = (BInteger) returns[1];
+        BByte bByte2 = (BByte) returns[2];
+        Assert.assertEquals(bByte1.byteValue(), (byte) (a >> b), "Invalid result");
+        Assert.assertEquals(bByte1.intValue(), Byte.toUnsignedInt((byte) (a >> b)), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), i >> j, "Invalid result");
+        Assert.assertEquals(bByte2.intValue(), Byte.toUnsignedInt((byte) (a >> j)), "Invalid result");
+    }
+
+    private void invokeRightShiftOperatorTestFunction2(byte a, byte b, int i, int j) {
+        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseRightShiftOperator2", args);
         Assert.assertEquals(returns.length, 3);
         BInteger bInteger1 = (BInteger) returns[0];
         BInteger bInteger2 = (BInteger) returns[1];
         BInteger bInteger3 = (BInteger) returns[2];
-        Assert.assertEquals(bInteger1.intValue(), a >> b, "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt((byte) (a >> b)), "Invalid result");
         Assert.assertEquals(bInteger2.intValue(), i >> j, "Invalid result");
-        Assert.assertEquals(bInteger3.intValue(), a >> j, "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a >> j)), "Invalid result");
     }
 
     @Test(description = "Test bitwise left shift operator 1")
@@ -483,7 +501,8 @@ public class BByteValueTest {
         byte b = 6;
         int i = 4567;
         int j = 7;
-        invokeLeftShiftOperatorTestFunction(a, b, i, j);
+        invokeLeftShiftOperatorTestFunction1(a, b, i, j);
+        invokeLeftShiftOperatorTestFunction2(a, b, i, j);
     }
 
 
@@ -493,19 +512,33 @@ public class BByteValueTest {
         byte b = 6;
         int i = -45678776;
         int j = 4;
-        invokeLeftShiftOperatorTestFunction(a, b, i, j);
+        invokeLeftShiftOperatorTestFunction1(a, b, i, j);
+        invokeLeftShiftOperatorTestFunction2(a, b, i, j);
     }
 
-    private void invokeLeftShiftOperatorTestFunction(byte a, byte b, int i, int j) {
+    private void invokeLeftShiftOperatorTestFunction1(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseLeftShiftOperator", args);
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseLeftShiftOperator1", args);
+        Assert.assertEquals(returns.length, 3);
+        BByte bByte1 = (BByte) returns[0];
+        BInteger bInteger2 = (BInteger) returns[1];
+        BByte bByte2 = (BByte) returns[2];
+        Assert.assertEquals(bByte1.byteValue(), (byte) (a << b), "Invalid result");
+        Assert.assertEquals(bByte1.intValue(), Byte.toUnsignedInt((byte) (a << b)), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), i << j, "Invalid result");
+        Assert.assertEquals(bByte2.intValue(), Byte.toUnsignedInt((byte) (a << j)), "Invalid result");
+    }
+
+    private void invokeLeftShiftOperatorTestFunction2(byte a, byte b, int i, int j) {
+        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseLeftShiftOperator2", args);
         Assert.assertEquals(returns.length, 3);
         BInteger bInteger1 = (BInteger) returns[0];
         BInteger bInteger2 = (BInteger) returns[1];
         BInteger bInteger3 = (BInteger) returns[2];
-        Assert.assertEquals(bInteger1.intValue(), a << b, "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt((byte) (a << b)), "Invalid result");
         Assert.assertEquals(bInteger2.intValue(), i << j, "Invalid result");
-        Assert.assertEquals(bInteger3.intValue(), a << j, "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a << j)), "Invalid result");
     }
 
     @Test(description = "Test bitwise unsigned right shift operator 1")
@@ -514,27 +547,42 @@ public class BByteValueTest {
         byte b = 3;
         int i = 45677654;
         int j = 5;
-        invokeUnsignedRightShiftTestFunction(a, b, i, j);
+        invokeUnsignedRightShiftTestFunction1(a, b, i, j);
+        invokeUnsignedRightShiftTestFunction2(a, b, i, j);
     }
 
     @Test(description = "Test bitwise unsigned right shift operator 2")
     public void testBitwiseUnsignedRightShiftOperator2() {
-        byte a = -12; // equal to 244 in ballerina
+        byte a = -12;
         byte b = 4;
         int i = -1236754;
         int j = 3;
-        invokeUnsignedRightShiftTestFunction(a, b, i, j);
+        invokeUnsignedRightShiftTestFunction1(a, b, i, j);
+        invokeUnsignedRightShiftTestFunction2(a, b, i, j);
     }
 
-    private void invokeUnsignedRightShiftTestFunction(byte a, byte b, int i, int j) {
+    private void invokeUnsignedRightShiftTestFunction1(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
-        BValue[] returns = BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOperator", args);
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOperator1", args);
+        Assert.assertEquals(returns.length, 3);
+        BByte bByte1 = (BByte) returns[0];
+        BInteger bInteger2 = (BInteger) returns[1];
+        BByte bByte2 = (BByte) returns[2];
+        Assert.assertEquals(bByte1.byteValue(), (byte) (a >>> b), "Invalid result");
+        Assert.assertEquals(bByte1.intValue(), Byte.toUnsignedInt((byte) (a >>> b)), "Invalid result");
+        Assert.assertEquals(bInteger2.intValue(), (long) i >>> (long) j, "Invalid result");
+        Assert.assertEquals(bByte2.intValue(), Byte.toUnsignedInt((byte) (a >>> j)), "Invalid result");
+    }
+
+    private void invokeUnsignedRightShiftTestFunction2(byte a, byte b, int i, int j) {
+        BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
+        BValue[] returns = BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOperator2", args);
         Assert.assertEquals(returns.length, 3);
         BInteger bInteger1 = (BInteger) returns[0];
         BInteger bInteger2 = (BInteger) returns[1];
         BInteger bInteger3 = (BInteger) returns[2];
-        Assert.assertEquals(bInteger1.intValue(), (long) a >>> (long) b, "Invalid result");
+        Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt((byte) (a >>> b)), "Invalid result");
         Assert.assertEquals(bInteger2.intValue(), (long) i >>> (long) j, "Invalid result");
-        Assert.assertEquals(bInteger3.intValue(), (long) a >>> (long) j, "Invalid result");
+        Assert.assertEquals(bInteger3.intValue(), Byte.toUnsignedInt((byte) (a >>> j)), "Invalid result");
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -258,16 +258,9 @@ function testBitwiseLeftShiftOperator2(byte a, byte b, int i, int j) returns (in
     return (r1, r2, r3);
 }
 
-function testBitwiseUnsignedRightShiftOperator1(byte a, byte b, int i, int j) returns (byte, int, byte){
-    byte r1 = a >>> b;
-    int r2 = i >>> j;
-    byte r3 = a >>> j;
-    return (r1, r2, r3);
-}
-
-function testBitwiseUnsignedRightShiftOperator2(byte a, byte b, int i, int j) returns (int, int, int){
-    int r1 = <int> (a >>> b);
-    int r2 = i >>> j;
-    int r3 = <int> (a >>> j);
-    return (r1, r2, r3);
+function testByteShift() returns byte {
+    byte a = 129;
+    byte c = a << 1;
+    byte d = c >> 1;
+    return d;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -230,23 +230,44 @@ function testBitwiseXorOperator(byte a, byte b, int i, int j) returns (byte, int
     return (b1, r1, r2, r3, r4);
 }
 
-function testBitwiseRightShiftOperator(byte a, byte b, int i, int j) returns (int, int, int){
-    int r1 = a >> b;
+function testBitwiseRightShiftOperator1(byte a, byte b, int i, int j) returns (byte, int, byte){
+    byte r1 = a >> b;
     int r2 = i >> j;
-    int r3 = a >> j;
+    byte r3 = a >> j;
     return (r1, r2, r3);
 }
 
-function testBitwiseLeftShiftOperator(byte a, byte b, int i, int j) returns (int, int, int){
-    int r1 = a << b;
+function testBitwiseRightShiftOperator2(byte a, byte b, int i, int j) returns (int, int, int){
+    int r1 = <int> (a >> b);
+    int r2 = i >> j;
+    int r3 = <int> (a >> j);
+    return (r1, r2, r3);
+}
+
+function testBitwiseLeftShiftOperator1(byte a, byte b, int i, int j) returns (byte, int, byte){
+    byte r1 = a << b;
     int r2 = i << j;
-    int r3 = a << j;
+    byte r3 = a << j;
     return (r1, r2, r3);
 }
 
-function testBitwiseUnsignedRightShiftOperator(byte a, byte b, int i, int j) returns (int, int, int){
-    int r1 = a >>> b;
+function testBitwiseLeftShiftOperator2(byte a, byte b, int i, int j) returns (int, int, int){
+    int r1 = <int> (a << b);
+    int r2 = i << j;
+    int r3 = <int> (a << j);
+    return (r1, r2, r3);
+}
+
+function testBitwiseUnsignedRightShiftOperator1(byte a, byte b, int i, int j) returns (byte, int, byte){
+    byte r1 = a >>> b;
     int r2 = i >>> j;
-    int r3 = a >>> j;
+    byte r3 = a >>> j;
+    return (r1, r2, r3);
+}
+
+function testBitwiseUnsignedRightShiftOperator2(byte a, byte b, int i, int j) returns (int, int, int){
+    int r1 = <int> (a >>> b);
+    int r2 = i >>> j;
+    int r3 = <int> (a >>> j);
     return (r1, r2, r3);
 }


### PR DESCRIPTION
This PR updates bitwise shift operator logic to properly handle byte value space. Introduced few instruction codes to differentiate byte related shift operations with int.