### PR TITLE
Fix XML element template literal source gen 

### DIFF
--- a/composer/modules/web/source-gen/tree.g
+++ b/composer/modules/web/source-gen/tree.g
@@ -513,7 +513,8 @@ TypeInitExpr
    ;
 
 UnaryExpr
-   : <operatorKind> <expression.source>
+   : <inTemplateLiteral?> {{ <operatorKind> <expression.source> }}
+   |                         <operatorKind> <expression.source>
    ;
 
 UnionTypeNode

--- a/composer/modules/web/src/plugins/ballerina/model/source-gen.js
+++ b/composer/modules/web/src/plugins/ballerina/model/source-gen.js
@@ -1680,8 +1680,13 @@ export default function getSourceOf(node, pretty = false, l = 0, replaceLambda) 
                  + join(node.expressions, pretty, replaceLambda, l, w, '', ',') + w() + ')';
             }
         case 'UnaryExpr':
-            return w() + node.operatorKind + b(' ')
+            if (node.inTemplateLiteral && node.operatorKind && node.expression) {
+                return w() + '{{' + w() + node.operatorKind + b(' ')
+                 + getSourceOf(node.expression, pretty, l, replaceLambda) + w() + '}}';
+            } else {
+                return w() + node.operatorKind + b(' ')
                  + getSourceOf(node.expression, pretty, l, replaceLambda);
+            }
         case 'UnionTypeNode':
             if (node.emptyParantheses) {
                 return w() + '(' + w() + ')';


### PR DESCRIPTION
## Purpose
>  This PR will fix the source gen issue of dropping "{{}}" in a string template literal available in the XML element's content.