### PR TITLE
Add responsive titles for definition dropdowns

### DIFF
--- a/composer/modules/web/scss/modules/ballerina-editor.scss
+++ b/composer/modules/web/scss/modules/ballerina-editor.scss
@@ -477,18 +477,21 @@ h6,
     padding: 4px 35px 0 30px !important;
     margin: 0 !important;
     background-color: #e7eaeb !important;
-    box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15) !important;
+    box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, .15) !important;
     min-height: 3.4rem !important;
     &.hidden {
         display: none !important;
     }
     .top-bar {
         >.ui.label {
+            &>.icon {
+                margin-right: .4em;
+            }
             &>span {
-                vertical-align: text-top;
+                vertical-align: top;
             }
             &>.detail {
-                margin-left: 0.5em;
+                margin-left: .2em;
             }
         }
         &.mobile-top-bar {
@@ -514,6 +517,21 @@ h6,
     }
     .definitions-menu {
         margin-top: 6px !important;
+    }
+}
+
+.definitions-popup-window .definitions-popup-window-header {
+    >.ui.label {
+        padding: 0;
+        &>.icon {
+            margin-right: .4em;
+        }
+        &>span {
+            vertical-align: top;
+        }
+        &>.detail {
+            margin-left: .2em;
+        }
     }
 }
 

--- a/composer/modules/web/src/plugins/ballerina/views/definition-view-menu.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/definition-view-menu.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Header, Icon, Grid, Popup, Button, Label } from 'semantic-ui-react';
+import { Icon, Popup, Label } from 'semantic-ui-react';
 import CompilationUnitNode from '../model/tree/compilation-unit-node';
 import TreeUtil from '../model/tree-util';
 import { RESPOSIVE_MENU_TRIGGER } from '../constants';
@@ -78,19 +78,29 @@ class DefinitionViewMenu extends React.Component {
                 { structs.length > 0 &&
                     <Popup
                         trigger={
-                          <Label as='a' color='white'>
-                              <Icon name={'fw fw-struct'} />
-                              <span>Objects</span>
-                              <Label.Detail>{structs.length}</Label.Detail>
-                          </Label>
+                            <Label as='a' color='white'>
+                                <Icon name={'fw fw-struct'} />
+                                <span>Objects</span>
+                                <Label.Detail>{structs.length}</Label.Detail>
+                            </Label>
                         }
                         className='definitions-popup-window'
                         position='bottom right'
                         flowing
                         wide
-                        hideOnScroll>
+                        hideOnScroll
+                    >
                         {
                             <div>
+                                { this.props.width < RESPOSIVE_MENU_TRIGGER.ICON_MODE &&
+                                    <div className='definitions-popup-window-header'>
+                                        <Label as='span' color='white'>
+                                            <Icon name={'fw fw-struct'} />
+                                            <span>Objects</span>
+                                        </Label>
+                                        <hr />
+                                    </div>
+                                }
                                 {
                                     structs.map((element) => {
                                         return this.getItem(element.getName().getValue(),
@@ -104,19 +114,29 @@ class DefinitionViewMenu extends React.Component {
                 { records.length > 0 &&
                     <Popup
                         trigger={
-                          <Label as='a' color='white'>
-                              <Icon name={'fw fw-records'} />
-                              <span>Records</span>
-                              <Label.Detail>{records.length}</Label.Detail>
-                          </Label>
+                            <Label as='a' color='white'>
+                                <Icon name={'fw fw-records'} />
+                                <span>Records</span>
+                                <Label.Detail>{records.length}</Label.Detail>
+                            </Label>
                         }
                         className='definitions-popup-window'
                         position='bottom right'
                         flowing
                         wide
-                        hideOnScroll>
+                        hideOnScroll
+                    >
                         {
                             <div>
+                                { this.props.width < RESPOSIVE_MENU_TRIGGER.ICON_MODE &&
+                                    <div className='definitions-popup-window-header'>
+                                        <Label as='span' color='white'>
+                                            <Icon name={'fw fw-records'} />
+                                            <span>Records</span>
+                                        </Label>
+                                        <hr />
+                                    </div>
+                                }
                                 {
                                     records.map((element) => {
                                         return this.getItem(element.getName().getValue(),
@@ -130,19 +150,29 @@ class DefinitionViewMenu extends React.Component {
                 { endpoints.length > 0 &&
                     <Popup
                         trigger={
-                          <Label as='a' color='white'>
-                              <Icon name={'fw fw-endpoint'} />
-                              <span>Endpoints</span>
-                              <Label.Detail>{endpoints.length}</Label.Detail>
-                          </Label>
+                            <Label as='a' color='white'>
+                                <Icon name={'fw fw-endpoint'} />
+                                <span>Endpoints</span>
+                                <Label.Detail>{endpoints.length}</Label.Detail>
+                            </Label>
                         }
                         className='definitions-popup-window'
                         position='bottom right'
                         flowing
                         wide
-                        hideOnScroll>
+                        hideOnScroll
+                    >
                             {
                                 <div>
+                                    { this.props.width < RESPOSIVE_MENU_TRIGGER.ICON_MODE &&
+                                        <div className='definitions-popup-window-header'>
+                                            <Label as='span' color='white'>
+                                                <Icon name={'fw fw-endpoint'} />
+                                                <span>Endpoints</span>
+                                            </Label>
+                                            <hr />
+                                        </div>
+                                    }
                                     {
                                         endpoints.map((element) => {
                                             return this.getItem(element.getName().getValue(),
@@ -160,6 +190,7 @@ class DefinitionViewMenu extends React.Component {
 
 DefinitionViewMenu.propTypes = {
     model: PropTypes.instanceOf(CompilationUnitNode).isRequired,
+    width: PropTypes.number.isRequired,
 };
 
 DefinitionViewMenu.defaultProps = {


### PR DESCRIPTION
## Purpose
> Add responsive titles for definition dropdowns along with some alignment style fixes.

![image](https://user-images.githubusercontent.com/7569427/43499791-edf7e2ac-956a-11e8-9dfc-092ab95a2ca2.png)

![image](https://user-images.githubusercontent.com/7569427/43499812-03e3e912-956b-11e8-86ae-a583cc1d1866.png)
