### PR TITLE
[gRPC] Fix service invocation issue with service org name

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/ServicesBuilderUtils.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/ServicesBuilderUtils.java
@@ -24,7 +24,6 @@ import org.ballerinalang.net.grpc.exception.GrpcServerException;
 import org.ballerinalang.net.grpc.listener.ServerCallHandler;
 import org.ballerinalang.net.grpc.listener.StreamingServerCallHandler;
 import org.ballerinalang.net.grpc.listener.UnaryServerCallHandler;
-import org.ballerinalang.net.grpc.proto.ServiceProtoConstants;
 import org.ballerinalang.net.grpc.proto.ServiceProtoUtils;
 
 import java.util.HashMap;
@@ -47,20 +46,8 @@ public class ServicesBuilderUtils {
     
     private static ServerServiceDefinition getServiceDefinition(Service service, Descriptors.ServiceDescriptor
             serviceDescriptor) throws GrpcServerException {
-        // Generate full service name for the service definition. <package>.<service>
-        final String serviceName;
-        if (ServiceProtoConstants.CLASSPATH_SYMBOL.equals(service.getPackage())) {
-            serviceName = service.getName();
-        } else {
-            String servicePackage = service.getPackage();
-            String serviceVersion = service.getPackageVersion();
-            if (servicePackage != null && servicePackage.endsWith(serviceVersion)) {
-                String[] pkgInfo = servicePackage.split(":");
-                servicePackage = pkgInfo.length > 1 ? pkgInfo[0] : servicePackage;
-            }
-
-            serviceName = servicePackage + ServiceProtoConstants.CLASSPATH_SYMBOL + service.getName();
-        }
+        // Get full service name for the service definition. <package>.<service>
+        final String serviceName = serviceDescriptor.getFullName();
         // Server Definition Builder for the service.
         ServerServiceDefinition.Builder serviceDefBuilder = ServerServiceDefinition.builder(serviceName);
         


### PR DESCRIPTION
## Purpose
Resolves #9549 

## Goals
This is to fix service invocation issue when service is build with an org name in toml file.

## Approach
Get service full name from the service descriptor which is derived at compile time[1]. Service full name derive at compile time is also used when generating the proto file. So better if we can use the same name when registering the service at runtime rather deriving again.

With this fix, it looks more consistent.

1. https://github.com/ballerina-platform/ballerina-lang/blob/master/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java#L95