### PR TITLE
Improvement to integration test groups execution

### DIFF
--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/auth/AuthnConfigInheritanceAuthDisableTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/auth/AuthnConfigInheritanceAuthDisableTest.java
@@ -23,8 +23,8 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -60,7 +60,7 @@ public class AuthnConfigInheritanceAuthDisableTest extends BaseTest {
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 
-    @BeforeTest(groups = "auth-test")
+    @BeforeGroups(value = "auth-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String basePath = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "auth").getAbsolutePath();
@@ -69,7 +69,7 @@ public class AuthnConfigInheritanceAuthDisableTest extends BaseTest {
         serverInstance.startBallerinaServer("authservices", args);
     }
 
-    @AfterTest(groups = "auth-test")
+    @AfterGroups(value = "auth-test", alwaysRun = true)
     public void cleanup() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/data/streaming/TableToXMLStreamingTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/data/streaming/TableToXMLStreamingTestCase.java
@@ -44,7 +44,7 @@ public class TableToXMLStreamingTestCase extends BaseTest {
     private TestDatabase testDatabase;
     private static final String DB_DIRECTORY = "./target/tempdb/";
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     private void setup() throws Exception {
         setUpDatabase();
         String balFile = Paths.get("src", "test", "resources", "data", "streaming", "xml_streaming_test.bal")

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/filter/MultpleFiltersTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/filter/MultpleFiltersTestCase.java
@@ -24,8 +24,8 @@ import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.ballerinalang.test.util.TestConstant;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -85,7 +85,7 @@ public class MultpleFiltersTestCase extends BaseTest {
         Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
     }
 
-    @BeforeTest(groups = "filter-test")
+    @BeforeGroups(value = "filter-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String basePath = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "filter").getAbsolutePath();
@@ -93,7 +93,7 @@ public class MultpleFiltersTestCase extends BaseTest {
         serverInstance.startBallerinaServer("filterservices", args);
     }
 
-    @AfterTest(groups = "filter-test")
+    @AfterGroups(value = "filter-test", alwaysRun = true)
     public void cleanup() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/jms/JMSConnectorTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/jms/JMSConnectorTestCase.java
@@ -40,7 +40,7 @@ public class JMSConnectorTestCase extends BaseTest {
     private EmbeddedBroker embeddedBroker;
     private JMSClientHandler clientHandler;
 
-    @BeforeClass()
+    @BeforeClass(alwaysRun = true)
     public void setUp() throws Exception {
         embeddedBroker = new EmbeddedBroker();
         embeddedBroker.startBroker();
@@ -153,7 +153,7 @@ public class JMSConnectorTestCase extends BaseTest {
         clientHandler.stop();
     }
 
-    @AfterClass()
+    @AfterClass(alwaysRun = true)
     private void cleanup() throws Exception {
         embeddedBroker.stop();
         clientHandler.clean();
@@ -169,7 +169,7 @@ public class JMSConnectorTestCase extends BaseTest {
         return logLeecher;
     }
 
-    @BeforeGroups(groups = "jms-test")
+    @BeforeGroups(value = "jms-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String basePath = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "jms").getAbsolutePath();
@@ -177,7 +177,7 @@ public class JMSConnectorTestCase extends BaseTest {
         serverInstance.startBallerinaServer("jmsservices", args);
     }
 
-    @AfterGroups(groups = "jms-test")
+    @AfterGroups(value = "jms-test", alwaysRun = true)
     public void stop() throws BallerinaTestException {
         serverInstance.stopServer();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingTestCase.java
@@ -24,8 +24,8 @@ import org.apache.commons.io.FileUtils;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -52,7 +52,7 @@ public class TracingTestCase extends BaseTest {
     private static final String DEST_FUNCTIONS_JAR = File.separator + "bre" + File.separator + "lib"
             + File.separator + TEST_NATIVES_JAR;
 
-    @BeforeTest(groups = "tracing-test")
+    @BeforeGroups(value = "tracing-test", alwaysRun = true)
     private void setup() throws Exception {
         copyFile(new File(System.getProperty(TEST_NATIVES_JAR)), new File(serverInstance.getServerHome()
                 + DEST_FUNCTIONS_JAR));
@@ -138,7 +138,7 @@ public class TracingTestCase extends BaseTest {
         Files.copy(source.toPath(), dest.toPath(), REPLACE_EXISTING);
     }
 
-    @AfterTest(groups = "tracing-test")
+    @AfterGroups(value = "tracing-test", alwaysRun = true)
     private void cleanup() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/securelistener/NoTokenPropagationTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/securelistener/NoTokenPropagationTest.java
@@ -24,8 +24,8 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -38,7 +38,7 @@ import java.util.Map;
 @Test(groups = "secure-listener-test")
 public class NoTokenPropagationTest extends BaseTest {
 
-    @BeforeTest(groups = "secure-listener-test")
+    @BeforeGroups(value = "secure-listener-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String basePath = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "secureListener").getAbsolutePath();
@@ -56,7 +56,7 @@ public class NoTokenPropagationTest extends BaseTest {
         Assert.assertEquals(response.getResponseCode(), 401, "Response code mismatched");
     }
 
-    @AfterTest(groups = "secure-listener-test")
+    @AfterGroups(value = "secure-listener-test", alwaysRun = true)
     public void cleanup() throws Exception {
         serverInstance.stopServer();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/security/HTTPResponseXMLSecurityTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/security/HTTPResponseXMLSecurityTestCase.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class HTTPResponseXMLSecurityTestCase extends BaseTest {
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
         String balFilePath = new File("src" + File.separator + "test" + File.separator + "resources"
                 + File.separator + "xmlSecurity" + File.separator +
@@ -92,7 +92,7 @@ public class HTTPResponseXMLSecurityTestCase extends BaseTest {
         return response;
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     private void cleanup() throws Exception {
         serverInstance.stopServer();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/GrpcBaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/GrpcBaseTest.java
@@ -20,8 +20,8 @@ package org.ballerinalang.test.service.grpc.sample;
 
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 
 import java.io.File;
 
@@ -31,7 +31,7 @@ import java.io.File;
  */
 public class GrpcBaseTest extends BaseTest {
 
-    @BeforeTest(groups = "grpc-test")
+    @BeforeGroups(value = "grpc-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "grpc").getAbsolutePath();
@@ -39,7 +39,7 @@ public class GrpcBaseTest extends BaseTest {
         serverInstance.startBallerinaServer("grpcservices", args);
     }
 
-    @AfterTest(groups = "grpc-test")
+    @AfterGroups(value = "grpc-test", alwaysRun = true)
     public void cleanup() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -20,8 +20,8 @@ package org.ballerinalang.test.service.http;
 
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 
 import java.io.File;
 
@@ -30,7 +30,7 @@ import java.io.File;
  * and after tests are run.
  */
 public class HttpBaseTest extends BaseTest {
-    @BeforeTest(groups = "http-test", alwaysRun = true)
+    @BeforeGroups(value = "http-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "http").getAbsolutePath();
@@ -38,7 +38,7 @@ public class HttpBaseTest extends BaseTest {
         serverInstance.startBallerinaServer("httpservices", args);
     }
 
-    @AfterTest(groups = "http-test")
+    @AfterGroups(value = "http-test", alwaysRun = true)
     public void cleanup() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 /**
  * Test whether the xml payload gets parsed properly, after the said payload has been retrieved as a byte array.
  */
+@Test(groups = "http-test")
 public class HttpPayloadTestCase extends BaseTest {
     @Test
     public void testXmlPayload() throws IOException {

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2ServerPushTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2ServerPushTestCase.java
@@ -22,8 +22,8 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -35,7 +35,7 @@ import java.io.IOException;
 @Test(groups = "http2-test")
 public class Http2ServerPushTestCase extends BaseTest {
 
-    @BeforeTest(groups = "http2-test")
+    @BeforeGroups(value = "http2-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "http2").getAbsolutePath();
@@ -43,7 +43,7 @@ public class Http2ServerPushTestCase extends BaseTest {
         serverInstance.startBallerinaServer("http2services", args);
     }
 
-    @AfterTest(groups = "http2-test")
+    @AfterGroups(value = "http2-test", alwaysRun = true)
     public void cleanup() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/resiliency/FailoverClientTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/resiliency/FailoverClientTestCase.java
@@ -25,7 +25,7 @@ import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.ballerinalang.test.util.TestConstant;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -190,7 +190,7 @@ public class FailoverClientTestCase extends BaseTest {
         Assert.assertEquals(secondResponse.getData(), "Failover start index is : 2", "Message content mismatched");
     }
 
-    @AfterClass
+    @AfterTest(alwaysRun = true)
     private void cleanup() throws Exception {
         serverInstance.stopServer();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
@@ -34,10 +34,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * Tests success and failure of client endpoint creation based on the different ways of its creation.
  */
+@Test(groups = "websocket-test")
 public class ClientServiceTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9090/client/service";
+    private static final String URL = "ws://localhost:9200/client/service";
     private WebSocketRemoteServer remoteServer;
 
     @BeforeClass(description = "Initializes the Ballerina server with the client_service.bal file")
@@ -47,7 +48,7 @@ public class ClientServiceTest extends WebSocketTestCommons {
         client = new WebSocketTestClient(URL);
     }
 
-    @Test(priority = 1, description = "Tests the client initialization without a callback service")
+    @Test(description = "Tests the client initialization without a callback service")
     public void testClientSuccessWithoutService() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);
@@ -59,8 +60,8 @@ public class ClientServiceTest extends WebSocketTestCommons {
         Assert.assertEquals(text, "Client worked");
     }
 
-    @Test(priority = 2,
-          description = "Tests the client initialization with a WebSocketClientService but without any resources")
+    @Test(description = "Tests the client initialization with a WebSocketClientService but without any resources",
+            dependsOnMethods = "testClientSuccessWithoutService")
     public void testClientSuccessWithWebSocketClientService() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.sendText("hey");
@@ -72,7 +73,8 @@ public class ClientServiceTest extends WebSocketTestCommons {
         Assert.assertEquals(text, "Client worked");
     }
 
-    @Test(priority = 3, description = "Tests the client initialization failure when used with a WebSocketService")
+    @Test(description = "Tests the client initialization failure when used with a WebSocketService",
+            dependsOnMethods = "testClientSuccessWithWebSocketClientService")
     public void testClientFailureWithWebSocketService() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.sendBinary(ByteBuffer.wrap("hey".getBytes()));

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketContinuationAndAggregationTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketContinuationAndAggregationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test WebSocket continuation frames and the aggregation of fragments when the content is other than a string.
  */
+@Test(groups = "websocket-test")
 public class WebSocketContinuationAndAggregationTest extends WebSocketTestCommons {
 
     @Test(description = "Tests string support for pushText and onText")

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketPushAndOnTextResourceTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketPushAndOnTextResourceTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test WebSocket endpoint method pushText and the onText resource.
  */
+@Test(groups = "websocket-test")
 public class WebSocketPushAndOnTextResourceTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
@@ -45,7 +45,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
         remoteServer.run();
     }
 
-    @Test(priority = 1, description = "Tests sending and receiving of text frames in WebSockets")
+    @Test(description = "Tests sending and receiving of text frames in WebSockets")
     public void testSendText() throws URISyntaxException, InterruptedException {
         WebSocketTestClient client = new WebSocketTestClient(URL);
         client.handshake();
@@ -58,7 +58,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
         client.shutDown();
     }
 
-    @Test(priority = 2, description = "Tests sending and receiving of binary frames in WebSockets")
+    @Test(description = "Tests sending and receiving of binary frames in WebSockets", dependsOnMethods = "testSendText")
     public void testSendBinary() throws URISyntaxException, InterruptedException {
         WebSocketTestClient client = new WebSocketTestClient(URL);
         client.handshake();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
@@ -21,8 +21,8 @@ package org.ballerinalang.test.service.websocket;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
 
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
@@ -41,7 +41,7 @@ public class WebSocketTestCommons extends BaseTest {
      *
      * @throws BallerinaTestException on Ballerina related issues.
      */
-    @BeforeTest(groups = "websocket-test")
+    @BeforeGroups(value = "websocket-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "websocket").getAbsolutePath();
@@ -49,7 +49,7 @@ public class WebSocketTestCommons extends BaseTest {
         serverInstance.startBallerinaServer("wsservices", args);
     }
 
-    @AfterTest(groups = "websocket-test")
+    @AfterGroups(value = "websocket-test", alwaysRun = true)
     public void stop() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/streaming/StreamsWithinServicesTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/streaming/StreamsWithinServicesTestCase.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class StreamsWithinServicesTestCase extends BaseTest {
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
         String relativePath = new File("src" + File.separator + "test" + File.separator + "resources"
                 + File.separator + "streaming" + File.separator +
@@ -79,7 +79,7 @@ public class StreamsWithinServicesTestCase extends BaseTest {
         Assert.assertNotEquals(responseMsg, "\"{'message' : 'NotAssigned'}\"");
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     private void cleanup() throws Exception {
         serverInstance.stopServer();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/transaction/MicroTransactionTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/transaction/MicroTransactionTestCase.java
@@ -23,8 +23,8 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.ballerinalang.test.util.SQLDBUtils;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -327,7 +327,7 @@ public class MicroTransactionTestCase extends BaseTest {
         }
     }
 
-    @BeforeTest(groups = "transactions-test")
+    @BeforeClass(groups = "transactions-test", alwaysRun = true)
     public void start() throws BallerinaTestException, IOException {
         SQLDBUtils.deleteFiles(new File(SQLDBUtils.DB_DIRECTORY), DB_NAME);
         sqlServer = SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "transaction/data.sql");
@@ -342,7 +342,7 @@ public class MicroTransactionTestCase extends BaseTest {
         serverInstance.startBallerinaServer("transactionservices", args, initiatorServicePort);
     }
 
-    @AfterTest(groups = "transactions-test")
+    @AfterClass(groups = "transactions-test", alwaysRun = true)
     public void stop() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -48,7 +48,7 @@
         </packages>
     </test>
 
-    <test name="ballerina-auth-tests" parallel="methods" thread-count="6">
+    <test name="ballerina-auth-tests" parallel="false">
         <groups>
             <run>
                 <exclude name="broken"/>
@@ -59,19 +59,19 @@
         </packages>
     </test>
 
-    <test name="ballerina-filter-tests" parallel="methods" thread-count="6">
+    <test name="ballerina-filter-tests" parallel="false">
         <packages>
             <package name="org.ballerinalang.test.filter"/>
         </packages>
     </test>
 
-    <test name="ballerina-transaction-tests" parallel="methods" thread-count="6">
+    <test name="ballerina-transaction-tests" parallel="false">
         <packages>
             <package name="org.ballerinalang.test.transaction"/>
         </packages>
     </test>
 
-    <test name="ballerina-secure-listener-tests" parallel="methods" thread-count="6">
+    <test name="ballerina-secure-listener-tests" parallel="false">
         <groups>
             <run>
                 <exclude name="broken"/>
@@ -131,7 +131,7 @@
         </classes>
     </test>
 
-    <test name="ballerina-data-streaming-tests">
+    <test name="ballerina-data-streaming-tests" parallel="false">
         <packages>
             <package name="org.ballerinalang.test.data.streaming"/>
         </packages>

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/client_service.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/client_service.bal
@@ -17,36 +17,36 @@
 import ballerina/http;
 import ballerina/log;
 
-@final string REMOTE_BACKEND_URL = "ws://localhost:15500/websocket";
+@final string REMOTE_BACKEND_URL200 = "ws://localhost:15500/websocket";
 
 @http:WebSocketServiceConfig {
     path: "/client/service"
 }
-service<http:WebSocketService> clientFailure bind { port: 9090 } {
+service<http:WebSocketService> clientFailure200 bind { port: 9200 } {
 
     onOpen(endpoint wsEp) {
         endpoint http:WebSocketClient wsClientEp {
-            url: REMOTE_BACKEND_URL
+            url: REMOTE_BACKEND_URL200
         };
         _ = wsEp->pushText("Client worked");
     }
 
     onText(endpoint caller, string text) {
         endpoint http:WebSocketClient wsClientEp {
-            url: REMOTE_BACKEND_URL,
-            callbackService: ClientService
+            url: REMOTE_BACKEND_URL200,
+            callbackService: ClientService200
         };
         _ = caller->pushText("Client worked");
     }
 
     onBinary(endpoint caller, byte[] data) {
         endpoint http:WebSocketClient wsClientEp {
-            url: REMOTE_BACKEND_URL,
-            callbackService: callback
+            url: REMOTE_BACKEND_URL200,
+            callbackService: callback200
         };
     }
 }
-service<http:WebSocketService> callback {
+service<http:WebSocketService> callback200 {
 }
-service<http:WebSocketClientService> ClientService {
+service<http:WebSocketClientService> ClientService200 {
 }


### PR DESCRIPTION
## Purpose
This will make test groups to run before and after groups logic more resiliently by using alwaysRun attribute with test groups. This improvement/robustness will make sure that for each test groups, the @before and @after methods will always run regardless of any failures so that server is properly stopped before next group run.

This PR also fixes a test failure with a web-socket integration test which the test service bal file was not added to the test package, which caused the test to fail due to unavailability of the service.

Also I have removed some of the parallel execution groups to avoid any intermittent failures.