### PR TITLE
Fix unit test coverage merge report generation issue

### DIFF
--- a/language-server/modules/test-coverage/pom.xml
+++ b/language-server/modules/test-coverage/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>language-server</artifactId>
+        <groupId>org.ballerinalang</groupId>
+        <version>0.981.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>language-server-test-coverage</artifactId>
+    <name>Ballerina - Language server - Unit Test Coverage Generation</name>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+
+                        <configuration>
+                            <target name="mergeReports">
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                         classpathref="maven.plugin.classpath" />
+                                <if>
+                                    <and>
+                                        <available
+                                                file="${language.server.compiler}/${target}/${coverge-report}/${individual.test.report.name}" />
+                                        <available
+                                                file="${language.server.core}/${target}/${coverge-report}/${individual.test.report.name}" />
+                                        <!-- After adding the test cases need to list the exec files here-->
+                                    </and>
+                                    <then>
+                                        <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                            <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
+                                        </taskdef>
+                                        <mkdir dir="${basedir}/target/coverage-report" />
+                                        <report>
+                                            <executiondata>
+                                                <fileset dir="${language.server.compiler}/${target}/${coverge-report}">
+                                                    <include name="${individual.test.report.name}" />
+                                                </fileset>
+                                                <fileset dir="${language.server.core}/${target}/${coverge-report}">
+                                                    <include name="${individual.test.report.name}" />
+                                                </fileset>
+                                            </executiondata>
+                                            <structure name="Language Server Component Coverage Report">
+                                                <group name="language.server.compiler">
+                                                    <classfiles>
+                                                        <fileset
+                                                                dir="${language.server.compiler}/${target}/${classes}" />
+                                                    </classfiles>
+                                                    <sourcefiles encoding="UTF-8">
+                                                        <fileset dir="${language.server.compiler}/${source}" />
+                                                    </sourcefiles>
+                                                </group>
+                                                <group name="language.server.core">
+                                                    <classfiles>
+                                                        <fileset dir="${language.server.core}/${target}/${classes}" />
+                                                    </classfiles>
+                                                    <sourcefiles encoding="UTF-8">
+                                                        <fileset dir="${language.server.core}/${source}" />
+                                                    </sourcefiles>
+                                                </group>
+                                            </structure>
+                                            <html destdir="${basedir}/target/coverage-report/site" />
+                                        </report>
+                                    </then>
+                                </if>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>org.jacoco.ant</artifactId>
+                        <version>${jacoco.ant.verision}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>ant-contrib</groupId>
+                        <artifactId>ant-contrib</artifactId>
+                        <version>${ant.contrib.version}</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>ant</groupId>
+                                <artifactId>ant</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <target>target</target>
+        <coverge-report>coverage-reports</coverge-report>
+        <individual.test.report.name>jacoco-unit.exec</individual.test.report.name>
+        <classes>classes</classes>
+        <source>src/main/java</source>
+
+        <language.server.compiler>${basedir}/../langserver-compiler</language.server.compiler>
+        <language.server.core>${basedir}/../langserver-core</language.server.core>
+        <language.server.stdio.launcher>${basedir}/../launchers/stdio-launcher</language.server.stdio.launcher>
+    </properties>
+</project>

--- a/language-server/pom.xml
+++ b/language-server/pom.xml
@@ -42,84 +42,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-
-                        <configuration>
-                            <target name="mergeReports">
-                                <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                <if>
-                                    <and>
-                                        <available file="${language.server.compiler}/${target}/${coverge-report}/${individual.test.report.name}" />
-                                        <available file="${language.server.core}/${target}/${coverge-report}/${individual.test.report.name}" />
-                                        <!-- After adding the test cases need to list the exec files here-->
-                                    </and>
-                                    <then>
-                                        <taskdef name="report" classname="org.jacoco.ant.ReportTask">
-                                            <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
-                                        </taskdef>
-                                        <mkdir dir="${basedir}/target/coverage-report" />
-                                        <report>
-                                            <executiondata>
-                                                <fileset dir="${language.server.compiler}/${target}/${coverge-report}">
-                                                    <include name="${individual.test.report.name}" />
-                                                </fileset>
-                                                <fileset dir="${language.server.core}/${target}/${coverge-report}">
-                                                    <include name="${individual.test.report.name}" />
-                                                </fileset>
-                                            </executiondata>
-                                            <structure name="Language Server Component Coverage Report">
-                                                    <group name="language.server.compiler">
-                                                        <classfiles>
-                                                            <fileset dir="${language.server.compiler}/${target}/${classes}" />
-                                                        </classfiles>
-                                                        <sourcefiles encoding="UTF-8">
-                                                            <fileset dir="${language.server.compiler}/${source}" />
-                                                        </sourcefiles>
-                                                    </group>
-                                                    <group name="language.server.core">
-                                                        <classfiles>
-                                                            <fileset dir="${language.server.core}/${target}/${classes}" />
-                                                        </classfiles>
-                                                        <sourcefiles encoding="UTF-8">
-                                                            <fileset dir="${language.server.core}/${source}" />
-                                                        </sourcefiles>
-                                                    </group>
-                                            </structure>
-                                            <html destdir="${basedir}/target/coverage-report/site" />
-                                        </report>
-                                    </then>
-                                </if>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>org.jacoco.ant</artifactId>
-                        <version>${jacoco.ant.verision}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>${ant.contrib.version}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -167,20 +89,11 @@
         <jacoco.maven.plugin.version>0.7.8</jacoco.maven.plugin.version>
         <jacoco.ant.verision>0.7.5.201505241946</jacoco.ant.verision>
         <ant.contrib.version>1.0b3</ant.contrib.version>
-
-        <target>target</target>
-        <coverge-report>coverage-reports</coverge-report>
-        <individual.test.report.name>jacoco-unit.exec</individual.test.report.name>
-        <classes>classes</classes>
-        <source>src/main/java</source>
-
-        <language.server.compiler>${basedir}/modules/langserver-compiler</language.server.compiler>
-        <language.server.core>${basedir}/modules/langserver-core</language.server.core>
-        <language.server.stdio.launcher>${basedir}/modules/launchers/stdio-launcher</language.server.stdio.launcher>
     </properties>
     <modules>
         <module>modules/langserver-compiler</module>
         <module>modules/langserver-core</module>
         <module>modules/launchers</module>
+        <module>modules/test-coverage</module>
     </modules>
 </project>

--- a/tests/ballerina-compiler-plugin-test/pom.xml
+++ b/tests/ballerina-compiler-plugin-test/pom.xml
@@ -102,7 +102,6 @@
                                 <exclude>org/wso2/ballerinalang/compiler/parser/antlr4/**</exclude>
                             </excludes>
                             <propertyName>jacoco.agent.argLine</propertyName>
-                            (2)
                             <destFile>${project.build.directory}/coverage-reports/jacoco.exec</destFile>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Purpose
> Merge report should be generated once all reports are generated in relevant sub modules. Currently, this merge report process is executed before the tests reports are being generated resulting to run "maven clean install" twice to generate the merged report. Thus, this PR moves merged report generation into a separate module to make it run after all other reports are generated.