### PR TITLE
Add support to current package aware of the version

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
@@ -25,6 +25,7 @@ import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.langserver.compiler.workspace.repository.WorkspacePackageRepository;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.repository.PackageRepository;
+import org.ballerinalang.toml.model.Manifest;
 import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.ballerinalang.util.diagnostic.DiagnosticListener;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -37,6 +38,7 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -107,13 +109,17 @@ public class LSCompiler {
         LSDocument sourceDocument = new LSDocument(filePath.toUri().toString(), sourceRoot);
 
         PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, documentManager);
-        PackageID packageID = new PackageID(Names.ANON_ORG, new Name(packageName), Names.DEFAULT_VERSION);
+        PackageID packageID;
         if ("".equals(packageName)) {
             Path path = filePath.getFileName();
             if (path != null) {
                 packageName = path.toString();
                 packageID = new PackageID(packageName);
+            } else {
+                packageID = new PackageID(Names.ANON_ORG, new Name(packageName), Names.DEFAULT_VERSION);
             }
+        } else {
+            packageID = generatePackageFromManifest(packageName, sourceRoot);
         }
         CompilerContext context = prepareCompilerContext(packageID, packageRepository, sourceDocument,
                                                                         true, documentManager, phase);
@@ -227,7 +233,7 @@ public class LSCompiler {
                 packageID = new PackageID(fileName);
                 pkgName = fileName;
             } else {
-                packageID = new PackageID(Names.ANON_ORG, new Name(pkgName), Names.DEFAULT_VERSION);
+                packageID = generatePackageFromManifest(pkgName, sourceRoot);
             }
             CompilerContext compilerContext =
                     prepareCompilerContext(packageID, packageRepository, sourceDocument,
@@ -250,6 +256,15 @@ public class LSCompiler {
 
     private boolean isBallerinaFile(File file) {
         return !file.isDirectory() && file.getName().endsWith(BAL_EXTENSION);
+    }
+    
+    private PackageID generatePackageFromManifest(String pkgName, String sourceRoot) {
+        Manifest manifest = LSCompilerUtil.getManifest(Paths.get(sourceRoot));
+        Name orgName = manifest.getName() == null || manifest.getName().isEmpty() ?
+                Names.ANON_ORG : new Name(manifest.getName());
+        Name version = manifest.getVersion() == null || manifest.getVersion().isEmpty() ?
+                Names.DEFAULT_VERSION : new Name(manifest.getVersion());
+        return new PackageID(orgName, new Name(pkgName), version);
     }
 }
 

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
@@ -24,6 +24,8 @@ import org.ballerinalang.langserver.compiler.workspace.repository.LangServerFSPr
 import org.ballerinalang.langserver.compiler.workspace.repository.LangServerFSProjectDirectory;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.repository.PackageRepository;
+import org.ballerinalang.toml.model.Manifest;
+import org.ballerinalang.toml.parser.ManifestProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.compiler.Compiler;
@@ -310,6 +312,21 @@ public class LSCompilerUtil {
      */
     public static Optional<Path> getUntitledFilePath(String filePath) {
         return getUntitledFileId(filePath).map(LSCompilerUtil::createTempFile);
+    }
+
+    /**
+     * Get the toml content from the config.
+     *
+     * @param projectDirPath    Project Directory Path
+     * @return {@link Manifest} Toml Model
+     */
+    static Manifest getManifest(Path projectDirPath) {
+        Path tomlFilePath = projectDirPath.resolve((ProjectDirConstants.MANIFEST_FILE_NAME));
+        try {
+            return ManifestProcessor.parseTomlContentFromFile(tomlFilePath.toString());
+        } catch (IOException e) {
+            return new Manifest();
+        }
     }
 }
 

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageCache.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageCache.java
@@ -18,8 +18,6 @@ package org.ballerinalang.langserver.compiler;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.ballerinalang.model.elements.PackageID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -38,7 +36,6 @@ public class LSPackageCache {
     private static final Object LOCK = new Object();
 
     private final ExtendedPackageCache packageCache;
-    private static final Logger logger = LoggerFactory.getLogger(LSPackageCache.class);
 
     public static LSPackageCache getInstance(CompilerContext context) {
         LSPackageCache lsPackageCache = context.get(LS_PACKAGE_CACHE_KEY);
@@ -116,7 +113,6 @@ public class LSPackageCache {
         }
 
         public void remove(PackageID packageID) {
-            // TODO: Revisit cache update/ compiler context reuse process
             if (packageID != null) {
                 this.packageMap.forEach((key, value) -> {
                     String alias = packageID.getName().toString();


### PR DESCRIPTION
## Purpose
> When creating the PackageId for preparing the compiler context, package information such as the orgName and version now being read from the manifest(Ballerina.toml)