### PR TITLE
Fix hidden context menu on code split view

### DIFF
--- a/composer/modules/web/scss/modules/ballerina-editor.scss
+++ b/composer/modules/web/scss/modules/ballerina-editor.scss
@@ -448,10 +448,6 @@ h6,
     display: none;
 }
 
-.SplitPane .vertical {
-    overflow: hidden;
-}
-
 .swagger-container .SplitPane .Pane2 {
     overflow: scroll;
     padding-bottom: 40px;


### PR DESCRIPTION
## Purpose
> This PR will fix the #9817 issue where the context menu is hidden when triggered on the split view, while the mouse curser is near the design view. Which will cause the context menu to be hidden under the design view pane.
