### PR TITLE
 Fix version compatibility error when building with older packages having incompatible versions in cache

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
@@ -1,8 +1,14 @@
 package org.wso2.ballerinalang.compiler.packaging.converters;
 
 import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
+import org.wso2.ballerinalang.programfile.ProgramFileConstants;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystemAlreadyExistsException;
@@ -10,8 +16,13 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provide functions to convert a patten to a stream of zip paths.
@@ -58,5 +69,65 @@ public class ZipConverter extends PathConverter {
         } catch (IOException e) {
             throw new BLangCompilerException("Error loading balo " + uri.getPath(), e);
         }
+    }
+
+    @Override
+    public Stream<Path> latest(Path path, PackageID packageID) {
+        if (Files.isDirectory(path)) {
+            try {
+                List<Path> pathList = new ArrayList<>();
+                if (packageID != null) {
+                    String pkgName = packageID.getName().getValue();
+                    pathList = Files.list(path)
+                                    .map(SortablePath::new)
+                                    .filter(SortablePath::valid)
+                                    .filter(sortablePath -> validBaloPath(pkgName, sortablePath))
+                                    .sorted(Comparator.reverseOrder())
+                                    .limit(1)
+                                    .map(SortablePath::getPath)
+                                    .collect(Collectors.toList());
+                    if (packageID.version.value.isEmpty() && !packageID.orgName.equals(Names.BUILTIN_ORG)
+                            && !packageID.orgName.equals(Names.ANON_ORG) && pathList.size() > 0) {
+                        packageID.version = new Name(pathList.get(0).toFile().getName());
+                    }
+                }
+                return pathList.stream();
+            } catch (IOException ignore) {
+            }
+        }
+        return Stream.of();
+    }
+
+    /**
+     * Validates the package with compiler version.
+     *
+     * @param pkgName      package name
+     * @param sortablePath sortable path
+     * @return if the package is compatible with the compiler version
+     */
+    private boolean validBaloPath(String pkgName, SortablePath sortablePath) {
+        Path zipPath = resolveIntoArchive(sortablePath.getPath()
+                                                      .resolve(pkgName + ProjectDirConstants.BLANG_COMPILED_PKG_EXT));
+        return filterByBaloVersion(zipPath.resolve(ProjectDirConstants.USER_REPO_OBJ_DIRNAME)
+                                          .resolve(pkgName + ProjectDirConstants.BLANG_COMPILED_PKG_BINARY_EXT));
+    }
+
+    /**
+     * Filter by balo version.
+     *
+     * @param path package path
+     * @return if the balo version of the package is compatible with compiler version
+     */
+    private boolean filterByBaloVersion(Path path) {
+        try (InputStream stream = Files.newInputStream(path)) {
+            byte[] data = new byte[6];
+            if (stream.read(data) != -1) {
+                short version = data[data.length - 1];
+                return (version >= ProgramFileConstants.MIN_SUPPORTED_VERSION) &&
+                        (version <= ProgramFileConstants.MAX_SUPPORTED_VERSION);
+            }
+        } catch (IOException ignore) {
+        }
+        return false;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -41,6 +41,7 @@ public class ProjectDirConstants {
     public static final String TEST_DIR_NAME = "tests";
     public static final String CACHES_DIR_NAME = "caches";
     public static final String BALLERINA_CENTRAL_DIR_NAME = "central.ballerina.io";
+    public static final String USER_REPO_OBJ_DIRNAME = "obj";
 
     public static final String HOME_REPO_ENV_KEY = "BALLERINA_HOME_DIR";
     public static final String HOME_REPO_DEFAULT_DIRNAME = ".ballerina";


### PR DESCRIPTION
## Purpose
> This PR will fix the balo version compatibility error given when building with older packages having incompatible versions in cache. If the balo version of the package in cache is incompatible with the compiler version, it should pull the latest package compatible with the compiler version from central.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
