### PR TITLE
Handle scopes with same name in separate functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1326,7 +1326,8 @@ public class CodeGenerator extends BLangNodeVisitor {
 
         // generating scope end instruction
         int pkgRefCPIndex = addPackageRefCPEntry(currentPkgInfo, currentPkgID);
-        int funcNameCPIndex = addUTF8CPEntry(currentPkgInfo, Names.GEN_VAR_PREFIX + scopeNode.name.getValue());
+        int funcNameCPIndex = addUTF8CPEntry(currentPkgInfo,
+                scopeNode.getCompensationFunction().function.name.getValue());
         FunctionRefCPEntry funcRefCPEntry = new FunctionRefCPEntry(pkgRefCPIndex, funcNameCPIndex);
         int funcRefCPIndex =  currentPkgInfo.addCPEntry(funcRefCPEntry);
         int i = 0;
@@ -1364,7 +1365,7 @@ public class CodeGenerator extends BLangNodeVisitor {
         //scopeName, child count, children
         Operand[] operands = new Operand[2 + children.size()];
 
-        int scopeNameCPIndex = addUTF8CPEntry(currentPkgInfo, compensate.invocation.name.value);
+        int scopeNameCPIndex = addUTF8CPEntry(currentPkgInfo, compensate.getScopeName().getValue());
         operands[i++] = getOperand(scopeNameCPIndex);
 
         operands[i++] = getOperand(children.size());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -172,7 +172,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -21,6 +21,7 @@ import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.AttachPoint;
 import org.ballerinalang.model.elements.Flag;
+import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
@@ -171,6 +172,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**
@@ -197,6 +199,11 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
     private boolean isSiddhiRuntimeEnabled;
 
     private Map<BLangBlockStmt, SymbolEnv> blockStmtEnvMap = new HashMap<>();
+    /**
+     * Keep track of unique names of the scopes, which are required for parent scopes
+     * to track the child scopes.
+     */
+    private Map<String, String> scopesMap = new HashMap<>();
 
     public static SemanticAnalyzer getInstance(CompilerContext context) {
         SemanticAnalyzer semAnalyzer = context.get(SYMBOL_ANALYZER_KEY);
@@ -1496,15 +1503,29 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         symbolEnter.defineNode(scopeNode.compensationFunction.function, env);
         typeChecker.checkExpr(scopeNode.compensationFunction, env);
         symbolEnter.defineNode(scopeNode, env);
+        BSymbol symbol = symResolver.lookupSymbol(env, names.fromString(scopeNode.name.getValue()), SymTag.SCOPE);
+        //Add to map to be used by parent scopes
+        String uniqueName = getUniqueScopeName(symbol.pkgID, symbol.owner, scopeNode.name.getValue());
+        scopesMap.put(scopeNode.name.getValue(), uniqueName);
+        if (!scopeNode.childScopes.isEmpty()) {
+            updateChildScopeNames(scopeNode.childScopes);
+        }
+        scopeNode.compensationFunction.function.name.setValue(Names.GEN_VAR_PREFIX + uniqueName);
+        scopeNode.compensationFunction.function.symbol.name.value = Names.GEN_VAR_PREFIX + uniqueName;
+        scopeNode.name.setValue(uniqueName);
     }
 
     @Override
     public void visit(BLangCompensate node) {
-        if (symTable.notFoundSymbol.equals(symResolver.lookupSymbol(env, names.fromString(node
+        BSymbol scopeSymbol = symResolver.lookupSymbol(env, names.fromString(node
                 .getScopeName()
-                .getValue()), SymTag.SCOPE))) {
+                .getValue()), SymTag.SCOPE);
+        if (symTable.notFoundSymbol.equals(scopeSymbol)) {
             dlog.error(node.pos, DiagnosticCode.UNDEFINED_SYMBOL, node.getScopeName().getValue());
+            return;
         }
+        //change to a unique name
+        node.scopeName.setValue(getUniqueScopeName(scopeSymbol.pkgID, scopeSymbol.owner, node.scopeName.getValue()));
     }
 
     // Private methods
@@ -2046,5 +2067,20 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             }
         }
         attribute.type = attributeSymbol.type;
+    }
+
+    private void updateChildScopeNames(Stack<String> childScopes) {
+        Stack<String> reversedStack = new Stack<>();
+        while (!childScopes.isEmpty()) {
+            reversedStack.push(scopesMap.get(childScopes.pop()));
+        }
+
+        while (!reversedStack.empty()) {
+            childScopes.push(reversedStack.pop());
+        }
+    }
+
+    private String getUniqueScopeName(PackageID pkgID, BSymbol owner, String name) {
+        return pkgID.name + owner.getName().getValue() + name;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1507,9 +1507,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         //Add to map to be used by parent scopes
         String uniqueName = getUniqueScopeName(symbol.pkgID, symbol.owner, scopeNode.name.getValue());
         scopesMap.put(scopeNode.name.getValue(), uniqueName);
-        if (!scopeNode.childScopes.isEmpty()) {
-            updateChildScopeNames(scopeNode.childScopes);
-        }
+        scopeNode.childScopes.replaceAll(s -> scopesMap.get(s));
         scopeNode.compensationFunction.function.name.setValue(Names.GEN_VAR_PREFIX + uniqueName);
         scopeNode.compensationFunction.function.symbol.name.value = Names.GEN_VAR_PREFIX + uniqueName;
         scopeNode.name.setValue(uniqueName);
@@ -2067,17 +2065,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             }
         }
         attribute.type = attributeSymbol.type;
-    }
-
-    private void updateChildScopeNames(Stack<String> childScopes) {
-        Stack<String> reversedStack = new Stack<>();
-        while (!childScopes.isEmpty()) {
-            reversedStack.push(scopesMap.get(childScopes.pop()));
-        }
-
-        while (!reversedStack.empty()) {
-            childScopes.push(reversedStack.pop());
-        }
     }
 
     private String getUniqueScopeName(PackageID pkgID, BSymbol owner, String name) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compensation/CompensationsStmtTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compensation/CompensationsStmtTest.java
@@ -18,7 +18,9 @@ package org.ballerinalang.test.statements.compensation;
 
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,5 +49,7 @@ public class CompensationsStmtTest {
     @Test(description = "Test nested scopes and scopes in loops")
     public void compensationStmtTest() {
         Assert.assertEquals(result.getErrorCount(), 0);
+        BValue[] returns = BRunUtil.invoke(result, "testCompensationLexicalScopes");
+        Assert.assertTrue(returns[0].stringValue().contains("last"));
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/statements/compensation/compensate-stmt.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/statements/compensation/compensate-stmt.bal
@@ -1,3 +1,5 @@
+json msg = "initial";
+
 function testNestedScopes() returns (int) {
     int a = 2;
 
@@ -7,6 +9,7 @@ function testNestedScopes() returns (int) {
             a = 5;
         } compensation {
             //compensate
+            msg = "in first scopeA";
         }
     } compensation {
 
@@ -39,3 +42,13 @@ function testLoopScopes() returns (int) {
     return a;
 }
 
+function testCompensationLexicalScopes() returns json {
+        scope scopeA {
+
+        } compensation {
+            msg = "last scopeA";
+        }
+
+    compensate scopeA;
+    return msg;
+}


### PR DESCRIPTION
## Purpose
> Fix the isuue that when scopes with the same name in different functions are compensated, all the handlers are executed. 
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9550.
## Approach
> This fixes above issue by appending the package ID and
symbol owner name to the scope name and generated scope functions.
