### PR TITLE
Fix issue where the Settings.toml file with the access token is not created the first time a user tries to push a package without signing up in central 

### DIFF
--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_token_updater/packaging_token_updater.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_token_updater/packaging_token_updater.bal
@@ -3,13 +3,6 @@ import ballerina/io;
 import ballerina/system;
 
 documentation {
-    Defines the endpoint to update the access token.
-}
-endpoint http:Listener listener {
-    port:9295
-};
-
-documentation {
     This function opens the file for writing content.
 
     P{{filePath}} File path
@@ -26,10 +19,9 @@ documentation{
     This service updates the access token.
 }
 @http:ServiceConfig {
-    endpoints:[listener],
     basePath:"/update-settings"
 }
-service<http:Service> update_token bind listener {
+service<http:Service> update_token bind { port: 9295 } {
 
     @http:ResourceConfig {
         methods:["GET"],

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -68,6 +68,7 @@ public class PushUtils {
             ProjectDirConstants.SETTINGS_FILE_NAME);
     private static PrintStream outStream = System.err;
     private static EmbeddedExecutor executor = EmbeddedExecutorProvider.getInstance().getExecutor();
+    private static Settings settings;
 
     /**
      * Push/Uploads packages to the central repository.
@@ -123,7 +124,7 @@ public class PushUtils {
             // Push package to central
             String resourcePath = resolvePkgPathInRemoteRepo(packageID);
             String msg = orgName + "/" + packageName + ":" + version + " [project repo -> central]";
-            Proxy proxy = RepoUtils.readSettings().getProxy();
+            Proxy proxy = settings.getProxy();
             String baloVersionOfPkg = String.valueOf(ProgramFileConstants.VERSION_NUMBER);
             executor.execute("packaging_push/packaging_push.balx", true, accessToken, mdFileContent,
                              description, homepageURL, repositoryURL, apiDocURL, authors, keywords, license,
@@ -276,7 +277,7 @@ public class PushUtils {
      * @return access token for generated for the CLI
      */
     private static String getAccessTokenOfCLI() {
-        Settings settings = RepoUtils.readSettings();
+        settings = RepoUtils.readSettings();
         if (settings.getCentral() != null) {
             return settings.getCentral().getAccessToken();
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -68,7 +68,7 @@ public class PushUtils {
             ProjectDirConstants.SETTINGS_FILE_NAME);
     private static PrintStream outStream = System.err;
     private static EmbeddedExecutor executor = EmbeddedExecutorProvider.getInstance().getExecutor();
-    private static Settings settings = new Settings();
+    private static Settings settings;
 
     /**
      * Push/Uploads packages to the central repository.

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -68,7 +68,7 @@ public class PushUtils {
             ProjectDirConstants.SETTINGS_FILE_NAME);
     private static PrintStream outStream = System.err;
     private static EmbeddedExecutor executor = EmbeddedExecutorProvider.getInstance().getExecutor();
-    private static Settings settings;
+    private static Settings settings = new Settings();
 
     /**
      * Push/Uploads packages to the central repository.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -33,8 +33,6 @@ public class RepoUtils {
     private static final boolean BALLERINA_DEV_STAGE_CENTRAL = Boolean.parseBoolean(
             System.getenv("BALLERINA_DEV_STAGE_CENTRAL"));
 
-    private static Settings settings = null;
-
     /**
      * Create and get the home repository path.
      *

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -95,8 +95,8 @@ public class RepoUtils {
      * @return settings object
      */
     public static Settings readSettings() {
-        String tomlFilePath = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.SETTINGS_FILE_NAME)
-                                       .toString();
+        String tomlFilePath = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.SETTINGS_FILE_NAME).
+                                    toString();
         try {
             return SettingsProcessor.parseTomlContentFromFile(tomlFilePath);
         } catch (IOException e) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -95,16 +95,13 @@ public class RepoUtils {
      * @return settings object
      */
     public static Settings readSettings() {
-        if (settings == null) {
-            String tomlFilePath = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.SETTINGS_FILE_NAME)
-                                           .toString();
-            try {
-                settings = SettingsProcessor.parseTomlContentFromFile(tomlFilePath);
-            } catch (IOException e) {
-                settings = new Settings();
-            }
+        String tomlFilePath = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.SETTINGS_FILE_NAME)
+                                       .toString();
+        try {
+            return SettingsProcessor.parseTomlContentFromFile(tomlFilePath);
+        } catch (IOException e) {
+            return new Settings();
         }
-        return settings;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> This PR fixes the issue where the Settings.toml file with the access token is not created the first time a user tries to push a package without signing up in central 

## Goals
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10251

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
