### PR TITLE
Add IO event execution for content in user buffer 

### DIFF
--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/BlobIOChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/BlobIOChannel.java
@@ -56,5 +56,4 @@ public class BlobIOChannel extends Channel {
     public boolean remaining() {
         return false;
     }
-
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/BlobIOChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/BlobIOChannel.java
@@ -52,4 +52,9 @@ public class BlobIOChannel extends Channel {
         return false;
     }
 
+    @Override
+    public boolean remaining() {
+        return false;
+    }
+
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/FileIOChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/FileIOChannel.java
@@ -67,4 +67,9 @@ public class FileIOChannel extends Channel {
     public boolean isSelectable() {
         return false;
     }
+
+    @Override
+    public boolean remaining() {
+        return false;
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/SocketIOChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/SocketIOChannel.java
@@ -68,6 +68,11 @@ public class SocketIOChannel extends Channel {
         return selectable;
     }
 
+    @Override
+    public boolean remaining() {
+        return false;
+    }
+
     /**
      * Shutdown the connection for reading.
      *

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/CharacterChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/CharacterChannel.java
@@ -206,7 +206,12 @@ public class CharacterChannel implements IOChannel {
     }
 
     /**
+     * <p>
      * Reads bytes asynchronously from the channel.
+     * </p>
+     * <p>
+     * This operation would not guarantee that all the content is read.
+     * </p>
      *
      * @param numberOfBytesRequired number of bytes required from the channel.
      * @param numberOfCharsRequired number of characters required.
@@ -219,12 +224,10 @@ public class CharacterChannel implements IOChannel {
         CharBuffer intermediateCharacterBuffer;
         //Provided at this point any remaining character left in the buffer is copied
         charBuffer = CharBuffer.allocate(numberOfBytesRequired);
-        do {
-            buffer = contentBuffer.get(numberOfBytesRequired, channel);
-            intermediateCharacterBuffer = bytesDecoder.decode(buffer);
-            numberOfCharsProcessed = numberOfCharsProcessed + intermediateCharacterBuffer.limit();
-            charBuffer.put(intermediateCharacterBuffer);
-        } while (!channel.hasReachedEnd() && numberOfCharsProcessed < numberOfCharsRequired);
+        buffer = contentBuffer.get(numberOfBytesRequired, channel);
+        intermediateCharacterBuffer = bytesDecoder.decode(buffer);
+        numberOfCharsProcessed = numberOfCharsProcessed + intermediateCharacterBuffer.limit();
+        charBuffer.put(intermediateCharacterBuffer);
         //We make the char buffer ready to read
         charBuffer.flip();
         processChars(numberOfCharsRequired, buffer, numberOfCharsProcessed);
@@ -419,5 +422,10 @@ public class CharacterChannel implements IOChannel {
     @Override
     public void close() throws IOException {
         channel.close();
+    }
+
+    @Override
+    public boolean remaining() {
+        return null != charBuffer && charBuffer.hasRemaining();
     }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DataChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DataChannel.java
@@ -346,4 +346,9 @@ public class DataChannel implements IOChannel {
     public void close() throws IOException {
         this.channel.close();
     }
+
+    @Override
+    public boolean remaining() {
+        return false;
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DelimitedRecordChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DelimitedRecordChannel.java
@@ -175,7 +175,6 @@ public class DelimitedRecordChannel implements IOChannel {
      */
     private String readRecord() throws BallerinaIOException, IOException {
         String record = null;
-        String readCharacters = "";
         final int minimumRecordCount = 1;
         final int numberOfSplits = 2;
         do {
@@ -192,9 +191,9 @@ public class DelimitedRecordChannel implements IOChannel {
                     recordCharacterCount = record.length();
                 }
             } else {
-                readCharacters = readRecordFromChannel();
+                readRecordFromChannel();
             }
-        } while (record == null && !readCharacters.isEmpty());
+        } while (record == null && !channel.hasReachedEnd());
 
         if (null == record) {
             record = readFinalRecord();
@@ -458,6 +457,11 @@ public class DelimitedRecordChannel implements IOChannel {
     @Override
     public void close() throws IOException {
         channel.close();
+    }
+
+    @Override
+    public boolean remaining() {
+        return persistentCharSequence.length() > 0;
     }
 
     /**

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/IOChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/IOChannel.java
@@ -69,4 +69,11 @@ public interface IOChannel {
      * @throws IOException during i/o error.
      */
     void close() throws IOException;
+
+    /**
+     * Specifies whether there're remaining content on user-space.
+     *
+     * @return true if there're remaining content false if not.
+     */
+    boolean remaining();
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/Event.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/Event.java
@@ -57,4 +57,11 @@ public interface Event extends Supplier<EventResult> {
      * @return byte channel which represents the event.
      */
      Channel getChannel();
+
+    /**
+     * Specifies whether there're remaining content in user-space.
+     *
+     * @return true if there're remaining content.
+     */
+     boolean remaining();
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/EventExecutor.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/EventExecutor.java
@@ -54,6 +54,10 @@ public class EventExecutor {
         return evt.getChannel();
     }
 
+    public boolean remaining() {
+        return evt.remaining();
+    }
+
     /**
      * Executes the task once ready.
      */

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/bytes/CloseByteChannelEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/bytes/CloseByteChannelEvent.java
@@ -87,4 +87,9 @@ public class CloseByteChannelEvent implements Event {
     public Channel getChannel() {
         return channel;
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/bytes/ReadBytesEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/bytes/ReadBytesEvent.java
@@ -132,4 +132,9 @@ public class ReadBytesEvent implements Event {
     public Channel getChannel() {
         return channel;
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/bytes/WriteBytesEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/bytes/WriteBytesEvent.java
@@ -97,4 +97,9 @@ public class WriteBytesEvent implements Event {
     public Channel getChannel() {
         return byteChannel;
     }
+
+    @Override
+    public boolean remaining() {
+        return byteChannel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/characters/CloseCharacterChannelEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/characters/CloseCharacterChannelEvent.java
@@ -91,4 +91,9 @@ public class CloseCharacterChannelEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/characters/ReadCharactersEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/characters/ReadCharactersEvent.java
@@ -111,4 +111,9 @@ public class ReadCharactersEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/characters/WriteCharactersEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/characters/WriteCharactersEvent.java
@@ -106,4 +106,9 @@ public class WriteCharactersEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/CloseDataChannelEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/CloseDataChannelEvent.java
@@ -87,4 +87,9 @@ public class CloseDataChannelEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadBoolEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadBoolEvent.java
@@ -91,4 +91,9 @@ public class ReadBoolEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadFloatEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadFloatEvent.java
@@ -97,4 +97,9 @@ public class ReadFloatEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadIntegerEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadIntegerEvent.java
@@ -96,4 +96,9 @@ public class ReadIntegerEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadStringEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/ReadStringEvent.java
@@ -109,4 +109,9 @@ public class ReadStringEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteBoolEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteBoolEvent.java
@@ -96,4 +96,9 @@ public class WriteBoolEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteFloatEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteFloatEvent.java
@@ -102,4 +102,9 @@ public class WriteFloatEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteIntegerEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteIntegerEvent.java
@@ -101,4 +101,9 @@ public class WriteIntegerEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteStringEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/data/WriteStringEvent.java
@@ -100,4 +100,9 @@ public class WriteStringEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/CloseDelimitedRecordEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/CloseDelimitedRecordEvent.java
@@ -90,4 +90,9 @@ public class CloseDelimitedRecordEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/DelimitedRecordReadAllEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/DelimitedRecordReadAllEvent.java
@@ -105,4 +105,9 @@ public class DelimitedRecordReadAllEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/DelimitedRecordReadEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/DelimitedRecordReadEvent.java
@@ -104,4 +104,9 @@ public class DelimitedRecordReadEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/DelimitedRecordWriteEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/DelimitedRecordWriteEvent.java
@@ -101,4 +101,9 @@ public class DelimitedRecordWriteEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/HasNextDelimitedRecordEvent.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/events/records/HasNextDelimitedRecordEvent.java
@@ -100,4 +100,9 @@ public class HasNextDelimitedRecordEvent implements Event {
     public Channel getChannel() {
         return channel.getChannel();
     }
+
+    @Override
+    public boolean remaining() {
+        return channel.remaining();
+    }
 }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/Base64Wrapper.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/Base64Wrapper.java
@@ -50,4 +50,9 @@ public class Base64Wrapper extends Channel {
     public boolean isSelectable() {
         return false;
     }
+
+    @Override
+    public boolean remaining() {
+        return false;
+    }
 }

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/util/EntityWrapper.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/util/EntityWrapper.java
@@ -53,4 +53,9 @@ public class EntityWrapper extends Channel {
     public boolean isSelectable() {
         return false;
     }
+
+    @Override
+    public boolean remaining() {
+        return false;
+    }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/MockByteChannel.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/MockByteChannel.java
@@ -52,7 +52,6 @@ public class MockByteChannel extends Channel {
         return false;
     }
 
-    @Override
     public boolean remaining() {
         return false;
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/MockByteChannel.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/MockByteChannel.java
@@ -51,4 +51,9 @@ public class MockByteChannel extends Channel {
     public boolean isSelectable() {
         return false;
     }
+
+    @Override
+    public boolean remaining() {
+        return false;
+    }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,6 +146,19 @@ public class ClientSocketTest {
         returnedSize = (BInteger) readReturns[1];
 
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Read size not match with the request size");
+    }
+
+    @Test(dependsOnMethods = "testOpenClientSocket", description = "Test content read/write records")
+    public void testReadRecords() {
+        String content = "Ballerina,122\r\nC++,12";
+        byte[] contentBytes = content.getBytes();
+        BValue[] args = {new BByteArray(contentBytes)};
+        final BValue[] writeReturns = BRunUtil.invokeStateful(socketClient, "write", args);
+        BInteger returnedSize = (BInteger) writeReturns[0];
+        Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
+        final BValue[] readReturns = BRunUtil.invokeStateful(socketClient, "readRecord");
+        BStringArray fields = (BStringArray) readReturns[0];
+        Assert.assertEquals(fields.get(0),"Ballerina");
     }
 
     @Test(dependsOnMethods = "testWriteReadContent",

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
@@ -158,7 +158,7 @@ public class ClientSocketTest {
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
         final BValue[] readReturns = BRunUtil.invokeStateful(socketClient, "readRecord");
         BStringArray fields = (BStringArray) readReturns[0];
-        Assert.assertEquals(fields.get(0),"Ballerina");
+        Assert.assertEquals(fields.get(0), "Ballerina");
     }
 
     @Test(dependsOnMethods = "testWriteReadContent",

--- a/tests/ballerina-unit-test/src/test/resources/test-src/io/client_socket_io.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/io/client_socket_io.bal
@@ -51,7 +51,9 @@ function read(int size) returns (byte[], int)|error {
 function readRecord() returns string[]|error {
     io:ByteChannel channel = socket.channel;
     io:CharacterChannel characterChannel = new(channel, "UTF-8");
-    io:DelimitedTextRecordChannel rChannel = new io:DelimitedTextRecordChannel(characterChannel, rs = "\r\n", fs = ",");
+    io:DelimitedTextRecordChannel rChannel = new io:DelimitedTextRecordChannel(characterChannel,
+                                                                               rs = "\r\n",
+                                                                               fs = ",");
     if (rChannel.hasNext()){
         var records = rChannel.getNext();
         match records {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/io/client_socket_io.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/io/client_socket_io.bal
@@ -2,24 +2,24 @@ import ballerina/io;
 
 io:Socket socket;
 
-function openSocketConnection (string host, int port) {
+function openSocketConnection(string host, int port) {
     io:Socket s = new;
     check s.connect(host, port);
     socket = s;
 }
 
-function openSocketConnectionWithProps (string host, int port, int localPort) returns io:Socket {
+function openSocketConnectionWithProps(string host, int port, int localPort) returns io:Socket {
     io:Socket s = new;
     check s.bindAddress(localPort);
     check s.connect(host, port);
     return s;
 }
 
-function closeSocket () {
+function closeSocket() {
     error? err = socket.close();
 }
 
-function write (byte[] content) returns int|error {
+function write(byte[] content) returns int|error {
     io:ByteChannel channel = socket.channel;
     var result = channel.write(content, 0);
     match result {
@@ -33,11 +33,11 @@ function write (byte[] content) returns int|error {
     }
 }
 
-function read (int size) returns (byte[], int)|error {
+function read(int size) returns (byte[], int)|error {
     io:ByteChannel channel = socket.channel;
     var result = channel.read(size);
-    match result{
-        (byte[] , int)  content => {
+    match result {
+        (byte[], int) content => {
             var (bytes, numberOfBytes) = content;
             io:println("Number of byte read from server: ", numberOfBytes);
             return (bytes, numberOfBytes);
@@ -48,6 +48,25 @@ function read (int size) returns (byte[], int)|error {
     }
 }
 
-function close (io:Socket localSocket) {
+function readRecord() returns string[]|error {
+    io:ByteChannel channel = socket.channel;
+    io:CharacterChannel characterChannel = new(channel, "UTF-8");
+    io:DelimitedTextRecordChannel rChannel = new io:DelimitedTextRecordChannel(characterChannel, rs = "\r\n", fs = ",");
+    if (rChannel.hasNext()){
+        var records = rChannel.getNext();
+        match records {
+            error e => {
+                return e;
+            }
+            string[] fields => {
+                return fields;
+            }
+        }
+    } else{
+        return {message:"No records found"};
+    }
+}
+
+function close(io:Socket localSocket) {
     error? err = localSocket.close();
 }


### PR DESCRIPTION
## Purpose

Currently io events are executed based on availability of content in kenral buffer. However, there will be situations specifically in sockets where content is already read into the user space. 

## Goals 

- Add support to execute io events based on the availability of content in user space
- Fix issue #10137



