### PR TITLE
Fix swagger template loading on windows

### DIFF
--- a/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/java/org/ballerinalang/code/generator/GeneratorConstants.java
+++ b/misc/swagger-ballerina/modules/ballerina-code-generator/src/main/java/org/ballerinalang/code/generator/GeneratorConstants.java
@@ -16,8 +16,6 @@
 
 package org.ballerinalang.code.generator;
 
-import java.io.File;
-
 /**
  * Constants for ballerina code generator.
  */
@@ -46,10 +44,10 @@ public class GeneratorConstants {
 
     public static final String TEMPLATES_SUFFIX = ".mustache";
     public static final String TEMPLATES_DIR_PATH_KEY = "templates.dir.path";
-    public static final String DEFAULT_TEMPLATE_DIR = File.separator + "templates";
-    public static final String DEFAULT_CLIENT_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "client";
-    public static final String DEFAULT_OPEN_API_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "oas3";
-    public static final String DEFAULT_SWAGGER_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "swagger2";
+    public static final String DEFAULT_TEMPLATE_DIR = "/templates";
+    public static final String DEFAULT_CLIENT_DIR = DEFAULT_TEMPLATE_DIR + "/client";
+    public static final String DEFAULT_OPEN_API_DIR = DEFAULT_TEMPLATE_DIR + "/oas3";
+    public static final String DEFAULT_SWAGGER_DIR = DEFAULT_TEMPLATE_DIR + "/swagger2";
 
     public static final String RES_CONFIG_ANNOTATION = "ResourceConfig";
     public static final String HTTP_PKG_ALIAS = "http";

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/GeneratorConstants.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/GeneratorConstants.java
@@ -16,7 +16,6 @@
 
 package org.ballerinalang.swagger.utils;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,17 +49,15 @@ public class GeneratorConstants {
     public static final String MOCK_TEMPLATE_NAME = "mock";
     public static final String IMPL_TEMPLATE_NAME = "impl";
     public static final String SCHEMA_TEMPLATE_NAME = "schemas";
-    public static final String COMMON_MODELS_TEMPLATE_NAME = "common";
 
     public static final String SCHEMA_FILE_NAME = "schema.bal";
-    public static final String COMMON_MODELS_FILE_NAME = "common.bal";
 
     public static final String TEMPLATES_SUFFIX = ".mustache";
     public static final String TEMPLATES_DIR_PATH_KEY = "templates.dir.path";
-    public static final String DEFAULT_TEMPLATE_DIR = File.separator + "templates";
-    public static final String DEFAULT_MOCK_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "mock";
-    public static final String DEFAULT_CLIENT_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "client";
-    public static final String DEFAULT_MODEL_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "model";
+    public static final String DEFAULT_TEMPLATE_DIR = "/templates";
+    public static final String DEFAULT_MOCK_DIR = DEFAULT_TEMPLATE_DIR + "/mock";
+    public static final String DEFAULT_CLIENT_DIR = DEFAULT_TEMPLATE_DIR + "/client";
+    public static final String DEFAULT_MODEL_DIR = DEFAULT_TEMPLATE_DIR + "/model";
 
     public static final String GEN_SRC_DIR = "gen";
     public static final String DEFAULT_CLIENT_PKG = "client";


### PR DESCRIPTION
## Purpose
When File.Separator is used to define the template resource paths, handlebars fail to load templates on windows. Reason for this is Handlebars use ClassLoader.gerResource() which requires '/' to be the path separator on any platform.

## Goals
Remove use of File.Separator so that resource loading works on all platforms including windows.
