### PR TITLE
Update web-socket remote servers to use different ports

### DIFF
--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/ServerInstance.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/ServerInstance.java
@@ -188,7 +188,7 @@ public class ServerInstance implements Server {
         serverErrorLogReader = new ServerLogReader("errorStream", process.getErrorStream());
         serverErrorLogReader.start();
         log.info("Waiting for ports to open");
-        Utils.waitForPorts(httpServicePorts, 1000 * 60 * 2, false, "localhost");
+        Utils.waitForPortsToOpen(httpServicePorts, 1000 * 60 * 2, false, "localhost");
         log.info("Server Started Successfully.");
         isServerRunning = true;
     }
@@ -240,7 +240,7 @@ public class ServerInstance implements Server {
             serverErrorLogReader.stop();
             process = null;
             //wait until port to close
-            Utils.waitForPortsToClosed(httpServicePorts, 30000);
+            Utils.waitForPortsToClose(httpServicePorts, 30000);
             httpServicePorts = new int[] {Constant.DEFAULT_HTTP_PORT};
             log.info("Server Stopped Successfully");
         }

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/Utils.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/Utils.java
@@ -48,7 +48,7 @@ public class Utils {
      * @param hostName The hostname that needs to be checked
      * @throws RuntimeException if the port is not opened within the timeout
      */
-    public static void waitForPorts(int[] ports, long timeout, boolean verbose, String hostName)
+    public static void waitForPortsToOpen(int[] ports, long timeout, boolean verbose, String hostName)
             throws RuntimeException {
 
         Arrays.stream(ports).parallel().forEach(port -> {
@@ -95,7 +95,7 @@ public class Utils {
      * @param ports   - http ports values
      * @param timeout - max time to wait
      */
-    public static void waitForPortsToClosed(int[] ports, int timeout) {
+    public static void waitForPortsToClose(int[] ports, int timeout) {
         Arrays.stream(ports).parallel().forEach(port -> {
             long time = System.currentTimeMillis() + timeout;
             boolean portOpen = Utils.isPortOpen(port);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.service.websocket;
 
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 import org.ballerinalang.test.util.websocket.server.WebSocketRemoteServer;
 import org.testng.Assert;
@@ -42,7 +43,7 @@ public class ClientServiceTest extends WebSocketTestCommons {
     private WebSocketRemoteServer remoteServer;
 
     @BeforeClass(description = "Initializes the Ballerina server with the client_service.bal file")
-    public void setup() throws URISyntaxException, InterruptedException {
+    public void setup() throws URISyntaxException, InterruptedException, BallerinaTestException {
         remoteServer = new WebSocketRemoteServer(15000);
         remoteServer.run();
         client = new WebSocketTestClient(URL);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
@@ -43,7 +43,7 @@ public class ClientServiceTest extends WebSocketTestCommons {
 
     @BeforeClass(description = "Initializes the Ballerina server with the client_service.bal file")
     public void setup() throws URISyntaxException, InterruptedException {
-        remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
+        remoteServer = new WebSocketRemoteServer(15000);
         remoteServer.run();
         client = new WebSocketTestClient(URL);
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
@@ -43,7 +43,7 @@ public class CustomHeaderClientSupportTest extends WebSocketTestCommons {
 
     @BeforeClass(description = "Initializes the Ballerina server with the custom_header_client.bal file")
     public void setup() throws InterruptedException, URISyntaxException {
-        remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
+        remoteServer = new WebSocketRemoteServer(15100);
         remoteServer.run();
         client = new WebSocketTestClient(URL);
         client.handshake();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
@@ -42,7 +42,7 @@ public class CustomHeaderClientSupportTest extends WebSocketTestCommons {
     private static final String RECEIVED_TEXT = "some-header-value";
 
     @BeforeClass(description = "Initializes the Ballerina server with the custom_header_client.bal file")
-    public void setup() throws InterruptedException, URISyntaxException {
+    public void setup() throws InterruptedException, URISyntaxException, BallerinaTestException {
         remoteServer = new WebSocketRemoteServer(15100);
         remoteServer.run();
         client = new WebSocketTestClient(URL);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
@@ -46,7 +46,7 @@ public class PingPongSupportTestCase extends WebSocketTestCommons {
 
     @BeforeClass(description = "Initializes the Ballerina server with the ping_pong.bal file")
     public void setup() throws InterruptedException, URISyntaxException {
-        remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
+        remoteServer = new WebSocketRemoteServer(15200);
         remoteServer.run();
         client = new WebSocketTestClient(URL);
         client.handshake();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
@@ -45,7 +45,7 @@ public class PingPongSupportTestCase extends WebSocketTestCommons {
     private static final ByteBuffer RECEIVING_BYTE_BUFFER = ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8));
 
     @BeforeClass(description = "Initializes the Ballerina server with the ping_pong.bal file")
-    public void setup() throws InterruptedException, URISyntaxException {
+    public void setup() throws InterruptedException, URISyntaxException, BallerinaTestException {
         remoteServer = new WebSocketRemoteServer(15200);
         remoteServer.run();
         client = new WebSocketTestClient(URL);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
@@ -41,7 +41,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
 
     @BeforeClass(description = "Initializes Ballerina")
     public void setup() throws InterruptedException {
-        remoteServer = new WebSocketRemoteServer(REMOTE_SERVER_PORT);
+        remoteServer = new WebSocketRemoteServer(15300);
         remoteServer.run();
     }
 

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.service.websocket;
 
+import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 import org.ballerinalang.test.util.websocket.server.WebSocketRemoteServer;
 import org.testng.Assert;
@@ -40,7 +41,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
     private static final String URL = "ws://localhost:9099";
 
     @BeforeClass(description = "Initializes Ballerina")
-    public void setup() throws InterruptedException {
+    public void setup() throws InterruptedException, BallerinaTestException {
         remoteServer = new WebSocketRemoteServer(15300);
         remoteServer.run();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
@@ -20,21 +20,16 @@ package org.ballerinalang.test.service.websocket;
 
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
 import org.testng.annotations.AfterGroups;
 import org.testng.annotations.BeforeGroups;
 
 import java.io.File;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Facilitate the common functionality of WebSocket integration tests.
  */
 public class WebSocketTestCommons extends BaseTest {
     protected static final int TIMEOUT_IN_SECS = 10;
-    protected static final int REMOTE_SERVER_PORT = 15500;
-
 
     /**
      * Initializes ans start Ballerina with the websocket services package.
@@ -55,22 +50,5 @@ public class WebSocketTestCommons extends BaseTest {
     public void stop() throws Exception {
         serverInstance.removeAllLeechers();
         serverInstance.stopServer();
-    }
-
-    /**
-     * This method is only used when ack is needed from Ballerina WebSocket Proxy in order to sync ballerina
-     * WebSocket Server and Client after the handshake in initiated from the {@link WebSocketTestClient}.
-     *
-     * @param client {@link WebSocketTestClient}.
-     * @throws InterruptedException If connection is interrupted during handshake.
-     */
-    protected void handshakeAndAck(WebSocketTestClient client) throws InterruptedException {
-        CountDownLatch ackCountDownLatch = new CountDownLatch(1);
-        client.setCountDownLatch(ackCountDownLatch);
-        client.handshake();
-        ackCountDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
-        if (!"send".equals(client.getTextReceived())) {
-            throw new IllegalArgumentException("Could not receive acknowledgment");
-        }
     }
 }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServer.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServer.java
@@ -24,11 +24,16 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import org.ballerinalang.test.context.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple WebSocket server for Test cases.
  */
 public final class WebSocketRemoteServer {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketRemoteServer.class);
 
     private final int port;
     private EventLoopGroup bossGroup;
@@ -39,6 +44,7 @@ public final class WebSocketRemoteServer {
     }
 
     public void run() throws InterruptedException {
+        log.info("Starting websocket remote server at '" + port + "'");
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup(5);
 
@@ -50,7 +56,9 @@ public final class WebSocketRemoteServer {
     }
 
     public void stop() {
+        log.info("Shutting down websocket remote server at '" + port + "'");
         bossGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
+        Utils.waitForPortsToClose(new int[]{port}, 36000);
     }
 }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServer.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServer.java
@@ -59,6 +59,6 @@ public final class WebSocketRemoteServer {
         log.info("Shutting down websocket remote server at '" + port + "'");
         bossGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
-        Utils.waitForPortsToClose(new int[]{port}, 36000);
+        Utils.waitForPortsToClose(new int[]{port}, 30000);
     }
 }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServer.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/server/WebSocketRemoteServer.java
@@ -24,6 +24,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.context.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +44,9 @@ public final class WebSocketRemoteServer {
         this.port = port;
     }
 
-    public void run() throws InterruptedException {
+    public void run() throws InterruptedException, BallerinaTestException {
         log.info("Starting websocket remote server at '" + port + "'");
+        Utils.checkPortAvailability(port);
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup(5);
 

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/client_service.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/client_service.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/log;
 
-@final string REMOTE_BACKEND_URL200 = "ws://localhost:15500/websocket";
+@final string REMOTE_BACKEND_URL200 = "ws://localhost:15000/websocket";
 
 @http:WebSocketServiceConfig {
     path: "/client/service"

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/custom_header_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/custom_header_client.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/log;
 
-@final string REMOTE_BACKEND_URL2 = "ws://localhost:15500/websocket";
+@final string REMOTE_BACKEND_URL2 = "ws://localhost:15100/websocket";
 @final string ASSOCIATED_CONNECTION2 = "ASSOCIATED_CONNECTION";
 @final string strData1 = "data";
 @final byte[] APPLICATION_DATA = strData1.toByteArray("UTF-8");

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/ping_pong.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/ping_pong.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/io;
 import ballerina/log;
 
-@final string REMOTE_BACKEND_URL3 = "ws://localhost:15500/websocket";
+@final string REMOTE_BACKEND_URL3 = "ws://localhost:15200/websocket";
 @final string ASSOCIATED_CONNECTION3 = "ASSOCIATED_CONNECTION";
 @final string strData2 = "data";
 @final byte[] APPLICATION_DATA3 = strData2.toByteArray("UTF-8");

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/simple_proxy_server.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/simple_proxy_server.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/log;
 
-@final string REMOTE_BACKEND_URL = "ws://localhost:15500/websocket";
+@final string REMOTE_BACKEND_URL = "ws://localhost:15300/websocket";
 @final string ASSOCIATED_CONNECTION5 = "ASSOCIATED_CONNECTION";
 
 @http:WebSocketServiceConfig {


### PR DESCRIPTION
## Purpose
This is to avoid any possible port conflicts that can arise with web-socket remote server initialization. The web-socket remote servers that are started from some of the web-socket related test cases now will use different port.