### PR TITLE
Add dialog box to validate invalid swagger definition

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/constants.js
+++ b/composer/modules/web/src/plugins/ballerina/constants.js
@@ -36,6 +36,7 @@ export const TOOLS = {
 export const DIALOGS = {
     OPEN_PROGRAM_DIR_CONFIRM: 'composer.dialog.ballerina.open-program-dir-confirm',
     FIX_PACKAGE_NAME_OR_PATH_CONFIRM: 'composer.dialog.ballerina.fix-package-name-or-path-confirm',
+    INVALID_SWAGGER_DIALOG: 'composer.dialog.ballerina.invalid-swagger-dialog',
 };
 
 export const EVENTS = {

--- a/composer/modules/web/src/plugins/ballerina/dialogs/InvalidSwaggerDialog.jsx
+++ b/composer/modules/web/src/plugins/ballerina/dialogs/InvalidSwaggerDialog.jsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import React from 'react';
+import { Button } from 'semantic-ui-react';
+import Dialog from 'core/view/Dialog';
+
+/**
+ * Ask user to fix all swagger related errors before closing
+ * the swagger view.
+ *
+ * @extends React.Component
+ */
+class InvalidSwaggerDialog extends React.Component {
+
+    /**
+     * @inheritdoc
+     */
+    constructor(props) {
+        super(props);
+        this.state = {
+            error: '',
+            showDialog: true,
+        };
+        this.onDialogHide = this.onDialogHide.bind(this);
+    }
+
+    /**
+     * Called when user hides the dialog
+     */
+    onDialogHide() {
+        this.setState({
+            error: '',
+            showDialog: false,
+        });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    render() {
+        return (
+            <Dialog
+                show={this.state.showDialog}
+                title='Invalid Swagger Definition'
+                titleIcon='info circle'
+                size='small'
+                onHide={this.onDialogHide}
+                actions={
+                    <Button
+                        key='fix-swagger-error-btn'
+                        secondary
+                        onClick={(evt) => {
+                            this.onDialogHide();
+                        }}
+                    >
+                        Ok
+                    </Button>
+                }
+            >
+                <p>
+                    {'You have entered an invalid swagger definition, please fix the errors to go back to ballerina source.'}
+                </p>
+            </Dialog>
+        );
+    }
+}
+
+
+export default InvalidSwaggerDialog;

--- a/composer/modules/web/src/plugins/ballerina/plugin.js
+++ b/composer/modules/web/src/plugins/ballerina/plugin.js
@@ -38,6 +38,7 @@ import { PLUGIN_ID, EDITOR_ID, DOC_VIEW_ID, COMMANDS as COMMAND_IDS, TOOLS as TO
             DIALOGS as DIALOG_IDS, EVENTS } from './constants';
 import OpenProgramDirConfirmDialog from './dialogs/OpenProgramDirConfirmDialog';
 import FixPackageNameOrPathConfirmDialog from './dialogs/FixPackageNameOrPathConfirmDialog';
+import InvalidSwaggerDialog from './dialogs/InvalidSwaggerDialog';
 import { isInCorrectPath, getCorrectPackageForPath, getCorrectPathForPackage } from './utils/program-dir-utils';
 import TreeBuilder from './model/tree-builder';
 import FragmentUtils from './utils/fragment-utils';
@@ -324,6 +325,15 @@ class BallerinaPlugin extends Plugin {
                 {
                     id: DIALOG_IDS.FIX_PACKAGE_NAME_OR_PATH_CONFIRM,
                     component: FixPackageNameOrPathConfirmDialog,
+                    propsProvider: () => {
+                        return {
+                            ballerinaPlugin: this,
+                        };
+                    },
+                },
+                {
+                    id: DIALOG_IDS.INVALID_SWAGGER_DIALOG,
+                    component: InvalidSwaggerDialog,
                     propsProvider: () => {
                         return {
                             ballerinaPlugin: this,

--- a/composer/modules/web/src/plugins/ballerina/views/swagger-view.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/swagger-view.jsx
@@ -25,6 +25,8 @@ import { Button, Icon } from 'semantic-ui-react';
 import SwaggerEditorBundle from 'swagger-editor-dist/swagger-editor-bundle';
 import ServiceNode from 'plugins/ballerina/model/tree/service-node';
 import { getSwaggerDefinition, getServiceDefinition } from 'api-client/api-client';
+import { COMMANDS as LAYOUT_COMMANDS } from 'core/layout/constants';
+import { DIALOGS as DIALOG_IDS } from '../constants';
 import TreeBuilder from './../model/tree-builder';
 import { SPLIT_VIEW } from './constants';
 import SwaggerUtil from '../swagger-util/swagger-util';
@@ -143,6 +145,10 @@ class SwaggerView extends React.Component {
         } else if (!this.hasSwaggerErrors()) {
             this.updateService();
             this.context.editor.setActiveView(SPLIT_VIEW);
+        } else if (this.hasSwaggerErrors()) { 
+            this.props.commandProxy.dispatch(LAYOUT_COMMANDS.POPUP_DIALOG, {
+                id: DIALOG_IDS.INVALID_SWAGGER_DIALOG,
+            });
         }
         this.props.resetSwaggerViewFun();
         /* this.context.astRoot.trigger('tree-modified', {


### PR DESCRIPTION
## Purpose
> Fixes #8360 issue by adding a error handling dialog box prompting user if the swagger definition is erroneous. 

