### PR TITLE
Make JVM version check only for JDK1.8

### DIFF
--- a/distribution/zip/ballerina/bin/ballerina
+++ b/distribution/zip/ballerina/bin/ballerina
@@ -158,7 +158,7 @@ if [ "$CMD" = "--java.debug" ]; then
 fi
 
 JDK_18=`$JAVA_HOME/bin/java -version 2>&1 | grep -e "1.8."`
-if [ "JDK_18" = "" ]; then
+if [ "$JDK_18" = "" ]; then
     echo "Error: Ballerina is supported only on JDK 1.8"
     exit 1
 fi

--- a/distribution/zip/ballerina/bin/ballerina
+++ b/distribution/zip/ballerina/bin/ballerina
@@ -157,14 +157,9 @@ if [ "$CMD" = "--java.debug" ]; then
   echo "Please start the remote debugging client to continue..."
 fi
 
-JDK_18_OR_HIGHER=`$JAVA_HOME/bin/java -version 2>&1 | grep -e "1.8." -e "9." -e "10."`
-JDK_18=`echo $JDK_18_OR_HIGHER | grep -e "1.8."`
-if [ -n "$JDK_18_OR_HIGHER" ]; then
-    if [ "$JDK_18" = "" ]; then
-        JAVA_MODULES="--add-modules java.corba"
-    fi
-else
-    echo "Error: Ballerina is supported only on JDK 1.8 and above"
+JDK_18=`$JAVA_HOME/bin/java -version 2>&1 | grep -e "1.8."`
+if [ "JDK_18" = "" ]; then
+    echo "Error: Ballerina is supported only on JDK 1.8"
     exit 1
 fi
 
@@ -215,7 +210,6 @@ $JAVACMD \
 	-XX:+HeapDumpOnOutOfMemoryError \
 	-XX:HeapDumpPath="$BALLERINA_HOME/heap-dump.hprof" \
 	$JAVA_OPTS \
-	$JAVA_MODULES \
 	-classpath "$BALLERINA_CLASSPATH" \
 	-Dballerina.home=$BALLERINA_HOME \
 	-Dballerina.version=${project.version} \

--- a/distribution/zip/ballerina/bin/ballerina.bat
+++ b/distribution/zip/ballerina/bin/ballerina.bat
@@ -113,19 +113,15 @@ set CMD=RUN %*
 :checkJdk8AndHigher
 set JVER=
 for /f tokens^=2-5^ delims^=.-_^" %%j in ('"%JAVA_HOME%\bin\java" -fullversion 2^>^&1') do set "JVER=%%j%%k"
-set JAVA_MODULES=
-rem In, JDK9 or above need to import 'java.corba' module
-if %JVER% GEQ 90 set JAVA_MODULES="--add-modules java.corba"
-if %JVER% GEQ 18 goto jdk8AndHigher
+if %JVER% EQU 18 goto jdk8
 goto unknownJdk
 
 :unknownJdk
-echo Ballerina is supported only on JDK 1.8 and above
+echo Ballerina is supported only on JDK 1.8
 goto end
 
-:jdk8AndHigher
+:jdk8
 goto runServer
-
 
 rem ----------------- Execute The Requested Command ----------------------------
 
@@ -137,7 +133,7 @@ rem ---------- Add jars to classpath ----------------
 
 set BALLERINA_CLASSPATH=.\bre\lib\bootstrap;%BALLERINA_CLASSPATH%
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%BALLERINA_HOME%\heap-dump.hprof"  -Dcom.sun.management.jmxremote -classpath %BALLERINA_CLASSPATH% %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%"  -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version} -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager" %JAVA_MODULES%
+set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%BALLERINA_HOME%\heap-dump.hprof"  -Dcom.sun.management.jmxremote -classpath %BALLERINA_CLASSPATH% %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%"  -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version} -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager"
 
 
 :runJava


### PR DESCRIPTION
## Purpose
> Ballerina recommended JDK version is 1.8. Thus, removed other version
support and changed the error message. This commit resolves https://github.com/ballerina-platform/ballerina-lang/issues/9620