### PR TITLE
Remove grpc streaming client from source gen test

### DIFF
--- a/composer/modules/integration-tests/src/test/resources/config.json
+++ b/composer/modules/integration-tests/src/test/resources/config.json
@@ -7,6 +7,7 @@
             "join_multiple_streams.bal",
             "table_queries.bal",
             "temporal_aggregations_and_windows.bal",
+            "grpc_bidirectional_streaming_client.bal",
             "table.bal",
             "csv_io.bal"
         ]

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
@@ -92,7 +92,7 @@ public class SourceGenTest {
         private List<File> files;
         private String[] ignoredFiles = {"identify_patterns.bal", "identify_trends.bal",
                 "join_multiple_streams.bal", "table_queries.bal", "temporal_aggregations_and_windows.bal",
-                "table.bal", "csv_io.bal"};
+                "table.bal", "csv_io.bal", "grpc_bidirectional_streaming_client.bal"};
 
         FileVisitor(List<File> ballerinaFiles) {
             this.files = ballerinaFiles;


### PR DESCRIPTION
## Purpose
> This will ignore the grpc bidirectional streaming client from source gen tests in both composer and language server