### PR TITLE
Adding default design view editable on new document.

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -130,12 +130,16 @@ class BallerinaFileEditor extends React.Component {
             }
         });
 
+        if (this.props.file.name === 'untitled' && this.fetchState('diagramMode') === undefined) {
+            this.state.diagramFitToWidth = false;
+        }
+
         this.resetSwaggerView = this.resetSwaggerView.bind(this);
         this.handleSplitChange = this.handleSplitChange.bind(this);
         this.onModeChange = this.onModeChange.bind(this);
         this.sourceEditorRef = undefined;
     }
-
+    
     /**
      * @override
      * @memberof Diagram
@@ -636,6 +640,9 @@ class BallerinaFileEditor extends React.Component {
         const showSwaggerView = (!this.state.parseFailed
             && !_.isNil(this.state.swaggerViewTargetService)
             && this.state.activeView === SWAGGER_VIEW);
+
+
+        
 
         const showLoadingOverlay = !this.skipLoadingOverlay && this.state.parsePending;
 

--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -139,7 +139,7 @@ class BallerinaFileEditor extends React.Component {
         this.onModeChange = this.onModeChange.bind(this);
         this.sourceEditorRef = undefined;
     }
-    
+
     /**
      * @override
      * @memberof Diagram

--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -641,9 +641,6 @@ class BallerinaFileEditor extends React.Component {
             && !_.isNil(this.state.swaggerViewTargetService)
             && this.state.activeView === SWAGGER_VIEW);
 
-
-        
-
         const showLoadingOverlay = !this.skipLoadingOverlay && this.state.parsePending;
 
         const sourceWidth = (this.state.activeView === SOURCE_VIEW) ? this.props.width :


### PR DESCRIPTION
## Purpose
> This PR will fix issue #9622 which will make design mode editable default for new documents.

## Goals
> A UX improvement to make new files editable by default.
