### PR TITLE
Improve the message printed when there are no test files in a project

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -206,10 +206,10 @@ public class BTestRunner {
         outStream.println();
         outStream.println("Running tests");
         if (testSuites.isEmpty()) {
-            if (buildWithTests) {
-                return;
-            }
             outStream.println("    No tests found");
+            if (buildWithTests) {
+                outStream.println();
+            }
             return;
         }
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -145,15 +145,14 @@ public class BTestRunner {
      * @param sourceFilePaths List of @{@link Path} of ballerina files
      */
     private void compileAndBuildSuites(String sourceRoot, Path[] sourceFilePaths, boolean buildWithTests)  {
-        if (sourceFilePaths.length == 0) {
-            outStream.println("Compiling tests");
-            outStream.println("    No tests found");
-            return;
-        }
         if (buildWithTests) {
             outStream.println();
         }
-        outStream.println(sourceFilePaths.length > 0 ? "Compiling tests" : "Compiling test");
+        outStream.println("Compiling tests");
+        if (sourceFilePaths.length == 0) {
+            outStream.println("    No tests found");
+            return;
+        }
         Arrays.stream(sourceFilePaths).forEach(sourcePackage -> {
 
             String packageName = Utils.getFullPackageName(sourcePackage.toString());

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -145,6 +145,8 @@ public class BTestRunner {
      * @param sourceFilePaths List of @{@link Path} of ballerina files
      */
     private void compileAndBuildSuites(String sourceRoot, Path[] sourceFilePaths, boolean buildWithTests)  {
+        // We need a new line to show a clear separation between the outputs of 'Compiling Sources' and
+        // 'Compiling tests'
         if (buildWithTests) {
             outStream.println();
         }
@@ -207,6 +209,8 @@ public class BTestRunner {
         outStream.println("Running tests");
         if (testSuites.isEmpty()) {
             outStream.println("    No tests found");
+            // We need a new line to show a clear separation between the outputs of 'Running Tests' and
+            // 'Generating Executable'
             if (buildWithTests) {
                 outStream.println();
             }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -146,6 +146,8 @@ public class BTestRunner {
      */
     private void compileAndBuildSuites(String sourceRoot, Path[] sourceFilePaths, boolean buildWithTests)  {
         if (sourceFilePaths.length == 0) {
+            outStream.println("Compiling tests");
+            outStream.println("    No tests found\n");
             return;
         }
         if (buildWithTests) {
@@ -206,7 +208,8 @@ public class BTestRunner {
             if (buildWithTests) {
                 return;
             }
-            outStream.println("No tests found");
+            outStream.println("Running tests");
+            outStream.println("    No tests found");
             return;
         }
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -147,7 +147,7 @@ public class BTestRunner {
     private void compileAndBuildSuites(String sourceRoot, Path[] sourceFilePaths, boolean buildWithTests)  {
         if (sourceFilePaths.length == 0) {
             outStream.println("Compiling tests");
-            outStream.println("    No tests found\n");
+            outStream.println("    No tests found");
             return;
         }
         if (buildWithTests) {
@@ -204,11 +204,12 @@ public class BTestRunner {
      */
     private void execute(boolean buildWithTests) {
         Map<String, TestSuite> testSuites = registry.getTestSuites();
+        outStream.println();
+        outStream.println("Running tests");
         if (testSuites.isEmpty()) {
             if (buildWithTests) {
                 return;
             }
-            outStream.println("Running tests");
             outStream.println("    No tests found");
             return;
         }
@@ -217,8 +218,6 @@ public class BTestRunner {
         LinkedList<String> keys = new LinkedList<>(testSuites.keySet());
         Collections.sort(keys);
 
-        outStream.println();
-        outStream.println("Running tests");
         keys.forEach(packageName -> {
             TestSuite suite = testSuites.get(packageName);
             if (packageName.equals(Names.DOT.value)) {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -206,7 +206,7 @@ public class BTestRunner {
             if (buildWithTests) {
                 return;
             }
-            outStream.println("No test functions found in the provided ballerina files.");
+            outStream.println("No tests found");
             return;
         }
 


### PR DESCRIPTION
## Purpose
> This PR improves the message printed when there are no test files

![test_output](https://user-images.githubusercontent.com/13446645/42985299-7e18d51e-8c0e-11e8-9e66-5d29e309062e.png)


Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9684