### PR TITLE
Fix the issue of adding 'package' for the the new files

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/plugin.js
+++ b/composer/modules/web/src/plugins/ballerina/plugin.js
@@ -164,18 +164,7 @@ class BallerinaPlugin extends Plugin {
                         };
                     },
                     newFileContentProvider: (fileFullPath) => {
-                        if (!fileFullPath) {
-                            return '';
-                        }
-                        const { workspace } = this.appContext;
-                        const pathSep = getPathSeperator();
-                        const pathParts = fileFullPath.split(pathSep);
-                        pathParts.splice(-1, 1);
-                        const filePath = pathParts.join(pathSep);
-                        const workspaceDir = workspace.getExplorerFolderForPath(filePath);
-                        const programDir = workspaceDir ? workspaceDir.fullPath : undefined;
-                        const pkg = getCorrectPackageForPath(programDir, filePath);
-                        return pkg ? `package ${pkg};` : '';
+                        return '';
                     },
                 },
             ],


### PR DESCRIPTION
## Purpose
> When adding new files into the package folders, composer adds 'package <package_name>' into the newly created file's content. This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/9437.