### PR TITLE
Fix xml payload issue

### DIFF
--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetByteArray.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetByteArray.java
@@ -78,10 +78,10 @@ public class GetByteArray extends BlockingNativeCallableUnit {
                 }
             } else {
                 result = EntityBodyHandler.constructBlobDataSource(entityStruct);
+                EntityBodyHandler.addMessageDataSource(entityStruct, result);
                 //Set byte channel to null, once the message data source has been constructed
                 entityStruct.addNativeData(ENTITY_BYTE_CHANNEL, null);
             }
-            EntityBodyHandler.addMessageDataSource(entityStruct, result);
             context.setReturnValues(result != null ? result : new BByteArray(new byte[0]));
         } catch (Throwable e) {
             context.setReturnValues(MimeUtil.createError

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetXml.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetXml.java
@@ -26,6 +26,7 @@ import org.ballerinalang.mime.util.MimeUtil;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.util.XMLUtils;
 import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXML;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
@@ -66,8 +67,9 @@ public class GetXml extends BlockingNativeCallableUnit {
                     if (dataSource instanceof BXML) {
                         result = (BXML) dataSource;
                     } else {
-                        // else, build the XML from the string representation of the payload.
-                        result = XMLUtils.parse(dataSource.stringValue());
+                        // Build the XML from string representation of the payload.
+                        BString payload = MimeUtil.getMessageAsString(dataSource);
+                        result = XMLUtils.parse(payload.stringValue());
                     }
                 } else {
                     result = EntityBodyHandler.constructXmlDataSource(entityStruct);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.service.http.sample;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.ballerinalang.test.IntegrationTestCase;
+import org.ballerinalang.test.context.ServerInstance;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.TestConstant;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Test whether the xml payload gets parsed properly, after the said payload has been retrieved as a byte array.
+ */
+public class HttpPayloadTestCase extends IntegrationTestCase {
+    private ServerInstance ballerinaServer;
+    String balFile = new File("src" + File.separator + "test" + File.separator + "resources"
+            + File.separator + "httpService" + File.separator + "http_payload.bal").getAbsolutePath();
+
+    @BeforeClass
+    private void setup() throws Exception {
+        ballerinaServer = ServerInstance.initBallerinaServer();
+        ballerinaServer.startBallerinaServer(balFile);
+    }
+
+    @Test
+    public void testXmlPayload() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(ballerinaServer.getServiceURLHttp("testService/"));
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
+                , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), "W3Schools Home PageRSS Tutorial", "Message content mismatched");
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        ballerinaServer.stopServer();
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
@@ -48,7 +48,7 @@ public class HttpPayloadTestCase extends IntegrationTestCase {
 
     @Test
     public void testXmlPayload() throws IOException {
-        HttpResponse response = HttpClientRequest.doGet(ballerinaServer.getServiceURLHttp("testService/"));
+        HttpResponse response = HttpClientRequest.doGet(ballerinaServer.getServiceURLHttp("test/"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");

--- a/tests/ballerina-integration-test/src/test/resources/httpService/http_payload.bal
+++ b/tests/ballerina-integration-test/src/test/resources/httpService/http_payload.bal
@@ -34,7 +34,7 @@ service<http:Service> testService bind { port: 9090 } {
         byte[] binaryPayload = check res.getBinaryPayload();
         xml payload = check res.getXmlPayload();
         xml descendants = payload.selectDescendants("title");
-        _ = caller->respond(descendants.getTextValue());
+        _ = caller->respond(untaint descendants.getTextValue());
     }
 }
 

--- a/tests/ballerina-integration-test/src/test/resources/httpService/http_payload.bal
+++ b/tests/ballerina-integration-test/src/test/resources/httpService/http_payload.bal
@@ -1,0 +1,64 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+endpoint http:Client clientEP1 {
+    url: "http://localhost:9091/"
+};
+
+@http:ServiceConfig {
+    basePath: "/test"
+}
+service<http:Service> testService bind { port: 9090 } {
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/"
+    }
+    getPayload(endpoint caller, http:Request request) {
+        http:Response res = check clientEP1->get("/payloadTest", message = ());
+        //First get the payload as a byte array, then take it as an xml
+        byte[] binaryPayload = check res.getBinaryPayload();
+        xml payload = check res.getXmlPayload();
+        xml descendants = payload.selectDescendants("title");
+        _ = caller->respond(descendants.getTextValue());
+    }
+}
+
+@http:ServiceConfig {
+    basePath: "/payloadTest"
+}
+service<http:Service> testPayload bind { port: 9091 } {
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/"
+    }
+    sendXml(endpoint caller, http:Request req) {
+        xml xmlPayload = xml `<xml version="1.0">
+                                <channel>
+                                    <title>W3Schools Home Page</title>
+                                    <link>https://www.w3schools.com</link>
+                                      <description>Free web building tutorials</description>
+                                      <item>
+                                        <title>RSS Tutorial</title>
+                                        <link>https://www.w3schools.com/xml/xml_rss.asp</link>
+                                        <description>New RSS tutorial on W3Schools</description>
+                                      </item>
+                                </channel>
+                              </xml>`;
+        _ = caller->respond(untaint xmlPayload);
+    }
+}


### PR DESCRIPTION
## Purpose
> After the payload has been retrieved as a byte array if we try to take it as an XML (actual content type is XML), a byte array was given as the payload instead of the parsed XML. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10028 


