### PR TITLE
Remove 0.0.0 from API docs generated from docerina

### DIFF
--- a/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-doc.help
+++ b/cli/ballerina-launcher/src/main/resources/cli-help/ballerina-doc.help
@@ -55,6 +55,7 @@ OPTIONS
      -v
      --verbose
          Prints debug level logs while generating documentation.
+
      -e <key=value>
          Sets Ballerina environment parameters as key/value pairs.
          If multiple parameters need to be provided, each parameter

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/model/Field.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/model/Field.java
@@ -34,12 +34,16 @@ public class Field extends Variable {
      * @param href         link of the data type.
      */
     public Field(String name, String dataType, String description, String defaultValue, String href) {
-        super(name, removeOrg(dataType), description, href);
+        super(name, clean(dataType), description, href);
         this.defaultValue = defaultValue;
     }
 
-    private static String removeOrg(String type) {
-        return type.replaceAll("[A-Za-z0-9]+/([A-Za-z0-9]+:)", "$1");
+    private static String clean(String type) {
+        // remove organization
+        type = type.replaceAll("[A-Za-z0-9]+/([A-Za-z0-9]+:)", "$1");
+        // remove version
+        type = type.replaceAll(":\\d\\.\\d\\.\\d", "");
+        return type;
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9738

## Purpose
> API docs generated from docerina included 0.0.0 in hrefs. This PR removes the 0.0.0.

## Goals
> Proper doc gen

## Approach
> Remove 0.0.0 from the data type value.