### PR TITLE
Fix the issue in enabling tracing.

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracersStore.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracersStore.java
@@ -117,4 +117,13 @@ public class TracersStore {
             return tracer.getTracer(name, serviceName);
         }
     }
+
+    /**
+     * Checks whether the tracer store is initialized.
+     *
+     * @return boolean value whether it's initialized.
+     */
+    public boolean isInitialized() {
+        return this.tracerStore != null;
+    }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracingLaunchListener.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/tracer/TracingLaunchListener.java
@@ -32,10 +32,12 @@ public class TracingLaunchListener implements LaunchListener {
 
     @Override
     public void beforeRunProgram(boolean service) {
-        ConfigRegistry configRegistry = ConfigRegistry.getInstance();
-        if (configRegistry.getAsBoolean(CONFIG_TRACING_ENABLED)) {
-            ObservabilityUtils.addObserver(new BallerinaTracingObserver());
-            TracersStore.getInstance().loadTracers();
+        if (!TracersStore.getInstance().isInitialized()) {
+            ConfigRegistry configRegistry = ConfigRegistry.getInstance();
+            if (configRegistry.getAsBoolean(CONFIG_TRACING_ENABLED)) {
+                ObservabilityUtils.addObserver(new BallerinaTracingObserver());
+                TracersStore.getInstance().loadTracers();
+            }
         }
     }
 

--- a/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/java/org/ballerinalang/observe/metrics/prometheus/PrometheusReporter.java
+++ b/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/java/org/ballerinalang/observe/metrics/prometheus/PrometheusReporter.java
@@ -74,7 +74,6 @@ public class PrometheusReporter implements MetricReporter {
             String key = configKeys.next();
             config.put(key, ConfigRegistry.getInstance().getAsString(key));
         }
-        config.remove(ObservabilityConstants.CONFIG_TRACING_ENABLED);
         return config;
     }
 


### PR DESCRIPTION
## Purpose
Tracing was disabled based on the race condition of starting the Prometheus balx service. And hence removing the tracing disabling part from the Prometheus reporting and loading the tracers only when once per BVM.