### PR TITLE
 Build sources before pushing to central

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -98,9 +98,8 @@ public class PushUtils {
         Path pkgPathFromPrjtDir = Paths.get(prjDirPath.toString(), ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
                                             ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, orgName,
                                             packageName, version, packageName + ".zip");
-        if (Files.notExists(pkgPathFromPrjtDir)) {
-            BuilderUtils.compileWithTestsAndWrite(prjDirPath, packageName, packageName, false, false, false, true);
-        }
+        // Build the package
+        BuilderUtils.compileWithTestsAndWrite(prjDirPath, packageName, packageName, false, false, false, false);
 
         if (installToRepo == null) {
             // Get access token

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -109,14 +108,6 @@ public class PushUtils {
                                           "artifact before pushing or run `ballerina push --build` to build and push " +
                                           "the artifact at once");
                 return;
-            } else {
-                outStream.print("The artifact to be pushed already exists. Push this artifact [yes/y, no/n]: (y) ");
-                Scanner scanner = new Scanner(System.in, Charset.defaultCharset().name());
-                String buildOnPush = scanner.nextLine().trim();
-
-                if (buildOnPush.equalsIgnoreCase("no") || buildOnPush.equalsIgnoreCase("n")) {
-                    return;
-                }
             }
         }
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
@@ -50,7 +50,7 @@ public class InstallCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
-    @Parameter(names = {"--build"}, description = "build on push")
+    @Parameter(names = {"--build"}, description = "build sources before installing to the home repository")
     private boolean build;
 
     @Override

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
@@ -50,8 +50,9 @@ public class InstallCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
-    @Parameter(names = {"--build"}, description = "build sources before installing to the home repository")
-    private boolean build;
+    @Parameter(names = {"--y"}, description = " Assume yes to all queries and do not prompt confirmation when " +
+            "installing the package to the home repository")
+    private boolean installToHome;
 
     @Override
     public void execute() {
@@ -62,10 +63,10 @@ public class InstallCommand implements BLauncherCmd {
         }
 
         if (argList == null || argList.size() == 0) {
-            PushUtils.pushAllPackages(sourceRoot, "home", build);
+            PushUtils.pushAllPackages(sourceRoot, "home", installToHome);
         } else if (argList.size() == 1) {
             String packageStr = argList.get(0);
-            PushUtils.pushPackages(packageStr, sourceRoot, "home", build);
+            PushUtils.pushPackages(packageStr, sourceRoot, "home", installToHome);
         } else {
             throw LauncherUtils.createUsageException("too many arguments");
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
@@ -50,8 +50,8 @@ public class InstallCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
-    @Parameter(names = {"--y"}, description = " Assume yes to all queries and do not prompt confirmation when " +
-            "installing the package to the home repository")
+    @CommandLine.Option(names = {"--y"}, description = " Assume yes to all queries and do not prompt confirmation " +
+            "when installing the package to the home repository")
     private boolean installToHome;
 
     @Override

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InstallCommand.java
@@ -50,6 +50,9 @@ public class InstallCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
+    @Parameter(names = {"--build"}, description = "build on push")
+    private boolean build;
+
     @Override
     public void execute() {
         if (helpFlag) {
@@ -59,10 +62,10 @@ public class InstallCommand implements BLauncherCmd {
         }
 
         if (argList == null || argList.size() == 0) {
-            PushUtils.pushAllPackages(sourceRoot, "home");
+            PushUtils.pushAllPackages(sourceRoot, "home", build);
         } else if (argList.size() == 1) {
             String packageStr = argList.get(0);
-            PushUtils.pushPackages(packageStr, sourceRoot, "home");
+            PushUtils.pushPackages(packageStr, sourceRoot, "home", build);
         } else {
             throw LauncherUtils.createUsageException("too many arguments");
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
@@ -57,8 +57,8 @@ public class PushCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
-    @Parameter(names = {"--y"}, description = " Assume yes to all queries and do not prompt confirmation when " +
-            "pushing the package to central")
+    @CommandLine.Option(names = {"--y"}, description = " Assume yes to all queries and do not prompt confirmation " +
+            "when pushing the package to central")
     private boolean pushToCentral;
 
     @Override

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
@@ -57,8 +57,9 @@ public class PushCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
-    @Parameter(names = {"--build"}, description = "build sources before pushing to central")
-    private boolean build;
+    @Parameter(names = {"--y"}, description = " Assume yes to all queries and do not prompt confirmation when " +
+            "pushing the package to central")
+    private boolean pushToCentral;
 
     @Override
     public void execute() {
@@ -74,10 +75,10 @@ public class PushCommand implements BLauncherCmd {
         }
 
         if (argList == null || argList.size() == 0) {
-            PushUtils.pushAllPackages(sourceRoot, repositoryHome, build);
+            PushUtils.pushAllPackages(sourceRoot, repositoryHome, pushToCentral);
         } else if (argList.size() == 1) {
             String packageName = argList.get(0);
-            PushUtils.pushPackages(packageName, sourceRoot, repositoryHome, build);
+            PushUtils.pushPackages(packageName, sourceRoot, repositoryHome, pushToCentral);
         } else {
             throw new BLangCompilerException("too many arguments");
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
@@ -57,6 +57,9 @@ public class PushCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
+    @Parameter(names = {"--build"}, description = "build on push")
+    private boolean build;
+
     @Override
     public void execute() {
         if (helpFlag) {
@@ -71,10 +74,10 @@ public class PushCommand implements BLauncherCmd {
         }
 
         if (argList == null || argList.size() == 0) {
-            PushUtils.pushAllPackages(sourceRoot, repositoryHome);
+            PushUtils.pushAllPackages(sourceRoot, repositoryHome, build);
         } else if (argList.size() == 1) {
             String packageName = argList.get(0);
-            PushUtils.pushPackages(packageName, sourceRoot, repositoryHome);
+            PushUtils.pushPackages(packageName, sourceRoot, repositoryHome, build);
         } else {
             throw new BLangCompilerException("too many arguments");
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/PushCommand.java
@@ -57,7 +57,7 @@ public class PushCommand implements BLauncherCmd {
             description = "path to the directory containing source files and packages")
     private String sourceRoot;
 
-    @Parameter(names = {"--build"}, description = "build on push")
+    @Parameter(names = {"--build"}, description = "build sources before pushing to central")
     private boolean build;
 
     @Override

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingInitTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingInitTestCase.java
@@ -321,6 +321,33 @@ public class PackagingInitTestCase extends BaseTest {
                                                   .resolve("foo").resolve("0.0.1").resolve("foo.zip")));
     }
 
+    @Test(description = "Test building a project with a single bal file using the target path")
+    public void testBuildWithTarget() throws Exception {
+        // Test ballerina init
+        Path projectPath = tempProjectDirectory.resolve("testPackageWithTarget");
+        Path genExecPath = tempProjectDirectory.resolve("generatedExec");
+        Files.createDirectories(projectPath);
+        Files.createDirectories(genExecPath);
+
+        String[] clientArgsForInit = {"-i"};
+        String[] options = {"\n", "\n", "\n", "m\n", "\n", "f"};
+        serverInstance.runMainWithClientOptions(clientArgsForInit, options, envVariables, "init",
+                                                 projectPath.toString());
+
+        Path sourceFilePath = projectPath.resolve("main.bal");
+        Assert.assertTrue(Files.exists(sourceFilePath));
+        Assert.assertTrue(Files.exists(projectPath.resolve("Ballerina.toml")));
+
+        // Remove the .ballerina inside the project because we only want the bal file
+        Files.deleteIfExists(projectPath.resolve(".ballerina").resolve(".gitignore"));
+        Files.deleteIfExists(projectPath.resolve(".ballerina"));
+
+        // Test ballerina build
+        String[] clientArgsForBuild = {"-o", genExecPath.resolve("foo.bal").toString(), "main.bal"};
+        serverInstance.runMain(clientArgsForBuild, envVariables, "build", projectPath.toString());
+
+        Assert.assertTrue(Files.exists(genExecPath.resolve("foo.balx")));
+    }
     /**
      * Run and test main function in project.
      *

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
@@ -67,7 +67,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         String msg = "ballerina: an org-name is required when pushing. This is not specified in Ballerina.toml " +
                 "inside the project";
 
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
 
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
@@ -87,7 +87,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         String msg = "ballerina: a package version is required when pushing. This is not specified in Ballerina.toml " +
                 "inside the project";
 
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
     }
@@ -103,7 +103,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         }
         String msg = "ballerina: an org-name is required when pushing. This is not specified in Ballerina.toml " +
                 "inside the project";
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
     }
@@ -117,7 +117,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         Path packageMDFilePath = projectPath.resolve(packageName).resolve("Package.md");
         Files.deleteIfExists(packageMDFilePath);
 
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         String msg = "ballerina: cannot find Package.md file in the artifact";
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
@@ -132,7 +132,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         Path packageMDFilePath = projectPath.resolve(packageName).resolve("Package.md");
         writeToFile(packageMDFilePath, "");
 
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         String msg = "ballerina: package.md in the artifact is empty";
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
@@ -147,7 +147,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         Path packageMDFilePath = projectPath.resolve(packageName).resolve("Package.md");
         writeToFile(packageMDFilePath, "## Hello World");
 
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         String msg = "ballerina: cannot find package summary";
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
@@ -164,7 +164,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         writeToFile(packageMDFilePath, "Hello I am the test package which was created during an integration" +
                 "test\n");
 
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         String msg = "ballerina: summary of the package exceeds 50 characters";
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
@@ -175,7 +175,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         Path projectPath = tempProjectDirectory.resolve("projectToInvalidRepo");
         initProject(projectPath);
 
-        String[] clientArgs = {packageName, "--repository", "test"};
+        String[] clientArgs = {"--y", packageName, "--repository", "test"};
         String msg = "ballerina: unknown repository provided to push the package";
         addLogLeecher(msg);
         serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
@@ -199,7 +199,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         initProject(projectPath);
 
         // First install the package
-        String[] clientArgs = {packageName};
+        String[] clientArgs = {"--y", packageName};
         serverInstance.runMain(clientArgs, envVariables, "install", projectPath.toString());
 
         // Try to install it again

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestCase.java
@@ -182,6 +182,7 @@ public class PackagingTestCase extends BaseTest {
 
     @Test(description = "Test pushing a package with syntax errors in source", dependsOnMethods = "testInitProject")
     public void testPushWithSyntaxErrorsInSource() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("initProject");
         String[] clientArgs = {"--y", packageName};
 
         // Add a new bal source file with syntax errors
@@ -189,19 +190,20 @@ public class PackagingTestCase extends BaseTest {
 
         // Remove the already created artifact
         Path dirPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, orgName, packageName, "0.0.1");
-        Files.deleteIfExists(tempProjectDirectory.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
+        Files.deleteIfExists(projectPath.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
 
-        serverInstance.runMain(clientArgs, envVariables, "push", tempProjectDirectory.toString());
+        serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
 
         Assert.assertFalse(Files.exists(tempHomeDirectory.resolve(".ballerina").resolve(dirPath)
                                                          .resolve(packageName + ".zip")));
 
         // Remove the newly added file
-        Files.deleteIfExists(tempProjectDirectory.resolve(packageName).resolve("main_errors.bal"));
+        Files.deleteIfExists(projectPath.resolve(packageName).resolve("main_errors.bal"));
     }
 
     @Test(description = "Test pushing a package with test failures", dependsOnMethods = "testInitProject")
     public void testPushWithTestFailures() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("initProject");
         String[] clientArgs = {"--y", packageName};
 
         // Add a new test bal with test failures
@@ -209,20 +211,21 @@ public class PackagingTestCase extends BaseTest {
 
         // Remove the already created artifact
         Path dirPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, orgName, packageName, "0.0.1");
-        Files.deleteIfExists(tempProjectDirectory.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
+        Files.deleteIfExists(projectPath.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
 
-        serverInstance.runMain(clientArgs, envVariables, "push", tempProjectDirectory.toString());
+        serverInstance.runMain(clientArgs, envVariables, "push", projectPath.toString());
 
         Assert.assertFalse(Files.exists(tempHomeDirectory.resolve(".ballerina").resolve(dirPath)
                                                          .resolve(packageName + ".zip")));
 
         // Remove the newly added file
-        Files.deleteIfExists(tempProjectDirectory.resolve(packageName).resolve("tests")
+        Files.deleteIfExists(projectPath.resolve(packageName).resolve("tests")
                                                  .resolve("main_test_errors.bal"));
     }
 
     @Test(description = "Test installing a package with syntax errors in source", dependsOnMethods = "testInitProject")
     public void testInstallWithSyntaxErrorsInSource() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("initProject");
         String[] clientArgs = {"--y", packageName};
 
         // Add a new bal source file with syntax errors
@@ -230,19 +233,20 @@ public class PackagingTestCase extends BaseTest {
 
         // Remove the already created artifact
         Path dirPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, orgName, packageName, "0.0.1");
-        Files.deleteIfExists(tempProjectDirectory.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
+        Files.deleteIfExists(projectPath.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
 
-        serverInstance.runMain(clientArgs, envVariables, "install", tempProjectDirectory.toString());
+        serverInstance.runMain(clientArgs, envVariables, "install", projectPath.toString());
 
         Assert.assertFalse(Files.exists(tempHomeDirectory.resolve(".ballerina").resolve(dirPath)
                                                          .resolve(packageName + ".zip")));
 
         // Remove the newly added file
-        Files.deleteIfExists(tempProjectDirectory.resolve(packageName).resolve("main_errors.bal"));
+        Files.deleteIfExists(projectPath.resolve(packageName).resolve("main_errors.bal"));
     }
 
     @Test(description = "Test installing a package with test failures", dependsOnMethods = "testInitProject")
     public void testInstallWithTestFailures() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("initProject");
         String[] clientArgs = {"--y", packageName};
 
         // Add a new test bal with test failures
@@ -250,15 +254,15 @@ public class PackagingTestCase extends BaseTest {
 
         // Remove the already created artifact
         Path dirPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, orgName, packageName, "0.0.1");
-        Files.deleteIfExists(tempProjectDirectory.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
+        Files.deleteIfExists(projectPath.resolve(".ballerina").resolve(dirPath).resolve(packageName + ".zip"));
 
-        serverInstance.runMain(clientArgs, envVariables, "install", tempProjectDirectory.toString());
+        serverInstance.runMain(clientArgs, envVariables, "install", projectPath.toString());
 
         Assert.assertFalse(Files.exists(tempHomeDirectory.resolve(".ballerina").resolve(dirPath)
                                                          .resolve(packageName + ".zip")));
 
         // Remove the newly added file
-        Files.deleteIfExists(tempProjectDirectory.resolve(packageName).resolve("tests")
+        Files.deleteIfExists(projectPath.resolve(packageName).resolve("tests")
                                                  .resolve("main_test_errors.bal"));
     }
 
@@ -267,9 +271,10 @@ public class PackagingTestCase extends BaseTest {
      * @throws IOException
      */
     private void writeInvalidSource() throws IOException {
+        Path projectPath = tempProjectDirectory.resolve("initProject");
         String incorrectContent = "import ballerina/io;\n\n function hello() {\n    io.println(\"Hello World!\");\n" +
                 "}\n";
-        Files.write(tempProjectDirectory.resolve(packageName).resolve("main_errors.bal"), incorrectContent.getBytes(),
+        Files.write(projectPath.resolve(packageName).resolve("main_errors.bal"), incorrectContent.getBytes(),
                     StandardOpenOption.CREATE_NEW);
     }
 
@@ -278,6 +283,7 @@ public class PackagingTestCase extends BaseTest {
      * @throws IOException
      */
     private void writeInvalidTestContent() throws IOException {
+        Path projectPath = tempProjectDirectory.resolve("initProject");
         // Add a new bal test source file with syntax errors
         String incorrectContent =  "import ballerina/test;\n" +
                                     "\n" +
@@ -295,7 +301,7 @@ public class PackagingTestCase extends BaseTest {
                                     "function afterFunc () {\n" +
                                     "    io:println(\"I'm the after function!\");\n" +
                                     "}\n";
-        Files.write(tempProjectDirectory.resolve(packageName).resolve("tests").resolve("main_test_errors.bal"),
+        Files.write(projectPath.resolve(packageName).resolve("tests").resolve("main_test_errors.bal"),
                     incorrectContent.getBytes(), StandardOpenOption.CREATE_NEW);
     }
 

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestsUtils.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestsUtils.java
@@ -17,6 +17,9 @@
  */
 package org.ballerinalang.test.packaging;
 
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.Constant;
+import org.ballerinalang.test.context.ServerInstance;
 import org.testng.Assert;
 
 import java.io.IOException;
@@ -95,5 +98,16 @@ public class PackagingTestsUtils {
             builder.append(alpha.charAt(character));
         }
         return builder.toString();
+    }
+
+    /**
+     * Get new instance of the ballerina server.
+     *
+     * @return new ballerina server instance
+     * @throws BallerinaTestException
+     */
+    static ServerInstance createNewBallerinaServer() throws BallerinaTestException {
+        String serverZipPath = System.getProperty(Constant.SYSTEM_PROP_SERVER_ZIP);
+        return new ServerInstance(serverZipPath);
     }
 }

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestsUtils.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestsUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.packaging;
+
+import org.testng.Assert;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Util methods needed for Packaging test cases.
+ */
+public class PackagingTestsUtils {
+
+    /**
+     * Delete files inside directories.
+     *
+     * @param dirPath directory path
+     * @throws IOException throw an exception if an issue occurs
+     */
+    static void deleteFiles(Path dirPath) throws IOException {
+        Files.walk(dirPath)
+             .sorted(Comparator.reverseOrder())
+             .forEach(path -> {
+                 try {
+                     Files.delete(path);
+                 } catch (IOException e) {
+                     Assert.fail(e.getMessage(), e);
+                 }
+             });
+    }
+
+    /**
+     * Get org-name of user.
+     *
+     * @return org name
+     */
+    static String getOrgName() {
+        String orgName = System.getProperty("user.name");
+        if (orgName == null) {
+            orgName = "my_org";
+        } else {
+            orgName = orgName.toLowerCase(Locale.getDefault());
+        }
+        return orgName;
+    }
+
+    /**
+     * Get environment variables and add ballerina_home as a env variable the tmp directory.
+     *
+     * @return env directory variable array
+     */
+    static String[] getEnvVariables() {
+        List<String> variables = new ArrayList<>();
+
+        Map<String, String> envVarMap = System.getenv();
+        envVarMap.forEach((key, value) -> variables.add(key + "=" + value));
+        return variables.toArray(new String[variables.size()]);
+    }
+
+    /**
+     * Generate random package name.
+     *
+     * @param count number of characters required
+     * @return generated name
+     */
+    static String randomPackageName(int count) {
+        String upperCaseAlpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String lowerCaseAlpha = "abcdefghijklmnopqrstuvwxyz";
+        String alpha = upperCaseAlpha + lowerCaseAlpha;
+        StringBuilder builder = new StringBuilder();
+        while (count-- != 0) {
+            int character = (int) (Math.random() * alpha.length());
+            builder.append(alpha.charAt(character));
+        }
+        return builder.toString();
+    }
+}

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestsUtils.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestsUtils.java
@@ -25,14 +25,13 @@ import org.testng.Assert;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
  * Util methods needed for Packaging test cases.
+ *
+ * @since 0.982.0
  */
 public class PackagingTestsUtils {
 
@@ -55,31 +54,13 @@ public class PackagingTestsUtils {
     }
 
     /**
-     * Get org-name of user.
-     *
-     * @return org name
-     */
-    static String getOrgName() {
-        String orgName = System.getProperty("user.name");
-        if (orgName == null) {
-            orgName = "my_org";
-        } else {
-            orgName = orgName.toLowerCase(Locale.getDefault());
-        }
-        return orgName;
-    }
-
-    /**
      * Get environment variables and add ballerina_home as a env variable the tmp directory.
      *
      * @return env directory variable array
      */
     static String[] getEnvVariables() {
-        List<String> variables = new ArrayList<>();
-
         Map<String, String> envVarMap = System.getenv();
-        envVarMap.forEach((key, value) -> variables.add(key + "=" + value));
-        return variables.toArray(new String[variables.size()]);
+        return envVarMap.keySet().stream().map(k -> k + "=" + envVarMap.get(k)).toArray(String[]::new);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> This PR will introduce a confirmation to the push command which will be prompted to the user asking permission to push the package to central. Build is mandated in push. A new flag is introduced --y which 
 assume yes to all queries and do not prompt confirmation when pushing to central.

The flow will be as follows:

- If the user has specified the flag `ballerina push <package> --y`, then a confirmation will not be prompted to the user before pushing and by default it will push the package to central

- If the user has not specified the flag , then we prompt the following confirmation:
"Push the artifact <org-name>/<package>:<version> to central  [yes/y, no/n]: (y) "
By default we push the package to central, if the user says no/n the package is not pushed.

This also contains some refactoring to the integration test cases of push, pull, search and install with these new changes. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9824

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
