### PR TITLE
Update in startSpan API

### DIFF
--- a/stdlib/observability/src/main/ballerina/observe/Package.md
+++ b/stdlib/observability/src/main/ballerina/observe/Package.md
@@ -51,6 +51,12 @@ It is possible to add tags to span by using the `observe:addTagToSpan()` api by 
 ```ballerina
     _ = observe:addTagToSpan(spanId, "Tag Key", "Tag Value");
 ```
+#### Attach a tag to a span in the system trace
+When no spanId is provided or -1 is given, the defined tags are added to the current active span in the ootb system trace.
+
+```ballerina
+    _ = observe:addTagToSpan("Tag Key", "Tag Value");
+```
 
 ## Metrics 
 There are mainly two kind of metrics instances supported; Counter and Gauge. A counter is a cumulative metric that 

--- a/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -109,8 +109,6 @@ public class OpenTracerBallerinaWrapper {
 
         return attachSpan(observerContext, false, spanName);
     }
-
-
     public int attachSpan(ObserverContext observerContext, boolean isClient, String spanName) {
         observerContext.setActionName(spanName);
         TracingUtils.startObservation(observerContext, isClient);

--- a/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -97,20 +97,20 @@ public class OpenTracerBallerinaWrapper {
         if (parentSpanId == SYSTEM_TRACE_INDICATOR) {
             ObservabilityUtils.getParentContext(context).ifPresent(observerContext::setParent);
             ObservabilityUtils.setObserverContextToWorkerExecutionContext(workerExecutionContext, observerContext);
-            return attachSpan(observerContext, true, spanName);
+            return startSpan(observerContext, true, spanName);
         } else if (parentSpanId != ROOT_SPAN_INDICATOR) {
             ObserverContext parentOContext = observerContextList.get(parentSpanId);
             if (parentOContext == null) {
                 return -1;
             }
             observerContext.setParent(parentOContext);
-            return attachSpan(observerContext, true, spanName);
+            return startSpan(observerContext, true, spanName);
         }
 
-        return attachSpan(observerContext, false, spanName);
+        return startSpan(observerContext, false, spanName);
     }
-    
-    private int attachSpan(ObserverContext observerContext, boolean isClient, String spanName) {
+
+    private int startSpan(ObserverContext observerContext, boolean isClient, String spanName) {
         observerContext.setActionName(spanName);
         TracingUtils.startObservation(observerContext, isClient);
         int spanId = this.spanId.getAndIncrement();

--- a/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -109,7 +109,8 @@ public class OpenTracerBallerinaWrapper {
 
         return attachSpan(observerContext, false, spanName);
     }
-    public int attachSpan(ObserverContext observerContext, boolean isClient, String spanName) {
+    
+    private int attachSpan(ObserverContext observerContext, boolean isClient, String spanName) {
         observerContext.setActionName(spanName);
         TracingUtils.startObservation(observerContext, isClient);
         int spanId = this.spanId.getAndIncrement();


### PR DESCRIPTION
## Purpose
Unable to obtain the root span while defining a user specified span. According to the startSpan function, by passing -1 as the parentSpanId we are expecting to attach the defined span as the child span to the current active span. But when we view the flow of spans in either zipkins or honeycomb, the root span goes missing.
Therefore we came up with a function to set the boolean variable, client, to true in startSpan function and by doing so the flow seems to be ordered as expected. 
If the defining span is recognised as root span (startRootSpan API is used) the boolean variable, client, is set to false and it is started as completely a different span. We have to pass the spanName as parameter as well in order to set the action name of the defining span.

## Goals
The goal is to maintain the hierarchy of the spans with ootb and self defined root spans.
