### PR TITLE
Fix 408 response issue and upgrade transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2134,7 +2134,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.224</transport.http.version>
+        <transport.http.version>6.0.225-SNAPSHOT</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2134,7 +2134,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.225-SNAPSHOT</transport.http.version>
+        <transport.http.version>6.0.227</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/IdleTimeoutResponseTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/IdleTimeoutResponseTestCase.java
@@ -129,7 +129,6 @@ public class IdleTimeoutResponseTestCase extends BaseTest {
         writeDelayedRequest(clientSocket);
         String expected = "HTTP/1.1 408 Request Timeout\r\n" +
                 "content-length: 0\r\n" +
-                "content-type: text/plain\r\n" +
                 "connection: close";
         readAndAssertResponse(clientSocket, expected);
     }


### PR DESCRIPTION
## Purpose
> Remove content-type header from 408 response when the content length is 0. The related change in the logic is done in the HTTP transport via https://github.com/wso2/transport-http/pull/241 PR. A test case result has changed in integration tests.

> Upgrade transport version to 6.0.227
