### PR TITLE
Improve WebSocket methods and resource signature

### DIFF
--- a/stdlib/http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/service_endpoint.bal
@@ -245,6 +245,8 @@ public type WebSocketListener object {
         Stops the registered service.
     }
     public function stop() {
+        WebSocketConnector webSocketConnector = getCallerActions();
+        check webSocketConnector.close(1001, "going away", timeoutInSecs = 0);
         httpEndpoint.stop();
     }
 };

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
@@ -64,11 +64,7 @@ public type WebSocketClient object {
     }
     public function stop() {
         WebSocketConnector webSocketConnector = getCallerActions();
-        error|() value = webSocketConnector.close(1001, "going away");
-        match value {
-            error err => throw err;
-            () => {}
-        }
+        check webSocketConnector.close(1001, "going away", timeoutInSecs = 0);
     }
 };
 

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_connector.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_connector.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/internal;
+
 documentation {
     Represents a WebSocket connector in ballerina. This include all connector oriented operations.
 }
@@ -23,12 +25,39 @@ public type WebSocketConnector object {
     documentation {
         Push text to the connection.
 
-        P{{text}} Text to be sent
+        P{{data}} Data to be sent, if byte[] it is converted to a UTF-8 string for sending
         P{{final}} True if this is a final frame of a (long) message
         R{{}} `error` if an error occurs when sending
     }
-    public extern function pushText(string text, boolean final = true) returns error?;
+    public function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean final = true) returns error? {
+        string text;
+        match data {
+            byte byteContent => {
+                text = <string>(<int>byteContent);
+            }
+            int integerContent => {
+                text = <string>integerContent;
+            }
+            float floatContent => {
+                text = <string>floatContent;
+            }
+            byte[] byteArrayContent => {
+                text = internal:byteArrayToString(byteArrayContent, "UTF-8");
+            }
+            string textContent => {
+                text = textContent;
+            }
+            xml xmlContent => {
+                text = <string>xmlContent;
+            }
+            json jsonContent => {
+                text = jsonContent.toString();
+            }
+        }
+        return externPushText(text, final);
+    }
 
+    extern function externPushText(string text, boolean final) returns error?;
     documentation {
         Push binary data to the connection.
 

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -132,7 +132,7 @@ public class WebSocketDispatcher {
             Executor.submit(onTextMessageResource, new WebSocketResourceCallableUnitCallback(webSocketConnection),
                             null, null, bValues);
         } else if (dataTypeTag == TypeTags.JSON_TAG || dataTypeTag == TypeTags.RECORD_TYPE_TAG ||
-                dataTypeTag == TypeTags.XML_TAG) {
+                dataTypeTag == TypeTags.XML_TAG || dataTypeTag == TypeTags.ARRAY_TAG) {
             if (finalFragment) {
                 aggregateString += textMessage.getText();
                 dispatchReourceWithAggregatedData(webSocketConnection, onTextMessageResource, bValues, dataType);
@@ -173,6 +173,7 @@ public class WebSocketDispatcher {
                         bValues[1] = new BByteArray(
                                 aggregateString.getBytes(Charset.forName(MimeConstants.UTF_8)));
                     } else {
+                        //Cannot reach here because of compiler validation
                         throw new BallerinaException("Incompatible Element type found inside an array " +
                                                              ((BArrayType) dataType).getElementType()
                                                                      .getName());

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -25,17 +25,28 @@ import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.Executor;
 import org.ballerinalang.connector.api.ParamDetail;
 import org.ballerinalang.connector.api.Resource;
+import org.ballerinalang.mime.util.MimeConstants;
+import org.ballerinalang.model.types.BArrayType;
+import org.ballerinalang.model.types.BStructureType;
+import org.ballerinalang.model.types.BType;
+import org.ballerinalang.model.types.TypeTags;
+import org.ballerinalang.model.util.JSONUtils;
+import org.ballerinalang.model.util.JsonParser;
+import org.ballerinalang.model.util.XMLNodeType;
+import org.ballerinalang.model.util.XMLUtils;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.model.values.BXML;
 import org.ballerinalang.services.ErrorHandlerUtils;
 import org.ballerinalang.util.BLangConstants;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.codegen.StructureTypeInfo;
+import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;
@@ -48,6 +59,7 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketTextMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +73,7 @@ import java.util.Map;
 public class WebSocketDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketDispatcher.class);
+    private static String aggregateString = "";
 
     private WebSocketDispatcher() {
     }
@@ -108,12 +121,75 @@ public class WebSocketDispatcher {
         List<ParamDetail> paramDetails = onTextMessageResource.getParamDetails();
         BValue[] bValues = new BValue[paramDetails.size()];
         bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = new BString(textMessage.getText());
-        if (paramDetails.size() == 3) {
-            bValues[2] = new BBoolean(textMessage.isFinalFragment());
+        boolean finalFragment = textMessage.isFinalFragment();
+        BType dataType = paramDetails.get(1).getVarType();
+        int dataTypeTag = dataType.getTag();
+        if (dataTypeTag == TypeTags.STRING_TAG) {
+            bValues[1] = new BString(textMessage.getText());
+            if (paramDetails.size() == 3) {
+                bValues[2] = new BBoolean(textMessage.isFinalFragment());
+            }
+            Executor.submit(onTextMessageResource, new WebSocketResourceCallableUnitCallback(webSocketConnection),
+                            null, null, bValues);
+        } else if (dataTypeTag == TypeTags.JSON_TAG || dataTypeTag == TypeTags.RECORD_TYPE_TAG ||
+                dataTypeTag == TypeTags.XML_TAG) {
+            if (finalFragment) {
+                aggregateString += textMessage.getText();
+                dispatchReourceWithAggregatedData(webSocketConnection, onTextMessageResource, bValues, dataType);
+                aggregateString = "";
+            } else {
+                aggregateString += textMessage.getText();
+                webSocketConnection.readNextFrame();
+            }
+
+        } else {
+            //Throw an exception because a different type is invalid.
+            //Cannot reach here because of compiler plugin validation.
+            throw new BallerinaConnectorException("Invalid resource signature.");
         }
-        Executor.submit(onTextMessageResource, new WebSocketResourceCallableUnitCallback(webSocketConnection), null,
-                        null, bValues);
+    }
+
+    private static void dispatchReourceWithAggregatedData(WebSocketConnection webSocketConnection,
+                                                          Resource onTextMessageResource, BValue[] bValues,
+                                                          BType dataType) {
+        try {
+            switch (dataType.getTag()) {
+                case TypeTags.JSON_TAG:
+                    bValues[1] = JsonParser.parse(aggregateString);
+                    break;
+                case TypeTags.XML_TAG:
+                    BXML bxml = XMLUtils.parse(aggregateString);
+                    if (bxml.getNodeType() != XMLNodeType.ELEMENT) {
+                        throw new BallerinaException("Invalid XML data");
+                    }
+                    bValues[1] = bxml;
+                    break;
+                case TypeTags.RECORD_TYPE_TAG:
+                    bValues[1] = JSONUtils.convertJSONToStruct(JsonParser.parse(aggregateString),
+                                                               (BStructureType) dataType);
+                    break;
+                case TypeTags.ARRAY_TAG:
+                    if (((BArrayType) dataType).getElementType().getTag() == TypeTags.BYTE_TAG) {
+                        bValues[1] = new BByteArray(
+                                aggregateString.getBytes(Charset.forName(MimeConstants.UTF_8)));
+                    } else {
+                        throw new BallerinaException("Incompatible Element type found inside an array " +
+                                                             ((BArrayType) dataType).getElementType()
+                                                                     .getName());
+                    }
+                    break;
+                default:
+                    //Throw an exception because a different type is invalid.
+                    //Cannot reach here because of compiler plugin validation.
+                    throw new BallerinaConnectorException("Invalid resource signature.");
+
+            }
+            Executor.submit(onTextMessageResource,
+                            new WebSocketResourceCallableUnitCallback(webSocketConnection),
+                            null, null, bValues);
+        } catch (BallerinaException ex) {
+            webSocketConnection.terminateConnection(1003, ex.getMessage());
+        }
     }
 
     static void dispatchBinaryMessage(WebSocketOpenConnectionInfo connectionInfo,

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/PushText.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/PushText.java
@@ -36,7 +36,7 @@ import org.ballerinalang.net.http.WebSocketUtil;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "http",
-        functionName = "pushText",
+        functionName = "externPushText",
         receiver = @Receiver(type = TypeKind.OBJECT, structType = WebSocketConstants.WEBSOCKET_CONNECTOR,
                              structPackage = "ballerina/http"),
         args = {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/compiler/WebSocketResourceValidator.java
@@ -94,19 +94,17 @@ public class WebSocketResourceValidator {
         int secondParamTypeTag = secondParamType.tag;
         if (secondParamTypeTag != TypeTags.STRING && secondParamTypeTag != TypeTags.JSON &&
                 secondParamTypeTag != TypeTags.XML && secondParamTypeTag != TypeTags.RECORD &&
-                (secondParamTypeTag != TypeTags.ARRAY || ((BArrayType) secondParamType).getElementType().tag !=
-                        org.ballerinalang.model.types.TypeTags.BYTE_TAG)) {
+                (secondParamTypeTag != TypeTags.ARRAY || (secondParamType instanceof BArrayType &&
+                        ((BArrayType) secondParamType).getElementType().tag !=
+                                org.ballerinalang.model.types.TypeTags.BYTE_TAG))) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, INVALID_RESOURCE_SIGNATURE_FOR
                     + resource.getName().getValue() + RESOURCE_IN_SERVICE + serviceName +
                     ": The second parameter should be a string, json, xml, byte[] or a record type");
-        }
-
-        if (paramDetails.size() == 3) {
-
+        } else if (paramDetails.size() == 3) {
             if (!"string".equals(secondParamType.toString())) {
                 dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, INVALID_RESOURCE_SIGNATURE_FOR
                         + resource.getName().getValue() + RESOURCE_IN_SERVICE + serviceName +
-                        ": Final fragment is not valid if the second parameter is a string");
+                        ": Final fragment is not valid if the second parameter is not a string");
             } else if (!"boolean".equals(paramDetails.get(2).type.toString())) {
                 dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, INVALID_RESOURCE_SIGNATURE_FOR
                         + resource.getName().getValue() + RESOURCE_IN_SERVICE + serviceName +
@@ -149,12 +147,12 @@ public class WebSocketResourceValidator {
         List<BLangVariable> paramDetails = resource.getParameters();
         validateParamDetailsSize(paramDetails, 3, serviceName, resource, dlog);
         validateEndpointParameter(serviceName, resource, dlog, paramDetails, isClient);
-        if (paramDetails.size() < 2 || !"int".equals(paramDetails.get(1).type.toString())) {
+        if (paramDetails.size() < 2 || TypeTags.INT != paramDetails.get(1).type.tag) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, INVALID_RESOURCE_SIGNATURE_FOR +
                     resource.getName().getValue() + RESOURCE_IN_SERVICE + serviceName +
                     ": The second parameter should be an int");
         }
-        if (paramDetails.size() < 3 || !"string".equals(paramDetails.get(2).type.toString())) {
+        if (paramDetails.size() < 3 || TypeTags.STRING != paramDetails.get(2).type.tag) {
             dlog.logDiagnostic(Diagnostic.Kind.ERROR, resource.pos, INVALID_RESOURCE_SIGNATURE_FOR
                     + resource.getName().getValue() + RESOURCE_IN_SERVICE + serviceName +
                     ": The third parameter should be a string");

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CancelWebSocketUpgradeTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CancelWebSocketUpgradeTest.java
@@ -30,7 +30,7 @@ import java.net.URISyntaxException;
 /**
  * This Class tests the cancelWebSocketUpgrade method of the http connector.
  */
-public class CancelWebSocketUpgradeTest extends WebSocketIntegrationTest {
+public class CancelWebSocketUpgradeTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
 

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientInitializationFailureTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientInitializationFailureTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test whether resource failure during client initialization causes a close frame to be sent.
  */
-public class ClientInitializationFailureTest extends WebSocketIntegrationTest {
+public class ClientInitializationFailureTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/client/failure";

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This Class tests receiving and sending of custom headers by Ballerina WebSocket client.
  */
-public class CustomHeaderClientSupportTest extends WebSocketIntegrationTest {
+public class CustomHeaderClientSupportTest extends WebSocketTestCommons {
 
     private WebSocketRemoteServer remoteServer;
     private WebSocketTestClient client;

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderServerSupportTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderServerSupportTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This Class tests receiving and sending of custom headers by Ballerina WebSocket server.
  */
-public class CustomHeaderServerSupportTest extends WebSocketIntegrationTest {
+public class CustomHeaderServerSupportTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/simple/custom/header/server";

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test whether the errors are received correctly to the onError resource in WebSocket server.
  */
-public class OnErrorWebSocketTest extends WebSocketIntegrationTest {
+public class OnErrorWebSocketTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/error/ws";

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This Class tests ping pong support of WebSocket client and server.
  */
-public class PingPongSupportTestCase extends WebSocketIntegrationTest {
+public class PingPongSupportTestCase extends WebSocketTestCommons {
 
     private WebSocketRemoteServer remoteServer;
     private WebSocketTestClient client;

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ResourceFailureTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ResourceFailureTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test whether resource failure causes a close frame to be sent.
  */
-public class ResourceFailureTest extends WebSocketIntegrationTest {
+public class ResourceFailureTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/simple?q1=name";

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/UpgradeResourceFailureTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/UpgradeResourceFailureTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test whether upgrade resource failure after handshake causes a close frame to be sent.
  */
-public class UpgradeResourceFailureTest extends WebSocketIntegrationTest {
+public class UpgradeResourceFailureTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/simple";

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketAutoPingPongTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketAutoPingPongTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This Class tests auto ping pong support of WebSocket client server if there's no onPing resource.
  */
-public class WebSocketAutoPingPongTest extends WebSocketIntegrationTest {
+public class WebSocketAutoPingPongTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
     private static final String URL = "ws://localhost:9090/test/without/ping/resource";

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketContinuationAndAggregationTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketContinuationAndAggregationTest.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.service.websocket;
+
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test WebSocket continuation frames and the aggregation of fragments when the content is other than a string.
+ */
+public class WebSocketContinuationAndAggregationTest extends WebSocketTestCommons {
+
+    @BeforeClass(description = "Initializes Ballerina")
+    public void setup() throws BallerinaTestException {
+        initBallerinaServer("push_and_onText.bal");
+    }
+
+    @Test(description = "Tests string support for pushText and onText")
+    public void testString() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9090/onTextString";
+        WebSocketTestClient client = new WebSocketTestClient(url);
+        client.handshake();
+        String msg = "Hello";
+        assertSuccess(client, msg, msg);
+        client.shutDown();
+    }
+
+    @Test(description = "Tests JSON support for pushText and onText")
+    public void testJson() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9091/onTextJSON";
+        WebSocketTestClient client = new WebSocketTestClient(url);
+        client.handshake();
+        assertSuccess(client, "{'id':1234, 'name':'Riyafa'}", "{\"id\":1234, \"name\":\"Riyafa\"}");
+        assertFailure(client, "{'id':1234, 'name':'Riyafa'", "expected , or } at line: 1 column: 29");
+        client.shutDown();
+    }
+
+    @Test(description = "Tests string support for pushText and onText")
+    public void testXml() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9092/onTextXML";
+        WebSocketTestClient client = new WebSocketTestClient(url);
+        client.handshake();
+        String msg = "<note><to>Tove</to></note>";
+        assertSuccess(client, msg, msg);
+        assertFailure(client, "<note><to>Tove</to>",
+                      "ParseError at [row,col]:[1,28]\nMessage: The element type \"note\"" +
+                              " must be terminated by the matching end-tag \"</note>\".");
+        client.shutDown();
+    }
+
+    @Test(description = "Tests string support for pushText and onText")
+    public void testRecord() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9093/onTextRecord";
+        WebSocketTestClient client = new WebSocketTestClient(url);
+        client.handshake();
+        assertSuccess(client, "{'id':1234, 'name':'Riyafa'}", "{\"id\":1234, \"name\":\"Riyafa\"}");
+        client.shutDown();
+    }
+
+    private void assertSuccess(WebSocketTestClient client, String msg, String expectedMsg)
+            throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        client.sendText(msg);
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        Assert.assertEquals(client.getTextReceived(), expectedMsg, "Invalid message received");
+    }
+
+    private void assertFailure(WebSocketTestClient client, String msg, String expected)
+            throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        client.sendText(msg);
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        CloseWebSocketFrame closeFrame = client.getReceivedCloseFrame();
+        Assert.assertEquals(closeFrame.statusCode(), 1003, "Invalid status code");
+        Assert.assertEquals(closeFrame.reasonText(), expected, "Invalid close reason");
+    }
+
+    @AfterClass(description = "Stops Ballerina")
+    public void cleanup() throws BallerinaTestException {
+        stopBallerinaServerInstance();
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketPushAndOnTextResourceTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketPushAndOnTextResourceTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.service.websocket;
+
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test WebSocket endpoint method pushText and the onText resource.
+ */
+public class WebSocketPushAndOnTextResourceTest extends WebSocketTestCommons {
+
+    private WebSocketTestClient client;
+
+    @BeforeClass(description = "Initializes Ballerina")
+    public void setup() throws BallerinaTestException {
+        initBallerinaServer("push_and_onText.bal");
+    }
+
+    @Test(description = "Tests string support for pushText and onText")
+    public void testString() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9090/onTextString";
+        client = new WebSocketTestClient(url);
+        client.handshake();
+        String msg = "Hello";
+        assertSuccess(msg, msg);
+        client.shutDown();
+    }
+
+    @Test(description = "Tests JSON support for pushText and onText")
+    public void testJson() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9091/onTextJSON";
+        testJsonAndRecord(url);
+    }
+
+    @Test(description = "Tests XML support for pushText and onText")
+    public void testXml() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9092/onTextXML";
+        client = new WebSocketTestClient(url);
+        client.handshake();
+        String msg = "<note><to>Tove</to></note>";
+        assertSuccess(msg, msg);
+        assertContinuationSuccess(msg, "<note>", "<to>Tove", "</to>", "</note>");
+        assertFailure("<note><to>Tove</to>",
+                      "ParseError at [row,col]:[1,28]\nMessage: The element type \"note\"" +
+                              " must be terminated by the matching end-tag \"</note>\".");
+        client.shutDown();
+    }
+
+    @Test(description = "Tests Record support for pushText and onText")
+    public void testRecord() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9093/onTextRecord";
+        testJsonAndRecord(url);
+    }
+
+    @Test(description = "Tests byte array support for pushText and onText")
+    public void testByteArray() throws URISyntaxException, InterruptedException {
+        String url = "http://localhost:9094/onTextByteArray";
+        client = new WebSocketTestClient(url);
+        client.handshake();
+        String msg = "Hello";
+        assertSuccess(msg, msg);
+        assertContinuationSuccess(msg, "Hel", "lo");
+        client.shutDown();
+    }
+
+    private void testJsonAndRecord(String url) throws URISyntaxException, InterruptedException {
+        client = new WebSocketTestClient(url);
+        client.handshake();
+        String expectedMsg = "{\"id\":1234, \"name\":\"Riyafa\"}";
+        assertSuccess("{'id':1234, 'name':'Riyafa'}", expectedMsg);
+        assertContinuationSuccess(expectedMsg, "{'id':1234, ", "'name':'Riyafa'}");
+        assertFailure("{'id':1234, 'name':'Riyafa'", "expected , or } at line: 1 column: 29");
+        client.shutDown();
+    }
+
+    private void assertSuccess(String msg, String expectedMsg)
+            throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        client.sendText(msg);
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        Assert.assertEquals(client.getTextReceived(), expectedMsg, "Invalid message received");
+    }
+
+    private void assertFailure(String msg, String expected)
+            throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        client.sendText(msg);
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        CloseWebSocketFrame closeFrame = client.getReceivedCloseFrame();
+        Assert.assertEquals(closeFrame.statusCode(), 1003, "Invalid status code");
+        Assert.assertEquals(closeFrame.reasonText(), expected, "Invalid close reason");
+    }
+
+    private void assertContinuationSuccess(String expectedMsg, String... msg)
+            throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        client.setCountDownLatch(countDownLatch);
+        for (int i = 0; i < msg.length - 1; i++) {
+            client.sendText(msg[i], false);
+        }
+        client.sendText(msg[msg.length - 1], true);
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+        Assert.assertEquals(client.getTextReceived(), expectedMsg, "Invalid message received");
+    }
+
+    @AfterClass(description = "Stops Ballerina")
+    public void cleanup() throws BallerinaTestException {
+        stopBallerinaServerInstance();
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketQueryAndPathParamSupportTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketQueryAndPathParamSupportTestCase.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test WebSocket Path and Query Parameters.
  */
-public class WebSocketQueryAndPathParamSupportTestCase extends WebSocketIntegrationTest {
+public class WebSocketQueryAndPathParamSupportTestCase extends WebSocketTestCommons {
 
     @BeforeClass(description = "Initializes Ballerina")
     public void setup() throws BallerinaTestException {

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketServiceNotFoundTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketServiceNotFoundTest.java
@@ -30,7 +30,7 @@ import java.net.URISyntaxException;
 /**
  * This Class tests the not finding a service/resource to handle a webSocket request.
  */
-public class WebSocketServiceNotFoundTest extends WebSocketIntegrationTest {
+public class WebSocketServiceNotFoundTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
 

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
@@ -26,7 +26,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
@@ -35,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test case to test simple WebSocket pass through scenarios.
  */
-public class WebSocketSimpleProxyTestCase extends WebSocketIntegrationTest {
+public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
 
     private WebSocketRemoteServer remoteServer;
     private static final String URL = "ws://localhost:9090/proxy/ws";
@@ -61,7 +60,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketIntegrationTest {
     }
 
     @Test(priority = 2, description = "Tests sending and receiving of binary frames in WebSockets")
-    public void testSendBinary() throws URISyntaxException, InterruptedException, IOException {
+    public void testSendBinary() throws URISyntaxException, InterruptedException {
         WebSocketTestClient client = new WebSocketTestClient(URL);
         client.handshake();
         CountDownLatch countDownLatch = new CountDownLatch(1);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Facilitate the common functionality of WebSocket integration tests.
  */
-public class WebSocketIntegrationTest {
+public class WebSocketTestCommons {
     private ServerInstance ballerinaServerInstance;
     protected static final int TIMEOUT_IN_SECS = 10;
     protected static final int REMOTE_SERVER_PORT = 15500;

--- a/tests/ballerina-integration-test/src/test/resources/websocket/push_and_onText.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/push_and_onText.bal
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+import ballerina/log;
+
+service<http:WebSocketService> onTextString bind { port: 9090 } {
+
+    onText(endpoint wsEp, string data, boolean final) {
+        _ = wsEp->pushText(data);
+    }
+}
+
+service<http:WebSocketService> onTextJSON bind { port: 9091 } {
+
+    onText(endpoint wsEp, json data) {
+        io:println(data);
+        _ = wsEp->pushText(data);
+    }
+}
+
+service<http:WebSocketService> onTextXML bind { port: 9092 } {
+
+    onText(endpoint wsEp, xml data) {
+        _ = wsEp->pushText(data);
+    }
+}
+type Person record {
+    int id,
+    string name,
+    !...
+};
+service<http:WebSocketService> onTextRecord bind { port: 9093 } {
+
+    onText(endpoint wsEp, Person data) {
+        _ = wsEp->pushText(check <json>data);
+    }
+}
+
+service<http:WebSocketService> onTextByteArray bind { port: 9094 } {
+
+    onText(endpoint wsEp, byte[] data) {
+        _ = wsEp->pushText(data);
+    }
+}

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/net/websocket/compilation/WebSocketCompilationTest.java
@@ -28,8 +28,8 @@ import org.testng.annotations.Test;
  * Test WebSocket Service Compilation.
  */
 public class WebSocketCompilationTest {
-    @Test(description = "Successfully compiling WebSocket service")
-    public void testSuccess() {
+    @Test(description = "Successfully compiling WebSocketService")
+    public void testSuccessServer() {
         CompileResult compileResult = BCompileUtil.compileAndSetup(
                 "test-src/net/websocket/compilation/success.bal");
 
@@ -74,13 +74,24 @@ public class WebSocketCompilationTest {
                 "wsService: Unexpected parameter count", 30, 5);
     }
 
-    @Test(description = "Invalid signature for onText resource")
-    public void testFailOnText() {
+    @Test(description = "Invalid signature for onText resource with int")
+    public void testFailOnTextInt() {
         CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onText.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
-        BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onText resource in service " +
-                "wsService: The second parameter should be a string", 30, 5);
+        BAssertUtil.validateError(compileResult, 0,
+                                  "Invalid resource signature for onText resource in service wsService: The second " +
+                                          "parameter should be a string, json, xml, byte[] or a record type", 21, 5);
+    }
+
+    @Test(description = "Invalid signature for onText resource with JSON and final fragment")
+    public void testFailOnTextJSON() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/net/websocket/compilation/fail_onText_JSON.bal");
+
+        assertExpectedDiagnosticsLength(compileResult, 1);
+        BAssertUtil.validateError(compileResult, 0,
+                                  "Invalid resource signature for onText resource in service wsService: Final " +
+                                          "fragment is not valid if the second parameter is not a string", 21, 5);
     }
 
     @Test(description = "Invalid signature for onBinary resource")

--- a/tests/ballerina-unit-test/src/test/resources/test-src/net/websocket/compilation/fail_onText_JSON.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/net/websocket/compilation/fail_onText_JSON.bal
@@ -18,6 +18,6 @@ import ballerina/http;
 
 service<http:WebSocketService> wsService bind { port: 9090 } {
 
-    onText(endpoint caller, int text, boolean final) {
+    onText(endpoint caller, json text, boolean final) {
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/net/websocket/compilation/success.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/net/websocket/compilation/success.bal
@@ -29,7 +29,7 @@ service<http:WebSocketService> wsService bind wsCaller {
     onOpen(endpoint caller) {
     }
 
-    onText(endpoint caller, string text) {
+    onText(endpoint caller, string text, boolean final) {
     }
 
     onBinary(endpoint caller, byte[] data, boolean final) {
@@ -48,5 +48,36 @@ service<http:WebSocketService> wsService bind wsCaller {
     }
 
     onError(endpoint caller, error err) {
+    }
+}
+
+
+service<http:WebSocketService> onTextJSON bind wsCaller {
+
+    onText(endpoint caller, json data) {
+    }
+}
+
+service<http:WebSocketService> onTextXML bind wsCaller {
+
+    onText(endpoint caller, xml data) {
+    }
+}
+
+service<http:WebSocketService> onTextbyteArray bind wsCaller {
+
+    onText(endpoint caller, byte[] data) {
+    }
+}
+
+type Person record {
+    int id,
+    string name,
+    !...
+};
+
+service<http:WebSocketService> onTextRecord bind wsCaller {
+
+    onText(endpoint caller, Person data) {
     }
 }


### PR DESCRIPTION
## Purpose
> Update `pushText` to take a union type
> Improve `onText` resource signature
 >    The `onText` resource signature now takes a string, json, xml, byte[] or a record type as a parameter.