### PR TITLE
Show a proper error message when there is no Ballerina.toml in the project when pushing and installing packages

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -79,6 +79,12 @@ public class PushUtils {
      */
     public static void pushPackages(String packageName, String sourceRoot, String installToRepo) {
         Path prjDirPath = LauncherUtils.getSourceRootPath(sourceRoot);
+        // Check if the Ballerina.toml exists
+        if (Files.notExists(prjDirPath.resolve(ProjectDirConstants.MANIFEST_FILE_NAME))) {
+            throw new BLangCompilerException("Could't locate Ballerina.toml in the project directory. Run " +
+                                                     "'ballerina init' to create the Ballerina.toml file " +
+                                                     "automatically and re-run the 'ballerina push' command");
+        }
         Manifest manifest = TomlParserUtils.getManifest(prjDirPath);
         if (manifest.getName().isEmpty()) {
             throw new BLangCompilerException("An org-name is required when pushing. This is not specified in " +

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
@@ -181,6 +181,22 @@ public class PackagingNegativeTestCase extends BaseTest {
                 new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
     }
 
+    @Test(description = "Test pushing a package without Ballerina.toml in the project directory")
+    public void testPushWithoutBallerinaToml() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectWithoutToml");
+        initProject(projectPath);
+
+        // Remove Ballerina.toml
+        Files.deleteIfExists(projectPath.resolve("Ballerina.toml"));
+
+        String msg = "ballerina: could't locate Ballerina.toml in the project directory. Run 'ballerina init' to " +
+                "create the Ballerina.toml file automatically and re-run the 'ballerina push' command";
+
+        String[] clientArgs = {packageName};
+        balClient.runMain("push", clientArgs, envVariables, new String[0],
+                          new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
+    }
+
     @Test(description = "Test search without keywords")
     public void testSearchWithoutKeyWords() throws Exception {
         String msg = "ballerina: no keyword given";


### PR DESCRIPTION
## Purpose
> This PR will show a proper error message when there is no Ballerina.toml in the project when pushing and installing packages. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10330

## Automation tests
 - Integration tests
   > Added an integration test case

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes