### PR TITLE
Add scope information to local variables to show only the current scope variables in the debug hit message

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/LocalVariableInfo.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/LocalVariableInfo.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.ballerinalang.util.codegen;
 
 import org.ballerinalang.model.types.BType;
@@ -34,14 +34,20 @@ public class LocalVariableInfo {
     private int varTypeSigCPIndex;
     private BType varType;
 
+    private int scopeStartLineNumber;
+    private int scopeEndLineNumber;
+
     int[] attachmentIndexes = new int[0];
 
-    public LocalVariableInfo(String varName, int varNameCPIndex, int varIndex, int varTypeSigCPIndex, BType varType) {
+    public LocalVariableInfo(String varName, int varNameCPIndex, int varIndex, int varTypeSigCPIndex, BType varType,
+                             int scopeStartLineNumber, int scopeEndLineNumber) {
         this.varName = varName;
         this.varNameCPIndex = varNameCPIndex;
         this.varIndex = varIndex;
         this.varTypeSigCPIndex = varTypeSigCPIndex;
         this.varType = varType;
+        this.scopeStartLineNumber = scopeStartLineNumber;
+        this.scopeEndLineNumber = scopeEndLineNumber;
     }
 
     public int[] getAttachmentIndexes() {
@@ -67,8 +73,16 @@ public class LocalVariableInfo {
     public BType getVariableType() {
         return varType;
     }
-    
+
     public String getVariableName() {
         return varName;
+    }
+
+    public int getScopeStartLineNumber() {
+        return scopeStartLineNumber;
+    }
+
+    public int getScopeEndLineNumber() {
+        return scopeEndLineNumber;
     }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1075,12 +1075,14 @@ public class PackageInfoReader {
         int variableIndex = dataInStream.readInt();
 
         int typeSigCPIndex = dataInStream.readInt();
+        int scopeStartLineNumber = dataInStream.readInt();
+        int scopeEndLineNumber = dataInStream.readInt();
 
         UTF8CPEntry typeSigCPEntry = (UTF8CPEntry) constantPool.getCPEntry(typeSigCPIndex);
 
         BType type = getBTypeFromDescriptor(packageInfo, typeSigCPEntry.getValue());
         LocalVariableInfo localVariableInfo = new LocalVariableInfo(varNameCPEntry.getValue(), varNameCPIndex,
-                variableIndex, typeSigCPIndex, type);
+                variableIndex, typeSigCPIndex, type, scopeStartLineNumber, scopeEndLineNumber);
         int attchmntIndexesLength = dataInStream.readShort();
         int[] attachmentIndexes = new int[attchmntIndexesLength];
         for (int i = 0; i < attchmntIndexesLength; i++) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -411,7 +411,12 @@ public class Debugger {
                     variableDTO.setBValue(ctx.workerLocal.refRegs[l.getVariableIndex()]);
                     break;
             }
-            frameDTO.addVariable(variableDTO);
+
+            // Show only the variables within the current scope
+            if ((l.getScopeStartLineNumber() < callingLine.getLineNumber()) &&
+                    (callingLine.getLineNumber() <= l.getScopeEndLineNumber())) {
+                frameDTO.addVariable(variableDTO);
+            }
         });
         return message;
     }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 
 package org.ballerinalang.util.debugger.dto;
 
@@ -83,7 +83,7 @@ public class VariableDTO {
             bValueString = bValueString + bValue.stringValue();
         } else if (bValue.getType().getTag() == TypeTags.OBJECT) {
             bValueString = "Object " + bValue.getType().getName() + " ";
-            bValueString = bValueString + bValue.stringValue();
+            bValueString = bValueString + ((BMap) bValue).stringValueIgnoreAccessRestriction();
         } else {
             bValueString = "<Complex_Value>";
         }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
@@ -83,7 +83,7 @@ public class VariableDTO {
             bValueString = bValueString + bValue.stringValue();
         } else if (bValue.getType().getTag() == TypeTags.OBJECT) {
             bValueString = "Object " + bValue.getType().getName() + " ";
-            bValueString = bValueString + ((BMap) bValue).stringValueIgnoreAccessRestriction();
+            bValueString = bValueString + ((BMap) bValue).absoluteStringValue();
         } else {
             bValueString = "<Complex_Value>";
         }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
@@ -94,4 +94,27 @@ public class VariableDTO {
     public String toString() {
         return "(" + scope + ") " + name + " = " + value + " {" + type + "}";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        VariableDTO var = (VariableDTO) o;
+        return scope.equals(var.scope) && name.equals(var.name) && type.equals(var.type) &&
+                (value != null ? value.equals(var.value) : var.value == null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = scope.hashCode();
+        result = 31 * result + name.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
@@ -78,8 +78,11 @@ public class VariableDTO {
             BMap bmap = (BMap) bValue;
             bValueString = "Map[" + bmap.size() + "] ";
             bValueString = bValueString + bmap.stringValue();
-        } else if (bValue.getType().getTag() == TypeTags.RECORD || bValue.getType().getTag() == TypeTags.OBJECT) {
-            bValueString = "struct " + bValue.getType().getName() + " ";
+        } else if (bValue.getType().getTag() == TypeTags.RECORD) {
+            bValueString = "Record " + bValue.getType().getName() + " ";
+            bValueString = bValueString + bValue.stringValue();
+        } else if (bValue.getType().getTag() == TypeTags.OBJECT) {
+            bValueString = "Object " + bValue.getType().getName() + " ";
             bValueString = bValueString + bValue.stringValue();
         } else {
             bValueString = "<Complex_Value>";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -895,7 +895,9 @@ public class CompiledPackageSymbolEnter {
         String varName = getUTF8CPEntryValue(dataInStream);
         // read variable index
         dataInStream.readInt();
-        getUTF8CPEntryValue(dataInStream);
+        dataInStream.readInt();
+        dataInStream.readInt();
+        dataInStream.readInt();
 
         int attchmntIndexesLength = dataInStream.readShort();
         for (int i = 0; i < attchmntIndexesLength; i++) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -3712,15 +3712,15 @@ public class CodeGenerator extends BLangNodeVisitor {
     private void setVariableScopeEnd(LocalVariableInfo localVarInfo, BLangVariable varNode) {
         if ((varNode.parent == null) && (varNode.pos != null)) {
             localVarInfo.scopeEndLineNumber = varNode.pos.eLine;
-        } else {
-            BLangNode parentNode = varNode;
-            while ((parentNode.parent != null)) {
-                parentNode = parentNode.parent;
-                if ((parentNode.getKind().equals(NodeKind.BLOCK)) && (parentNode.parent != null) &&
-                        (parentNode.parent.pos != null)) {
-                    localVarInfo.scopeEndLineNumber = parentNode.parent.pos.eLine;
-                    break;
-                }
+            return;
+        }
+        BLangNode parentNode = varNode;
+        while ((parentNode.parent != null)) {
+            parentNode = parentNode.parent;
+            if ((parentNode.getKind().equals(NodeKind.BLOCK)) && (parentNode.parent != null) &&
+                    (parentNode.parent.pos != null)) {
+                localVarInfo.scopeEndLineNumber = parentNode.parent.pos.eLine;
+                break;
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1622,7 +1622,7 @@ public class CodeGenerator extends BLangNodeVisitor {
         // Add local variable indexes to the parameters and return parameters
         visitInvokableNodeParams(invokableNode.symbol, callableUnitInfo, localVarAttributeInfo);
 
-        if(invokableNode.pos != null) {
+        if (invokableNode.pos != null) {
             localVarAttributeInfo.localVars.forEach(param -> {
                 param.scopeStartLineNumber = invokableNode.pos.sLine;
                 param.scopeEndLineNumber = invokableNode.pos.eLine;
@@ -2894,7 +2894,7 @@ public class CodeGenerator extends BLangNodeVisitor {
         generateFinallyInstructions(abortNode, NodeKind.TRANSACTION);
         this.emit(abortInstructions.peek());
     }
-    
+
     public void visit(BLangDone doneNode) {
         generateFinallyInstructions(doneNode, NodeKind.DONE);
         this.emit(InstructionCodes.HALT);
@@ -3570,11 +3570,11 @@ public class CodeGenerator extends BLangNodeVisitor {
         paramAttrInfo.defaultableParamsCount = invokableNode.defaultableParams.size();
         paramAttrInfo.restParamCount = invokableNode.restParam != null ? 1 : 0;
         callableUnitInfo.addAttributeInfo(AttributeInfo.Kind.PARAMETERS_ATTRIBUTE, paramAttrInfo);
-        
+
         // Add parameter default values
         addParameterDefaultValues(invokableNode, callableUnitInfo);
     }
-    
+
     private void addParameterDefaultValues(BLangInvokableNode invokableNode, CallableUnitInfo callableUnitInfo) {
         int paramDefaultsAttrNameIndex =
                 addUTF8CPEntry(currentPkgInfo, AttributeInfo.Kind.PARAMETER_DEFAULTS_ATTRIBUTE.value());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/LocalVariableInfo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/LocalVariableInfo.java
@@ -30,6 +30,9 @@ public class LocalVariableInfo {
 
     public int[] attachmentIndexes = new int[0];
 
+    public int scopeStartLineNumber;
+    public int scopeEndLineNumber;
+
     public LocalVariableInfo(int varNameCPIndex, int varTypeSigCPIndex, int varIndex) {
         this.varNameCPIndex = varNameCPIndex;
         this.varTypeSigCPIndex = varTypeSigCPIndex;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/PackageInfoWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/PackageInfoWriter.java
@@ -631,6 +631,9 @@ public class PackageInfoWriter {
         dataOutStream.writeInt(localVariableInfo.varIndex);
         dataOutStream.writeInt(localVariableInfo.varTypeSigCPIndex);
 
+        dataOutStream.writeInt(localVariableInfo.scopeStartLineNumber);
+        dataOutStream.writeInt(localVariableInfo.scopeEndLineNumber);
+
         int[] attachmentsIndexes = localVariableInfo.attachmentIndexes;
         dataOutStream.writeShort(attachmentsIndexes.length);
         for (int attachmentIndex : attachmentsIndexes) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -1,31 +1,34 @@
 /*
-*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.debugger;
 
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BByte;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.test.utils.debug.DebugPoint;
 import org.ballerinalang.test.utils.debug.ExpectedResults;
 import org.ballerinalang.test.utils.debug.Util;
 import org.ballerinalang.test.utils.debug.VMDebuggerUtil;
 import org.ballerinalang.util.debugger.Debugger;
 import org.ballerinalang.util.debugger.dto.BreakPointDTO;
-import org.ballerinalang.util.debugger.dto.MessageDTO;
 import org.ballerinalang.util.debugger.dto.VariableDTO;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -74,7 +77,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 43, RESUME, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 7);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 7, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
@@ -85,7 +88,7 @@ public class VMDebuggerTest {
 
         List<DebugPoint> debugPoints = new ArrayList<>();
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 0);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 0, 0, new ArrayList<>(), false);
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
 
@@ -94,29 +97,29 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".", FILE, 5, 8, 41);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 12, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 15, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 16, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 20, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME,  1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 12, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 15, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 16, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 20, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 25, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN,  1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN,  1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 21);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 21, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
@@ -130,7 +133,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 3);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 3, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
@@ -147,7 +150,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 10, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 6);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 6, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
@@ -166,7 +169,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 41, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 8);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 8, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
@@ -181,7 +184,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 20, RESUME, 4));
         debugPoints.add(Util.createDebugPoint(".", FILE, 22, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 11);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 11, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
@@ -194,7 +197,11 @@ public class VMDebuggerTest {
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", "while-statement.bal", 5, RESUME, 5));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 5);
+        List<VariableDTO> variables = new ArrayList<>();
+        variables.add(Util.createVariable("i", "Local", new BInteger(4)));
+        variables.add(Util.createVariable("args", "Local", new BStringArray(new String[]{"Hello", "World"})));
+
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 5, 0, variables, true);
 
         VMDebuggerUtil.startDebug("test-src/debugger/while-statement.bal", breakPoints, expRes);
     }
@@ -204,7 +211,7 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".",
                 "try-catch-finally.bal", 19);
 
-        String file  = "try-catch-finally.bal";
+        String file = "try-catch-finally.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", file, 19, STEP_IN, 1));
@@ -224,7 +231,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 58, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 60, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 16);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 16, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/try-catch-finally.bal", breakPoints, expRes);
     }
@@ -234,7 +241,7 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".",
                 "test-worker.bal", 3, 9, 10, 18, 19, 23, 48);
 
-        String file  = "test-worker.bal";
+        String file = "test-worker.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", file, 3, RESUME, 1));
@@ -249,7 +256,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 48, RESUME, 5));
         debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 15);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 15, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-worker.bal", breakPoints, expRes);
     }
@@ -259,7 +266,7 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".",
                 "test-package-init.bal", 3, 9);
 
-        String file  = "test-package-init.bal";
+        String file = "test-package-init.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_OVER, 1));
@@ -278,7 +285,13 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 15);
+        List<VariableDTO> variables = new ArrayList<>();
+        variables.add(Util.createVariable("val1", "Global", new BInteger(60)));
+        variables.add(Util.createVariable("val2", "Global", new BInteger(20)));
+        variables.add(Util.createVariable("cal", "Local", new BInteger(80)));
+        variables.add(Util.createVariable("args", "Local", new BStringArray(new String[]{"Hello", "World"})));
+
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 15, 2, variables, true);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test-package-init.bal", breakPoints, expRes);
     }
@@ -288,7 +301,7 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".",
                 "test_object_and_match.bal", 3, 48, 66, 54);
 
-        String file  = "test_object_and_match.bal";
+        String file = "test_object_and_match.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_IN, 1));
@@ -329,7 +342,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 67, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 37);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 37, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test_object_and_match.bal", breakPoints, expRes);
     }
@@ -337,38 +350,42 @@ public class VMDebuggerTest {
     @Test(description = "Testing global variables availability in debug hit message")
     public void testGlobalVarAvailability() {
         String file = "test_variables.bal";
-        BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".", file, 12);
+        BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".", file, 10);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 11, RESUME, 1));
 
-        VMDebuggerUtil.getDebugHits().clear();
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 2);
+        List<VariableDTO> variables = new ArrayList<>();
+        variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));
+        variables.add(Util.createVariable("gStr", "Global", new BString("str")));
+        variables.add(Util.createVariable("gBool", "Global", new BBoolean(true)));
+        variables.add(Util.createVariable("gByte", "Global", new BByte((byte) 255)));
+
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 2, 4, variables, false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
+    }
 
-        ArrayList<MessageDTO> debugHitMsgs = VMDebuggerUtil.getDebugHits();
+    @Test(description = "Testing local variables scopes")
+    public void testLocalVarScope() {
+        String file = "test_variables.bal";
+        BreakPointDTO[] breakPoints = Util.createBreakNodeLocations(".", file, 9);
 
-        List<VariableDTO> variables = debugHitMsgs.get(0).getFrames().get(0).getVariables();
-        List<VariableDTO> globalVariables = new ArrayList<>();
+        List<DebugPoint> debugPoints = new ArrayList<>();
+        debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1));
 
-        for (VariableDTO var : variables) {
-            if (var.getScope().equals("Global")) {
-                globalVariables.add(var);
-            }
-        }
-        Assert.assertEquals(globalVariables.size(), 8);
+        List<VariableDTO> variables = new ArrayList<>();
+        variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));
+        variables.add(Util.createVariable("gStr", "Global", new BString("str")));
+        variables.add(Util.createVariable("gBool", "Global", new BBoolean(true)));
+        variables.add(Util.createVariable("gByte", "Global", new BByte((byte) 255)));
+        variables.add(Util.createVariable("args", "Local", new BStringArray(new String[]{"Hello", "World"})));
+        variables.add(Util.createVariable("x", "Local", new BInteger(10)));
+        variables.add(Util.createVariable("z", "Local", new BInteger(15)));
 
-        Assert.assertEquals(globalVariables.get(0).getName(), "gInt");
-        Assert.assertEquals(globalVariables.get(0).getType(), "int");
-        Assert.assertEquals(globalVariables.get(0).getValue(), "5");
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 1, 4, variables, true);
 
-        Assert.assertEquals(globalVariables.get(5).getName(), "gRec");
-        Assert.assertEquals(globalVariables.get(5).getType(), "Foo");
-        Assert.assertEquals(globalVariables.get(5).getValue(), "struct Foo {count:5, last:\"last\"}");
-
-        Assert.assertEquals(globalVariables.get(6).getName(), "gObj");
-        Assert.assertEquals(globalVariables.get(6).getType(), "Person");
+        VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/ExpectedResults.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/ExpectedResults.java
@@ -1,23 +1,24 @@
 /*
-*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.utils.debug;
 
 import org.ballerinalang.util.debugger.dto.BreakPointDTO;
+import org.ballerinalang.util.debugger.dto.VariableDTO;
 
 import java.util.List;
 
@@ -29,12 +30,20 @@ import java.util.List;
 public class ExpectedResults {
 
     private List<DebugPoint> debugPoints;
+    private int expDebugPointsCount;
 
-    private int expCount;
+    private int expGlobalVarCount;
 
-    public ExpectedResults(List<DebugPoint> debugPoints, int expCount) {
+    private List<VariableDTO> expVariables;
+    private boolean exactVarMatchRequired;
+
+    public ExpectedResults(List<DebugPoint> debugPoints, int expDebugPointsCount, int expGlobalVarCount,
+                           List<VariableDTO> expVariables, boolean exactVarMatchRequired) {
         this.debugPoints = debugPoints;
-        this.expCount = expCount;
+        this.expDebugPointsCount = expDebugPointsCount;
+        this.expGlobalVarCount = expGlobalVarCount;
+        this.expVariables = expVariables;
+        this.exactVarMatchRequired = exactVarMatchRequired;
     }
 
     DebugPoint getDebugHit(BreakPointDTO breakPoint) {
@@ -47,7 +56,19 @@ public class ExpectedResults {
     }
 
     int getDebugCount() {
-        return expCount;
+        return expDebugPointsCount;
+    }
+
+    public int getExpGlobalVarCount() {
+        return expGlobalVarCount;
+    }
+
+    public List<VariableDTO> getExpVariables() {
+        return expVariables;
+    }
+
+    public boolean isExactVarMatchRequired() {
+        return exactVarMatchRequired;
     }
 
     @Override

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/Util.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/Util.java
@@ -1,23 +1,25 @@
 /*
-*   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.utils.debug;
 
+import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.util.debugger.dto.BreakPointDTO;
+import org.ballerinalang.util.debugger.dto.VariableDTO;
 
 /**
  * Test Util class with helper methods.
@@ -39,5 +41,11 @@ public class Util {
             i++;
         }
         return breakPointDTOS;
+    }
+
+    public static VariableDTO createVariable(String name, String scope, BValue bValue) {
+        VariableDTO var = new VariableDTO(name, scope);
+        var.setBValue(bValue);
+        return var;
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/VMDebuggerUtil.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/VMDebuggerUtil.java
@@ -1,20 +1,20 @@
 /*
-*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.utils.debug;
 
 import org.ballerinalang.launcher.util.BCompileUtil;
@@ -22,10 +22,13 @@ import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.util.debugger.Debugger;
 import org.ballerinalang.util.debugger.dto.BreakPointDTO;
 import org.ballerinalang.util.debugger.dto.MessageDTO;
+import org.ballerinalang.util.debugger.dto.VariableDTO;
 import org.testng.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Test debug util class to test debug scenarios.
@@ -34,7 +37,7 @@ import java.util.Arrays;
  */
 public class VMDebuggerUtil {
 
-    private static ArrayList<MessageDTO> debugHits = new ArrayList<>();
+    private static final String GLOBAL = "Global";
 
     public static void startDebug(String srcPath, BreakPointDTO[] bPoints, ExpectedResults expRes) {
 
@@ -47,6 +50,8 @@ public class VMDebuggerUtil {
         debugger.startDebug();
 
         int hitCount = 0;
+        ArrayList<MessageDTO> debugHits = new ArrayList<>();
+
         while (true) {
             debugger.getClientHandler().aquireSem();
             if (debugger.getClientHandler().isExit()) {
@@ -64,6 +69,19 @@ public class VMDebuggerUtil {
             executeDebuggerCmd(debugger, debugHit.getThreadId(), debugPoint.getNextStep());
         }
         Assert.assertEquals(hitCount, expRes.getDebugCount(), "Missing debug point hits - " + expRes);
+
+        if (!debugHits.isEmpty()) {
+            List<VariableDTO> vars = debugHits.get(hitCount - 1).getFrames().get(0).getVariables();
+            List<VariableDTO> globalVars = vars.stream().filter(var -> var.getScope().equals(GLOBAL)).
+                    collect(Collectors.toList());
+
+            Assert.assertEquals(globalVars.size(), expRes.getExpGlobalVarCount(), "Global variables count mismatch");
+            Assert.assertTrue(vars.containsAll(expRes.getExpVariables()), "One or more expected variables not found");
+
+            if (expRes.isExactVarMatchRequired()) {
+                Assert.assertEquals(vars.size(), expRes.getExpVariables().size(), "Variables count mismatch");
+            }
+        }
     }
 
     private static void executeDebuggerCmd(Debugger debugManager, String workerId, Step cmd) {
@@ -97,9 +115,5 @@ public class VMDebuggerUtil {
                 new ArrayList<>(Arrays.asList(breakPoints)));
         (new Thread(executor)).start();
         return debugger;
-    }
-
-    public static ArrayList<MessageDTO> getDebugHits() {
-        return debugHits;
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_variables.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_variables.bal
@@ -20,8 +20,8 @@ type Foo record {
 };
 
 type Person object {
-public int age,
-public string name,
-public Person? parent,
-private string email = "default@abc.com",
+    public int age,
+    public string name,
+    public Person? parent,
+    private string email = "default@abc.com",
 };

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_variables.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_variables.bal
@@ -1,17 +1,14 @@
 int gInt = 5;
 string gStr = "str";
 boolean gBool = true;
-float gFloat = 12.4;
 byte gByte = 255;
-Foo gRec = { count: 5, last: "last" };
-Person gObj = new;
-@final int gConst = 5;
 
 function main(string... args) {
-    gObj.name = "abc";
-    gObj.age = 21;
-    gInt = gInt + 5;
-    int y = gInt + 10;
+    int x = 10;
+    int z = gInt + x;
+    int y = x + z;
+    Foo foo = { count: 5, last: "last" };
+    Person p = new;
 }
 
 type Foo record {


### PR DESCRIPTION
## Purpose

Currently, debug hit messages include all the local variables available, irrespective of the scope and current execution line (issue https://github.com/ballerina-platform/ballerina-lang/issues/9965). This PR resolves it by adding scope information to local variables at the runtime to show only the current scope variables in the debug hit messages.  This PR also includes the following fixes or modifications.

- Rename `Struct` as `Object`/`Record` in the debug hit message (resoves https://github.com/ballerina-platform/ballerina-lang/issues/9962)
- Add non-public fields of an object to its strigified value, which will be printed in the debug hit message (resolves https://github.com/ballerina-platform/ballerina-lang/issues/9964)
- Modify debug test suite
  a. Modifications to include local/global variable inspections
  b. New test case to check the newly introduced local variable scoping