### PR TITLE
Disable pattern query test with AND operator

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/PatternTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/PatternTest.java
@@ -61,7 +61,7 @@ public class PatternTest {
         Assert.assertEquals(tempDifference.get("userAction").stringValue(), "stop");
     }
 
-    @Test(description = "Test pattern streaming query with 'And'")
+    @Test(enabled = false, description = "Test pattern streaming query with 'And'")
     public void testPatternQuery3() {
         BValue[] roomActions = BRunUtil.invoke(result, "runPatternQuery3");
 


### PR DESCRIPTION
## Purpose
Purpose of this PR is to temporarily disable the pattern query test with `AND` operator, to get rid of the intermittent test fails.