### PR TITLE
Make ballerina plugin configurations use the GUI editor

### DIFF
--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -46,27 +46,20 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "Ballerina configuration",
+            "title": "Ballerina",
             "properties": {
                 "ballerina.home": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "description": "Specifies the path to the ballerina home directory"
                 },
                 "ballerina.showLSErrors": {
-                    "type": [
-                        "boolean"
-                    ],
+                    "type": "boolean",
                     "default": false,
                     "description": "If set to true the language server's error log will be printed in the plugins console"
                 },
                 "ballerina.debugLog": {
-                    "type": [
-                        "boolean"
-                    ],
+                    "type": "boolean",
                     "default": false,
                     "description": "If set to true the stdout and stderr of back end services will be printed in the plugins output channel"
                 }


### PR DESCRIPTION
## Purpose
When a config has multiple possible types the GUI only links the setting.json file instead of providing GUI features. So instead of an array we specify the exact type.

Fixes #9786
