### PR TITLE
Add support for tags to default spans

### DIFF
--- a/stdlib/observability/src/main/ballerina/observe/Package.md
+++ b/stdlib/observability/src/main/ballerina/observe/Package.md
@@ -51,6 +51,12 @@ It is possible to add tags to span by using the `observe:addTagToSpan()` api by 
 ```ballerina
     _ = observe:addTagToSpan(spanId, "Tag Key", "Tag Value");
 ```
+#### Attach a tag to a span in the system trace
+When no spanId is provided or -1 is given, the defined tags are added to the current active span in the ootb system trace.
+
+```ballerina
+    _ = observe:addTagToSpan("Tag Key", "Tag Value");
+```
 
 ## Metrics 
 There are mainly two kind of metrics instances supported; Counter and Gauge. A counter is a cumulative metric that 

--- a/stdlib/observability/src/main/ballerina/observe/natives.bal
+++ b/stdlib/observability/src/main/ballerina/observe/natives.bal
@@ -42,12 +42,12 @@ public extern function startSpan(string spanName, map<string>? tags = (), int pa
 documentation {
    Add a key value pair as a tag to the span.
 
-    P{{spanId}} Id of span to which the tags should be added
+    P{{spanId}} Id of span to which the tags should be added or -1 to add tags to the current active span
     P{{tagKey}} Key of the tag
     P{{tagValue}} Value of the tag
     R{{error}} An error if an error occured while attaching tag to the span
 }
-public extern function addTagToSpan(int spanId, string tagKey, string tagValue) returns error?;
+public extern function addTagToSpan(int spanId = -1, string tagKey, string tagValue) returns error?;
 
 documentation {
         Finish the current span.
@@ -70,7 +70,7 @@ documentation {
     P{{tags}} The key/value pair tags that associated with the metric that should be looked up.
     R{{metric}} The metric instance.
 }
-public extern function lookupMetric(string name, map<string>? tags=()) returns Counter|Gauge|();
+public extern function lookupMetric(string name, map<string>? tags = ()) returns Counter|Gauge|();
 
 documentation {
     This represents the metric type - counter, that can be only increased by an integer number.
@@ -94,12 +94,12 @@ public type Counter object {
                    will be used.
          F{{tags}} The key/value pair of Tags. If no tags are provided, the default nil value will be used.
     }
-    public new(name, string? desc = "", map<string>? tags=()) {
+    public new(name, string? desc = "", map<string>? tags = ()) {
         description = desc but {
             () => ""
         };
         metricTags = tags but {
-            () =>  DEFAULT_TAGS
+            () => DEFAULT_TAGS
         };
         initialize();
     }
@@ -181,7 +181,7 @@ public type Gauge object {
             () => ""
         };
         metricTags = tags but {
-            () =>  DEFAULT_TAGS
+            () => DEFAULT_TAGS
         };
         statisticConfigs = statisticConfig but {
             () => DEFAULT_GAUGE_STATS_CONFIG

--- a/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/AddTagToSpan.java
+++ b/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/AddTagToSpan.java
@@ -48,7 +48,7 @@ public class AddTagToSpan extends BlockingNativeCallableUnit {
         String tagKey = context.getStringArgument(0);
         String tagValue = context.getStringArgument(1);
 
-        boolean tagAdded = OpenTracerBallerinaWrapper.getInstance().addTag(tagKey, tagValue, spanId);
+        boolean tagAdded = OpenTracerBallerinaWrapper.getInstance().addTag(tagKey, tagValue, spanId, context);
 
         if (!tagAdded) {
             context.setReturnValues(Utils.createErrorStruct(context,

--- a/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -32,6 +32,7 @@ import org.ballerinalang.util.tracer.TracersStore;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.ballerinalang.util.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
@@ -137,13 +138,21 @@ public class OpenTracerBallerinaWrapper {
      * @param tagKey   the key of the tag
      * @param tagValue the value of the tag
      * @param spanId   id of the Span
+     * @param context  native context
      * @return boolean to indicate if tag was added to the span
      */
-    public boolean addTag(String tagKey, String tagValue, int spanId) {
+    public boolean addTag(String tagKey, String tagValue, int spanId, Context context) {
         if (!enabled) {
             return false;
         }
         ObserverContext observerContext = observerContextList.get(spanId);
+        if (spanId == -1) {
+            Optional<ObserverContext> observer = ObservabilityUtils.getParentContext(context);
+            if (observer.isPresent()) {
+                observer.get().addTag(tagKey, tagValue);
+                return true;
+            }
+        }
         if (observerContext != null) {
             observerContext.addTag(tagKey, tagValue);
             return true;

--- a/tests/ballerina-integration-test/src/test/resources/observability/tracing/tracingservices/trace-test-user-trace-true.bal
+++ b/tests/ballerina-integration-test/src/test/resources/observability/tracing/tracingservices/trace-test-user-trace-true.bal
@@ -19,44 +19,44 @@ import ballerina/testobserve;
 import ballerina/observe;
 
 endpoint http:Listener listener2 {
-    port : 9092
+    port: 9092
 };
 
 @http:ServiceConfig {
-    basePath:"/echoService"
+    basePath: "/echoService"
 }
 service echoService2 bind listener2 {
-    resourceOne (endpoint caller, http:Request clientRequest) {
+    resourceOne(endpoint caller, http:Request clientRequest) {
         int spanId = observe:startRootSpan("uSpanThree");
         http:Response outResponse = new;
         var response = check callNextResource2(spanId);
         outResponse.setTextPayload("Hello, World!");
-        _ = caller -> respond(outResponse);
+        _ = caller->respond(outResponse);
         _ = observe:finishSpan(spanId);
     }
 
-    resourceTwo (endpoint caller, http:Request clientRequest) {
+    resourceTwo(endpoint caller, http:Request clientRequest) {
         http:Response res = new;
         res.setTextPayload("Hello, World 2!");
-        _ = caller -> respond(res);
+        _ = caller->respond(res);
     }
 
     getMockTracers(endpoint caller, http:Request clientRequest) {
         http:Response res = new;
         json returnString = testobserve:getMockTracers();
         res.setJsonPayload(returnString);
-        _ = caller -> respond(res);
+        _ = caller->respond(res);
     }
 }
 
-function callNextResource2(int parentSpanId) returns (http:Response | error) {
+function callNextResource2(int parentSpanId) returns (http:Response|error) {
     endpoint http:Client httpEndpoint {
         url: "http://localhost:9092/echoService"
     };
     int spanId = check observe:startSpan("uSpanFour", parentSpanId = parentSpanId);
-    http:Response resp = check httpEndpoint -> get("/resourceTwo");
-    _ = observe:addTagToSpan(spanId, "Allowed", "Successful");
+    http:Response resp = check httpEndpoint->get("/resourceTwo");
+    _ = observe:addTagToSpan(spanId = spanId, "Allowed", "Successful");
     _ = observe:finishSpan(spanId);
-    _ = observe:addTagToSpan(spanId, "Disallowed", "Unsuccessful");
+    _ = observe:addTagToSpan(spanId = spanId, "Disallowed", "Unsuccessful");
     return resp;
 }


### PR DESCRIPTION
## Purpose
To add user defined tags to default spans which are started when a resource starts to serve a request.

## Goals
User defined tags are listed with the default tags and this makes it easier to observe narrowly with these defined tags.
To add the user defined tags by passing -1 as the span Id argument to the addTagToSpan function as shown below.

>  _ = observe:addTagToSpan(-1, "tot_requests",req_count);

If the tag is added within a self defined span with -1 as the argument for span Id, the tag is added to the  current active span in the span hierarchy.

## Approach
 Checks if the default span is already created and if it is present, it is returned as observer context and the tag is added as key value pair.
