### PR TITLE
Make vscode debugger project aware

### DIFF
--- a/tool-plugins/vscode/plugin/debugger/DebugManager/DebugManager.js
+++ b/tool-plugins/vscode/plugin/debugger/DebugManager/DebugManager.js
@@ -218,7 +218,10 @@ class DebugManager extends EventEmitter {
      */
     publishBreakpoints() {
         try {
-            const message = { command: 'SET_POINTS', points: this.debugPoints };
+            const message = { 
+                command: 'SET_POINTS',
+                points: this.debugPoints 
+            };
             this.channel.sendMessage(message);
         } catch (e) {
             // @todo log

--- a/tool-plugins/vscode/plugin/debugger/index.js
+++ b/tool-plugins/vscode/plugin/debugger/index.js
@@ -22,6 +22,7 @@ const {
 } = require('vscode-debugadapter');
 const DebugManager = require('./DebugManager');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
 const openport = require('openport');
@@ -135,9 +136,11 @@ class BallerinaDebugSession extends LoggingDebugSession {
 
     getRunningInfo(currentPath, root, ballerinaPackage) {
         if (fs.existsSync(path.join(currentPath, '.ballerina'))) {
-            return {
-                sourceRoot: currentPath,
-                ballerinaPackage,
+            if (currentPath != os.homedir()) {
+                return {
+                    sourceRoot: currentPath,
+                    ballerinaPackage,
+                }
             }
         }
 

--- a/tool-plugins/vscode/plugin/debugger/index.js
+++ b/tool-plugins/vscode/plugin/debugger/index.js
@@ -26,32 +26,91 @@ const path = require('path');
 const { spawn } = require('child_process');
 const openport = require('openport');
 const ps = require('ps-node');
+const toml = require('toml');
 
 class BallerinaDebugSession extends LoggingDebugSession {
     initializeRequest(response, args) {
         response.body = response.body || {};
         response.body.supportsConfigurationDoneRequest = true;
-        this.packagePaths = {};
+
         this.dirPaths = {};
         this.threadIndexes = {};
-        this.threads = [];
-        this.debugArgs = {};
+
+        this.nextThreadId = 1;
+        this.nextFrameId = 1;
+        this.nextVariableRefId = 1;
+        this.threads = {};
+        this.frames = {};
+        this.variableRefs = {};
+        
         this.debugManager = new DebugManager();
 
         this.debugManager.on('debug-hit', debugArgs => {
-            const threadId = debugArgs.threadId || debugArgs.workerId;
-            this.debugArgs[threadId] = debugArgs;
-            this.currentThreadId = threadId;
-            if (!this.threadIndexes[threadId]) {
-                const index = this.threads.length + 1;
-                this.threads.push({
-                    threadId,
-                    index, 
-                    name: threadId.split('-')[0],
-                });
-                this.threadIndexes[threadId] = index;
+            const serverThreadId = debugArgs.threadId || debugArgs.workerId;
+
+            if (!this.threadIndexes[serverThreadId]) {
+                const thread = {
+                    id: this.nextThreadId++,
+                    name: serverThreadId.split('-')[0],
+                    serverThreadId,
+                    frameIds: [],
+                };
+
+                this.threads[thread.id] = thread;
+                this.threadIndexes[serverThreadId] = thread.id;
             }
-            this.sendEvent(new StoppedEvent('breakpoint', this.threadIndexes[threadId]));
+
+            const threadId = this.threadIndexes[serverThreadId];
+            const threadObj = this.threads[this.threadIndexes[serverThreadId]];
+
+            // Clear other frames for this thread
+            threadObj.frameIds.forEach(frameId => {
+                const frame = this.frames[frameId];
+                frame.scopes.forEach(scope => {
+                    delete this.variableRefs[scope.variablesReference];
+                });
+
+                delete this.frames[frameId];
+            })
+
+            threadObj.frameIds = [];
+
+            debugArgs.frames.forEach(frame => {
+                const {fileName, frameName, lineID, packageName: packageInfo } = frame;
+                let packageNameParts = packageInfo.split(':')[0].split('/');
+                const packageDirname = packageNameParts[1] || packageNameParts[0];
+
+                const frameObj = {
+                    threadId,
+                    id: this.nextFrameId++,
+                    scopes: [],
+                    fileName: path.join(packageDirname, fileName),
+                    frameName,
+                    line: lineID
+                };
+
+                ['Local', 'Global'].forEach(scopeName => {
+                    const scope = {
+                        name: scopeName,
+                        variablesReference: this.nextVariableRefId++,
+                        expensive: false,
+                    };
+
+                    const variables = frame.variables.filter(
+                        variable => variable.scope === scopeName);
+
+                    frameObj.scopes.push(scope);
+                    this.variableRefs[scope.variablesReference] = {
+                        threadId,
+                        variables,
+                    };
+                });
+
+                threadObj.frameIds.push(frameObj.id);
+                this.frames[frameObj.id] = frameObj;
+            });
+
+            this.sendEvent(new StoppedEvent('breakpoint', this.threadIndexes[serverThreadId]));
         });
 
         this.debugManager.on('execution-ended', () => {
@@ -74,6 +133,22 @@ class BallerinaDebugSession extends LoggingDebugSession {
         });
     }
 
+    getRunningInfo(currentPath, root, ballerinaPackage) {
+        if (fs.existsSync(path.join(currentPath, '.ballerina'))) {
+            return {
+                sourceRoot: currentPath,
+                ballerinaPackage,
+            }
+        }
+
+        if (currentPath === root) {
+            return {};
+        }
+
+        return this.getRunningInfo(
+            path.dirname(currentPath), root, path.basename(currentPath));
+    }
+
     launchRequest(response, args) {
         if (!args['ballerina.home']) {
             this.terminate("Couldn't start the debug server. Please set ballerina.home.");
@@ -83,16 +158,27 @@ class BallerinaDebugSession extends LoggingDebugSession {
         const openFile = args.script;
         let cwd = path.dirname(openFile);
         let fileName = path.basename(openFile);
-        
-        const content = fs.readFileSync(openFile);
-        const pkgMatch = content.toString().match('package\\s+([a-zA_Z_][\\.\\w]*);');
-        if (pkgMatch && pkgMatch[1]) {
-            const pkg = pkgMatch[1];
-            const pkgParts = pkg.split('.');
-            for(let i=0; i<pkgParts.length; i++) {
-                cwd = path.dirname(cwd);
+        this.sourceRoot = cwd;
+        this.ballerinaPackage = '.';
+
+        const { sourceRoot, ballerinaPackage } =
+            this.getRunningInfo(cwd, path.parse(openFile).root);
+
+        if (sourceRoot) {
+            this.sourceRoot = sourceRoot;
+        }
+
+        if (ballerinaPackage) {
+            this.ballerinaPackage = ballerinaPackage;
+            fileName = ballerinaPackage;
+            cwd = sourceRoot;
+
+            try {
+                const balConfigString = fs.readFileSync(path.join(sourceRoot, 'Ballerina.toml'));
+                this.projectConfig = toml.parse(balConfigString).project;
+            } catch(e) {
+                // no log file
             }
-            fileName = path.join(...pkgParts);
         }
 
         let executable = path.join(args['ballerina.home'], 'bin', 'ballerina');
@@ -100,9 +186,9 @@ class BallerinaDebugSession extends LoggingDebugSession {
             executable += '.bat';
         }
 
-        // find an open port 
+        // find an open port
         openport.find((err, port) => {
-            if(err) { 
+            if(err) {
                 this.terminate("Couldn't find an open port to start the debug server.");
                 return;
             }
@@ -110,10 +196,10 @@ class BallerinaDebugSession extends LoggingDebugSession {
             let debugServer;
             debugServer = this.debugServer = spawn(
                 executable,
-                ['run', fileName, '--debug', port],
+                ['run', '--debug', port, fileName],
                 { cwd }
             );
-    
+
             debugServer.on('error', (err) => {
                 this.terminate("Could not start the debug server.");
             });
@@ -143,13 +229,14 @@ class BallerinaDebugSession extends LoggingDebugSession {
         let fileName = args.source.path;
         let pkg = '.';
 
-        const content = fs.readFileSync(args.source.path);
-        const pkgMatch = content.toString().match('package\\s+([a-zA_Z_][\\.\\w]*);');
-        if (pkgMatch && pkgMatch[1]) {
-            pkg = pkgMatch[1];
-            fileName = args.source.name;
-            this.packagePaths[pkg] = path.dirname(args.source.path);
+        const { projectConfig, ballerinaPackage } = this;
+        if (ballerinaPackage) {
+            pkg = ballerinaPackage;
         }
+        if (projectConfig) {
+            pkg = `${projectConfig['org-name']}/${ballerinaPackage}:${projectConfig.version}`;
+        }
+        
         this.dirPaths[args.source.name] = path.dirname(args.source.path);
         
         this.debugManager.removeAllBreakpoints(fileName);
@@ -171,31 +258,27 @@ class BallerinaDebugSession extends LoggingDebugSession {
     }
 
     threadsRequest(response, args) {
-        const a = args;
-        const threads = this.threads.map(thread => (
-            {id: thread.index, name: thread.name}
+        const threads = Object.keys(this.threads).map(key => (
+            {id: this.threads[key].id, name: this.threads[key].name}
         ));
         response.body = { threads };
         this.sendResponse(response);
     }
 
-    stackTraceRequest(response, args) { 
-        const threadId = this.getThreadId(args);
-        const { packagePath } = this.debugArgs[threadId].location;
+    stackTraceRequest(response, args) {
+        const thread = this.threads[args.threadId];
 
-        const stk = this.debugArgs[threadId].frames.map((frame, i) => {
-            let root = this.dirPaths[frame.fileName];
-            if (packagePath !== '.') {
-                root = this.packagePaths[packagePath];
-            }
+        const stk = thread.frameIds.map((frameId) => {
+            const frame = this.frames[frameId];
+            const filePath = path.join(this.sourceRoot, frame.fileName);
 
             return {
-                id: i,
+                id: frameId,
                 name: frame.frameName,
-                line: frame.lineID,
+                line: frame.line,
                 source: {
                     name: frame.fileName,
-                    path: path.join(root, frame.fileName),
+                    path: filePath,
                 }
             };
         });
@@ -208,34 +291,17 @@ class BallerinaDebugSession extends LoggingDebugSession {
     }
 
     scopesRequest(response, args) {
+        const frame = this.frames[args.frameId];
         response.body = {
-            scopes:[
-                {
-                    name: 'Local',
-                    variablesReference: args.frameId + 1, // This can't be 0. As 0 indicates "don't fetch".
-                    expensive: false,
-                },
-                {
-                    name: 'Global',
-                    variablesReference: args.frameId + 1001, // variableRefs larger than 1000 refer to globals
-                    expensive: false,
-                },
-            ]
+            scopes: frame.scopes,
         };
         this.sendResponse(response);
     }
 
     variablesRequest(response, args) {
-        let scope = "Local";
-        let frameId = args.variablesReference - 1;
-        if (frameId > 999) {
-            scope = "Global";
-            frameId = frameId - 1000;
-        }
-        const frame = this.debugArgs[this.currentThreadId].frames[frameId];
-        const varsInScope = frame.variables.filter(v => v.scope === scope);
+        const variables = this.variableRefs[args.variablesReference].variables;
         response.body = {
-            variables: varsInScope.map(variable => ({
+            variables: variables.map(variable => ({
                 name: variable.name,
                 type: "integer",
                 value: variable.value,
@@ -246,25 +312,25 @@ class BallerinaDebugSession extends LoggingDebugSession {
     }
 
     continueRequest(response, args) { 
-        const threadId = this.getThreadId(args);
+        const threadId = this.threads[args.threadId].serverThreadId;
         this.sendEvent(new ContinuedEvent(threadId, false));
         this.debugManager.resume(threadId);
     }
 
     nextRequest(response, args) { 
-        const threadId = this.getThreadId(args);
+        const threadId = this.threads[args.threadId].serverThreadId;
         this.debugManager.stepOver(threadId);
         this.sendResponse(response);
     }
 
-    stepInRequest(response, args) { 
-        const threadId = this.getThreadId(args);
+    stepInRequest(response, args) {
+        const threadId = this.threads[args.threadId].serverThreadId;
         this.debugManager.stepIn(threadId);
         this.sendResponse(response);
     }
 
     stepOutRequest(response, args) {
-        const threadId = this.getThreadId(args);
+        const threadId = this.threads[args.threadId].serverThreadId;
         this.debugManager.stepOut(threadId);
         this.sendResponse(response);
     }
@@ -287,11 +353,6 @@ class BallerinaDebugSession extends LoggingDebugSession {
     terminate(msg) {
         this.sendEvent(new OutputEvent(msg));
         this.sendEvent(new TerminatedEvent());
-    }
-
-    getThreadId(args) {
-        const threadIndex = args.threadId;
-        return this.threads[threadIndex - 1].threadId;
     }
 }
 

--- a/tool-plugins/vscode/plugin/package-lock.json
+++ b/tool-plugins/vscode/plugin/package-lock.json
@@ -2133,6 +2133,11 @@
                 }
             }
         },
+        "toml": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+            "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+        },
         "tough-cookie": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",

--- a/tool-plugins/vscode/plugin/package.json
+++ b/tool-plugins/vscode/plugin/package.json
@@ -186,6 +186,7 @@
         "openport": "0.0.4",
         "ps-node": "^0.1.6",
         "request-promise": "^4.2.2",
+        "toml": "^2.3.3",
         "vscode": "^1.1.21",
         "vscode-debugadapter": "^1.31.0",
         "vscode-languageclient": "^3.4.2",


### PR DESCRIPTION
## Purpose
debugger will check if its run on a project or a single bal file. Previously debugging was broken on projects.

Further refactor debugger code to make it not use concatted ids (threadId + frameid) for frames and variable refs.
