### PR TITLE
Add Enum support for request/response messages

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/GrpcConstants.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/GrpcConstants.java
@@ -65,6 +65,8 @@ public class GrpcConstants {
     public static final String REQUEST_SENDER = "REQUEST_SENDER";
     public static final String GRPC_CLIENT = "GrpcClient";
     public static final String REQUEST_MESSAGE_DEFINITION = "REQUEST_DEFINITION";
+    public static final String REGEX_DOT_SEPERATOR = "\\.";
+    public static final String DOT = ".";
 
     public static final String CLIENT = "Client";
     public static final String ANN_RESOURCE_CONFIG = "ResourceConfig";

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/Message.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/Message.java
@@ -226,7 +226,8 @@ public class Message {
                             messages.add(input.readEnum());
                             this.fields.put(name, messages);
                         } else {
-                            this.fields.put(name, input.readEnum());
+                            this.fields.put(name,
+                                    fieldDescriptor.getEnumType().findValueByNumber(input.readEnum()).toString());
                         }
                         break;
                     }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/MessageUtils.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/MessageUtils.java
@@ -30,6 +30,7 @@ import org.ballerinalang.connector.api.ParamDetail;
 import org.ballerinalang.connector.api.Resource;
 import org.ballerinalang.model.types.BArrayType;
 import org.ballerinalang.model.types.BField;
+import org.ballerinalang.model.types.BFiniteType;
 import org.ballerinalang.model.types.BStructureType;
 import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.TypeKind;
@@ -516,6 +517,9 @@ public class MessageUtils {
                         }
                         requestStruct.put(structFieldName, bArrayValue);
                     }
+                } else if (structFieldType instanceof BFiniteType) {
+                    BValue bEnumValue = new BString((String) request.getFields().get(structField.fieldName));
+                    requestStruct.put(structFieldName, bEnumValue);
                 }
             }
             bValue = requestStruct;

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
@@ -68,6 +68,10 @@ public class Field {
         public Field build() {
             String fieldType = FIELD_TYPE_MAP.get(fieldDescriptor.getType()) != null ? FIELD_TYPE_MAP.get
                     (fieldDescriptor.getType()) : fieldDescriptor.getTypeName();
+            if (fieldType.startsWith(".")) {
+                String[] fieldTypeArray = fieldType.split(("\\."));
+                fieldType = fieldTypeArray[fieldTypeArray.length - 1];
+            }
             String fieldLabel = FIELD_LABEL_MAP.get(fieldDescriptor.getLabel());
             return new Field(fieldDescriptor.getName(), fieldType, fieldLabel, fieldDescriptor.getDefaultValue());
         }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
@@ -18,8 +18,12 @@
 package org.ballerinalang.net.grpc.builder.components;
 
 import com.google.protobuf.DescriptorProtos;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.ballerinalang.net.grpc.GrpcConstants.DOT;
+import static org.ballerinalang.net.grpc.GrpcConstants.REGEX_DOT_SEPERATOR;
 
 /**
  * Field definition bean class.
@@ -68,8 +72,8 @@ public class Field {
         public Field build() {
             String fieldType = FIELD_TYPE_MAP.get(fieldDescriptor.getType()) != null ? FIELD_TYPE_MAP.get
                     (fieldDescriptor.getType()) : fieldDescriptor.getTypeName();
-            if (fieldType.startsWith(".")) {
-                String[] fieldTypeArray = fieldType.split(("\\."));
+            if (fieldType.startsWith(DOT)) {
+                String[] fieldTypeArray = fieldType.split(REGEX_DOT_SEPERATOR);
                 fieldType = fieldTypeArray[fieldTypeArray.length - 1];
             }
             String fieldLabel = FIELD_LABEL_MAP.get(fieldDescriptor.getLabel());

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java
@@ -27,11 +27,13 @@ import org.ballerinalang.model.tree.ResourceNode;
 import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.statements.BlockNode;
 import org.ballerinalang.model.tree.statements.StatementNode;
+import org.ballerinalang.model.types.FiniteType;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.net.grpc.config.ResourceConfiguration;
 import org.ballerinalang.net.grpc.config.ServiceConfiguration;
 import org.ballerinalang.net.grpc.exception.GrpcServerException;
 import org.ballerinalang.net.grpc.proto.definition.EmptyMessage;
+import org.ballerinalang.net.grpc.proto.definition.EnumField;
 import org.ballerinalang.net.grpc.proto.definition.Field;
 import org.ballerinalang.net.grpc.proto.definition.File;
 import org.ballerinalang.net.grpc.proto.definition.Message;
@@ -44,6 +46,7 @@ import org.ballerinalang.net.grpc.proto.definition.UserDefinedMessage;
 import org.ballerinalang.net.grpc.proto.definition.WrapperMessage;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStructureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -510,6 +513,19 @@ public class ServiceProtoUtils {
                 }
                 fieldType = elementType;
                 fieldLabel = "repeated";
+            } else if (fieldType instanceof FiniteType) {
+                UserDefinedEnumMessage.Builder enumBuilder = UserDefinedEnumMessage
+                        .newBuilder(fieldType.tsymbol.name.value);
+                BFiniteType finiteType = (BFiniteType) fieldType;
+                int enumFieldIndex = 0;
+                EnumField.Builder enumFieldBuilder = EnumField.newBuilder();
+                EnumField enumField;
+                for (BLangExpression bLangExpression : finiteType.valueSpace) {
+                    String enumValue = String.valueOf(bLangExpression);
+                    enumField = enumFieldBuilder.setIndex(enumFieldIndex++).setName(enumValue).build();
+                    enumBuilder.addFieldDefinition(enumField);
+                }
+                messageBuilder.addMessageDefinition(enumBuilder.build());
             }
             messageField = Field.newBuilder(fieldName)
                     .setIndex(++fieldIndex)

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/definition/Field.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/definition/Field.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.net.grpc.proto.definition;
 
 import com.google.protobuf.DescriptorProtos;
+import org.ballerinalang.model.types.FiniteType;
 import org.ballerinalang.net.grpc.exception.GrpcServerException;
 import org.ballerinalang.net.grpc.proto.ServiceProtoConstants;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStructureType;
@@ -105,7 +106,7 @@ public class Field {
             if (primType != null) {
                 fieldDescriptorBuilder.setType(primType);
             } else {
-                if (type instanceof BStructureType) {
+                if (type instanceof BStructureType || type instanceof FiniteType) {
                     fieldDescriptorBuilder.setTypeName(fieldType);
                 } else {
                     throw new GrpcServerException("Unsupported field type, field type " + type.getKind().typeName() +

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/definition/UserDefinedMessage.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/definition/UserDefinedMessage.java
@@ -114,7 +114,6 @@ public class UserDefinedMessage extends Message {
         public Builder addMessageDefinition(Message messageDefinition) {
             if (messageDefinition instanceof UserDefinedEnumMessage) {
                 UserDefinedEnumMessage enumMessage = (UserDefinedEnumMessage) messageDefinition;
-                messageDescriptorBuilder.addEnumType(enumMessage.getDescriptorProto());
                 nestedEnumList.add(enumMessage);
             } else if (messageDefinition instanceof UserDefinedMessage) {
                 UserDefinedMessage message = (UserDefinedMessage) messageDefinition;

--- a/stdlib/grpc/src/main/resources/templates/skeleton/clientStub.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/clientStub.mustache
@@ -73,9 +73,9 @@ type {{messageName}} record {
     {{/fieldList}}
 };
 {{/messageList}}
-{{#enumList}}public type {{messageName}} {{#fieldList}}{{number}}{{#unless @last}}|{{/unless}}{{/fieldList}};
+{{#enumList}}public type {{messageName}} {{#fieldList}}"{{name}}"{{#unless @last}}|{{/unless}}{{/fieldList}};
 {{#fieldList}}
-@final public {{../messageName}} {{name}} = {{number}};
+@final public {{../messageName}} {{name}} = "{{name}}";
 {{/fieldList}}{{/enumList}}
 @final string DESCRIPTOR_KEY = "{{rootDescriptorKey}}";
 map descriptorMap = {

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/UnaryBlockingEnumTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/UnaryBlockingEnumTestCase.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.service.grpc.sample;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.test.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Test class for testing Enum.
+ */
+@Test(groups = "grpc-test")
+public class UnaryBlockingEnumTestCase extends GrpcBaseTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    private void setup() throws Exception {
+        TestUtils.prepareBalo(this);
+        Path balFilePath = Paths.get("src", "test", "resources", "grpc", "clients", "grpc_enum_test_client.bal");
+        result = BCompileUtil.compile(balFilePath.toAbsolutePath().toString());
+    }
+
+    @Test
+    public void testEnumBlockingBallerinaClient() {
+        final String serverMsg = "r";
+        BValue[] responses = BRunUtil.invoke(result, "testEnum");
+        Assert.assertEquals(responses.length, 1);
+        Assert.assertTrue(responses[0] instanceof BString);
+        Assert.assertEquals(responses[0].stringValue(), serverMsg);
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/MutualSSLTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/MutualSSLTestCase.java
@@ -32,7 +32,6 @@ public class MutualSSLTestCase extends HttpBaseTest {
 
     private BMainInstance ballerinaClient;
 
-
     @Test(description = "Test mutual ssl")
     public void testMutualSSL() throws Exception {
         String serverMessage = "successful";

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_enum_test_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_enum_test_client.bal
@@ -20,7 +20,7 @@ function testEnum() returns (string) {
         url:"http://localhost:8555"
     };
 
-    orderInfo orderReq = {id:"100500", mode:r};
+    orderInfo orderReq = { id:"100500", mode:r };
     var addResponse = blockingEp->testEnum(orderReq);
     match addResponse {
         (string, grpc:Headers) payload => {

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_enum_test_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_enum_test_client.bal
@@ -1,0 +1,139 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/grpc;
+
+function testEnum() returns (string) {
+    endpoint testEnumServiceBlockingClient blockingEp {
+        url:"http://localhost:8555"
+    };
+
+    orderInfo orderReq = {id:"100500", mode:r};
+    var addResponse = blockingEp->testEnum(orderReq);
+    match addResponse {
+        (string, grpc:Headers) payload => {
+            string result;
+            (result, _) = payload;
+            return result;
+        }
+        error err => {
+            return "Error from Connector: " + err.message;
+        }
+    }
+}
+
+public type testEnumServiceBlockingStub object {
+    public grpc:Client clientEndpoint;
+    public grpc:Stub stub;
+
+    function initStub (grpc:Client ep) {
+        grpc:Stub navStub = new;
+        navStub.initStub(ep, "blocking", DESCRIPTOR_KEY, descriptorMap);
+        self.stub = navStub;
+    }
+
+    function testEnum (orderInfo req, grpc:Headers? headers = ()) returns ((string, grpc:Headers)|error) {
+
+        var unionResp = self.stub.blockingExecute("grpcservices.testEnumService/testEnum", req, headers = headers);
+        match unionResp {
+            error payloadError => {
+                return payloadError;
+            }
+            (any, grpc:Headers) payload => {
+                grpc:Headers resHeaders;
+                any result;
+                (result, resHeaders) = payload;
+                return (<string>result, resHeaders);
+            }
+        }
+    }
+
+};
+
+public type testEnumServiceStub object {
+    public grpc:Client clientEndpoint;
+    public grpc:Stub stub;
+
+    function initStub (grpc:Client ep) {
+        grpc:Stub navStub = new;
+        navStub.initStub(ep, "non-blocking", DESCRIPTOR_KEY, descriptorMap);
+        self.stub = navStub;
+    }
+
+    function testEnum (orderInfo req, typedesc listener, grpc:Headers? headers = ()) returns (error?) {
+
+        return self.stub.nonBlockingExecute("grpcservices.testEnumService/testEnum", req, listener, headers = headers);
+    }
+
+};
+
+
+public type testEnumServiceBlockingClient object {
+    public grpc:Client client;
+    public testEnumServiceBlockingStub stub;
+
+    public function init (grpc:ClientEndpointConfig config) {
+        // initialize client endpoint.
+        grpc:Client c = new;
+        c.init(config);
+        self.client = c;
+        // initialize service stub.
+        testEnumServiceBlockingStub s = new;
+        s.initStub(c);
+        self.stub = s;
+    }
+
+    public function getCallerActions () returns testEnumServiceBlockingStub {
+        return self.stub;
+    }
+};
+
+public type testEnumServiceClient object {
+    public grpc:Client client;
+    public testEnumServiceStub stub;
+
+    public function init (grpc:ClientEndpointConfig config) {
+        // initialize client endpoint.
+        grpc:Client c = new;
+        c.init(config);
+        self.client = c;
+        // initialize service stub.
+        testEnumServiceStub s = new;
+        s.initStub(c);
+        self.stub = s;
+    }
+
+    public function getCallerActions () returns testEnumServiceStub {
+        return self.stub;
+    }
+};
+
+
+type orderInfo record {
+    string id;
+    Mode mode;
+
+};
+
+public type Mode "r";
+
+@final public Mode r = "r";
+
+@final string DESCRIPTOR_KEY = "grpcservices.testEnumService.proto";
+map descriptorMap = {
+    "grpcservices.testEnumService.proto":"0A1574657374456E756D536572766963652E70726F746F120C6772706373657276696365731A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F22430A096F72646572496E666F120E0A0269641801200128095202696412260A046D6F646518022001280E32122E6772706373657276696365732E4D6F646552046D6F64652A0D0A044D6F646512050A0172100032540A0F74657374456E756D5365727669636512410A0874657374456E756D12172E6772706373657276696365732E6F72646572496E666F1A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33",
+    "google.protobuf.wrappers.proto":"0A0E77726170706572732E70726F746F120F676F6F676C652E70726F746F62756622230A0B446F75626C6556616C756512140A0576616C7565180120012801520576616C756522220A0A466C6F617456616C756512140A0576616C7565180120012802520576616C756522220A0A496E74363456616C756512140A0576616C7565180120012803520576616C756522230A0B55496E74363456616C756512140A0576616C7565180120012804520576616C756522220A0A496E74333256616C756512140A0576616C7565180120012805520576616C756522230A0B55496E74333256616C756512140A0576616C756518012001280D520576616C756522210A09426F6F6C56616C756512140A0576616C7565180120012808520576616C756522230A0B537472696E6756616C756512140A0576616C7565180120012809520576616C756522220A0A427974657356616C756512140A0576616C756518012001280C520576616C756542570A13636F6D2E676F6F676C652E70726F746F627566420D577261707065727350726F746F50015A057479706573F80101A20203475042AA021E476F6F676C652E50726F746F6275662E57656C6C4B6E6F776E5479706573620670726F746F33"
+
+};

--- a/tests/ballerina-integration-test/src/test/resources/grpc/grpcservices/grpc_enum_test_service.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/grpcservices/grpc_enum_test_service.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/grpc;
+
+endpoint grpc:Listener listener {
+    host:"localhost",
+    port:8555
+};
+
+map<orderInfo> ordersMap;
+
+type orderInfo record {
+    string id;
+    Mode mode;
+};
+
+public type Mode "r";
+@final public Mode READ = "r";
+
+@grpc:ServiceConfig
+service testEnumService bind listener {
+    testEnum(endpoint caller, orderInfo orderReq) {
+        string orderId = orderReq.id;
+        ordersMap[orderReq.id] = orderReq;
+        string permission;
+        match orderReq.mode {
+            READ => permission = "r";
+        }
+        _ = caller->send(permission);
+        _ = caller->complete();
+    }
+}

--- a/tests/ballerina-integration-test/src/test/resources/grpc/grpcservices/grpc_enum_test_service.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/grpcservices/grpc_enum_test_service.bal
@@ -33,8 +33,6 @@ public type Mode "r";
 @grpc:ServiceConfig
 service testEnumService bind listener {
     testEnum(endpoint caller, orderInfo orderReq) {
-        string orderId = orderReq.id;
-        ordersMap[orderReq.id] = orderReq;
         string permission;
         match orderReq.mode {
             READ => permission = "r";

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -160,6 +160,7 @@
             <class name="org.ballerinalang.test.service.grpc.sample.ServiceUnavailableTestCase"/>
             <class name="org.ballerinalang.test.service.grpc.sample.ProtoBuilderTestCase"/>
             <class name="org.ballerinalang.test.service.grpc.sample.ServerStreamingTestCase"/>
+            <class name="org.ballerinalang.test.service.grpc.sample.UnaryBlockingEnumTestCase"/>
             <class name="org.ballerinalang.test.service.grpc.sample.ErrorServiceTestCase"/>
             <class name="org.ballerinalang.test.service.grpc.tool.InvalidServiceContractTestCase"/>
             <class name="org.ballerinalang.test.service.grpc.tool.ClientStubGeneratorTestCase"/>


### PR DESCRIPTION
## Purpose
Fix the issue: https://github.com/ballerina-platform/ballerina-lang/issues/10038

## Automation tests
 - Integration tests
   Contains an integration test.

## Samples
grpc service
```
endpoint grpc:Listener listener {
    host:"localhost",
    port:8555
};

map<orderInfo> ordersMap;

type orderInfo record {
    string id;
    Mode mode;
};

public type Mode "r";
@final public Mode READ = "r";

@grpc:ServiceConfig
service testEnumService bind listener {
    testEnum(endpoint caller, orderInfo orderReq) {
        string permission;
        match orderReq.mode {
            READ => permission = "r";
        }
        _ = caller->send(permission);
        _ = caller->complete();
    }
}
```
Generated proto file.
```
syntax = "proto3";
package grpcservices;
import "google/protobuf/wrappers.proto";
service testEnumService {
		rpc testEnum(orderInfo) returns (google.protobuf.StringValue);
}
message orderInfo {
	string id = 1;
	Mode mode = 2;
}
enum Mode {
	r = 0;
}
```
grpc client
```
public function main (string... args) {

       endpoint testEnumServiceBlockingClient blockingEp {
        url:"http://localhost:8555"
    };

    orderInfo orderReq = {id:"100500", mode:r};
    var addResponse = blockingEp->testEnum(orderReq);
    match addResponse {
        (string, grpc:Headers) payload => {
            string result;
            (result, _) = payload;
            log:printInfo("Response - " + result + "\n");        }
        error err => {
            log:printError("Error from Connector: " + err.message + "\n");
        }
    }
}
```