### PR TITLE
Fix path issues when building an executable for a single bal file

### DIFF
--- a/cli/ballerina-cli-utils/pom.xml
+++ b/cli/ballerina-cli-utils/pom.xml
@@ -139,6 +139,7 @@
                             </systemProperties>
                             <arguments>
                                 <argument>${ballerina.source.directory}/packaging_pull</argument>
+                                <argument>packaging_pull.bal</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -151,6 +152,7 @@
                         <configuration>
                             <arguments>
                                 <argument>${ballerina.source.directory}/packaging_push</argument>
+                                <argument>packaging_push.bal</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -163,6 +165,7 @@
                         <configuration>
                             <arguments>
                                 <argument>${ballerina.source.directory}/packaging_search</argument>
+                                <argument>packaging_search.bal</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -175,6 +178,7 @@
                         <configuration>
                             <arguments>
                                 <argument>${ballerina.source.directory}/packaging_token_updater</argument>
+                                <argument>packaging_token_updater.bal</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/GenerateBalx.java
+++ b/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/GenerateBalx.java
@@ -22,6 +22,7 @@ package org.ballerinalang.cli.utils;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.wso2.ballerinalang.compiler.Compiler;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
@@ -43,6 +44,7 @@ public class GenerateBalx {
 
     public static void main(String[] args) {
         Path prjctDir = Paths.get(args[0]);
+        String sourcePath = args[1];
         CompilerContext context = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, prjctDir.toString());
@@ -51,7 +53,10 @@ public class GenerateBalx {
         options.put(SKIP_TESTS, Boolean.toString(true));
 
         Compiler compiler = Compiler.getInstance(context);
-        compiler.write(compiler.build());
+        BLangPackage bLangPackage = compiler.build(sourcePath);
+
+        Path targetFilePath = prjctDir.resolve(sourcePath);
+        compiler.write(bLangPackage, targetFilePath.toString());
 
         BLangDiagnosticLog diagnosticLog = BLangDiagnosticLog.getInstance(context);
         if (diagnosticLog.errorCount > 0) {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -23,8 +23,11 @@ import com.beust.jcommander.Parameters;
 import org.ballerinalang.launcher.BLauncherCmd;
 import org.ballerinalang.launcher.LauncherUtils;
 import org.ballerinalang.packerina.BuilderUtils;
+import org.ballerinalang.util.BLangConstants;
+import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -84,17 +87,70 @@ public class BuildCommand implements BLauncherCmd {
         } else {
             // ballerina build pkgName [-o outputFileName]
             String targetFileName;
-            Path sourcePath = Paths.get(argList.get(0));
+            String pkgName = argList.get(0);
+            if (pkgName.endsWith("/")) {
+                pkgName = pkgName.substring(0, pkgName.length() - 1);
+            }
             if (outputFileName != null && !outputFileName.isEmpty()) {
                 targetFileName = outputFileName;
             } else {
-                targetFileName = sourcePath.toString();
+                targetFileName = pkgName;
             }
 
-            BuilderUtils.compileWithTestsAndWrite(sourceRootPath, sourcePath.toString(), targetFileName,
-                                                  buildCompiledPkg, offline, lockEnabled, skiptests);
+            Path sourcePath = Paths.get(pkgName);
+            Path resolvedFullPath = sourceRootPath.resolve(sourcePath);
+            // If the source is a single bal file which is not inside a project
+            if (Files.isRegularFile(resolvedFullPath) &&
+                    sourcePath.toString().endsWith(BLangConstants.BLANG_SRC_FILE_SUFFIX) &&
+                    !RepoUtils.hasProjectRepo(sourceRootPath)) {
+                // If there is no output file name provided, then the executable (balx) should be created in the user's
+                // current directory with the same source file name with a balx extension. So if there's no output file
+                // name provided (with flag -o) and the target file name contains the full path (along with its parent
+                // path) and not only the source file name, then we extract the name of the source file to be the target
+                // file name
+                targetFileName = getTargetFileName(Paths.get(targetFileName));
+
+                // The source root path should be the parent of the source file
+                Path parent = resolvedFullPath.getParent();
+                sourceRootPath = parent != null ? parent : sourceRootPath;
+
+                // The package name/source should be the source file name
+                Path resolvedFileName = resolvedFullPath.getFileName();
+                pkgName = resolvedFileName != null ? resolvedFileName.toString() : pkgName;
+
+            } else if (Files.isDirectory(sourceRootPath)) { // If the source is a package from a project
+                // Checks if the source is a package and if its inside a project (with a .ballerina folder)
+                if (Files.isDirectory(resolvedFullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
+                    outStream.println("error: do you mean to build the ballerina package as a project? If so run" +
+                                              " ballerina init to make it a project with a .ballerina directory");
+                    return;
+                }
+            } else {
+                // Invalid source file provided
+                outStream.println("error: invalid Ballerina source path, it should either be a directory or a" +
+                                          "file  with a \'" + BLangConstants.BLANG_SRC_FILE_SUFFIX + "\' extension");
+                return;
+            }
+            BuilderUtils.compileWithTestsAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg,
+                                                  offline, lockEnabled, skiptests);
         }
         Runtime.getRuntime().exit(0);
+    }
+
+    /**
+     * Get the target file path for a single bal file.
+     *
+     * @param targetPath target path given
+     * @return actual target path
+     */
+    private String getTargetFileName(Path targetPath) {
+        if (outputFileName == null && targetPath.getParent() != null) {
+            Path targetFileName = targetPath.getFileName();
+            if (targetFileName != null) {
+                return targetFileName.toString();
+            }
+        }
+        return targetPath.toString();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
@@ -31,6 +31,7 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -95,7 +96,9 @@ public class FileSystemProgramDirectory implements SourceDirectory {
 
     @Override
     public Path saveCompiledProgram(InputStream source, String fileName) {
-        Path targetFilePath = programDirPath.resolve(fileName);
+        // When building a single bal file the executable (balx) should be generated in the current directory of
+        // the user
+        Path targetFilePath = Paths.get(fileName);
         try {
             outStream.println("    " + fileName);
             Files.copy(source, targetFilePath, StandardCopyOption.REPLACE_EXISTING);

--- a/misc/metrics-extensions/modules/ballerina-prometheus-extension/pom.xml
+++ b/misc/metrics-extensions/modules/ballerina-prometheus-extension/pom.xml
@@ -120,6 +120,7 @@
                             </systemProperties>
                             <arguments>
                                 <argument>${ballerina.source.directory}/prometheus</argument>
+                                <argument>reporter.bal</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingInitTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingInitTestCase.java
@@ -315,6 +315,26 @@ public class PackagingInitTestCase {
         runMainFunction(projectPath, generatedBalx.toString());
     }
 
+    @Test(description = "Test building a package in a project")
+    public void testBuildPackage() throws Exception {
+        // Test ballerina init
+        ServerInstance ballerinaServer = createNewBallerinaServer();
+        Path projectPath = tempProjectDirectory.resolve("testBuildPackage");
+        Files.createDirectories(projectPath);
+
+        String[] clientArgsForInit = {"-i"};
+        String[] options = {"\n", "integrationtests\n", "\n", "m\n", "foo\n", "f\n"};
+        ballerinaServer.runMainWithClientOptions(clientArgsForInit, options, getEnvVariables(), "init",
+                                                 projectPath.toString());
+
+        // Test ballerina build
+        ballerinaServer = createNewBallerinaServer();
+        ballerinaServer.runMain(new String[] {"foo"}, getEnvVariables(), "build", projectPath.toString());
+
+        Assert.assertTrue(Files.exists(projectPath.resolve("target").resolve("foo.balx")));
+        Assert.assertTrue(Files.exists(projectPath.resolve(".ballerina").resolve("repo").resolve("integrationtests")
+                                                  .resolve("foo").resolve("0.0.1").resolve("foo.zip")));
+    }
     @Test(description = "Test building a project with a single bal file using the target path")
     public void testBuildWithTarget() throws Exception {
         // Test ballerina init

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingSingleBalBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingSingleBalBuildTestCase.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.packaging;
+
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.Constant;
+import org.ballerinalang.test.context.ServerInstance;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Testing building of a single bal file.
+ */
+public class PackagingSingleBalBuildTestCase {
+    private String serverZipPath;
+    private Path tempProjectDirectory;
+    private Path balFilePath;
+
+    @BeforeClass()
+    public void setUp() throws BallerinaTestException, IOException {
+        tempProjectDirectory = Files.createTempDirectory("bal-test-integration-packaging-single-bal-");
+        Path tempPackage = tempProjectDirectory.resolve("sourcePkg");
+        Files.createDirectories(tempPackage);
+
+        // Write bal file
+        balFilePath = tempPackage.resolve("main.bal");
+        Files.createFile(balFilePath);
+        String mainFuncContent = "import ballerina/io;\n" +
+                "\n" +
+                "documentation {\n" +
+                "   Prints `Hello World`.\n" +
+                "}\n" +
+                "function main(string... args) {\n" +
+                "    io:println(\"Hello World!\");\n" +
+                "}\n";
+        Files.write(balFilePath, mainFuncContent.getBytes(), StandardOpenOption.CREATE);
+
+        serverZipPath = System.getProperty(Constant.SYSTEM_PROP_SERVER_ZIP);
+    }
+
+    @Test(description = "Test building a bal file by giving the absolute path")
+    public void testBuildingSourceWithAbsolutePath() throws Exception {
+        Path currentDirPath = tempProjectDirectory.resolve("foo");
+        Files.createDirectories(currentDirPath);
+
+        // Test ballerina build
+        ServerInstance ballerinaServer = createNewBallerinaServer();
+        String[] clientArgs = {balFilePath.toString()};
+        ballerinaServer.runMain(clientArgs, getEnvVariables(), "build", currentDirPath.toString());
+        Path generatedBalx = currentDirPath.resolve("main.balx");
+        Assert.assertTrue(Files.exists(generatedBalx));
+    }
+
+    @Test(description = "Test building a bal file by giving the path from the current directory")
+    public void testBuildingSourceWithCurrentDir() throws Exception {
+        // Test ballerina build
+        ServerInstance ballerinaServer = createNewBallerinaServer();
+        String[] clientArgs = {Paths.get("sourcePkg", "main.bal").toString()};
+        ballerinaServer.runMain(clientArgs, getEnvVariables(), "build", tempProjectDirectory.toString());
+        Path generatedBalx = tempProjectDirectory.resolve("main.balx");
+        Assert.assertTrue(Files.exists(generatedBalx));
+    }
+
+    @Test(description = "Test building a bal file to the output file givenby the user")
+    public void testBuildingSourceToOutput() throws Exception {
+        Path targetDirPath = tempProjectDirectory.resolve("target");
+        Files.createDirectories(targetDirPath);
+
+        // Test ballerina build
+        ServerInstance ballerinaServer = createNewBallerinaServer();
+        String[] clientArgs = {balFilePath.toString(), "-o", targetDirPath.resolve("main.bal").toString()};
+        ballerinaServer.runMain(clientArgs, getEnvVariables(), "build", tempProjectDirectory.toString());
+        Path generatedBalx = targetDirPath.resolve("main.balx");
+        Assert.assertTrue(Files.exists(generatedBalx));
+    }
+
+    /**
+     * Get new instance of the ballerina server.
+     *
+     * @return new ballerina server instance
+     * @throws BallerinaTestException
+     */
+    private ServerInstance createNewBallerinaServer() throws BallerinaTestException {
+        return new ServerInstance(serverZipPath);
+    }
+
+    /**
+     * Get environment variables and add ballerina_home as a env variable the tmp directory.
+     *
+     * @return env directory variable array
+     */
+    private String[] getEnvVariables() {
+        List<String> variables = new ArrayList<>();
+
+        Map<String, String> envVarMap = System.getenv();
+        envVarMap.forEach((key, value) -> variables.add(key + "=" + value));
+        return variables.toArray(new String[variables.size()]);
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        deleteFiles(tempProjectDirectory);
+    }
+
+    /**
+     * Delete files inside directories.
+     *
+     * @param dirPath directory path
+     * @throws IOException throw an exception if an issue occurs
+     */
+    private void deleteFiles(Path dirPath) throws IOException {
+        Files.walk(dirPath)
+             .sorted(Comparator.reverseOrder())
+             .forEach(path -> {
+                 try {
+                     Files.delete(path);
+                 } catch (IOException e) {
+                     Assert.fail(e.getMessage(), e);
+                 }
+             });
+    }
+}

--- a/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
@@ -28,6 +28,7 @@
             <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingInitTestCase"/>
             <class name="org.ballerinalang.test.packaging.grpc.ServicePackagingTestCase"/>
+            <class name="org.ballerinalang.test.packaging.PackagingSingleBalBuildTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> This PR will fix the path issues when building a single bal file. It will always build the executable (balx) in the current directory of the user 

- Allow building a bal file by giving the absolute path : ballerina build a/b/c/foo.bal
- Allow building a bal file by giving the path from the current directory: ballerina build c/foo.bal

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
