### PR TITLE
Add resuming capability for failover EPs

### DIFF
--- a/stdlib/http/src/main/ballerina/http/commons.bal
+++ b/stdlib/http/src/main/ballerina/http/commons.bal
@@ -19,6 +19,9 @@
 
 @final int DEFAULT_LISTENER_TIMEOUT = 120000; //2 mins
 
+documentation {Constant for the default failover starting index for failover endpoints}
+@final int DEFAULT_FAILOVER_EP_STARTING_INDEX = 0;
+
 documentation {Represents multipart primary type}
 @final public string MULTIPART_AS_PRIMARY_TYPE = "multipart/";
 // TODO: Document these. Should we make FORWARD a private constant?

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/resiliency/FailoverClientTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/resiliency/FailoverClientTestCase.java
@@ -1,0 +1,205 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.service.resiliency;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
+import org.ballerinalang.test.IntegrationTestCase;
+import org.ballerinalang.test.context.ServerInstance;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.TestConstant;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test cases for the failover scenarios.
+ */
+public class FailoverClientTestCase extends IntegrationTestCase {
+    private ServerInstance ballerinaServer;
+    private static final String TYPICAL_SERVICE_PATH = "fo" + File.separator + "typical";
+
+    @BeforeMethod
+    private void setup() throws Exception {
+        ballerinaServer = ServerInstance.initBallerinaServer();
+        String balFile = new File("src" + File.separator + "test" + File.separator + "resources"
+                + File.separator + "resiliency" + File.separator + "http_failover.bal").getAbsolutePath();
+        ballerinaServer.startBallerinaServer(balFile);
+    }
+
+    @Test(description = "Test basic failover functionality")
+    public void testSimpleFailover() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
+        HttpResponse response = HttpClientRequest.doPost(ballerinaServer
+                        .getServiceURLHttp(TYPICAL_SERVICE_PATH)
+                , "{\"Name\":\"Ballerina\"}", headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), "Mock Resource is Invoked.", "Message content mismatched");
+    }
+
+    @Test(description = "Test failover functionality with multipart requests")
+    public void testMultiPart() throws IOException {
+        String multipartDataBoundary = Long.toHexString(PlatformDependent.threadLocalRandom().nextLong());
+        String multipartBody = "--" + multipartDataBoundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"foo\"" + "\r\n" +
+                "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
+                "\r\n" +
+                "Part1" +
+                "\r\n" +
+                "--" + multipartDataBoundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"filepart\"; filename=\"file-01.txt\"" + "\r\n" +
+                "Content-Type: text/plain" + "\r\n" +
+                "Content-Transfer-Encoding: binary" + "\r\n" +
+                "\r\n" +
+                "Part2" + StringUtil.NEWLINE +
+                "\r\n" +
+                "--" + multipartDataBoundary + "--" + "\r\n";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), "multipart/form-data; boundary=" +
+ multipartDataBoundary);
+        HttpResponse response = HttpClientRequest.doPost(ballerinaServer
+                        .getServiceURLHttp(TYPICAL_SERVICE_PATH)
+                , multipartBody, headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertTrue(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                        .contains("multipart/form-data;boundary=" + multipartDataBoundary),
+                "Response is not form of multipart");
+        Assert.assertTrue(response.getData().contains("form-data;name=\"foo\"content-id: 0Part1")
+                , "Message content mismatched");
+        Assert.assertTrue(response.getData().
+                        contains("form-data;name=\"filepart\";filename=\"file-01.txt\"content-id: 1Part2")
+                , "Message content mismatched");
+    }
+
+    @Test(description = "Test failover functionality when request has nested body parts")
+    public void testNestedMultiPart() throws IOException {
+        String multipartDataBoundary = Long.toHexString(PlatformDependent.threadLocalRandom().nextLong());
+        String multipartMixedBoundary = Long.toHexString(PlatformDependent.threadLocalRandom().nextLong());
+        String nestedMultipartBody = "--" + multipartDataBoundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"parent1\"" + "\r\n" +
+                "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
+                "\r\n" +
+                "Parent Part" + "\r\n" +
+                "--" + multipartDataBoundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"parent2\"" + "\r\n" +
+                "Content-Type: multipart/mixed; boundary=" + multipartMixedBoundary + "\r\n" +
+                "\r\n" +
+                "--" + multipartMixedBoundary + "\r\n" +
+                "Content-Disposition: attachment; filename=\"file-02.txt\"" + "\r\n" +
+                "Content-Type: text/plain" + "\r\n" +
+                "Content-Transfer-Encoding: binary" + "\r\n" +
+                "\r\n" +
+                "Child Part 1" + StringUtil.NEWLINE +
+                "\r\n" +
+                "--" + multipartMixedBoundary + "\r\n" +
+                "Content-Disposition: attachment; filename=\"file-02.txt\"" + "\r\n" +
+                "Content-Type: text/plain" + "\r\n" +
+                "Content-Transfer-Encoding: binary" + "\r\n" +
+                "\r\n" +
+                "Child Part 2" + StringUtil.NEWLINE +
+                "\r\n" +
+                "--" + multipartMixedBoundary + "--" + "\r\n" +
+                "--" + multipartDataBoundary + "--" + "\r\n";
+        String expectedChildPart1 =
+                "Content-Transfer-Encoding: binary" +
+                        "content-type: text/plain" +
+                        "content-disposition: attachment;filename=\"file-02.txt\"content-id: 0" +
+                        "Child Part 1";
+        String expectedChildPart2 = "Content-Transfer-Encoding: binary" +
+                "content-type: text/plain" +
+                "content-disposition: attachment;filename=\"file-02.txt\"content-id: 1" +
+                "Child Part 2";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), "multipart/form-data; boundary=" +
+ multipartDataBoundary);
+        HttpResponse response = HttpClientRequest.doPost(ballerinaServer.getServiceURLHttp(TYPICAL_SERVICE_PATH)
+                , nestedMultipartBody, headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertTrue(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                        .contains("multipart/form-data;boundary=" + multipartDataBoundary),
+                "Response is not form of multipart");
+        Assert.assertTrue(response.getData().contains(expectedChildPart1), "Message content mismatched");
+        Assert.assertTrue(response.getData().contains(expectedChildPart2), "Message content mismatched");
+    }
+
+    @Test(description = "Test the functionality for all endpoints failure scenario")
+    public void testAllEndpointFailure() throws IOException {
+        String expectedMessage = "All the failover endpoints failed. Last error was Idle timeout" +
+                " triggered before initiating inbound response";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
+        HttpResponse response = HttpClientRequest.doPost(ballerinaServer
+                        .getServiceURLHttp("fo/failures")
+                , "{\"Name\":\"Ballerina\"}", headers);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), expectedMessage, "Message content mismatched");
+    }
+
+    @Test(description = "Test the functionality for all endpoints failure scenario")
+    public void testResponseWithErrorStatusCodes() throws IOException {
+        String expectedMessage = "All the failover endpoints failed. " +
+                "Last endpoint returned response is: 503 Service Unavailable";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
+        HttpResponse response = HttpClientRequest.doPost(ballerinaServer
+                        .getServiceURLHttp("fo/failurecodes")
+                , "{\"Name\":\"Ballerina\"}", headers);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), expectedMessage, "Message content mismatched");
+    }
+
+    @Test(description = "Test to verify whether failover will test from last successful endpoint")
+    public void testFailoverStartingPosition() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
+        HttpResponse response = HttpClientRequest.doPost(ballerinaServer
+                        .getServiceURLHttp("fo/index")
+                , "{\"Name\":\"Ballerina\"}", headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), "Failover start index is : 0", "Message content mismatched");
+        HttpResponse secondResponse = HttpClientRequest.doPost(ballerinaServer
+                        .getServiceURLHttp("fo/index")
+                , "{\"Name\":\"Ballerina\"}", headers);
+        Assert.assertEquals(secondResponse.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(secondResponse.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(secondResponse.getData(), "Failover start index is : 2", "Message content mismatched");
+    }
+
+    @AfterMethod
+    private void cleanup() throws Exception {
+        ballerinaServer.stopServer();
+    }
+}

--- a/tests/ballerina-integration-test/src/test/resources/resiliency/http_failover.bal
+++ b/tests/ballerina-integration-test/src/test/resources/resiliency/http_failover.bal
@@ -1,0 +1,271 @@
+// Copyright (c) 2018 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/io;
+import ballerina/mime;
+import ballerina/runtime;
+
+// Create an endpoint with port 8080 for the mock backend services.
+endpoint http:Listener backendEP {
+    port: 8080
+};
+
+// Define the failover client end point to call the backend services.
+endpoint http:FailoverClient foBackendEP {
+    timeoutMillis: 5000,
+    failoverCodes: [501, 502, 503],
+    intervalMillis: 5000,
+    // Define set of HTTP Clients that needs to be Failover.
+    targets: [
+        { url: "http://localhost:3000/inavalidEP" },
+        { url: "http://localhost:8080/echo" },
+        { url: "http://localhost:8080/mock" },
+        { url: "http://localhost:8080/mock" }
+    ]
+
+};
+
+endpoint http:FailoverClient foBackendFailureEP {
+    timeoutMillis: 5000,
+    failoverCodes: [501, 502, 503],
+    intervalMillis: 5000,
+    // Define set of HTTP Clients that needs to be Failover.
+    targets: [
+        { url: "http://localhost:3000/inavalidEP" },
+        { url: "http://localhost:8080/echo" },
+        { url: "http://localhost:8080/echo" }
+    ]
+
+};
+
+endpoint http:FailoverClient foStatusCodesEP {
+    timeoutMillis: 5000,
+    failoverCodes: [501, 502, 503],
+    intervalMillis: 5000,
+    // Define set of HTTP Clients that needs to be Failover.
+    targets: [
+        { url: "http://localhost:8080/statuscodes" },
+        { url: "http://localhost:8080/statuscodes" },
+        { url: "http://localhost:8080/statuscodes" }
+    ]
+
+};
+
+@http:ServiceConfig {
+    basePath: "/fo"
+}
+service<http:Service> failoverDemoService bind { port: 9090 } {
+    @http:ResourceConfig {
+        methods: ["GET", "POST"],
+        path: "/typical"
+    }
+    invokeEndpoint(endpoint caller, http:Request request) {
+        var backendRes = foBackendEP->forward("/", request);
+        match backendRes {
+            http:Response response => {
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+            error responseError => {
+                // Create a new HTTP response by looking at the error message.
+                http:Response response = new;
+                response.statusCode = 500;
+                response.setPayload(responseError.message);
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET", "POST"],
+        path: "/failures"
+    }
+    invokeAllFailureEndpoint(endpoint caller, http:Request request) {
+        var backendRes = foBackendFailureEP->forward("/", request);
+        match backendRes {
+            http:Response response => {
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+            error responseError => {
+                // Create a new HTTP response by looking at the error message.
+                http:Response response = new;
+                response.statusCode = 500;
+                response.setPayload(responseError.message);
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET", "POST"],
+        path: "/failurecodes"
+    }
+    invokeAllFailureStatusCodesEndpoint(endpoint caller, http:Request request) {
+        var backendRes = foStatusCodesEP->forward("/", request);
+        match backendRes {
+            http:Response response => {
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+            error responseError => {
+                // Create a new HTTP response by looking at the error message.
+                http:Response response = new;
+                response.statusCode = 500;
+                response.setPayload(responseError.message);
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET", "POST"],
+        path: "/index"
+    }
+    failoverStartIndex(endpoint caller, http:Request request) {
+        http:FailoverActions foClient = foBackendEP.getCallerActions();
+        string startIndex = <string> foClient.succeededEndpointIndex;
+        var backendRes = foBackendEP->forward("/", request);
+        match backendRes {
+            http:Response response => {
+                string responseMessage = "Failover start index is : " + startIndex;
+                response.setPayload(responseMessage);
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+            error responseError => {
+                // Create a new HTTP response by looking at the error message.
+                http:Response response = new;
+                response.statusCode = 500;
+                response.setPayload(responseError.message);
+                caller->respond(response) but {
+                    error e => log:printError("Error sending response", err = e)
+                };
+            }
+        }
+    }
+}
+
+// Define the sample service to mock connection timeouts and service outages.
+@http:ServiceConfig {
+    basePath: "/echo"
+}
+service echo bind backendEP {
+    @http:ResourceConfig {
+        methods: ["POST", "PUT", "GET"],
+        path: "/"
+    }
+    echoResource(endpoint caller, http:Request req) {
+        http:Response outResponse = new;
+        // Delay the response for 30000 milliseconds to mimic network level delays.
+        runtime:sleep(30000);
+
+        outResponse.setPayload("echo Resource is invoked");
+        caller->respond(outResponse) but {
+            error e => log:printError(
+                           "Error sending response from mock service", err = e)
+        };
+    }
+}
+
+public int counter = 1;
+// Define the sample service to mock a healthy service.
+@http:ServiceConfig {
+    basePath: "/mock"
+}
+service mock bind backendEP {
+    @http:ResourceConfig {
+        methods: ["POST", "PUT", "GET"],
+        path: "/"
+    }
+    mockResource(endpoint caller, http:Request req) {
+        counter++;
+        if (counter % 5 == 0) {
+            runtime:sleep(30000);
+        }
+        http:Response response = new;
+        if (req.hasHeader(mime:CONTENT_TYPE)
+            && req.getHeader(mime:CONTENT_TYPE).hasPrefix(http:MULTIPART_AS_PRIMARY_TYPE)) {
+            match req.getBodyParts() {
+                // Setting the error response in case of an error
+                error err => {
+                    log:printError(err.message);
+                    response.setPayload("Error in decoding multiparts!");
+                    response.statusCode = 500;
+                }
+                // Iterate through the body parts.
+                mime:Entity[] bodyParts => {
+                    foreach bodyPart in bodyParts {
+                        if (bodyPart.hasHeader(mime:CONTENT_TYPE)
+                            && bodyPart.getHeader(mime:CONTENT_TYPE).hasPrefix(http:MULTIPART_AS_PRIMARY_TYPE)) {
+                            mime:Entity[] childParts = check bodyPart.getBodyParts();
+                            foreach childPart in childParts {
+                                // When performing passthrough scenarios, message needs to be built before
+                                // invoking the endpoint to create a message datasource.
+                                var childBlobContent = childPart.getByteArray();
+                            }
+                            io:println(bodyPart.getContentType());
+                            bodyPart.setBodyParts(untaint childParts, contentType = untaint bodyPart.getContentType());
+                        } else {
+                            var bodyPartBlobContent = bodyPart.getByteArray();
+                        }
+                    }
+                    response.setBodyParts(untaint bodyParts, contentType = untaint req.getContentType());
+                }
+            }
+        } else {
+            response.setPayload("Mock Resource is Invoked.");
+        }
+        caller->respond(response) but {
+            error e => log:printError(
+                           "Error sending response from mock service", err = e)
+        };
+
+    }
+}
+
+// Define the sample service to mock connection timeouts and service outages.
+@http:ServiceConfig {
+    basePath: "/statuscodes"
+}
+service failureStatusCodeService bind backendEP {
+    @http:ResourceConfig {
+        methods: ["POST", "PUT", "GET"],
+        path: "/"
+    }
+    errorStatusResource(endpoint caller, http:Request req) {
+        http:Response outResponse = new;
+        outResponse.statusCode = 503;
+        outResponse.setPayload("Failure status code scenario");
+        caller->respond(outResponse) but {
+            error e => log:printError(
+                           "Error sending response from mock service", err = e)
+        };
+    }
+}

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -34,6 +34,7 @@
         <packages>
             <package name="org.ballerinalang.test.service.http.sample"/>
             <package name="org.ballerinalang.test.service.http2"/>
+            <package name="org.ballerinalang.test.service.resiliency"/>
             <package name="org.ballerinalang.test.transaction"/>
             <package name="org.ballerinalang.test.filter"/>
             <package name="org.ballerinalang.test.auth"/>


### PR DESCRIPTION
If initial endpoints get failed and one of the latter endpoints is successful failover should resume from that successful endpoint for subsequent calls. Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/9787

## Purpose
To fix: https://github.com/ballerina-platform/ballerina-lang/issues/9787

## Automation tests
 - Integration tests 
   > Yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```java
import ballerina/http;
import ballerina/log;
import ballerina/io;
import ballerina/runtime;

// Create an endpoint with port 8080 for the mock backend services.
endpoint http:Listener backendEP {
    port: 8080
};

// Define the failover client end point to call the backend services.
endpoint http:FailoverClient foBackendEP {
    timeoutMillis: 5000,
    failoverCodes: [501, 502, 503],
    intervalMillis: 5000,
    // Define set of HTTP Clients that needs to be Failover.
    targets: [
        { url: "http://localhost:3000/inavalidEP" },
        { url: "http://localhost:8080/echo" },
        { url: "http://localhost:8080/mock" },
        { url: "http://localhost:8080/mock" }
    ]

};

@http:ServiceConfig {
    basePath: "/fo"
}
service<http:Service> failoverDemoService bind { port: 9090 } {
    // Create a REST resource within the API.
    @http:ResourceConfig {
        methods: ["GET", "POST"],
        path: "/"
    }
    // Parameters include a reference to the caller endpoint and a object with the request data.
    invokeEndpoint(endpoint caller, http:Request request) {
        http:FailoverActions foClient = foBackendEP.getCallerActions();
        //io:println(req.getJsonPayload());
        var backendRes = foBackendEP->forward("/", request);
        // `match` is used to handle union-type returns.
        // If a response is returned, the normal process runs.
        // If the service does not get the expected response,
        // the error-handling logic is executed.
        match backendRes {
            http:Response response => {
                // `->` signifies remote call.
                caller->respond(response) but {
                    error e => log:printError("Error sending response", err = e)
                };
            }
            error responseError => {
                // Create a new HTTP response by looking at the error message.
                http:Response response = new;
                response.statusCode = 500;
                response.setPayload(responseError.message);
                caller->respond(response) but {
                    error e => log:printError("Error sending response", err = e)
                };
            }
        }
    }
}

// Define the sample service to mock connection timeouts and service outages.
@http:ServiceConfig {
    basePath: "/echo"
}
service echo bind backendEP {
    @http:ResourceConfig {
        methods: ["POST", "PUT", "GET"],
        path: "/"
    }
    echoResource(endpoint caller, http:Request req) {
        http:Response outResponse = new;
        //io:println(req.getJsonPayload());
        // Delay the response for 30000 milliseconds to mimic network level delays.
        runtime:sleep(30000);

        outResponse.setPayload("echo Resource is invoked");
        caller->respond(outResponse) but {
            error e => log:printError(
                           "Error sending response from mock service", err = e)
        };
    }
}
public int counter = 1;
// Define the sample service to mock a healthy service.
@http:ServiceConfig {
    basePath: "/mock"
}
service mock bind backendEP {
    @http:ResourceConfig {
        methods: ["POST", "PUT", "GET"],
        path: "/"
    }
    mockResource(endpoint caller, http:Request req) {
        io:println(req.getJsonPayload());
        counter++;
        runtime:sleep(30000);
        if (counter % 5 == 0) {
            runtime:sleep(30000);
        }
        http:Response outResponse = new;
        outResponse.setPayload("Mock Resource is Invoked.");
        caller->respond(outResponse) but {
            error e => log:printError(
                           "Error sending response from mock service", err = e)
        };

    }
}
```
