### PR TITLE
Fix breakpoints are not being deployed correctly

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
@@ -100,7 +100,12 @@ public class SourceDirectoryManager {
     public PackageID getPackageID(String sourcePackage) {
         List<String> sourceFileNames = this.sourceDirectory.getSourceFileNames();
         if (sourceFileNames.contains(sourcePackage)) {
-            return new PackageID(sourcePackage);
+            Manifest manifest = getManifest();
+            Name sourcePkg = names.fromString(sourcePackage);
+            PackageID pkgId = new PackageID(getOrgName(manifest), sourcePkg, new Name(manifest.getVersion()));
+            pkgId.isUnnamed = true;
+            pkgId.sourceFileName = sourcePkg;
+            return pkgId;
         }
 
         List<String> packageNames = this.sourceDirectory.getSourcePackageNames();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -280,27 +280,29 @@ public class SymbolEnter extends BLangNodeVisitor {
         // TODO Clean this code up. Can we move the this to BLangPackageBuilder class
         // Create import package symbol
         Name orgName;
+        Name version;
+        PackageID enclPackageID = env.enclPkg.packageID;
         if (importPkgNode.orgName.value == null || importPkgNode.orgName.value.isEmpty()) {
             // means it's in 'import <pkg-name>' style
-            orgName = env.enclPkg.packageID.orgName;
+            orgName = enclPackageID.orgName;
+            version = enclPackageID.version;
         } else {
             // means it's in 'import <org-name>/<pkg-name>' style
             orgName = names.fromIdNode(importPkgNode.orgName);
+            version = names.fromIdNode(importPkgNode.version);
         }
         List<Name> nameComps = importPkgNode.pkgNameComps.stream()
                 .map(identifier -> names.fromIdNode(identifier))
                 .collect(Collectors.toList());
 
-        String version = names.fromIdNode(importPkgNode.version).getValue();
-        PackageID pkgId = new PackageID(orgName, nameComps, new Name(version));
+        PackageID pkgId = new PackageID(orgName, nameComps, version);
         if (pkgId.name.getValue().startsWith(Names.BUILTIN_PACKAGE.value)) {
             dlog.error(importPkgNode.pos, DiagnosticCode.PACKAGE_NOT_FOUND,
                     importPkgNode.getQualifiedPackageName());
             return;
         }
 
-        BPackageSymbol pkgSymbol = pkgLoader.loadPackageSymbol(pkgId, env.enclPkg.packageID,
-                env.enclPkg.packageRepository);
+        BPackageSymbol pkgSymbol = pkgLoader.loadPackageSymbol(pkgId, enclPackageID, env.enclPkg.packageRepository);
         if (pkgSymbol == null) {
             dlog.error(importPkgNode.pos, DiagnosticCode.PACKAGE_NOT_FOUND,
                     importPkgNode.getQualifiedPackageName());


### PR DESCRIPTION
## Purpose
Breakpoints sent from the Debug Client are not correctly being deployed for the projects structures as mentioned in https://github.com/ballerina-platform/ballerina-lang/issues/10056. This is due to the fact that `packagesInfoMap` inside the DebugInfoHolder contains the built packages without the `organization` and `version` whenever a `Ballerina.toml` presents.
## Approach
Therefore, added a fix to add the version and the organization into the top level built package. Versions of the package imports inside the code will also receive the project version through the enclosure package.

This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/10056