### PR TITLE
Fix context menu icon not hiding when collapsed

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/graphical-editor/controllers/worker-node.jsx
+++ b/composer/modules/web/src/plugins/ballerina/graphical-editor/controllers/worker-node.jsx
@@ -168,6 +168,11 @@ class DefaultCtrl extends React.Component {
         const y = bBox.y + bBox.h;
         const x = bBox.x;
 
+        if (model.parent.viewState.collapsed ||
+            (model.parent.parent && model.parent.parent.viewState.collapsed)) {
+            return null;
+        }
+
         return (
             <HoverButton
                 style={{


### PR DESCRIPTION
## Purpose
> This PR will fix the issue #9765 where the context menu icon is not hiding when the diagram is collapsed. 

