### PR TITLE
Improve taint checking for worker interactions and readability

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -534,8 +534,7 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                         bracedOrTupleExpr.pos));
             } else if (varRefExpr.getKind() == NodeKind.XML_ATTRIBUTE_ACCESS_EXPR) {
                 overridingAnalysis = false;
-                updatedVarRefTaintedState(((BLangXMLAttributeAccess) varRefExpr).expr,
-                        varTaintedStatus);
+                updatedVarRefTaintedState(((BLangXMLAttributeAccess) varRefExpr).expr, varTaintedStatus);
                 overridingAnalysis = true;
             } else {
                 setTaintedStatus((BLangVariableReference) varRefExpr, varTaintedStatus);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -532,6 +532,11 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 // Propagate tainted status to fields, when field symbols are present (Example: struct).
                 bracedOrTupleExpr.expressions.forEach(expr -> visitAssignment(expr, varTaintedStatus,
                         bracedOrTupleExpr.pos));
+            } else if (varRefExpr.getKind() == NodeKind.XML_ATTRIBUTE_ACCESS_EXPR) {
+                overridingAnalysis = false;
+                updatedVarRefTaintedState(((BLangXMLAttributeAccess) varRefExpr).expr,
+                        varTaintedStatus);
+                overridingAnalysis = true;
             } else {
                 setTaintedStatus((BLangVariableReference) varRefExpr, varTaintedStatus);
             }
@@ -606,8 +611,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangIf ifNode) {
-        ifNode.body.accept(this);
         overridingAnalysis = false;
+        ifNode.body.accept(this);
         if (ifNode.elseStmt != null) {
             ifNode.elseStmt.accept(this);
         }
@@ -691,7 +696,7 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangForkJoin forkJoin) {
-        analyzeWorkers(forkJoin.workers);
+        analyzeWorkers(forkJoin.workers, true);
         if (currForkIdentifier != null) {
             TaintedStatus taintedStatus = workerInteractionTaintedStatusMap.get(currForkIdentifier);
             if (taintedStatus != null) {
@@ -801,9 +806,13 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         }
         workerSendNode.expr.accept(this);
         TaintedStatus taintedStatus = workerInteractionTaintedStatusMap.get(workerSendNode.workerIdentifier);
-        if (taintedStatus == TaintedStatus.IGNORED) {
+        if (taintedStatus == null) {
             workerInteractionTaintedStatusMap.put(workerSendNode.workerIdentifier, this.taintedStatus);
         } else if (this.taintedStatus == TaintedStatus.TAINTED) {
+            // Worker interactions should be non-overriding. Hence changing the status only if the expression used in
+            // sending is evaluated to be a tainted value. By doing so, analyzer will not change an interaction that
+            // was identified to return a `Tainted` value to be `Untainted` later on. (Example: Conditional worker
+            // interactions)
             workerInteractionTaintedStatusMap.put(workerSendNode.workerIdentifier, TaintedStatus.TAINTED);
         }
     }
@@ -811,7 +820,7 @@ public class TaintAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangWorkerReceive workerReceiveNode) {
         TaintedStatus taintedStatus = workerInteractionTaintedStatusMap.get(currWorkerIdentifier);
-        if (taintedStatus == TaintedStatus.IGNORED) {
+        if (taintedStatus == null) {
             blockedOnWorkerInteraction = true;
             stopAnalysis = true;
         } else {
@@ -967,9 +976,9 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTernaryExpr ternaryExpr) {
+        overridingAnalysis = false;
         ternaryExpr.thenExpr.accept(this);
         TaintedStatus thenTaintedCheckResult = this.taintedStatus;
-        overridingAnalysis = false;
         ternaryExpr.elseExpr.accept(this);
         overridingAnalysis = true;
         TaintedStatus elseTaintedCheckResult = this.taintedStatus;
@@ -1634,31 +1643,35 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         if (invokableNode.workers.isEmpty()) {
             analyzeNode(invokableNode.body, symbolEnv);
         } else {
-            analyzeWorkers(invokableNode.workers);
+            analyzeWorkers(invokableNode.workers, true);
         }
         if (stopAnalysis) {
             stopAnalysis = false;
         }
     }
 
-    private void analyzeWorkers (List<BLangWorker> workers) {
-        workerInteractionTaintedStatusMap = new HashMap<>();
-        boolean doScan = true;
-        while (doScan) {
-            doScan = false;
-            for (BLangWorker worker : workers) {
-                blockedOnWorkerInteraction = false;
-                worker.endpoints.forEach(endpoint -> endpoint.accept(this));
-                worker.accept(this);
-                if (this.blockedNode != null || taintErrorSet.size() > 0) {
-                    return;
-                } else if (blockedOnWorkerInteraction) {
-                    doScan = true;
-                    stopAnalysis = false;
-                } else if (stopAnalysis) {
-                    return;
-                }
+    private void analyzeWorkers(List<BLangWorker> workers, boolean resetStatusMap) {
+        if (resetStatusMap) {
+            workerInteractionTaintedStatusMap = new HashMap<>();
+        }
+        boolean recurse = false;
+        for (BLangWorker worker : workers) {
+            blockedOnWorkerInteraction = false;
+            worker.endpoints.forEach(endpoint -> endpoint.accept(this));
+            worker.accept(this);
+            if (this.blockedNode != null || taintErrorSet.size() > 0) {
+                return;
+            } else if (blockedOnWorkerInteraction) {
+                recurse = true;
+                stopAnalysis = false;
+            } else if (stopAnalysis) {
+                return;
             }
+        }
+        // If any of the workers were blocked on a worker interaction, re-analyze the workers after completing the
+        // analysis of all workers, to resolve blocked interactions.
+        if (recurse) {
+            analyzeWorkers(workers, false);
         }
     }
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -156,11 +156,12 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testXMLNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/xml-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 4);
+        Assert.assertTrue(result.getDiagnostics().length == 5);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 7, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 10, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 13, 20);
         BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'secureIn'", 14, 20);
+        BAssertUtil.validateError(result, 4, "tainted value passed to sensitive parameter 'secureIn'", 18, 20);
     }
 
     @Test

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -456,7 +456,7 @@ public class TaintedStatusPropagationTest {
     }
 
     @Test
-    public void testSimpleWorkerInteractionBlockedNegative() {
+    public void testSimpleBlockedWorkerInteractionNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal");
         Assert.assertTrue(result.getDiagnostics().length == 1);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -185,9 +185,11 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testIfConditionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/if-condition-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertTrue(result.getDiagnostics().length == 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 16, 20);
+        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 24, 20);
+        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'secureIn'", 32, 20);
     }
 
     @Test

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -454,6 +454,14 @@ public class TaintedStatusPropagationTest {
     }
 
     @Test
+    public void testSimpleWorkerInteractionBlockedNegative() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 1);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 5, 24);
+    }
+
+    @Test
     public void testSimpleWorkerInteractionWithTupleAssignment() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-with-tuple-assignment.bal");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/if-condition-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/if-condition-negative.bal
@@ -14,6 +14,22 @@ function main (string... args) {
         path1 = args[0];
     }
     secureFunction(path1, path1);
+
+    string path2 = args[0];
+    if (lengthof args > 0) {
+        path2 = "/home";
+    } else {
+        // Empty
+    }
+    secureFunction(path2, path2);
+
+    string path3 = args[0];
+    if (lengthof args > 0) {
+        // Empty
+    } else {
+        path3 = "/home";
+    }
+    secureFunction(path3, path3);
 }
 
 public function secureFunction (@sensitive string secureIn, string insecureIn) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal
@@ -1,0 +1,17 @@
+function main (string... args) {
+    worker w1 {
+        string data = "string";
+        args[0] -> w2;
+        data <- w2;
+        secureFunction(data, data);
+    }
+    worker w2 {
+        string data1 = "string";
+        data1 <- w1;
+        secureFunction(data1, data1);
+        data1 -> w1;
+    }
+}
+function secureFunction (@sensitive string secureIn, string insecureIn) {
+
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal
@@ -1,15 +1,15 @@
 function main (string... args) {
     worker w1 {
-        string data = "string";
-        args[0] -> w2;
-        data <- w2;
-        secureFunction(data, data);
+        string data1 = "string";
+        data1 <- w2;
+        secureFunction(data1, data1);
+        data1 -> w2;
     }
     worker w2 {
-        string data1 = "string";
-        data1 <- w1;
-        secureFunction(data1, data1);
-        data1 -> w1;
+        string data = "string";
+        args[0] -> w1;
+        data <- w1;
+        secureFunction(data, data);
     }
 }
 function secureFunction (@sensitive string secureIn, string insecureIn) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/xml-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/xml-negative.bal
@@ -12,6 +12,10 @@ function main (string... args) {
     xml x3 = xml `<ns0:book ns0:status="{{data}}" count="5"/>`;
     secureFunction(x3@[ns0:status], x3@[ns0:status]);
     secureFunction(x3@[ns0:count], x3@[ns0:count]);
+
+    var x4 = xml `<root xmlns:ns4="http://sample.com/wso2/f"></root>`;
+    x4@["foo1"] = args[0];
+    secureFunction(x4, x4);
 }
 
 public function secureFunction (@sensitive any secureIn, any insecureIn) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/xml.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/xml.bal
@@ -12,6 +12,10 @@ function main (string... args) {
     xml x3 = xml `<ns0:book ns0:status="{{data}}" count="5"/>`;
     secureFunction(x3@[ns0:status], x3@[ns0:status]);
     secureFunction(x3@[ns0:count], x3@[ns0:count]);
+
+    var x4 = xml `<root xmlns:ns4="http://sample.com/wso2/f"></root>`;
+    x4@["foo1"] = "foo";
+    secureFunction(x4, x4);
 }
 
 public function secureFunction (@sensitive any secureIn, any insecureIn) {


### PR DESCRIPTION
## Purpose
* Change worker interaction block resolution to use recursion instead of loop (code quality improvement)
* Bug fix in block resolution for worker interactions (unit test added)
* When doing an assignment with `XML_ATTRIBUTE_ACCESS_EXPR` (` x1@["foo1"] = tainted_value;`), allow correctly setting tainted/untainted status of the XML. 
* Change `if` and `ternary` expression analysis to be  nonOverridingAnalysis (unit test added)

Previously following code resulted in making the `example` variable untainted:
```
var example = tainted_value;
if (condition) {
   example = "untainted_value";
} else {
}
```

whereas the following code will result in `example` remaining as untainted variable:
```
var example = tainted_value;
if (condition) {
} else {
   example = "untainted_value";
}
```

This is because only the `else` block was considered `nonOverridingAnalysis`, which is wrong since we do not know which block (if or else) would execute in runtime.

This was corrected to consider both IF block and the ELSE block as `nonOverriding`.