### PR TITLE
Fix inconsistency in run and build command if the given source path starts with './' or '.\' 

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -271,7 +271,8 @@ public class Main {
                 programArgs = new String[0];
             }
 
-            LauncherUtils.runProgram(sourceRootPath, sourcePath, functionName, runtimeParams,
+            // Normalize the source path to remove './' or '.\' characters that can appear before the name
+            LauncherUtils.runProgram(sourceRootPath, sourcePath.normalize(), functionName, runtimeParams,
                                      configFilePath, programArgs, offline, observeFlag, printReturn);
         }
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -89,13 +89,18 @@ public class BuildCommand implements BLauncherCmd {
             if (pkgName.endsWith("/")) {
                 pkgName = pkgName.substring(0, pkgName.length() - 1);
             }
+
+            Path sourcePath = Paths.get(pkgName);
+
+            // Normalize the source path to remove './' or '.\' characters that can appear before the name
+            pkgName = sourcePath.normalize().toString();
+
             if (outputFileName != null && !outputFileName.isEmpty()) {
                 targetFileName = outputFileName;
             } else {
                 targetFileName = pkgName;
             }
 
-            Path sourcePath = Paths.get(pkgName);
             Path resolvedFullPath = sourceRootPath.resolve(sourcePath);
             // If the source is a single bal file which is not inside a project
             if (Files.isRegularFile(resolvedFullPath) &&

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/RunTopLevelBalInProjectTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/RunTopLevelBalInProjectTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.packaging;
+
+import org.ballerinalang.test.BaseTest;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.test.context.Utils;
+import org.ballerinalang.test.utils.PackagingTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Testing running a top level bal file inside a project.
+ *
+ * @since 0.982.0
+ */
+public class RunTopLevelBalInProjectTestCase extends BaseTest {
+    private Path tempProjectDirectory;
+    private Map<String, String> envVariables;
+
+    @BeforeClass()
+    public void setUp() throws BallerinaTestException, IOException {
+        tempProjectDirectory = Files.createTempDirectory("bal-test-integration-packaging-project-");
+        envVariables = PackagingTestUtils.getEnvVariables();
+    }
+
+    @Test(description = "Test running a top level bal file inside a project")
+    public void testRunningBalInsideProject() throws Exception {
+        // Test ballerina init
+        String[] options = {"\n", "\n", "\n", "m\n", "\n", "f\n"};
+        balClient.runMain("init", new String[]{"-i"}, envVariables, options, new LogLeecher[]{},
+                          tempProjectDirectory.toString());
+        Assert.assertTrue(Files.exists(tempProjectDirectory.resolve("main.bal")));
+
+        // Test ballerina run by giving the file name of the bal file along with for forward slash in Ubuntu and Mac
+        // and backward slash in Windows
+        // Source path with forward slash for Ubuntu and Mac OS
+        String sourcePath = "./main.bal";
+        // Source path with backward slash for Windows
+        if (Utils.getOSName().toLowerCase(Locale.ENGLISH).contains("windows")) {
+            sourcePath = ".\\main.bal";
+        }
+
+        LogLeecher logLeecher = new LogLeecher("Hello World!");
+        balClient.runMain("run", new String[]{sourcePath}, envVariables, new String[0],
+                          new LogLeecher[]{logLeecher}, tempProjectDirectory.toString());
+        logLeecher.waitForText(2000);
+
+        // Test ballerina run by giving the file name of the bal file
+        balClient.runMain("run", new String[]{"main.bal"}, envVariables, new String[0],
+                          new LogLeecher[]{logLeecher}, tempProjectDirectory.toString());
+        logLeecher.waitForText(2000);
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        PackagingTestUtils.deleteFiles(tempProjectDirectory);
+    }
+}

--- a/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
@@ -25,14 +25,15 @@
 
     <test name="ballerina-packaging-sample-tests" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>
-            <class name="org.ballerinalang.test.packaging.PackagingInitTestCase"/>
-            <class name="org.ballerinalang.test.packaging.TestExecutionTestCase"/>
+            <class name="org.ballerinalang.test.packaging.BalRunWithConfigTestCase"/>
             <class name="org.ballerinalang.test.packaging.DocGenTestCase"/>
             <class name="org.ballerinalang.test.packaging.ListDependencyTestCase"/>
+            <class name="org.ballerinalang.test.packaging.PackagingInitTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingNegativeTestCase"/>
+            <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>
+            <class name="org.ballerinalang.test.packaging.RunTopLevelBalInProjectTestCase"/>
             <class name="org.ballerinalang.test.packaging.SingleBalBuildTestCase"/>
-            <class name="org.ballerinalang.test.packaging.BalRunWithConfigTestCase"/>
+            <class name="org.ballerinalang.test.packaging.TestExecutionTestCase"/>
             <class name="org.ballerinalang.test.grpc.ServicePackagingTestCase"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
> This PR fixes the inconsistency in run and build command if the given source path is within a project and starts with './' in Ubuntu or Mac or '.\' in Windows  

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9683

## Automation tests
 - Integration tests
   > Added an integration test case

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes