### PR TITLE
Add BBE for composer source gen test using maven

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tool-plugins/vscode/plugin/ballerina-grammar"]
 	path = tool-plugins/vscode/plugin/ballerina-grammar
 	url = https://github.com/ballerina-platform/ballerina-grammar
-[submodule "composer/modules/integration-tests/src/test/resources/ballerina-examples"]
-	path = composer/modules/integration-tests/src/test/resources/ballerina-examples
-	url = https://github.com/ballerina-platform/ballerina-examples

--- a/composer/modules/integration-tests/pom.xml
+++ b/composer/modules/integration-tests/pom.xml
@@ -31,6 +31,12 @@
             <artifactId>composer-server-distribution</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-examples</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -47,6 +53,19 @@
                         <configuration>
                             <includeClassifiers>ballerina-binary-repo</includeClassifiers>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-examples</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>
+                                ballerina-examples
+                            </includeArtifactIds>
+                            <outputDirectory>src/test/resources/ballerina-examples</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -125,7 +144,6 @@
                                 </copy>
                             </target>
                         </configuration>
-
                     </execution>
                     <execution>
                         <id>set-npm-executable</id>
@@ -141,6 +159,18 @@
                                 </condition>
                             </target>
                             <exportAntProperties>true</exportAntProperties>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>delete-examples</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <delete dir="src/test/resources/ballerina-examples" includeemptydirs="true" deleteonexit="true" />
+                            </target>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Purpose
> This will remove the git submodule for ballerina-examples git repo in composer integration tests and add examples using ballerina-examples maven dependency.  