### PR TITLE
Fix token deletion issue with multiple files parsed

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionCustomErrorStrategy.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionCustomErrorStrategy.java
@@ -57,26 +57,47 @@ public class CompletionCustomErrorStrategy extends LSCustomErrorStrategy {
 
     @Override
     public void reportInputMismatch(Parser parser, InputMismatchException e) {
+        if (!parser.getContext().start.getTokenSource().getSourceName()
+                .equals(context.get(DocumentServiceKeys.FILE_NAME_KEY))) {
+            return;
+        }
         this.context.put(CompletionKeys.TOKEN_STREAM_KEY, parser.getTokenStream());
     }
 
     @Override
     public void reportMissingToken(Parser parser) {
+        if (!parser.getContext().start.getTokenSource().getSourceName()
+                .equals(context.get(DocumentServiceKeys.FILE_NAME_KEY))) {
+            return;
+        }
         this.context.put(CompletionKeys.TOKEN_STREAM_KEY, parser.getTokenStream());
     }
 
     @Override
     public void reportNoViableAlternative(Parser parser, NoViableAltException e) {
+        if (!parser.getContext().start.getTokenSource().getSourceName()
+                .equals(context.get(DocumentServiceKeys.FILE_NAME_KEY))) {
+            return;
+        }
         this.context.put(CompletionKeys.TOKEN_STREAM_KEY, parser.getTokenStream());
     }
 
     @Override
     public void reportUnwantedToken(Parser parser) {
+        if (!parser.getContext().start.getTokenSource().getSourceName()
+                .equals(context.get(DocumentServiceKeys.FILE_NAME_KEY))) {
+            return;
+        }
         this.context.put(CompletionKeys.TOKEN_STREAM_KEY, parser.getTokenStream());
     }
 
     @Override
     public void reportMatch(Parser recognizer) {
+        if (!recognizer.getContext().start.getTokenSource().getSourceName()
+                .equals(context.get(DocumentServiceKeys.FILE_NAME_KEY))) {
+            super.reportMatch(recognizer);
+            return;
+        }
         removePendingTokensAfterThisToken(recognizer, lastTerminationToken);
         super.reportMatch(recognizer);
         if (recognizer.getCurrentToken().getType() != BallerinaParser.EOF && isInLastTermination(recognizer)) {
@@ -86,6 +107,11 @@ public class CompletionCustomErrorStrategy extends LSCustomErrorStrategy {
 
     @Override
     public void sync(Parser recognizer) throws RecognitionException {
+        if (!recognizer.getContext().start.getTokenSource().getSourceName()
+                .equals(context.get(DocumentServiceKeys.FILE_NAME_KEY))) {
+            super.sync(recognizer);
+            return;
+        }
         removePendingTokensAfterThisToken(recognizer, lastTerminationToken);
         if (recognizer.getCurrentToken().getType() != BallerinaParser.EOF && isInFirstTokenOfCursorLine(recognizer)) {
             deleteTokensUpToCursor(recognizer, false);


### PR DESCRIPTION
## Purpose
> When there are multiple files in the compiled project, tokens are being deleted from the non-relevant files as well. With this fix, we check for the file name of the token and skip the invalid files.