### PR TITLE
 Add proper error message when trying to run and build a bal inside a package from a project

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -103,18 +103,17 @@ public class LauncherUtils {
             programFile = compile(fullPath.getParent(), fullPath.getFileName(), offline);
         } else if (Files.isDirectory(sourceRootPath)) {
             if (Files.isDirectory(fullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
-                throw createLauncherException("did you mean to run the Ballerina package as a project? If so run "
-                                                      + "'ballerina init' to make it a project with a .ballerina "
-                                                      + "directory");
+                throw createLauncherException("did you mean to run the package ? If so, either run from the project " +
+                                              "folder or use --sourceroot to specify the project path and run the " +
+                                              "package");
             }
             // If we are trying to run a bal file inside a package from inside a project directory an error is thrown.
             // To differentiate between top level bals and bals inside packages we need to check if the parent of the
             // sourcePath given is null. If it is null then its a top level bal else its a bal inside a package
             if (Files.isRegularFile(fullPath) && srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX) &&
                     sourcePath.getParent() != null) {
-                throw createLauncherException("you are trying to run a ballerina file inside a " +
-                                                                    "package within a project. Try running 'ballerina run " +
-                                                                    "<package-name>'");
+                throw createLauncherException("you are trying to run a ballerina file inside a package within a " +
+                                                      "project. Try running 'ballerina run <package-name>'");
             }
             programFile = compile(sourceRootPath, sourcePath, offline);
         } else {

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -107,6 +107,15 @@ public class LauncherUtils {
                                                       + "'ballerina init' to make it a project with a .ballerina "
                                                       + "directory");
             }
+            // If we are trying to run a bal file inside a package from inside a project directory an error is thrown.
+            // To differentiate between top level bals and bals inside packages we need to check if the parent of the
+            // sourcePath given is null. If it is null then its a top level bal else its a bal inside a package
+            if (Files.isRegularFile(fullPath) && srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX) &&
+                    sourcePath.getParent() != null) {
+                throw createLauncherException("you are trying to run a ballerina file inside a " +
+                                                                    "package within a project. Try running 'ballerina run " +
+                                                                    "<package-name>'");
+            }
             programFile = compile(sourceRootPath, sourcePath, offline);
         } else {
             throw createLauncherException("only packages, " + BLANG_SRC_FILE_SUFFIX + " and " + BLANG_EXEC_FILE_SUFFIX

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -138,9 +138,8 @@ public class BuildCommand implements BLauncherCmd {
             } else if (Files.isDirectory(sourceRootPath)) { // If the source is a package from a project
                 // Checks if the source is a package and if its inside a project (with a .ballerina folder)
                 if (Files.isDirectory(resolvedFullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
-                    throw LauncherUtils.createLauncherException("error: do you mean to build the ballerina package " +
-                                                                "as a project? If so run 'ballerina build' from " +
-                                                                        "within the project");
+                    throw LauncherUtils.createLauncherException("did you mean to build the package ? If so build " +
+                                                                        "from the project folder");
                 }
                 // If we are trying to run a bal file inside a package from a project directory an error is thrown.
                 // To differentiate between top level bals and bals inside packages we need to check if the parent of
@@ -150,14 +149,14 @@ public class BuildCommand implements BLauncherCmd {
                         parentPath != null) {
                     Path fileName = parentPath.getFileName();
                     String srcPkgName = fileName != null ? fileName.toString() : "";
-                    throw LauncherUtils.createLauncherException("error: you are trying to build a ballerina file " +
-                                                                "inside a package within a project. Try running " +
+                    throw LauncherUtils.createLauncherException("you are trying to build a ballerina file inside a " +
+                                                                        "package within a project. Try running " +
                                                                         "'ballerina build <package-name>'");
                 }
             } else {
                 // Invalid source file provided
-                throw LauncherUtils.createLauncherException("error: invalid Ballerina source path, it should either " +
-                                                            "be a directory or a file  with a \'"
+                throw LauncherUtils.createLauncherException("invalid Ballerina source path, it should either be a " +
+                                                                    "directory or a file  with a \'"
                                                             + BLangConstants.BLANG_SRC_FILE_SUFFIX + "\' extension");
             }
             BuilderUtils.compileWithTestsAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg,

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -155,7 +155,7 @@ public class BuildCommand implements BLauncherCmd {
                 }
             } else {
                 // Invalid source file provided
-                throw LauncherUtils.createLauncherException("invalid Ballerina source path, it should either be a " +
+                throw LauncherUtils.createLauncherException("invalid ballerina source path, it should either be a " +
                                                                     "directory or a file  with a \'"
                                                             + BLangConstants.BLANG_SRC_FILE_SUFFIX + "\' extension");
             }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -138,9 +138,9 @@ public class BuildCommand implements BLauncherCmd {
             } else if (Files.isDirectory(sourceRootPath)) { // If the source is a package from a project
                 // Checks if the source is a package and if its inside a project (with a .ballerina folder)
                 if (Files.isDirectory(resolvedFullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
-                    outStream.println("error: do you mean to build the ballerina package as a project? If so run" +
-                                              " ballerina init to make it a project with a .ballerina directory");
-                    return;
+                    throw LauncherUtils.createLauncherException("error: do you mean to build the ballerina package " +
+                                                                "as a project? If so run ballerina init to make it a " +
+                                                                        "project with a .ballerina directory");
                 }
                 // If we are trying to run a bal file inside a package from a project directory an error is thrown.
                 // To differentiate between top level bals and bals inside packages we need to check if the parent of
@@ -150,15 +150,15 @@ public class BuildCommand implements BLauncherCmd {
                         parentPath != null) {
                     Path fileName = parentPath.getFileName();
                     String srcPkgName = fileName != null ? fileName.toString() : "";
-                    outStream.println("error: you are trying to build a ballerina file inside a package within a " +
-                                              "project. Try running 'ballerina build " + srcPkgName + "'");
-                    return;
+                    throw LauncherUtils.createLauncherException("error: you are trying to build a ballerina file " +
+                                                                "inside a package within a project. Try running " +
+                                                                        "'ballerina build " + srcPkgName + "'");
                 }
             } else {
                 // Invalid source file provided
-                outStream.println("error: invalid Ballerina source path, it should either be a directory or a" +
-                                          "file  with a \'" + BLangConstants.BLANG_SRC_FILE_SUFFIX + "\' extension");
-                return;
+                throw LauncherUtils.createLauncherException("error: invalid Ballerina source path, it should either " +
+                                                            "be a directory or a file  with a \'"
+                                                            + BLangConstants.BLANG_SRC_FILE_SUFFIX + "\' extension");
             }
             BuilderUtils.compileWithTestsAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg,
                                                   offline, lockEnabled, skiptests);

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -139,8 +139,8 @@ public class BuildCommand implements BLauncherCmd {
                 // Checks if the source is a package and if its inside a project (with a .ballerina folder)
                 if (Files.isDirectory(resolvedFullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
                     throw LauncherUtils.createLauncherException("error: do you mean to build the ballerina package " +
-                                                                "as a project? If so run ballerina init to make it a " +
-                                                                        "project with a .ballerina directory");
+                                                                "as a project? If so run 'ballerina build' from " +
+                                                                        "within the project");
                 }
                 // If we are trying to run a bal file inside a package from a project directory an error is thrown.
                 // To differentiate between top level bals and bals inside packages we need to check if the parent of
@@ -152,7 +152,7 @@ public class BuildCommand implements BLauncherCmd {
                     String srcPkgName = fileName != null ? fileName.toString() : "";
                     throw LauncherUtils.createLauncherException("error: you are trying to build a ballerina file " +
                                                                 "inside a package within a project. Try running " +
-                                                                        "'ballerina build " + srcPkgName + "'");
+                                                                        "'ballerina build <package-name>'");
                 }
             } else {
                 // Invalid source file provided

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
@@ -305,6 +306,28 @@ public class PackagingNegativeTestCase extends BaseTest {
         String msg = "ballerina: no packages found to push in " + projectPath.toString();
         balClient.runMain("push", new String[0], envVariables, new String[0],
                 new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
+    }
+
+    @Test(description = "Test running a bal file inside a package within a project")
+    public void testRunningBalInsidePackage() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectxyz");
+        initProject(projectPath);
+        String msg = "error: you are trying to run a ballerina file inside a package within a project. Try running " +
+                "'ballerina run" + packageName + "'";
+        String sourcePath = Paths.get(packageName, "main.bal").toString();
+        balClient.runMain("run", new String[] {sourcePath}, envVariables, new String[0],
+                          new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
+    }
+
+    @Test(description = "Test building a bal file inside a package within a project",
+            dependsOnMethods = "testRunningBalInsidePackage")
+    public void testBuildingBalInsidePackage() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectxyz");
+        String msg = "error: you are trying to build a ballerina file inside a package within a project. Try running " +
+                "'ballerina build" + packageName + "'";
+        String sourcePath = Paths.get(packageName, "main.bal").toString();
+        balClient.runMain("build", new String[] {sourcePath}, envVariables, new String[0],
+                          new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
     }
 
     /**

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
@@ -313,7 +313,7 @@ public class PackagingNegativeTestCase extends BaseTest {
         Path projectPath = tempProjectDirectory.resolve("projectxyz");
         initProject(projectPath);
         String msg = "error: you are trying to run a ballerina file inside a package within a project. Try running " +
-                "'ballerina run" + packageName + "'";
+                "'ballerina run <package-name>'";
         String sourcePath = Paths.get(packageName, "main.bal").toString();
         balClient.runMain("run", new String[] {sourcePath}, envVariables, new String[0],
                           new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
@@ -324,7 +324,7 @@ public class PackagingNegativeTestCase extends BaseTest {
     public void testBuildingBalInsidePackage() throws Exception {
         Path projectPath = tempProjectDirectory.resolve("projectxyz");
         String msg = "error: you are trying to build a ballerina file inside a package within a project. Try running " +
-                "'ballerina build" + packageName + "'";
+                "'ballerina build <package-name>'";
         String sourcePath = Paths.get(packageName, "main.bal").toString();
         balClient.runMain("build", new String[] {sourcePath}, envVariables, new String[0],
                           new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());


### PR DESCRIPTION
## Purpose
>  This PR will add a proper error message when trying to run and build a ballerina file inside a package from a project which is not allowed

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10364

## Automation tests
 - Integration tests
   > Added integration test cases

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes