### PR TITLE
Enable batch mode in Travis and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8.9.0
   - nvm use 8.9.0
-  - mvn install -V -pl '!tool-plugins/vscode/plugin,!tool-plugins/vscode'
+  - mvn install -B -V -pl '!tool-plugins/vscode/plugin,!tool-plugins/vscode'
 
 script: echo "Done"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - cmd: mvn --version
   - cmd: java -version
 build_script:
-  - mvn clean install -V -DskipTests
+  - mvn clean install -B -V -DskipTests
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml


### PR DESCRIPTION
## Purpose
This PR enables batch mode so the download progress, etc wont be logged. This is needed to make sure the log size don't exceed 4mb which will stop the Travis build.