### PR TITLE
Fix typo in compiler phase name

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerPhase.java
@@ -52,7 +52,7 @@ public enum CompilerPhase {
                 return TYPE_CHECK;
             case "codeAnalyze":
                 return CODE_ANALYZE;
-            case "documentationAnalyzer":
+            case "documentationAnalyze":
                 return DOCUMENTATION_ANALYZE;
             case "taintAnalyze":
                 return TAINT_ANALYZE;


### PR DESCRIPTION
## Purpose
This PR fixes a typo in one of the compiler phase names checked in `fromValue` method.