### PR TITLE
Fix issue with 'ballerina init' when it goes into a loop without exiting when enter is pressed

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -109,11 +109,17 @@ public class InitCommand implements BLauncherCmd {
 
                 String srcInput;
                 boolean validInput = false;
+                boolean firstPrompt = true;
                 do {
-                    out.print("Ballerina source [service/s, main/m, finish/f]: (f) ");
+                    if (firstPrompt) {
+                        out.print("Ballerina source [service/s, main/m, finish/f]: (s) ");
+                    } else {
+                        out.print("Ballerina source [service/s, main/m, finish/f]: (f) ");
+                    }
                     srcInput = scanner.nextLine().trim();
 
-                    if (srcInput.equalsIgnoreCase("service") || srcInput.equalsIgnoreCase("s") || srcInput.isEmpty()) {
+                    if (srcInput.equalsIgnoreCase("service") || srcInput.equalsIgnoreCase("s")
+                            || (srcInput.isEmpty() && firstPrompt)) {
                         String packageName;
                         do {
                             out.print("Package for the service: (no package) ");
@@ -127,6 +133,7 @@ public class InitCommand implements BLauncherCmd {
                             PackageMdFile packageMdFile = new PackageMdFile(packageName, FileType.SERVICE);
                             packageMdFiles.add(packageMdFile);
                         }
+                        firstPrompt = false;
                     } else if (srcInput.equalsIgnoreCase("main") || srcInput.equalsIgnoreCase("m")) {
                         String packageName;
                         do {
@@ -141,8 +148,10 @@ public class InitCommand implements BLauncherCmd {
                             PackageMdFile packageMdFile = new PackageMdFile(packageName, FileType.MAIN);
                             packageMdFiles.add(packageMdFile);
                         }
+                        firstPrompt = false;
                     } else if (srcInput.isEmpty() || srcInput.equalsIgnoreCase("f")) {
                         validInput = true;
+                        firstPrompt = false;
                     } else {
                         out.println("Invalid input");
                     }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -111,7 +111,8 @@ public class InitCommand implements BLauncherCmd {
                 boolean validInput = false;
                 boolean firstPrompt = true;
                 do {
-                    // Following will be the first prompt and it will create a service by default
+                    // Following will be the first prompt and it will create a service by default. This is to align
+                    // with the non-interactive implementation.
                     if (firstPrompt) {
                         // Here if the user presses enter or "s" a service will be created (This will have the same
                         // behavior as running ballerina init without the interactive mode)

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -111,9 +111,15 @@ public class InitCommand implements BLauncherCmd {
                 boolean validInput = false;
                 boolean firstPrompt = true;
                 do {
+                    // Following will be the first prompt and it will create a service by default
                     if (firstPrompt) {
+                        // Here if the user presses enter or "s" a service will be created (This will have the same
+                        // behavior as running ballerina init without the interactive mode)
                         out.print("Ballerina source [service/s, main/m, finish/f]: (s) ");
                     } else {
+                        // Following will be prompted after the first prompt
+                        // Here if the user presses enter, "f" or "finish" the command will be exited. If user gives
+                        // "m" a main function and "s" a service will be created.
                         out.print("Ballerina source [service/s, main/m, finish/f]: (f) ");
                     }
                     srcInput = scanner.nextLine().trim();
@@ -149,7 +155,8 @@ public class InitCommand implements BLauncherCmd {
                             packageMdFiles.add(packageMdFile);
                         }
                         firstPrompt = false;
-                    } else if (srcInput.isEmpty() || srcInput.equalsIgnoreCase("f")) {
+                    } else if (srcInput.isEmpty() || srcInput.equalsIgnoreCase("f") ||
+                            srcInput.equalsIgnoreCase("finish")) {
                         validInput = true;
                         firstPrompt = false;
                     } else {

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingInitTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingInitTestCase.java
@@ -332,6 +332,21 @@ public class PackagingInitTestCase extends BaseTest {
                 .resolve("foo").resolve("0.0.1").resolve("foo.zip")));
     }
 
+    @Test(description = "Test creating a project in the interactive mode by giving enter as the option")
+    public void testInitPrjctWithoutOpts() throws Exception {
+        // Test ballerina init
+        Path projectPath = tempProjectDirectory.resolve("projectWithoutOpts");
+        Files.createDirectories(projectPath);
+
+        String[] clientArgsForInit = {"-i"};
+        String[] options = {"\n", "\n", "\n", "\n", "\n", "\n"};
+        balClient.runMain("init", clientArgsForInit, envVariables, options, new LogLeecher[]{},
+                          projectPath.toString());
+
+        Assert.assertTrue(Files.exists(projectPath.resolve(".ballerina")));
+        Assert.assertTrue(Files.exists(projectPath.resolve("Ballerina.toml")));
+        Assert.assertTrue(Files.exists(projectPath.resolve("hello_service.bal")));
+    }
     /**
      * Run and test main function in project.
      *


### PR DESCRIPTION
## Purpose
> This PR will fix the issue with 'ballerina init' when it goes into a loop without exiting when enter is pressed

The following will be prompted first: "Ballerina source [service/s, main/m, finish/f]: (s)"
If the user presses enter or "s" a service will be created (This will be the same behavior as running ballerina init without the interactive mode)

Afterwards the following will be prompted: "Ballerina source [service/s, main/m, finish/f]: (f) "
If the user presses enter the command will be exited. If user gives "m" a main function and "s" a service will be created.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10384
## Automation tests
 - Integration tests
   > Added an integration test case

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes