### PR TITLE
Add integration test coverage to the report

### DIFF
--- a/bvm/ballerina-streaming/siddhi-core/pom.xml
+++ b/bvm/ballerina-streaming/siddhi-core/pom.xml
@@ -98,7 +98,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/bvm/ballerina-streaming/siddhi-query-api/pom.xml
+++ b/bvm/ballerina-streaming/siddhi-query-api/pom.xml
@@ -60,7 +60,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/bvm/ballerina-streaming/siddhi-query-compiler/pom.xml
+++ b/bvm/ballerina-streaming/siddhi-query-compiler/pom.xml
@@ -97,7 +97,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/misc/docerina/pom.xml
+++ b/misc/docerina/pom.xml
@@ -146,7 +146,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/misc/metrics-extensions/modules/ballerina-metrics-extension/pom.xml
+++ b/misc/metrics-extensions/modules/ballerina-metrics-extension/pom.xml
@@ -164,7 +164,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/pom.xml
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/pom.xml
@@ -128,7 +128,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
@@ -128,7 +128,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/misc/testerina/modules/testerina-core/pom.xml
+++ b/misc/testerina/modules/testerina-core/pom.xml
@@ -474,7 +474,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,16 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
+        <repository>
+            <id>nuiton</id>
+            <name>nuiton Repository</name>
+            <url>http://maven.nuiton.org/release/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -1151,7 +1161,7 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
                 <classifier>runtime</classifier>
-                <version>${jacoco.version}</version>
+                <version>${jacoco.agent.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -1489,6 +1499,11 @@
                 <artifactId>ballerina-examples</artifactId>
                 <version>${ballerina.examples.version}</version>
                 <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>com.sun</groupId>
+                <artifactId>tools</artifactId>
+                <version>${com.sun.tools.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -2059,6 +2074,11 @@
                     <artifactId>protobuf-maven-plugin</artifactId>
                     <version>${protobuf.maven.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${maven.jacoco.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -2151,7 +2171,7 @@
         <geronimo.stax>1.0.1</geronimo.stax>
         <mime4j.version>0.7.2</mime4j.version>
         <staxon.version>1.2.0.wso2v2</staxon.version>
-        <jacoco.version>0.7.5.201505241946</jacoco.version>
+        <jacoco.agent.version>0.8.1</jacoco.agent.version>
         <mockito.version>1.9.0</mockito.version>
         <netty.version>4.1.19.Final</netty.version>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
@@ -2227,6 +2247,7 @@
         <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <maven.replacer.plugin.version>1.5.3</maven.replacer.plugin.version>
+        <maven.jacoco.plugin.version>0.8.1</maven.jacoco.plugin.version>
 
         <apache.rat.plugin.version>0.11</apache.rat.plugin.version>
         <clirr.maven.plugin.version>2.7</clirr.maven.plugin.version>
@@ -2261,7 +2282,7 @@
         <chewiebug.gcviewer.version>1.35</chewiebug.gcviewer.version>
 
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
-
+        <com.sun.tools.version>1.7.0.13</com.sun.tools.version>
     </properties>
 
 </project>

--- a/tests/ballerina-compiler-plugin-test/pom.xml
+++ b/tests/ballerina-compiler-plugin-test/pom.xml
@@ -101,7 +101,6 @@
                                 <exclude>org/wso2/ballerinalang/compiler/parser/antlr4/**</exclude>
                             </excludes>
                             <propertyName>jacoco.agent.argLine</propertyName>
-                            (2)
                             <destFile>${project.build.directory}/coverage-reports/jacoco.exec</destFile>
                         </configuration>
                     </execution>

--- a/tests/ballerina-compiler-plugin-test/pom.xml
+++ b/tests/ballerina-compiler-plugin-test/pom.xml
@@ -88,7 +88,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/tests/ballerina-integration-test-utils/pom.xml
+++ b/tests/ballerina-integration-test-utils/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>testng</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -61,6 +65,19 @@
                 <version>${os.maven.plugin.version}</version>
             </extension>
         </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Agent-Class>org.ballerinalang.test.agent.BallerinaExitAgent</Agent-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <properties>

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaExitAgent.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaExitAgent.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 /**
  * JAVA agent which will be attached to Ballerina run time and trigger the shutdown sequence.
+ *
+ * @since 0.982.0
  */
 public class BallerinaExitAgent {
     /**
@@ -69,7 +71,7 @@ public class BallerinaExitAgent {
             return;
         }
 
-        Thread haltThread = new Thread(() -> {
+        Thread killThread = new Thread(() -> {
             long startTime = System.currentTimeMillis();
             long endTime = startTime;
             while (endTime - startTime < timeout) {
@@ -84,8 +86,8 @@ public class BallerinaExitAgent {
                 }
             }
         });
-        haltThread.setDaemon(true);
-        haltThread.start();
+        killThread.setDaemon(true);
+        killThread.start();
     }
 
     private static Map<String, String> decodeAgentArgs(final String agentArgs) {

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaExitAgent.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/agent/BallerinaExitAgent.java
@@ -1,0 +1,119 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.test.agent;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JAVA agent which will be attached to Ballerina run time and trigger the shutdown sequence.
+ */
+public class BallerinaExitAgent {
+    /**
+     * Argument name for exist status.
+     */
+    private static final String EXIT_STATUS = "exitStatus";
+
+    private static final int DEFAULT_EXIT_STATUS = 0;
+
+    /**
+     * Argument name for waiting period if graceful shutdown fails.
+     */
+    private static final String EXIT_TIMEOUT = "timeout";
+
+    /**
+     * Default exit timeout in milliseconds, -1 or 0 means wait forever.
+     */
+    private static final long DEFAULT_EXIT_TIMEOUT = -1;
+
+    /**
+     * Argument name for kill status.
+     */
+    private static final String KILL_STATUS = "killStatus";
+
+    private static final int DEFAULT_KILL_STATUS = 1;
+
+    private BallerinaExitAgent() {
+    }
+
+    /**
+     * Method which will be called when agent installs.
+     *
+     * @param agentArgs arguments for the agent.
+     */
+    public static void agentmain(final String agentArgs) {
+        Map<String, String> args = decodeAgentArgs(agentArgs);
+        final long timeout = getValue(EXIT_TIMEOUT, DEFAULT_EXIT_TIMEOUT, args);
+        final int exitStatus = (int) getValue(EXIT_STATUS, DEFAULT_EXIT_STATUS, args);
+        final int killStatus = (int) getValue(KILL_STATUS, DEFAULT_KILL_STATUS, args);
+
+        new Thread(() -> Runtime.getRuntime().exit(exitStatus)).start();
+
+        if (timeout <= 0) {
+            return;
+        }
+
+        Thread haltThread = new Thread(() -> {
+            long startTime = System.currentTimeMillis();
+            long endTime = startTime;
+            while (endTime - startTime < timeout) {
+                try {
+                    Thread.sleep(timeout);
+                } catch (InterruptedException e) {
+                    //ignore
+                }
+                endTime = System.currentTimeMillis();
+                if (endTime - startTime >= timeout) {
+                    Runtime.getRuntime().halt(killStatus);
+                }
+            }
+        });
+        haltThread.setDaemon(true);
+        haltThread.start();
+    }
+
+    private static Map<String, String> decodeAgentArgs(final String agentArgs) {
+        if (agentArgs == null) {
+            return Collections.emptyMap();
+        }
+
+        String[] splitted = agentArgs.split(",");
+        Map<String, String> result = new HashMap<>();
+
+        for (String argString : splitted) {
+            String[] argParts = argString.split("=");
+            String key = argParts[0];
+            if (argParts.length == 1) {
+                result.put(key, null);
+                continue;
+            }
+            result.put(key, argParts[1]);
+        }
+
+        return result;
+    }
+
+    private static long getValue(String argName, long defaultValue, Map<String, String> args) {
+        String value = args.get(argName);
+        if (value == null || value.isEmpty()) {
+            return defaultValue;
+        }
+        return Long.parseLong(value);
+    }
+}

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/Constant.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/Constant.java
@@ -44,4 +44,5 @@ public class Constant {
     public static final String VFS_LOCATION = "FTPLocation";
 
     public static final String PROJECT_BUILD_DIR = "project.build.directory";
+    public static final String EXIT_AGENT_LOCATION = "ballerina.test.exit.agent.location";
 }

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/ServerInstance.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/ServerInstance.java
@@ -17,6 +17,10 @@
  */
 package org.ballerinalang.test.context;
 
+import com.sun.tools.attach.AgentInitializationException;
+import com.sun.tools.attach.AgentLoadException;
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.mina.util.ConcurrentHashSet;
 import org.slf4j.Logger;
@@ -31,6 +35,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
@@ -221,9 +229,21 @@ public class ServerInstance implements Server {
                     killServer.waitFor(15, TimeUnit.SECONDS);
                     killServer.destroy();
                 } else {
-                    Process killServer = Runtime.getRuntime().exec("kill -9 " + pid);
-                    killServer.waitFor(15, TimeUnit.SECONDS);
-                    killServer.destroy();
+                    String exitAgentPath = System.getProperty(Constant.EXIT_AGENT_LOCATION);
+
+                    if (exitAgentPath == null || exitAgentPath.isEmpty()) {
+                        log.warn("Ballerina test exit agent not provided, hence integration " +
+                                "test coverage won't be available");
+                        Process killServer = Runtime.getRuntime().exec("kill -9 " + pid);
+                        killServer.waitFor(15, TimeUnit.SECONDS);
+                        killServer.destroy();
+                    } else {
+                        VirtualMachine vm = VirtualMachine.attach(pid);
+                        vm.loadAgent(exitAgentPath, "exitStatus=1,timeout=15000,killStatus=5");
+
+                        //TODO remove below sleep by correctly waiting for the port
+                        Thread.sleep(1000);
+                    }
                 }
             } catch (IOException e) {
                 log.error("Error getting process id for the server in port - " + httpServerPort
@@ -231,6 +251,18 @@ public class ServerInstance implements Server {
                 throw new BallerinaTestException("Error while getting the server process id", e);
             } catch (InterruptedException e) {
                 log.error("Error stopping the server in port - " + httpServerPort + " error - " + e.getMessage(), e);
+                throw new BallerinaTestException("Error waiting for services to stop", e);
+            } catch (AttachNotSupportedException e) {
+                log.error("Error stopping the server in port - " + httpServerPort + ", " +
+                        "ballerina agent attachment failed, error - " + e.getMessage(), e);
+                throw new BallerinaTestException("Error waiting for services to stop", e);
+            } catch (AgentInitializationException e) {
+                log.error("Error stopping the server in port - " + httpServerPort + ", " +
+                        "ballerina agent initialization failed, error - " + e.getMessage(), e);
+                throw new BallerinaTestException("Error waiting for services to stop", e);
+            } catch (AgentLoadException e) {
+                log.error("Error stopping the server in port - " + httpServerPort + ", " +
+                        "ballerina agent loading failed, error - " + e.getMessage(), e);
                 throw new BallerinaTestException("Error waiting for services to stop", e);
             }
             process.destroy();
@@ -427,6 +459,7 @@ public class ServerInstance implements Server {
      * @throws BallerinaTestException if configuring server failed
      */
     protected void configServer() throws BallerinaTestException {
+        modifyScriptsWithJacoco();
     }
 
     /**
@@ -551,6 +584,37 @@ public class ServerInstance implements Server {
         } catch (IOException e) {
             throw new BallerinaTestException("Error starting services", e);
         }
+    }
+
+    /**
+     * This is a helper method to add jacoco agent arg line to ballerina scripts if available.
+     */
+    private void modifyScriptsWithJacoco() {
+        String jacocoArgLine = System.getProperty("jacoco.agent.argLine");
+        if (jacocoArgLine == null || jacocoArgLine.isEmpty()) {
+            log.warn("Running integration test without jacoco test coverage");
+            return;
+        }
+        //Modifying only sh file for the time being
+        Path path = Paths.get(serverHome + File.separator + "bin" +
+                File.separator + Constant.BALLERINA_SERVER_SCRIPT_NAME);
+        Charset charset = StandardCharsets.UTF_8;
+
+        try {
+            String content = new String(Files.readAllBytes(path), charset);
+            if (content.contains("-javaagent")) {
+                return;
+            }
+
+            content = content.replaceAll("-classpath \"\\$BALLERINA_CLASSPATH\" \\\\",
+                    jacocoArgLine + " \\\\\n\t"
+                            + "-classpath \"\\$BALLERINA_CLASSPATH\" \\\\");
+            Files.write(path, content.getBytes(charset));
+        } catch (IOException e) {
+            log.warn("Ballerina script modification failed, Running tests without jacoco test coverage");
+        }
+
+        //TODO add this for windows scripts (ballerina.bat)
     }
 
     /**

--- a/tests/ballerina-integration-test/pom.xml
+++ b/tests/ballerina-integration-test/pom.xml
@@ -242,6 +242,14 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.ballerinalang</groupId>
+                                    <artifactId>ballerina-integration-test-utils</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
@@ -270,6 +278,8 @@
                         <server.zip>
                             ${basedir}/../../distribution/zip/ballerina/target/ballerina-${project.version}.zip
                         </server.zip>
+                        <jacoco.agent.argLine>${jacoco.agent.argLine}</jacoco.agent.argLine>
+                        <ballerina.test.exit.agent.location>${project.build.directory}/ballerina-integration-test-utils-${project.version}.jar</ballerina.test.exit.agent.location>
                         <integration.test.utils.service.file>
                             ${basedir}/../../tests/ballerina-integration-test-utils/src/main/ballerina/httpService/common_backend.bal
                         </integration.test.utils.service.file>
@@ -290,7 +300,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>

--- a/tests/ballerina-tools-integration-test/pom.xml
+++ b/tests/ballerina-tools-integration-test/pom.xml
@@ -44,6 +44,31 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.ballerinalang</groupId>
+                                    <artifactId>ballerina-integration-test-utils</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>${jacoco.agent.argLine}</argLine>
@@ -51,6 +76,8 @@
                         <server.zip>
                             ${basedir}/../../distribution/zip/ballerina-tools/target/ballerina-tools-${project.version}.zip
                         </server.zip>
+                        <jacoco.agent.argLine>${jacoco.agent.argLine}</jacoco.agent.argLine>
+                        <ballerina.test.exit.agent.location>${project.build.directory}/ballerina-integration-test-utils-${project.version}.jar</ballerina.test.exit.agent.location>
                         <integration.test.utils.service.file>
                             ${basedir}/../../tests/ballerina-integration-test-utils/src/main/ballerina/httpService/common_backend.bal
                         </integration.test.utils.service.file>
@@ -67,7 +94,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>
@@ -285,7 +311,7 @@
                     <dependency>
                         <groupId>org.jacoco</groupId>
                         <artifactId>org.jacoco.ant</artifactId>
-                        <version>${jacoco.version}</version>
+                        <version>${jacoco.agent.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>

--- a/tests/ballerina-tools-integration-test/pom.xml
+++ b/tests/ballerina-tools-integration-test/pom.xml
@@ -27,6 +27,14 @@
             <artifactId>ballerina-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-packerina</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-launcher</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
@@ -71,7 +79,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${jacoco.agent.argLine}</argLine>
+                    <!--<argLine>${jacoco.agent.argLine}</argLine>-->
                     <systemPropertyVariables>
                         <server.zip>
                             ${basedir}/../../distribution/zip/ballerina-tools/target/ballerina-tools-${project.version}.zip
@@ -144,6 +152,7 @@
                                     <and>
                                         <available file="${ballerina.unit.test.coverage}/${individual.test.report.name}" />
                                         <available file="${ballerina.integration.test.coverage}/${individual.test.report.name}" />
+                                        <available file="${ballerina.tools.integration.test.coverage}/${individual.test.report.name}" />
                                         <available file="${ballerina.compiler.plugin.test.coverage}/${individual.test.report.name}" />
                                         <available file="${docerina.test.coverage}/${individual.test.report.name}" />
                                         <available file="${ballerina.metrics.extension.test.coverage}/${individual.test.report.name}" />
@@ -162,6 +171,9 @@
                                                     <include name="${individual.test.report.name}" />
                                                 </fileset>
                                                 <fileset dir="${ballerina.integration.test.coverage}">
+                                                    <include name="${individual.test.report.name}" />
+                                                </fileset>
+                                                <fileset dir="${ballerina.tools.integration.test.coverage}">
                                                     <include name="${individual.test.report.name}" />
                                                 </fileset>
                                                 <fileset dir="${ballerina.compiler.plugin.test.coverage}">
@@ -318,6 +330,7 @@
 
         <ballerina.unit.test.coverage>${basedir}/../ballerina-unit-test/target/coverage-reports</ballerina.unit.test.coverage>
         <ballerina.integration.test.coverage>${basedir}/../ballerina-integration-test/target/coverage-reports</ballerina.integration.test.coverage>
+        <ballerina.tools.integration.test.coverage>${build.directory}/coverage-reports</ballerina.tools.integration.test.coverage>
         <ballerina.compiler.plugin.test.coverage>${basedir}/../ballerina-compiler-plugin-test/target/coverage-reports</ballerina.compiler.plugin.test.coverage>
         <docerina.test.coverage>${basedir}/../../misc/docerina/target/coverage-reports</docerina.test.coverage>
         <ballerina.metrics.extension.test.coverage>${basedir}/../../misc/metrics-extensions/modules/ballerina-metrics-extension/target/coverage-reports</ballerina.metrics.extension.test.coverage>

--- a/tests/ballerina-unit-test/pom.xml
+++ b/tests/ballerina-unit-test/pom.xml
@@ -432,7 +432,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>prepare-it-test-agent</id>


### PR DESCRIPTION
## Purpose
Adding integration test coverage to the final report

## Approach
Current coverage report doesn't include integration test coverage, because integration tests runs against a ballerina instance which is running on a separate jvm, hence this PR includes the process to collect code coverage data from that separate vm and include them to the final report.
