### PR TITLE
fixes #9270 JMS request reply capability

### DIFF
--- a/stdlib/jms/src/main/ballerina/jms/destination.bal
+++ b/stdlib/jms/src/main/ballerina/jms/destination.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+documentation { Destination object
+    F{{destinationName}} name of the destination
+    F{{destinationType}} type of the destination, either queue or topic.
+}
+public type Destination object {
+    public string destinationName;
+    public string destinationType;
+};

--- a/stdlib/jms/src/main/ballerina/jms/message.bal
+++ b/stdlib/jms/src/main/ballerina/jms/message.bal
@@ -164,4 +164,14 @@ public type Message object {
         R{{}} The JMS correlation ID header value or JMS error or nil if header is not set
     }
     public native function getCorrelationID() returns @tainted (string|error)?;
+
+    documentation { Gets JMS replyTo header from the message
+        R{{}} The JMS replyTo Destination or JMS error or nil if header is not set
+    }
+    public native function getReplyTo() returns @tainted (Destination|error)?;
+
+    documentation { Set the replyTo destination from the message
+        P{{replyTo}} replyTo destination.
+    }
+    public native function setReplyTo(Destination replyTo) returns error?;
 };

--- a/stdlib/jms/src/main/ballerina/jms/queue_receiver.bal
+++ b/stdlib/jms/src/main/ballerina/jms/queue_receiver.bal
@@ -98,4 +98,11 @@ public type QueueReceiverActions object {
         R{{}} Returns a message or nill if the timeout exceededs. Returns an error on jms provider internal error.
     }
     public native function receive(int timeoutInMilliSeconds = 0) returns (Message|error)?;
+
+    documentation { Synchronously receive a message from a given destination
+        P{{destination}} destination to subscribe to.
+        P{{timeoutInMilliSeconds}} time to wait until a message is received
+        R{{}} Returns a message or nill if the timeout exceededs. Returns an error on jms provider internal error.
+    }
+    public native function receiveFrom(Destination destination, int timeoutInMilliSeconds = 0) returns (Message|error)?;
 };

--- a/stdlib/jms/src/main/ballerina/jms/queue_sender.bal
+++ b/stdlib/jms/src/main/ballerina/jms/queue_sender.bal
@@ -74,7 +74,7 @@ documentation { Configurations related to a QueueSender object
 }
 public type QueueSenderEndpointConfiguration record {
     Session? session;
-    string queueName;
+    string? queueName;
 };
 
 documentation { JMS QueueSender action handling object }
@@ -84,4 +84,10 @@ public type QueueSenderActions object {
         P{{message}} message to be sent to the JMS provider
     }
     public native function send(Message message) returns error?;
+
+    documentation { Sends a message to the JMS provider
+        P{{destination}} destination used for the message sender
+        P{{message}} message to be sent to the JMS provider
+    }
+    public native function sendTo(Destination destination, Message message) returns error?;
 };

--- a/stdlib/jms/src/main/ballerina/jms/session.bal
+++ b/stdlib/jms/src/main/ballerina/jms/session.bal
@@ -48,6 +48,26 @@ public type Session object {
         P{{subscriptionId}} the name used to identify this subscription
     }
     public native function unsubscribe(string subscriptionId) returns error?;
+
+    documentation { 
+        Creates a JMS Queue which can be used as temporary response destination.
+    }
+    public native function createTemporaryQueue() returns Destination|error;
+
+    documentation { 
+        Creates a JMS Topic which can be used as temporary response destination.
+    }
+    public native function createTemporaryTopic() returns Destination|error;
+ 
+    documentation { Creates a JMS Queue which can be used with a message producer.
+        P{{queueName}} name of the Queue
+    }
+    public native function createQueue(string queueName) returns Destination|error;
+
+    documentation { Creates a JMS Topic which can be used with a message producer.
+        P{{topicName}} name of the Topic
+    }
+    public native function createTopic(string topicName) returns Destination|error;
 };
 
 documentation { Configurations related to a JMS session

--- a/stdlib/jms/src/main/ballerina/jms/topic_publisher.bal
+++ b/stdlib/jms/src/main/ballerina/jms/topic_publisher.bal
@@ -82,4 +82,10 @@ public type TopicPublisherActions object {
         P{{message}} Message to be sent to the JMS provider
     }
     public native function send(Message message) returns error?;
+    
+    documentation { Sends a message to the JMS provider
+        P{{destination}} destination used for the message sender
+        P{{message}} message to be sent to the JMS provider
+    }
+    public native function sendTo(Destination destination, Message message) returns error?;
 };

--- a/stdlib/jms/src/main/ballerina/jms/topic_subscriber.bal
+++ b/stdlib/jms/src/main/ballerina/jms/topic_subscriber.bal
@@ -95,4 +95,11 @@ public type TopicSubscriberActions object {
         R{{}} Returns a message or nill if the timeout exceededs. Returns an error on jms provider internal error.
     }
     public native function receive(int timeoutInMilliSeconds = 0) returns (Message|error)?;
+
+    documentation { Synchronously receive a message from the JMS provider
+        P{{destination}} destination to subscribe to
+        P{{timeoutInMilliSeconds}} Time to wait until a message is received
+        R{{}} Returns a message or nill if the timeout exceededs. Returns an error on jms provider internal error.
+    }
+    public native function receiveFrom(Destination destination, int timeoutInMilliSeconds = 0) returns (Message|error)?;
 };

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/Constants.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/Constants.java
@@ -57,12 +57,18 @@ public class Constants {
     public static final String CONSUMER_IDENTIFIER = "identifier";
     public static final String CONSUMER_ACTIONS = "consumerActions";
 
+    // Destination fields
+    public static final String DESTINATION_NAME = "destinationName";
+    public static final String DESTINATION_TYPE = "destinationType";
+
     // Native objects
     public static final String JMS_CONNECTION = "jms_connection_object";
     public static final String JMS_SESSION = "jms_session_object";
     public static final String JMS_PRODUCER_OBJECT = "jms_producer_object";
     public static final String JMS_MESSAGE_OBJECT = "jms_message_object";
     public static final String JMS_CONSUMER_OBJECT = "jms_consumer_object";
+    public static final String JMS_DESTINATION_OBJECT = "jms_destination_object";
+
     // Used to keep the session wrapper
     public static final String SESSION_CONNECTOR_OBJECT = "jms_session_connector_object";
 
@@ -130,6 +136,8 @@ public class Constants {
     public static final Map<String, String> MAPPING_PARAMETERS = Collections.unmodifiableMap(mappingParameters);
 
     public static final String JMS_MESSAGE_STRUCT_NAME = "Message";
+
+    public static final String JMS_DESTINATION_STRUCT_NAME = "Destination";
 
     /**
      * Acknowledge Modes.

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/CloseConsumerHandler.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/CloseConsumerHandler.java
@@ -38,14 +38,18 @@ public class CloseConsumerHandler {
 
     public static void handle(Context context) {
         BMap<String, BValue> connectorBObject = (BMap<String, BValue>) context.getRefArgument(1);
-        MessageConsumer consumer = BallerinaAdapter.getNativeObject(connectorBObject,
-                                                                    Constants.JMS_CONSUMER_OBJECT,
-                                                                    MessageConsumer.class,
-                                                                    context);
-        try {
-            consumer.close();
-        } catch (JMSException e) {
-            BallerinaAdapter.throwBallerinaException("Error closing message consumer.", context, e);
+        if (connectorBObject.getNativeData(Constants.JMS_CONSUMER_OBJECT) != null) {
+            MessageConsumer consumer = BallerinaAdapter.getNativeObject(connectorBObject,
+                                                                        Constants.JMS_CONSUMER_OBJECT,
+                                                                        MessageConsumer.class,
+                                                                        context);
+            try {
+                if (consumer != null) {
+                    consumer.close();
+                }
+            } catch (JMSException e) {
+                BallerinaAdapter.throwBallerinaException("Error closing message consumer.", context, e);
+            }
         }
     }
 

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/ReceiveFromActionHandler.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/ReceiveFromActionHandler.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.common;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+/**
+ * {@code Receive} is the receive action implementation of the JMS Connector.
+ */
+public class ReceiveFromActionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReceiveFromActionHandler.class);
+
+    private ReceiveFromActionHandler() {
+    }
+
+    public static void handle(Context context) {
+
+        Struct connectorBObject = BallerinaAdapter.getReceiverObject(context);
+        SessionConnector sessionConnector = BallerinaAdapter.getNativeObject(connectorBObject,
+                                                                             Constants.SESSION_CONNECTOR_OBJECT,
+                                                                             SessionConnector.class,
+                                                                             context);
+        BMap<String, BValue> destinationBObject = ((BMap<String, BValue>) context.getRefArgument(1));
+        Destination destination = BallerinaAdapter.getNativeObject(destinationBObject,
+                                                        Constants.JMS_DESTINATION_OBJECT,
+                                                        Destination.class,
+                                                        context);
+        
+                                                        
+//        long timeInMilliSeconds = context.getIntArgument(2);
+        long timeInMilliSeconds = 5000;
+        
+        try {
+            Session session = sessionConnector.getSession();
+            sessionConnector.handleTransactionBlock(context);
+            MessageConsumer consumer = session.createConsumer(destination);
+            Message message = consumer.receive(timeInMilliSeconds);
+            if (Objects.nonNull(message)) {
+                BMap<String, BValue> messageBObject = BLangConnectorSPIUtil.createBStruct(context,
+                                                                             Constants.BALLERINA_PACKAGE_JMS,
+                                                                             Constants.JMS_MESSAGE_STRUCT_NAME);
+                messageBObject.addNativeData(Constants.JMS_MESSAGE_OBJECT, message);
+                context.setReturnValues(messageBObject);
+                consumer.close();
+            } else {
+                context.setReturnValues();
+            }
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Message receiving failed.", context, e);
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/SendToActionHandler.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/SendToActionHandler.java
@@ -28,6 +28,7 @@ import org.ballerinalang.net.jms.utils.BallerinaAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
@@ -35,33 +36,37 @@ import javax.jms.MessageProducer;
 /**
  * Message send action handler.
  */
-public class SendActionHandler {
+public class SendToActionHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SendActionHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendToActionHandler.class);
 
-    private SendActionHandler() {
+    private SendToActionHandler() {
     }
 
     public static void handle(Context context) {
-        
-           
-            Struct queueSenderBObject = BallerinaAdapter.getReceiverObject(context);
-            MessageProducer messageProducer = BallerinaAdapter.getNativeObject(queueSenderBObject,
+        Struct queueSenderBObject = BallerinaAdapter.getReceiverObject(context);
+        MessageProducer messageProducer = BallerinaAdapter.getNativeObject(queueSenderBObject,
                                                                            Constants.JMS_PRODUCER_OBJECT,
                                                                            MessageProducer.class,
                                                                            context);
-            SessionConnector sessionConnector = BallerinaAdapter.getNativeObject(queueSenderBObject,
+        SessionConnector sessionConnector = BallerinaAdapter.getNativeObject(queueSenderBObject,
                                                                              Constants.SESSION_CONNECTOR_OBJECT,
                                                                              SessionConnector.class,
                                                                              context);
-            BMap<String, BValue> messageBObject = ((BMap<String, BValue>) context.getRefArgument(1));
-            Message message = BallerinaAdapter.getNativeObject(messageBObject,
+        
+        BMap<String, BValue> destinationBObject = ((BMap<String, BValue>) context.getRefArgument(1));
+        BMap<String, BValue> messageBObject = ((BMap<String, BValue>) context.getRefArgument(2));
+        Message message = BallerinaAdapter.getNativeObject(messageBObject,
                                                            Constants.JMS_MESSAGE_OBJECT,
                                                            Message.class,
                                                            context);
+        Destination destination = BallerinaAdapter.getNativeObject(destinationBObject,
+                                                           Constants.JMS_DESTINATION_OBJECT,
+                                                           Destination.class,
+                                                           context);
         try {
             sessionConnector.handleTransactionBlock(context);
-            messageProducer.send(message);       
+            messageProducer.send(destination, message);
         } catch (JMSException e) {
             BallerinaAdapter.returnError("Message receiving failed.", context, e);
         }

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/action/QueueReceiveFrom.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/action/QueueReceiveFrom.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.queue.receiver.action;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.ReceiveFromActionHandler;
+
+/**
+ * {@code Send} is the send action implementation of the JMS Connector.
+ */
+@BallerinaFunction(orgName = "ballerina",
+                   packageName = "jms",
+                   functionName = "receiveFrom",
+                   receiver = @Receiver(type = TypeKind.OBJECT,
+                                        structType = "QueueReceiverActions",
+                                        structPackage = "ballerina/jms"),
+                   args = {
+                           @Argument(name = "destination",
+                                     type = TypeKind.OBJECT),
+                           @Argument(name = "timeInMilliSeconds",
+                                     type = TypeKind.INT)
+                   },
+                   returnType = {
+                           @ReturnType(type = TypeKind.OBJECT,
+                                       structPackage = "ballerina/jms",
+                                       structType = "Message")
+                   },
+                   isPublic = true
+)
+public class QueueReceiveFrom extends AbstractBlockinAction {
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callback) {
+        ReceiveFromActionHandler.handle(context);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/sender/InitQueueSender.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/sender/InitQueueSender.java
@@ -22,6 +22,7 @@ package org.ballerinalang.net.jms.nativeimpl.endpoint.queue.sender;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
 import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.connector.api.Value;
 import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BMap;
@@ -33,7 +34,6 @@ import org.ballerinalang.net.jms.Constants;
 import org.ballerinalang.net.jms.JMSUtils;
 import org.ballerinalang.net.jms.nativeimpl.endpoint.common.SessionConnector;
 import org.ballerinalang.net.jms.utils.BallerinaAdapter;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
@@ -64,10 +64,11 @@ public class InitQueueSender implements NativeCallableUnit {
     public void execute(Context context, CallableUnitCallback callableUnitCallback) {
         Struct queueSenderBObject = BallerinaAdapter.getReceiverObject(context);
         Struct queueSenderConfig = queueSenderBObject.getStructField(Constants.QUEUE_SENDER_FIELD_CONFIG);
-        String queueName = queueSenderConfig.getStringField(Constants.QUEUE_SENDER_FIELD_QUEUE_NAME);
+        Value vQueueName = queueSenderConfig.getRefField(Constants.QUEUE_SENDER_FIELD_QUEUE_NAME);
 
-        if (JMSUtils.isNullOrEmptyAfterTrim(queueName)) {
-            throw new BallerinaException("Queue name cannot be null", context);
+        String queueName = null;
+        if (vQueueName != null) {
+            queueName = vQueueName.getStringValue();
         }
 
         BMap<String, BValue> sessionBObject = (BMap<String, BValue>) context.getRefArgument(1);

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/sender/action/SendTo.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/sender/action/SendTo.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.queue.sender.action;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.SendToActionHandler;
+
+/**
+ * {@code Send} is the send action implementation of the JMS Connector.
+ */
+@BallerinaFunction(orgName = "ballerina",
+                   packageName = "jms",
+                   functionName = "sendTo",
+                   receiver = @Receiver(type = TypeKind.OBJECT,
+                                        structType = "QueueSenderActions",
+                                        structPackage = "ballerina/jms"),
+                   args = {
+                           @Argument(name = "destination", type = TypeKind.OBJECT),
+                           @Argument(name = "message", type = TypeKind.OBJECT)
+                   },
+                   isPublic = true
+)
+public class SendTo extends AbstractBlockinAction {
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+        SendToActionHandler.handle(context);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateQueue.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateQueue.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.session;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import javax.jms.Session;
+
+/**
+ * Create Text JMS Message.
+ */
+@BallerinaFunction(orgName = "ballerina", packageName = "jms",
+                   functionName = "createQueue",
+                   receiver = @Receiver(type = TypeKind.OBJECT, structType = "Session",
+                                        structPackage = "ballerina/jms"),
+                   args = { @Argument(name = "name", type = TypeKind.STRING) },
+                   returnType = {
+                           @ReturnType(type = TypeKind.OBJECT, structPackage = "ballerina/jms",
+                                        structType = "Destination")
+                   },
+                   isPublic = true)
+public class CreateQueue extends AbstractBlockinAction {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(CreateQueue.class);
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+
+        Struct sessionBObject = BallerinaAdapter.getReceiverObject(context);
+
+        Session session = BallerinaAdapter.getNativeObject(sessionBObject, Constants.JMS_SESSION, Session.class,
+                                                           context);
+        String queueName = context.getStringArgument(0);
+        Queue jmsDestination;
+
+        BMap<String, BValue> bStruct = BLangConnectorSPIUtil.createBStruct(context, Constants.BALLERINA_PACKAGE_JMS,
+                                                              Constants.JMS_DESTINATION_STRUCT_NAME);
+        try {
+            jmsDestination = session.createQueue(queueName);
+            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, jmsDestination);
+            bStruct.put(Constants.DESTINATION_NAME, new BString(jmsDestination.getQueueName()));
+            bStruct.put(Constants.DESTINATION_TYPE, new BString("queue"));
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Failed to create queue destination.", context, e);
+        }
+        context.setReturnValues(bStruct);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateTemporaryQueue.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateTemporaryQueue.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.session;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import javax.jms.Session;
+
+/**
+ * Create Text JMS Message.
+ */
+@BallerinaFunction(orgName = "ballerina", packageName = "jms",
+                   functionName = "createTemporaryQueue",
+                   receiver = @Receiver(type = TypeKind.OBJECT, structType = "Session",
+                                        structPackage = "ballerina/jms"),
+                   returnType = {
+                           @ReturnType(type = TypeKind.OBJECT, structPackage = "ballerina/jms",
+                                        structType = "Destination")
+                   },
+                   isPublic = true)
+public class CreateTemporaryQueue extends AbstractBlockinAction {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(CreateTemporaryQueue.class);
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+
+        Struct sessionBObject = BallerinaAdapter.getReceiverObject(context);
+
+        Session session = BallerinaAdapter.getNativeObject(sessionBObject, Constants.JMS_SESSION, Session.class,
+                                                           context);
+
+        Queue jmsDestination;
+
+        BMap<String, BValue> bStruct = BLangConnectorSPIUtil.createBStruct(context, Constants.BALLERINA_PACKAGE_JMS,
+                                                              Constants.JMS_DESTINATION_STRUCT_NAME);
+        try {
+            jmsDestination = session.createTemporaryQueue();
+            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, jmsDestination);
+            bStruct.put(Constants.DESTINATION_NAME, new BString(jmsDestination.getQueueName()));
+            bStruct.put(Constants.DESTINATION_TYPE, new BString("queue"));
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Failed to create temporary destination.", context, e);
+        }
+        context.setReturnValues(bStruct);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateTemporaryTopic.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateTemporaryTopic.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.session;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.JMSException;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+/**
+ * Create Text JMS Message.
+ */
+@BallerinaFunction(orgName = "ballerina", packageName = "jms",
+                   functionName = "createTemporaryTopic",
+                   receiver = @Receiver(type = TypeKind.OBJECT, structType = "Session",
+                                        structPackage = "ballerina/jms"),
+                   returnType = {
+                           @ReturnType(type = TypeKind.OBJECT, structPackage = "ballerina/jms",
+                                        structType = "Destination")
+                   },
+                   isPublic = true)
+public class CreateTemporaryTopic extends AbstractBlockinAction {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(CreateTemporaryTopic.class);
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+
+        Struct sessionBObject = BallerinaAdapter.getReceiverObject(context);
+
+        Session session = BallerinaAdapter.getNativeObject(sessionBObject, Constants.JMS_SESSION, Session.class,
+                                                           context);
+
+        Topic jmsDestination;
+
+        BMap<String, BValue> bStruct = BLangConnectorSPIUtil.createBStruct(context, Constants.BALLERINA_PACKAGE_JMS,
+                                                              Constants.JMS_DESTINATION_STRUCT_NAME);
+        try {
+            jmsDestination = session.createTemporaryTopic();
+            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, jmsDestination);
+            bStruct.put(Constants.DESTINATION_NAME, new BString(jmsDestination.getTopicName()));
+            bStruct.put(Constants.DESTINATION_TYPE, new BString("topic"));
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Failed to create temporary destination.", context, e);
+        }
+        context.setReturnValues(bStruct);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateTopic.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/session/CreateTopic.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.session;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.JMSException;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+/**
+ * Create Text JMS Message.
+ */
+@BallerinaFunction(orgName = "ballerina", packageName = "jms",
+                   functionName = "createTopic",
+                   receiver = @Receiver(type = TypeKind.OBJECT, structType = "Session",
+                                        structPackage = "ballerina/jms"),
+                   args = { @Argument(name = "name", type = TypeKind.STRING) },
+                   returnType = {
+                           @ReturnType(type = TypeKind.OBJECT, structPackage = "ballerina/jms",
+                                        structType = "Destination")
+                   },
+                   isPublic = true)
+public class CreateTopic extends AbstractBlockinAction {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(CreateTopic.class);
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+
+        Struct sessionBObject = BallerinaAdapter.getReceiverObject(context);
+
+        Session session = BallerinaAdapter.getNativeObject(sessionBObject, Constants.JMS_SESSION, Session.class,
+                                                           context);
+
+        String topicName = context.getStringArgument(0);
+        Topic jmsDestination;
+
+        BMap<String, BValue> bStruct = BLangConnectorSPIUtil.createBStruct(context, Constants.BALLERINA_PACKAGE_JMS,
+                                                              Constants.JMS_DESTINATION_STRUCT_NAME);
+        try {
+            jmsDestination = session.createTopic(topicName);
+            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, jmsDestination);
+            bStruct.put(Constants.DESTINATION_NAME, new BString(jmsDestination.getTopicName()));
+            bStruct.put(Constants.DESTINATION_TYPE, new BString("topic"));
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Failed to create topic destination.", context, e);
+        }
+        context.setReturnValues(bStruct);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/publisher/InitTopicPublisher.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/publisher/InitTopicPublisher.java
@@ -33,7 +33,6 @@ import org.ballerinalang.net.jms.Constants;
 import org.ballerinalang.net.jms.JMSUtils;
 import org.ballerinalang.net.jms.nativeimpl.endpoint.common.SessionConnector;
 import org.ballerinalang.net.jms.utils.BallerinaAdapter;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
@@ -60,10 +59,6 @@ public class InitTopicPublisher extends AbstractBlockinAction {
         Struct topicProducerBObject = BallerinaAdapter.getReceiverObject(context);
         Struct topicProducerConfig = topicProducerBObject.getStructField(Constants.TOPIC_PUBLISHER_FIELD_CONFIG);
         String topicPattern = topicProducerConfig.getStringField(Constants.TOPIC_PUBLISHER_FIELD_TOPIC_PATTERN);
-
-        if (JMSUtils.isNullOrEmptyAfterTrim(topicPattern)) {
-            throw new BallerinaException("Topic pattern cannot be null", context);
-        }
 
         BMap<String, BValue> sessionBObject = (BMap<String, BValue>) context.getRefArgument(1);
         Session session = BallerinaAdapter.getNativeObject(sessionBObject,

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/publisher/action/SendTo.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/publisher/action/SendTo.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.topic.publisher.action;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.SendToActionHandler;
+
+/**
+ * {@code Send} is the send action implementation of the topic producer Connector.
+ */
+@BallerinaFunction(orgName = "ballerina",
+                   packageName = "jms",
+                   functionName = "sendTo",
+                   receiver = @Receiver(type = TypeKind.OBJECT,
+                                        structType = "TopicPublisherActions",
+                                        structPackage = "ballerina/jms"),
+                   args = { 
+                            @Argument(name = "destination", type = TypeKind.OBJECT),
+                            @Argument(name = "message", type = TypeKind.OBJECT) 
+                        },
+                   isPublic = true
+)
+public class SendTo extends AbstractBlockinAction {
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+        SendToActionHandler.handle(context);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/subscriber/action/ReceiveFrom.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/subscriber/action/ReceiveFrom.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.topic.durable.subscriber.action;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.ReceiveFromActionHandler;
+
+/**
+ * {@code Receive} is the receive action implementation of the JMS topic subscriber connector.
+ */
+@BallerinaFunction(orgName = "ballerina",
+                   packageName = "jms",
+                   functionName = "receiveFrom",
+                   receiver = @Receiver(type = TypeKind.OBJECT,
+                                        structType = "TopicSubscriberActions",
+                                        structPackage = "ballerina/jms"),
+                   args = {
+                           @Argument(name = "destination",
+                                     type = TypeKind.OBJECT),
+                           @Argument(name = "timeInMilliSeconds",
+                                     type = TypeKind.INT)
+                   },
+                   returnType = {
+                           @ReturnType(type = TypeKind.OBJECT,
+                                       structPackage = "ballerina/jms",
+                                       structType = "Message")
+                   },
+                   isPublic = true
+)
+public class ReceiveFrom extends AbstractBlockinAction {
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callback) {
+        ReceiveFromActionHandler.handle(context);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/GetReplyTo.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/GetReplyTo.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.message;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
+/**
+ * Get a float property in the JMS Message.
+ */
+@BallerinaFunction(
+        orgName = "ballerina",
+        packageName = "jms",
+        functionName = "getReplyTo",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "Message", structPackage = "ballerina/jms"),
+        returnType = { @ReturnType(type = TypeKind.OBJECT, structType = "Destination",
+                                        structPackage = "ballerina/jms")},
+        isPublic = true
+)
+public class GetReplyTo extends AbstractBlockinAction {
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+        Struct messageStruct = BallerinaAdapter.getReceiverObject(context);
+        Message message = BallerinaAdapter.getNativeObject(messageStruct,
+                                                        Constants.JMS_MESSAGE_OBJECT,
+                                                        Message.class,
+                                                        context);
+        BMap<String, BValue> bStruct = BLangConnectorSPIUtil.createBStruct(context, 
+                                        Constants.BALLERINA_PACKAGE_JMS,
+                                        Constants.JMS_DESTINATION_STRUCT_NAME);
+        Destination destination = message.getJMSReplyTo();
+        if (destination instanceof Queue) {
+            Queue replyTo = (Queue) destination;
+            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, replyTo);
+            bStruct.put(Constants.DESTINATION_NAME, new BString(replyTo.getQueueName()));
+            bStruct.put(Constants.DESTINATION_TYPE, new BString("queue"));
+            context.setReturnValues(bStruct);
+        } else {
+            //it must be a topic
+            Topic replyTo = (Topic) destination;
+            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, replyTo);
+            bStruct.put(Constants.DESTINATION_NAME, new BString(replyTo.getTopicName()));
+            bStruct.put(Constants.DESTINATION_TYPE, new BString("topic"));
+            context.setReturnValues(bStruct);
+        }
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/GetReplyTo.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/GetReplyTo.java
@@ -35,6 +35,7 @@ import org.ballerinalang.net.jms.Constants;
 import org.ballerinalang.net.jms.utils.BallerinaAdapter;
 
 import javax.jms.Destination;
+import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.Topic;
@@ -63,20 +64,24 @@ public class GetReplyTo extends AbstractBlockinAction {
         BMap<String, BValue> bStruct = BLangConnectorSPIUtil.createBStruct(context, 
                                         Constants.BALLERINA_PACKAGE_JMS,
                                         Constants.JMS_DESTINATION_STRUCT_NAME);
-        Destination destination = message.getJMSReplyTo();
-        if (destination instanceof Queue) {
-            Queue replyTo = (Queue) destination;
-            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, replyTo);
-            bStruct.put(Constants.DESTINATION_NAME, new BString(replyTo.getQueueName()));
-            bStruct.put(Constants.DESTINATION_TYPE, new BString("queue"));
-            context.setReturnValues(bStruct);
-        } else {
-            //it must be a topic
-            Topic replyTo = (Topic) destination;
-            bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, replyTo);
-            bStruct.put(Constants.DESTINATION_NAME, new BString(replyTo.getTopicName()));
-            bStruct.put(Constants.DESTINATION_TYPE, new BString("topic"));
-            context.setReturnValues(bStruct);
+        try {
+            Destination destination = message.getJMSReplyTo();
+            if (destination instanceof Queue) {
+                Queue replyTo = (Queue) destination;
+                bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, replyTo);
+                bStruct.put(Constants.DESTINATION_NAME, new BString(replyTo.getQueueName()));
+                bStruct.put(Constants.DESTINATION_TYPE, new BString("queue"));
+                context.setReturnValues(bStruct);
+            } else {
+                //it must be a topic
+                Topic replyTo = (Topic) destination;
+                bStruct.addNativeData(Constants.JMS_DESTINATION_OBJECT, replyTo);
+                bStruct.put(Constants.DESTINATION_NAME, new BString(replyTo.getTopicName()));
+                bStruct.put(Constants.DESTINATION_TYPE, new BString("topic"));
+                context.setReturnValues(bStruct);
+            }
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Error when retrieving replyTo", context, e);
         }
     }
 }

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/SetReplyTo.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/message/SetReplyTo.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.message;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.jms.AbstractBlockinAction;
+import org.ballerinalang.net.jms.Constants;
+import org.ballerinalang.net.jms.utils.BallerinaAdapter;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+/**
+ * Set a string property in the JMS Message.
+ */
+@BallerinaFunction(
+        orgName = "ballerina",
+        packageName = "jms",
+        functionName = "setReplyTo",
+        receiver = @Receiver(type = TypeKind.OBJECT,
+                             structType = "Message",
+                             structPackage = "ballerina/jms"),
+        args = { @Argument(type = TypeKind.OBJECT, structType = "Session",
+                           structPackage = "ballerina/jms", name = "replyTo")
+        },
+        isPublic = true
+)
+public class SetReplyTo extends AbstractBlockinAction {
+
+    @Override
+    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+
+        Struct messageStruct = BallerinaAdapter.getReceiverObject(context);
+        Message message = BallerinaAdapter.getNativeObject(messageStruct,
+                                                           Constants.JMS_MESSAGE_OBJECT,
+                                                           Message.class,
+                                                           context);
+        BMap<String, BValue> destinationBObject = ((BMap<String, BValue>) context.getRefArgument(1));
+        Destination destination = BallerinaAdapter.getNativeObject(destinationBObject,
+                                                            Constants.JMS_DESTINATION_OBJECT,
+                                                            Destination.class,
+                                                            context);
+        try {
+            message.setJMSReplyTo(destination);
+        } catch (JMSException e) {
+            BallerinaAdapter.returnError("Error when setting replyTo destination", context, e);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Provide request/reply capabilities to the JMS endpoint implementation as discussed in ticket #9270 .

There is still something missing I couldn't get to work.
The timeout parameter is given to the receiveFrom function as a parameter with a default value. I couldn't figure out how to read this value. This needs to be fixed before it is merged into master.

file: org.ballerinalang.net.jms.nativeimpl.endpoint.common.ReceiveFromActionHandler
line: 63

## Samples
I used the following samples to work with the implementation:

JMS Queue Receiver:
```
import ballerina/io;
import ballerina/jms;

jms:Connection jmsConnection = new ({   
    initialContextFactory:"com.tibco.tibjms.naming.TibjmsInitialContextFactory",
    providerUrl:"tcp://localhost:7222",
    connectionFactoryName: "QueueConnectionFactory",
    username:"admin",
    password:"admin",
    properties:{
        "java.naming.security.principal":"admin",
        "java.naming.security.credentials":"admin"
    }
});

jms:Session jmsSession = new (jmsConnection, {
    acknowledgementMode: "AUTO_ACKNOWLEDGE"
});

endpoint jms:QueueReceiver consumer {
    session: jmsSession,
    queueName: "test.queue.a"
};

endpoint jms:QueueSender jmsProducer {
    session: jmsSession
};

service<jms:Consumer> jmsListener bind consumer {
    onMessage (endpoint ep_consumer, jms:Message message) {
        io:println("receiving msg");
        io:println("building response1");
        var replyDest = message.getReplyTo(); 
        io:println("building response2");
        io:println(replyDest);
        io:println("building response3");
        match(replyDest){
            jms:Destination replyTo =>{ 
                var x = jmsSession.createTextMessage("Response text");
                match(x){
                    jms:Message msg => {
                    io:println("reply to "+replyTo.destinationName);
                        io:println("sending...");
                        var y = jmsProducer->sendTo(replyTo, msg);
                        io:println("done...");
                        io:println(y);
                    }
                    error e => io:println(e);
                }
            }
            error e =>{ io:println(e);}
            () => io:println("nothing found");
        }
      
    }
}
```

JMS Queue Requestor:
```
import ballerina/io;
import ballerina/jms;

jms:Connection jmsConnection = new ({   
    initialContextFactory:"com.tibco.tibjms.naming.TibjmsInitialContextFactory",
    providerUrl:"tcp://localhost:7222",
    connectionFactoryName: "QueueConnectionFactory",
    username:"admin",
    password:"admin",
    properties:{
        "java.naming.security.principal":"admin",
        "java.naming.security.credentials":"admin"
    }
});

jms:Session jmsSession = new (jmsConnection, {
    acknowledgementMode: "AUTO_ACKNOWLEDGE"
});

endpoint jms:QueueReceiver consumer {
    session: jmsSession
};

endpoint jms:QueueSender jmsProducer {
    session: jmsSession
};

function main(string... args){
    jms:Destination replyDest = check jmsSession.createTemporaryQueue();
    jms:Destination requestDest = check jmsSession.createQueue("test.queue.a");
    io:println("created destination");
    var x = jmsSession.createTextMessage("test request");
    io:println("created message");
    match(x) {
        jms:Message m => {
            _ = m.setReplyTo(replyDest);
            io:println("set reply");
            _ = jmsProducer->sendTo(requestDest,m);
            io:println("wait for response");
    
            var replyMsg = consumer->receiveFrom(replyDest,timeoutInMilliSeconds=5000);
            io:println(replyMsg);
            io:println("done.");
        }
        error err => {}
    }

}
```

JMS Topic Receiver:
```
import ballerina/io;
import ballerina/jms;

jms:Connection jmsConnection = new ({   
    initialContextFactory:"com.tibco.tibjms.naming.TibjmsInitialContextFactory",
    providerUrl:"tcp://localhost:7222",
    connectionFactoryName: "TopicConnectionFactory",
    username:"admin",
    password:"admin",
    properties:{
        "java.naming.security.principal":"admin",
        "java.naming.security.credentials":"admin"
    }
});

jms:Session jmsSession = new (jmsConnection, {
    acknowledgementMode: "AUTO_ACKNOWLEDGE"
});

endpoint jms:TopicSubscriber consumer {
    session: jmsSession,
    topicPattern: "test.topic.a"
};

endpoint jms:TopicPublisher jmsProducer {
    session: jmsSession
};

service<jms:Consumer> jmsListener bind consumer {
    onMessage (endpoint ep_consumer, jms:Message message) {
        io:println("receiving msg");
        io:println("building response1");
        var replyDest = message.getReplyTo(); 
        io:println("building response2");
        io:println(replyDest);
        io:println("building response3");
        match(replyDest){
            jms:Destination replyTo =>{ 
                var x = jmsSession.createTextMessage("Response text");
                match(x){
                    jms:Message msg => {
                    io:println("reply to "+replyTo.destinationName);
                        io:println("sending...");
                        var y = jmsProducer->sendTo(replyTo, msg);
                        io:println("done...");
                        io:println(y);
                    }
                    error e => io:println(e);
                }
            }
            error e =>{ io:println(e);}
            () => io:println("nothing found");
        }
      
    }
}

```
JMS Topic Requestor:
```
import ballerina/io;
import ballerina/jms;

jms:Connection jmsConnection = new ({   
    initialContextFactory:"com.tibco.tibjms.naming.TibjmsInitialContextFactory",
    providerUrl:"tcp://localhost:7222",
    connectionFactoryName: "TopicConnectionFactory",
    username:"admin",
    password:"admin",
    properties:{
        "java.naming.security.principal":"admin",
        "java.naming.security.credentials":"admin"
    }
});

jms:Session jmsSession = new (jmsConnection, {
    acknowledgementMode: "AUTO_ACKNOWLEDGE"
});

endpoint jms:TopicSubscriber consumer {
    session: jmsSession,
    topicPattern: "test.topic.a"
};

endpoint jms:TopicPublisher jmsProducer {
    session: jmsSession
};

function main(string... args){
    jms:Destination replyDest = check jmsSession.createTemporaryTopic();
    jms:Destination requestDest = check jmsSession.createTopic("test.topic.a");
    var x = jmsSession.createTextMessage("test request");
    match (x){
        jms:Message m => {
            _ = m.setReplyTo(replyDest);
            _ = jmsProducer -> sendTo(requestDest,m);
            var replyMsg = consumer->receiveFrom(replyDest,timeoutInMilliSeconds=5000);
            match (replyMsg) {
                jms:Message m2 => {
                    io:println("got response message");
                    var t = m2.getTextMessageContent();
                    match(t){
                        string str => io:println(str);
                        error err =>{}
                       
                    }
                }
                error err => {}
                () => {}
            }
            io:println("done.");
        }
        error e => {}
    }
   

}
```

