### PR TITLE
Add comma as a separator for list options

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestCmd.java
@@ -75,13 +75,13 @@ public class TestCmd implements BLauncherCmd {
     @CommandLine.Option(names = {"--list-groups", "-lg"}, description = "list the groups available in the tests")
     private boolean listGroups;
 
-    @CommandLine.Option(names = "--groups", description = "test groups to be executed")
+    @CommandLine.Option(names = "--groups", split = ",", description = "test groups to be executed")
     private List<String> groupList;
 
-    @CommandLine.Option(names = "--disable-groups", description = "test groups to be disabled")
+    @CommandLine.Option(names = "--disable-groups", split = ",", description = "test groups to be disabled")
     private List<String> disableGroupList;
 
-    @CommandLine.Option(names = "--exclude-packages", description = "packages to be excluded")
+    @CommandLine.Option(names = "--exclude-packages", split = ",", description = "packages to be excluded")
     private List<String> excludedPackageList;
 
     public void execute() {


### PR DESCRIPTION
## Purpose
This PR adds commas as a separator for list typed options.

This would make both the following valid:
```cmd
ballerina test testerina_group_tests.bal --groups g1 --groups g2
```

```cmd
ballerina test testerina_group_tests.bal --groups g1,g2
```