### PR TITLE
Improve code coverage

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -846,12 +846,6 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         TaintedStatus isTainted = TaintedStatus.UNTAINTED;
         for (BLangRecordLiteral.BLangRecordKeyValue keyValuePair : recordLiteral.keyValuePairs) {
             keyValuePair.valueExpr.accept(this);
-            // Update field symbols with tainted status of the individual field (Example: struct).
-            if (keyValuePair.key.fieldSymbol != null) {
-                if (overridingAnalysis || !keyValuePair.key.fieldSymbol.tainted) {
-                    setTaintedStatus(keyValuePair.key.fieldSymbol, this.taintedStatus);
-                }
-            }
             // Used to update the variable this literal is getting assigned to.
             if (this.taintedStatus == TaintedStatus.TAINTED) {
                 isTainted = TaintedStatus.TAINTED;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/match/MatchExpressionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/match/MatchExpressionTest.java
@@ -186,6 +186,12 @@ public class MatchExpressionTest {
     }
 
     @Test
+    public void testRecordMatchIndirectly() {
+        BValue[] results = BRunUtil.invoke(compileResult, "testRecordMatchIndirectly");
+        Assert.assertEquals(results[0].stringValue(), "Not John");
+    }
+
+    @Test
     public void testMatchExprNegative() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/expressions/match/match-expr-negative.bal");
         BAssertUtil.validateError(negativeResult, 0, "incompatible types: expected 'string', found 'int'", 8, 36);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/OpenRecordConstrainedJSONNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/OpenRecordConstrainedJSONNegativeTest.java
@@ -27,6 +27,8 @@ import org.testng.annotations.Test;
 
 /**
  * Negative test cases for constraining json types with open records.
+ *
+ * @since 0.982.0
  */
 public class OpenRecordConstrainedJSONNegativeTest {
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/OpenRecordConstrainedJSONNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/OpenRecordConstrainedJSONNegativeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.ballerinalang.test.types.json;
+
+import org.ballerinalang.launcher.util.BAssertUtil;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Negative test cases for constraining json types with open records.
+ */
+public class OpenRecordConstrainedJSONNegativeTest {
+
+    private CompileResult negativeResult;
+
+    @BeforeClass
+    public void setup() {
+        negativeResult = BCompileUtil.compile("test-src/types/jsontype/open_record_constrained_json_negative_test.bal");
+    }
+
+    @Test(description = "Test basic json struct constraint")
+    public void testConstrainedJSONNegative() {
+        Assert.assertEquals(negativeResult.getErrorCount(), 4);
+        BAssertUtil.validateError(negativeResult, 0,
+                "incompatible types: json cannot be constrained with open record type 'json'", 16, 5);
+        BAssertUtil.validateError(negativeResult, 1, "invalid literal for type 'other'", 16, 22);
+        BAssertUtil.validateError(negativeResult,
+                2, "incompatible types: 'json' cannot be constrained with 'Student'", 20, 5);
+        BAssertUtil.validateError(negativeResult, 3, "invalid literal for type 'other'", 20, 23);
+    }
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/match/match-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/match/match-expr.bal
@@ -114,3 +114,20 @@ function testMatchErrorWithCauses() {
     }
 }
 
+type Person record {
+    string name,
+    !...
+};
+
+type Employee record {
+    string name,
+    int age,
+    !...
+};
+
+function testRecordMatchIndirectly () returns string {
+    Employee emp = { name: "John" };
+    Employee|Person pUnion = emp;
+    Person person = pUnion but { Employee => { name:"Not John" }};
+    return person.name;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/jsontype/open_record_constrained_json_negative_test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/jsontype/open_record_constrained_json_negative_test.bal
@@ -1,0 +1,21 @@
+type Person record {
+    string name;
+    int age;
+    string address;
+    string...
+};
+
+type Student record {
+    string name;
+    int age;
+    string address;
+    string class;
+};
+
+function testWithConstrainedRestParam() {
+    json<Person> j = {name:"John", address:"Doe", age:20, height:5.5};
+}
+
+function testWithOpenRecord() {
+    json<Student> j = {name:"John Doe", age:20, address:"London"};
+}


### PR DESCRIPTION
Improve code coverage related to Record literal and Match Expression.
Code related to safe assignment operator has been removed from Desugar phase.
Usage of fieldSymbol of Record literal is removed from TaintAnalyzer