### PR TITLE
Fix build failure due to missing dependency

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/SerializationBValueProviderTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/SerializationBValueProviderTest.java
@@ -25,7 +25,6 @@ import org.ballerinalang.model.util.serializer.providers.bvalue.NumericBValuePro
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
-import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -95,7 +94,7 @@ public class SerializationBValueProviderTest {
 
     @Test(description = "test Date SerializationBValue")
     public void testDateBValueProvider() {
-        Date date = DateTime.now().toDate();
+        Date date = new Date();
         String serialize = new JsonSerializer().serialize(date);
         Date dsDate = new JsonSerializer().deserialize(serialize, Date.class);
         Assert.assertEquals(date, dsDate);


### PR DESCRIPTION
## Purpose
Fix build failure due to missing dependency.

## Approach
Remove the reference to org.joda.time.DateTime and replace with a alternative.

## Related PRs
Issue introduced from https://github.com/ballerina-platform/ballerina-lang/pull/10201

