### PR TITLE
Fix perm issue while building vscode plugin

### DIFF
--- a/tool-plugins/vscode/plugin/pom.xml
+++ b/tool-plugins/vscode/plugin/pom.xml
@@ -97,6 +97,7 @@
                             <executable>${npm.executable}</executable>
                             <arguments>
                                 <argument>install</argument>
+                                <argument>--unsafe-perm</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
VSCode Plugin now uses type script compiler and npm install for compiler breaks due to this on jenkins.
