### PR TITLE
Rollback JMS session when transaction fails

### DIFF
--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/SessionConnector.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/SessionConnector.java
@@ -73,7 +73,7 @@ public class SessionConnector implements BallerinaTransactionContext {
     public void rollback() {
         try {
             if (session.getAcknowledgeMode() == Session.SESSION_TRANSACTED) {
-                session.commit();
+                session.rollback();
             }
         } catch (JMSException e) {
             throw new BallerinaException("transaction rollback failed: " + e.getLocalizedMessage(), e);


### PR DESCRIPTION
## Purpose

JMS Transactions are not rollbacked without this fix when the transaction fails.
