### PR TITLE
Add resource annotation to specify request/response message type

### DIFF
--- a/stdlib/grpc/src/main/ballerina/grpc/annotation.bal
+++ b/stdlib/grpc/src/main/ballerina/grpc/annotation.bal
@@ -25,6 +25,8 @@
 #                     sets to true, if the service defines as bidirectional streaming.
 public type GrpcServiceConfig record {
     string name;
+    typedesc requestType;
+    typedesc responseType;
     boolean clientStreaming;
     boolean serverStreaming;
 };
@@ -38,6 +40,8 @@ public annotation<service> ServiceConfig GrpcServiceConfig;
 #               multiple responses per request.
 public type GrpcResourceConfig record {
     boolean streaming;
+    typedesc requestType;
+    typedesc responseType;
 };
 
 # Service resource configuration. Sets only for server streaming service.

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/config/ResourceConfiguration.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/config/ResourceConfiguration.java
@@ -20,37 +20,23 @@ package org.ballerinalang.net.grpc.config;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 
 /**
- * Service configuration of gRPC Service.
+ * Resource configuration of gRPC Service.
  *
- * @since 1.0.0
+ * @since 0.982.0
  */
-public class ServiceConfiguration {
-
-    private String rpcEndpoint;
+public class ResourceConfiguration {
+    private boolean streaming;
     private BType requestType;
     private BType responseType;
-    private boolean clientStreaming;
-    private boolean serverStreaming;
 
-    public ServiceConfiguration(String rpcEndpoint, BType requestType, BType responseType, boolean clientStreaming,
-                                boolean serverStreaming) {
-        this.rpcEndpoint = rpcEndpoint;
+    public ResourceConfiguration(boolean streaming, BType requestType, BType responseType) {
+        this.streaming = streaming;
         this.requestType = requestType;
         this.responseType = responseType;
-        this.clientStreaming = clientStreaming;
-        this.serverStreaming = serverStreaming;
     }
 
-    public String getRpcEndpoint() {
-        return rpcEndpoint;
-    }
-    
-    public boolean isClientStreaming() {
-        return clientStreaming;
-    }
-    
-    public boolean isServerStreaming() {
-        return serverStreaming;
+    public boolean isStreaming() {
+        return streaming;
     }
 
     public BType getRequestType() {

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoConstants.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoConstants.java
@@ -47,10 +47,15 @@ public class ServiceProtoConstants {
     public static final String TMP_DIRECTORY_PATH = System.getProperty("java.io.tmpdir");
 
     public static final String ANN_SERVICE_CONFIG = "ServiceConfig";
+    public static final String ANN_RESOURCE_CONFIG = "ResourceConfig";
 
     public static final String SERVICE_CONFIG_RPC_ENDPOINT = "name";
     public static final String SERVICE_CONFIG_CLIENT_STREAMING = "clientStreaming";
     public static final String SERVICE_CONFIG_SERVER_STREAMING = "serverStreaming";
+
+    public static final String RESOURCE_CONFIG_STREAMING = "streaming";
+    public static final String RESOURCE_CONFIG_REQUEST_TYPE = "requestType";
+    public static final String RESOURCE_CONFIG_RESPONSE_TYPE = "responseType";
 
     public static final Map<Integer, String> FIELD_TYPE_MAP;
     static {

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java
@@ -22,11 +22,13 @@ import com.google.protobuf.Descriptors;
 import org.ballerinalang.connector.api.Annotation;
 import org.ballerinalang.connector.api.Struct;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
+import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.ResourceNode;
 import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.statements.BlockNode;
 import org.ballerinalang.model.tree.statements.StatementNode;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.net.grpc.config.ResourceConfiguration;
 import org.ballerinalang.net.grpc.config.ServiceConfiguration;
 import org.ballerinalang.net.grpc.exception.GrpcServerException;
 import org.ballerinalang.net.grpc.proto.definition.EmptyMessage;
@@ -50,6 +52,8 @@ import org.wso2.ballerinalang.compiler.tree.BLangVariable;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
@@ -112,6 +116,8 @@ public class ServiceProtoUtils {
     
     static ServiceConfiguration getServiceConfiguration(ServiceNode serviceNode) {
         String rpcEndpoint = null;
+        BType requestType = null;
+        BType responseType = null;
         boolean clientStreaming = false;
         boolean serverStreaming = false;
         
@@ -124,20 +130,27 @@ public class ServiceProtoUtils {
                         .getExpression()).getKeyValuePairs();
                 for (BLangRecordLiteral.BLangRecordKeyValue attributeNode : attributes) {
                     String attributeName = attributeNode.getKey().toString();
-                    String attributeValue = attributeNode.getValue() != null ? attributeNode.getValue().toString() :
-                            null;
+                    BLangExpression attributeValue = attributeNode.getValue();
                     
                     switch (attributeName) {
                         case ServiceProtoConstants.SERVICE_CONFIG_RPC_ENDPOINT: {
-                            rpcEndpoint = attributeValue;
+                            rpcEndpoint = attributeValue != null ? attributeValue.toString() : null;
                             break;
                         }
                         case ServiceProtoConstants.SERVICE_CONFIG_CLIENT_STREAMING: {
-                            clientStreaming = attributeValue != null && Boolean.parseBoolean(attributeValue);
+                            clientStreaming = attributeValue != null && Boolean.parseBoolean(attributeValue.toString());
                             break;
                         }
                         case ServiceProtoConstants.SERVICE_CONFIG_SERVER_STREAMING: {
-                            serverStreaming = attributeValue != null && Boolean.parseBoolean(attributeValue);
+                            serverStreaming = attributeValue != null && Boolean.parseBoolean(attributeValue.toString());
+                            break;
+                        }
+                        case ServiceProtoConstants.RESOURCE_CONFIG_REQUEST_TYPE: {
+                            requestType = getMessageBType(attributeValue);
+                            break;
+                        }
+                        case ServiceProtoConstants.RESOURCE_CONFIG_RESPONSE_TYPE: {
+                            responseType = getMessageBType(attributeValue);
                             break;
                         }
                         default: {
@@ -147,7 +160,56 @@ public class ServiceProtoUtils {
                 }
             }
         }
-        return new ServiceConfiguration(rpcEndpoint, clientStreaming, serverStreaming);
+        return new ServiceConfiguration(rpcEndpoint, requestType, responseType, clientStreaming, serverStreaming);
+    }
+
+    private static BType getMessageBType(BLangExpression attributeValue) {
+        BType requestType = null;
+        if (NodeKind.SIMPLE_VARIABLE_REF.equals(attributeValue.getKind())) {
+            requestType = ((BLangSimpleVarRef) attributeValue).symbol.getType();
+        } else if (NodeKind.TYPEDESC_EXPRESSION.equals(attributeValue.getKind())) {
+            requestType = ((BLangTypedescExpr) attributeValue).resolvedType;
+        }
+        return requestType;
+    }
+
+    private static ResourceConfiguration getResourceConfiguration(ResourceNode resourceNode) {
+        boolean streaming = false;
+        BType requestType = null;
+        BType responseType = null;
+
+        for (AnnotationAttachmentNode annotationNode : resourceNode.getAnnotationAttachments()) {
+            if (!ServiceProtoConstants.ANN_RESOURCE_CONFIG.equals(annotationNode.getAnnotationName().getValue())) {
+                continue;
+            }
+            if (annotationNode.getExpression() instanceof BLangRecordLiteral) {
+                List<BLangRecordLiteral.BLangRecordKeyValue> attributes = ((BLangRecordLiteral) annotationNode
+                        .getExpression()).getKeyValuePairs();
+                for (BLangRecordLiteral.BLangRecordKeyValue attributeNode : attributes) {
+                    String attributeName = attributeNode.getKey().toString();
+                    BLangExpression attributeValue = attributeNode.getValue();
+
+                    switch (attributeName) {
+                        case ServiceProtoConstants.RESOURCE_CONFIG_STREAMING: {
+                            streaming = attributeValue != null && Boolean.parseBoolean(attributeValue.toString());
+                            break;
+                        }
+                        case ServiceProtoConstants.RESOURCE_CONFIG_REQUEST_TYPE: {
+                            requestType = getMessageBType(attributeValue);
+                            break;
+                        }
+                        case ServiceProtoConstants.RESOURCE_CONFIG_RESPONSE_TYPE: {
+                            responseType = getMessageBType(attributeValue);
+                            break;
+                        }
+                        default: {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return new ResourceConfiguration(streaming, requestType, responseType);
     }
     
     private static Service getUnaryServiceDefinition(ServiceNode serviceNode, File.Builder fileBuilder) throws
@@ -156,7 +218,13 @@ public class ServiceProtoUtils {
         Service.Builder serviceBuilder = Service.newBuilder(serviceNode.getName().getValue());
         
         for (ResourceNode resourceNode : serviceNode.getResources()) {
-            Message requestMessage = getRequestMessage(resourceNode);
+            ResourceConfiguration resourceConfiguration = getResourceConfiguration(resourceNode);
+            Message requestMessage;
+            if (resourceConfiguration.getRequestType() != null) {
+                requestMessage = generateMessageDefinition(resourceConfiguration.getRequestType());
+            } else {
+                requestMessage = getRequestMessage(resourceNode);
+            }
             if (requestMessage == null) {
                 throw new GrpcServerException("Error while deriving request message of the resource");
             }
@@ -168,7 +236,12 @@ public class ServiceProtoUtils {
                 fileBuilder.setDependency(requestMessage.getDependency());
             }
 
-            Message responseMessage = getResponseMessage(resourceNode);
+            Message responseMessage;
+            if (resourceConfiguration.getResponseType() != null) {
+                responseMessage = generateMessageDefinition(resourceConfiguration.getResponseType());
+            } else {
+                responseMessage = getResponseMessage(resourceNode);
+            }
             if (responseMessage == null) {
                 throw new GrpcServerException("Connection send expression not found in resource body");
             }
@@ -222,20 +295,28 @@ public class ServiceProtoUtils {
         Service.Builder serviceBuilder = Service.newBuilder(serviceNode.getName().getValue());
         Message requestMessage = null;
         Message responseMessage = null;
-        for (ResourceNode resourceNode : serviceNode.getResources()) {
-            if (ON_MESSAGE_RESOURCE.equals(resourceNode.getName().getValue())) {
-                requestMessage = getRequestMessage(resourceNode);
-                Message respMsg = getResponseMessage(resourceNode);
-                if (respMsg != null && !(MessageKind.EMPTY.equals(respMsg.getMessageKind()))) {
-                    responseMessage = respMsg;
-                    break;
+        if (serviceConfig.getRequestType() != null) {
+            requestMessage = generateMessageDefinition(serviceConfig.getRequestType());
+        }
+        if (serviceConfig.getResponseType() != null) {
+            responseMessage = generateMessageDefinition(serviceConfig.getResponseType());
+        }
+        if (requestMessage == null || responseMessage == null) {
+            for (ResourceNode resourceNode : serviceNode.getResources()) {
+                if (ON_MESSAGE_RESOURCE.equals(resourceNode.getName().getValue())) {
+                    requestMessage = requestMessage == null ? getRequestMessage(resourceNode) : requestMessage;
+                    Message respMsg = responseMessage == null ? getResponseMessage(resourceNode) : responseMessage;
+                    if (respMsg != null && !(MessageKind.EMPTY.equals(respMsg.getMessageKind()))) {
+                        responseMessage = respMsg;
+                        break;
+                    }
                 }
-            }
-            
-            if (ON_COMPLETE_RESOURCE.equals(resourceNode.getName().getValue())) {
-                Message respMsg = getResponseMessage(resourceNode);
-                if (respMsg != null && !(MessageKind.EMPTY.equals(respMsg.getMessageKind()))) {
-                    responseMessage = respMsg;
+
+                if (ON_COMPLETE_RESOURCE.equals(resourceNode.getName().getValue())) {
+                    Message respMsg = responseMessage == null ? getResponseMessage(resourceNode) : responseMessage;
+                    if (respMsg != null && !(MessageKind.EMPTY.equals(respMsg.getMessageKind()))) {
+                        responseMessage = respMsg;
+                    }
                 }
             }
         }
@@ -545,7 +626,12 @@ public class ServiceProtoUtils {
         }
     }
 
-    private static byte[] hexStringToByteArray(String s) {
+    /**
+     * Convert Hex string value to byte array.
+     * @param s hexadecimal string value
+     * @return Byte array
+     */
+    public static byte[] hexStringToByteArray(String s) {
         int len = s.length();
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {

--- a/tests/ballerina-integration-test/src/test/resources/grpc/errorservices/streaming_service_with_annotation.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/errorservices/streaming_service_with_annotation.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This is server implementation for bidirectional streaming scenario
+
+import ballerina/grpc;
+import ballerina/io;
+
+// Server endpoint configuration
+endpoint grpc:Listener ep {
+    port:9095
+};
+
+@grpc:ServiceConfig {name:"chat",
+    requestType: ChatMessage,
+    responseType: string,
+    clientStreaming:true,
+    serverStreaming:true}
+service Chat bind ep {
+
+    onOpen(endpoint client) {
+    }
+
+    onMessage(endpoint client, ChatMessage chatMsg) {
+    }
+
+    onError(endpoint client, error err) {
+    }
+
+    onComplete(endpoint client) {
+    }
+}
+
+type ChatMessage record {
+    string name;
+    string message;
+};

--- a/tests/ballerina-integration-test/src/test/resources/grpc/errorservices/unary_service_with_annotation.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/errorservices/unary_service_with_annotation.bal
@@ -1,0 +1,105 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+import ballerina/grpc;
+
+endpoint grpc:Listener ep {
+    port:9100
+};
+
+service TestService bind ep {
+    @grpc:ResourceConfig {
+        requestType: string,
+        responseType: string
+    }
+    hello(endpoint caller, string name) {
+    }
+
+    @grpc:ResourceConfig {
+        requestType: int,
+        responseType: int,
+        streaming: true
+    }
+    testInt(endpoint caller, int age) {
+    }
+
+    @grpc:ResourceConfig {
+        requestType: float,
+        responseType: float
+    }
+    testFloat(endpoint caller, float salary) {
+    }
+
+    @grpc:ResourceConfig {
+        requestType: boolean,
+        responseType: boolean
+    }
+    testBoolean(endpoint caller, boolean available) {
+    }
+
+    @grpc:ResourceConfig {
+        requestType: Request,
+        responseType: Response
+    }
+    testStruct(endpoint caller, Request msg) {
+    }
+
+    @grpc:ResourceConfig {
+        responseType: string
+    }
+    testNoRequest(endpoint caller) {
+        string resp = "service invoked with no request";
+        error? err = caller->send(resp);
+        io:println(err.message but { () => ("response : " + resp) });
+        _ = caller->complete();
+    }
+
+    @grpc:ResourceConfig {
+        requestType: string
+    }
+    testNoResponse(endpoint caller, string msg) {
+        io:println("Request: " + msg);
+    }
+
+
+    @grpc:ResourceConfig {
+        requestType: Person,
+        responseType: string
+    }
+    testInputNestedStruct(endpoint caller, Person req) {
+    }
+}
+
+type Request record {
+    string name;
+    string message;
+    int age;
+};
+
+type Response record {
+    string resp;
+};
+
+type Person record {
+    string name;
+    Address address;
+};
+
+type Address record {
+    int postalCode;
+    string state;
+    string country;
+};


### PR DESCRIPTION
## Purpose
Resolves #9895

## Goals
Support specifying request/response message type through resource annotation. This will be an optional annotation

## User stories
New optional annotation fields called requestType and responseType available in ServiceConfig and ResourceConfig

## Automation tests
 - Integration tests
   > avaliable