### PR TITLE
Fix iterable operations expected type check issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
@@ -511,12 +511,14 @@ public class IterableAnalyzer {
             final BTupleType tupleType = collectionType.tupleType;
             if (expectedType.tag == TypeTags.ARRAY && tupleType.tupleTypes.size() == 1) {
                 // Convert result into an array.
-                context.resultType = new BArrayType(tupleType.tupleTypes.get(0));
+                context.resultType = types.checkType(lastOperation.pos, new BArrayType(tupleType.tupleTypes.get(0)),
+                        expectedType, DiagnosticCode.INCOMPATIBLE_TYPES);
                 return;
             } else if (expectedType.tag == TypeTags.MAP && tupleType.tupleTypes.size() == 2
                     && tupleType.tupleTypes.get(0).tag == TypeTags.STRING) {
                 // Convert result into a map.
-                context.resultType = new BMapType(TypeTags.MAP, tupleType.tupleTypes.get(1), null);
+                context.resultType = types.checkType(lastOperation.pos, new BMapType(TypeTags.MAP,
+                        tupleType.tupleTypes.get(1), null), expectedType, DiagnosticCode.INCOMPATIBLE_TYPES);
                 return;
             } else if (expectedType.tag == TypeTags.TABLE) {
                 // expectedTypes hold the types of expected return values (types of references) of the iterable

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
@@ -50,7 +50,7 @@ public class IterableOperationsTests {
 
     @Test
     public void testNegative() {
-        Assert.assertEquals(negative.getErrorCount(), 20);
+        Assert.assertEquals(negative.getErrorCount(), 23);
         BAssertUtil.validateError(negative, 0, "undefined function 'int.foreach'", 6, 5);
         BAssertUtil.validateError(negative, 1, "undefined function 'string.map'", 8, 5);
         BAssertUtil.validateError(negative, 2, "variable assignment is required", 14, 5);
@@ -80,6 +80,9 @@ public class IterableOperationsTests {
         BAssertUtil.validateError(negative, 18, "not enough return arguments are defined for operation 'filter'", 67,
                 14);
         BAssertUtil.validateError(negative, 19, "unknown type 'person'", 68, 33);
+        BAssertUtil.validateError(negative, 20, "incompatible types: expected 'int[]', found 'any[]'", 73, 23);
+        BAssertUtil.validateError(negative, 21, "incompatible types: expected 'int[]', found 'string[]'", 82, 27);
+        BAssertUtil.validateError(negative, 22, "incompatible types: expected 'int[]', found 'string[]'", 93, 30);
     }
 
     @Test

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/iterable-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/iterable-negative.bal
@@ -67,3 +67,28 @@ function test7(){
     s.filter((person p)=>{});
     _ = s.filter((string s) => (person) {return null;});
 }
+
+function test8() {
+    int[] arr = [-5, 2, 4, 5, 7, -8, -3, 2];
+    int[] a = arr.map((int v) => (any) {
+                        return v + 1;
+                   });
+}
+
+function test9() {
+    int[] arr = [-5, 2, 4, 5, 7, -8, -3, 2];
+    int[] a = arr.map((int v) => (int) {
+                        return v + 1;
+                   }).map((int v) => (string) {
+                        return "Test" + v;
+                   });
+}
+
+function test10() {
+    int[] arr = [-5, 2, 4, 5, 7, -8, -3, 2];
+    int[] a = arr.map((int v) => (int) {
+                        return v + 1;
+                   }).map((int v) => (string) {
+                        return "Test" + v;
+                   }).filter((string s) => boolean { return true;});
+}


### PR DESCRIPTION
## Purpose
This PR will fix the issue where type checking was not enforced for iterable operations with the expected type.

For example the following should result in a compilation error.

```ballerina
int[] arr = [-5, 2, 4, 5, 7, -8, -3, 2];
int[] a = arr.map((int v) => (any) {
                    return v + 1;
                });
```

Resolves #10089 
