### PR TITLE
Improve WebSocket connection closure

### DIFF
--- a/stdlib/http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/service_endpoint.bal
@@ -246,7 +246,7 @@ public type WebSocketListener object {
     }
     public function stop() {
         WebSocketConnector webSocketConnector = getCallerActions();
-        check webSocketConnector.close(1001, "going away", timeoutInSecs = 0);
+        check webSocketConnector.close(statusCode = 1001, reason = "going away", timeoutInSecs = 0);
         httpEndpoint.stop();
     }
 };

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
@@ -64,7 +64,7 @@ public type WebSocketClient object {
     }
     public function stop() {
         WebSocketConnector webSocketConnector = getCallerActions();
-        check webSocketConnector.close(1001, "going away", timeoutInSecs = 0);
+        check webSocketConnector.close(statusCode = 1001, reason = "going away", timeoutInSecs = 0);
     }
 };
 

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_connector.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_connector.bal
@@ -95,7 +95,20 @@ public type WebSocketConnector object {
                            within waiting period the connection is terminated immediately.
         R{{}} `error` if an error occurs when sending
     }
-    public extern function close(int statusCode, string reason, int timeoutInSecs = 60) returns error?;
+    public function close(int? statusCode = 1000, string? reason = (), int timeoutInSecs = 60) returns error? {
+        match statusCode {
+            int code => {
+                if (code <= 999 || code >= 1004 && code <= 1006 || code >= 1012 && code <= 2999 || code > 4999) {
+                    error err = { message: "Failed to execute close. Invalid status code: " + code };
+                    return err;
+                }
+                return externClose(code, reason ?: "", timeoutInSecs);
+            }
+            () => return externClose(-1, "", timeoutInSecs);
+        }
+    }
+
+    extern function externClose(int statusCode, string reason, int timeoutInSecs) returns error?;
 
     documentation {
         Called when the endpoint is ready to receive messages. Can be called only once per endpoint. For the

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -81,6 +81,7 @@ public class WebSocketConstants {
     public static final String CONNECTOR_IS_READY_FIELD = "isReady";
 
     public static final int STATUS_CODE_ABNORMAL_CLOSURE = 1006;
+    public static final int STATUS_CODE_FOR_NO_STATUS_CODE_PRESENT = 1005;
 
     private WebSocketConstants() {
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
@@ -91,7 +91,7 @@ public class PingPongSupportTestCase extends WebSocketTestCommons {
     }
 
     @AfterClass(description = "Stops the Ballerina server")
-    public void cleanup() throws BallerinaTestException, InterruptedException {
+    public void cleanup() throws InterruptedException {
         client.shutDown();
         remoteServer.stop();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTestCase.java
@@ -59,7 +59,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
         client.shutDown();
     }
 
-    @Test(description = "Tests sending and receiving of binary frames in WebSockets", dependsOnMethods = "testSendText")
+    @Test(description = "Tests sending and receiving of binary frames in WebSocket")
     public void testSendBinary() throws URISyntaxException, InterruptedException {
         WebSocketTestClient client = new WebSocketTestClient(URL);
         client.handshake();
@@ -67,7 +67,7 @@ public class WebSocketSimpleProxyTestCase extends WebSocketTestCommons {
         client.setCountDownLatch(countDownLatch);
         ByteBuffer bufferSent = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
         client.sendBinary(bufferSent);
-        countDownLatch.await(1000, TimeUnit.SECONDS);
+        countDownLatch.await(TIMEOUT_IN_SECS, TimeUnit.SECONDS);
         Assert.assertEquals(client.getBufferReceived(), bufferSent);
         client.shutDown();
     }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
@@ -38,9 +38,9 @@ public class WebSocketTestCommons extends BaseTest {
      */
     @BeforeGroups(value = "websocket-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
-        int[] requiredPorts =
-                new int[]{9081, 9082, 9083, 9084, 9086, 9087, 9088, 9090, 9091, 9092, 9093, 9094, 9095, 9096, 9097,
-                        9098, 9099, 9100};
+        int[] requiredPorts = new int[]{
+                9081, 9082, 9083, 9084, 9085, 9086, 9087, 9088, 9090, 9091, 9092, 9093, 9094, 9095, 9096, 9097, 9098,
+                9099, 9100};
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                                           "websocket").getAbsolutePath();
         String[] args = new String[]{"--sourceroot", balFile};

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClient.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/util/websocket/client/WebSocketTestClient.java
@@ -219,6 +219,18 @@ public class WebSocketTestClient {
     }
 
     /**
+     * Sends a close frame without a close code.
+     *
+     * @throws InterruptedException if connection is interrupted while sending the message.
+     */
+    public void sendCloseFrameWithoutCloseCode() throws InterruptedException {
+        if (channel == null) {
+            logger.error("Channel is null. Cannot send close frame.");
+            throw new IllegalArgumentException("Cannot find the channel to write");
+        }
+        channel.writeAndFlush(new CloseWebSocketFrame()).sync();
+    }
+    /**
      * @return the text received from the server.
      */
     public String getTextReceived() {
@@ -288,4 +300,11 @@ public class WebSocketTestClient {
         group.shutdownGracefully();
     }
 
+    /**
+     * Shutdown the WebSocket Client.
+     */
+    public void shutDownWithoutCloseFrame() {
+        channel.close();
+        group.shutdownGracefully();
+    }
 }

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/client_close.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/client_close.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+@http:WebSocketServiceConfig {
+    path: "/"
+}
+service<http:WebSocketService> clientClose bind { port: 9085 } {
+    onClose(endpoint wsEp, int statusCode, string reason) {
+        io:println("Status code: " + statusCode);
+    }
+
+}

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/simple_proxy_server.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/simple_proxy_server.bal
@@ -54,7 +54,7 @@ service<http:WebSocketService> simpleProxy9 bind { port: 9099 } {
 
     onClose(endpoint wsEp, int statusCode, string reason) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint3(wsEp);
-        clientEp->close(statusCode, reason) but {
+        clientEp->close(statusCode = statusCode, reason = reason) but {
             error e => log:printError("server closing error", err = e)
         };
     }
@@ -78,7 +78,7 @@ service<http:WebSocketClientService> clientCallbackService9 {
 
     onClose(endpoint wsEp, int statusCode, string reason) {
         endpoint http:WebSocketListener serviceEp = getAssociatedListener3(wsEp);
-        serviceEp->close(statusCode, reason) but {
+        serviceEp->close(statusCode = statusCode, reason = reason) but {
             error e => log:printError("client closing error", err = e)
         };
     }


### PR DESCRIPTION
## Purpose
- Improve the close action to fail for invalid close status codes.
- Make the statusCode and reason as optional parameters for the close action of WebSocket connector.
- Handle the case when close code is 1005

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/10135

**P.S. Need to merge transport PR https://github.com/ballerina-platform/ballerina-lang/issues/10135 and upgrade transport version**