### PR TITLE
 [Debugger] Add variable evaluation feature 

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -2435,7 +2435,7 @@ public class CPU {
                 .getLineNumber(ctx.callableUnitInfo.getPackageInfo().getPkgPath(), ctx.ip);
         /*
          Below if check stops hitting the same debug line again and again in case that single line has
-         multctx.iple instructions.
+         multiple instructions.
          */
         if (currentExecLine.equals(debugContext.getLastLine())) {
             return false;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugClientHandler.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugClientHandler.java
@@ -85,6 +85,13 @@ public interface DebugClientHandler {
     void notifyHalt(MessageDTO message);
 
     /**
+     * Send the results of an expression to the client after evaluating it.
+     *
+     * @param message results to be sent to the client.
+     */
+    void sendExpressionResults(MessageDTO message);
+
+    /**
      * Send a custom message to the client.
      *
      * @param message message to send to the client

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugConstants.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugConstants.java
@@ -40,6 +40,7 @@ public class DebugConstants {
     static final String CMD_RESUME = "RESUME";
     static final String CMD_STEP_IN = "STEP_IN";
     static final String CMD_STEP_OUT = "STEP_OUT";
+    static final String CMD_EVALUATE_EXP = "EVALUATE_EXPRESSION";
 
     // messages sent back to client
     static final String CODE_HIT = "DEBUG_HIT";
@@ -51,6 +52,7 @@ public class DebugConstants {
     static final String MSG_INVALID_BREAKPOINT = "Invalid Breakpoint : ";
 
     static final String CODE_ACK = "ACK";
+    static final String CODE_EXP_RESULTS = "EXPRESSION_RESULTS";
 
     static final String CODE_EXIT = "EXIT";
     static final String MSG_EXIT = "Exiting from debugger.";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugInfoHolder.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugInfoHolder.java
@@ -146,6 +146,7 @@ class DebugInfoHolder {
         }
 
         boolean markDebugPoint(BreakPointDTO breakPointDTO) {
+            // TODO: Need to improve/change this logic.
             String fileName = breakPointDTO.getFileName();
             if (fileName.contains("/")) {
                 String[] pathArray = fileName.split("/");

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -404,7 +404,7 @@ public class Debugger {
             // TODO: Need to change the 'contains' logic, if we allow user-defined variable names to have '$'
             if (!packVarInfo.getName().contains(META_DATA_VAR_PATTERN)) {
                 VariableDTO variableDTO = constructGlobalVariable(ctx, packVarInfo);
-                if (variableDTO.getValue() != null || variableDTO.getType().equals(TYPE_JSON)) {
+                if (variableDTO.getValue() != null || packVarInfo.getType().getTag() == TypeTags.JSON_TAG) {
                     frameDTO.addVariable(variableDTO);
                 }
             }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -433,37 +433,36 @@ public class Debugger {
      * @return Constructed global variable.
      */
     public static VariableDTO constructGlobalVariable(WorkerExecutionContext ctx, PackageVarInfo packVarInfo) {
-        int pkgIndex = ctx.callableUnitInfo.getPackageInfo().pkgIndex;
-        VariableDTO variableDTO = new VariableDTO(packVarInfo.getName(), GLOBAL);
+        int pkgIndex = ctx.callableUnitInfo.getPackageInfo().pkgIndex;VariableDTO variableDTO = new VariableDTO(packVarInfo.getName(), GLOBAL);
+                switch (packVarInfo.getType().getTag()) {
+                    case TypeTags.INT_TAG:
+                        variableDTO.setBValue(new BInteger(ctx.programFile.globalMemArea.getIntField(pkgIndex,
+                                packVarInfo.getGlobalMemIndex())));
+                        break;
+                    case TypeTags.BYTE_TAG:
+                        variableDTO.setBValue(new BByte((byte) (ctx.programFile.globalMemArea.getBooleanField(pkgIndex,
+                                packVarInfo.getGlobalMemIndex()))));
+                        break;
+                    case TypeTags.FLOAT_TAG:
+                        variableDTO.setBValue(new BFloat(ctx.programFile.globalMemArea.getFloatField(pkgIndex,
+                                packVarInfo.getGlobalMemIndex())));
+                        break;
+                    case TypeTags.STRING_TAG:
+                        variableDTO.setBValue(new BString(ctx.programFile.globalMemArea.getStringField(pkgIndex,
+                                packVarInfo.getGlobalMemIndex())));
+                        break;
+                    case TypeTags.BOOLEAN_TAG:
+                        variableDTO.setBValue(new BBoolean(ctx.programFile.globalMemArea.getBooleanField(pkgIndex,
+                                packVarInfo.getGlobalMemIndex()) == 1));
+                        break;
+                    default:
+                        variableDTO.setBValue(ctx.programFile.globalMemArea.getRefField(pkgIndex,
+                                packVarInfo.getGlobalMemIndex()));
+                        break;
+                }
+                returnvariableDTO;
+            }
 
-        switch (packVarInfo.getType().getTag()) {
-            case TypeTags.INT_TAG:
-                variableDTO.setBValue(new BInteger(ctx.programFile.globalMemArea.getIntField(pkgIndex,
-                        packVarInfo.getGlobalMemIndex())));
-                break;
-            case TypeTags.BYTE_TAG:
-                variableDTO.setBValue(new BByte((byte) (ctx.programFile.globalMemArea.getBooleanField(pkgIndex,
-                        packVarInfo.getGlobalMemIndex()))));
-                break;
-            case TypeTags.FLOAT_TAG:
-                variableDTO.setBValue(new BFloat(ctx.programFile.globalMemArea.getFloatField(pkgIndex,
-                        packVarInfo.getGlobalMemIndex())));
-                break;
-            case TypeTags.STRING_TAG:
-                variableDTO.setBValue(new BString(ctx.programFile.globalMemArea.getStringField(pkgIndex,
-                        packVarInfo.getGlobalMemIndex())));
-                break;
-            case TypeTags.BOOLEAN_TAG:
-                variableDTO.setBValue(new BBoolean(ctx.programFile.globalMemArea.getBooleanField(pkgIndex,
-                        packVarInfo.getGlobalMemIndex()) == 1));
-                break;
-            default:
-                variableDTO.setBValue(ctx.programFile.globalMemArea.getRefField(pkgIndex,
-                        packVarInfo.getGlobalMemIndex()));
-                break;
-        }
-        return variableDTO;
-    }
 
     /**
      * Method to construct a @{@link VariableDTO} that represents a local variable.

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -434,6 +434,7 @@ public class Debugger {
      *
      * @param ctx         Current context.
      * @param packVarInfo Package variable info.
+     * @param pkgIndex    Package index.
      * @return Constructed global variable.
      */
     public static VariableDTO constructGlobalVariable(WorkerExecutionContext ctx, PackageVarInfo packVarInfo,

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -460,7 +460,7 @@ public class Debugger {
                                 packVarInfo.getGlobalMemIndex()));
                         break;
                 }
-                returnvariableDTO;
+                return variableDTO;
             }
 
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -413,7 +413,6 @@ public class Debugger {
         localVarAttrInfo.getLocalVariables().forEach(variableInfo -> {
             // TODO: Need to change the 'contains' logic, if we allow user-defined variable names to have '$'
             if (!variableInfo.getVariableName().contains(META_DATA_VAR_PATTERN)) {
-
                 VariableDTO variableDTO = constructLocalVariable(ctx, variableInfo);
 
                 // Show only the variables within the current scope

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -29,6 +29,7 @@ import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.runtime.Constants;
 import org.ballerinalang.util.codegen.LineNumberInfo;
+import org.ballerinalang.util.codegen.LocalVariableInfo;
 import org.ballerinalang.util.codegen.PackageVarInfo;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.codegen.attributes.AttributeInfo;
@@ -61,6 +62,8 @@ public class Debugger {
 
     private DebugInfoHolder debugInfoHolder;
 
+    private ExpressionEvaluator expressionEvaluator;
+
     private volatile Semaphore executionSem;
 
     private static final String META_DATA_VAR_PATTERN = "$";
@@ -69,6 +72,7 @@ public class Debugger {
 
     public Debugger(ProgramFile programFile) {
         this.programFile = programFile;
+        this.expressionEvaluator = new ExpressionEvaluator();
         String debug = System.getProperty(Constants.SYSTEM_PROP_BAL_DEBUG);
         if (debug != null && !debug.isEmpty()) {
             debugEnabled = true;
@@ -174,6 +178,11 @@ public class Debugger {
                 //TODO: Revisit sending acknowledgement message when there's invalid breakpoints
                 sendAcknowledge("Debug points updated");
                 break;
+            case DebugConstants.CMD_EVALUATE_EXP:
+                // we expect { "command": "EVALUATE_EXPRESSION", "expression": <exp>, "threadId": <threadId> }
+                String results = evaluateVariable(command.getThreadId(), command.getVariableName());
+                sendResults(results);
+                break;
             case DebugConstants.CMD_START:
                 // Client needs to explicitly start the execution once connected.
                 // This will allow client to set the breakpoints before starting the execution.
@@ -267,6 +276,19 @@ public class Debugger {
         clientHandler.clearChannel();
     }
 
+    /**
+     * Method to evaluate a given variable.
+     *
+     * @param workerId     Current workerId.
+     * @param variableName Name of the variable to be evaluated.
+     * @return Evaluated value.
+     */
+    public String evaluateVariable(String workerId, String variableName) {
+        WorkerExecutionContext ctx = getWorkerContext(workerId);
+        LineNumberInfo currentExecLine = getLineNumber(ctx.callableUnitInfo.getPackageInfo().getPkgPath(), ctx.ip);
+        return expressionEvaluator.evaluateVariable(ctx, currentExecLine, variableName);
+    }
+
     private WorkerExecutionContext getWorkerContext(String workerId) {
         WorkerExecutionContext ctx = clientHandler.getWorkerContext(workerId);
         if (ctx == null) {
@@ -336,6 +358,16 @@ public class Debugger {
     }
 
     /**
+     * Send expression results to the client.
+     *
+     * @param results to be sent to the client.
+     */
+    private void sendResults(String results) {
+        MessageDTO message = new MessageDTO(DebugConstants.CODE_EXP_RESULTS, results);
+        clientHandler.sendExpressionResults(message);
+    }
+
+    /**
      * Generate debug hit message.
      *
      * @param ctx             Current context.
@@ -362,80 +394,109 @@ public class Debugger {
                 callingLine.getLineNumber());
         message.addFrame(frameDTO);
 
-        int pkgIndex = ctx.callableUnitInfo.getPackageInfo().pkgIndex;
-
+        // Add global variables to the frame
         PackageVarInfo[] packageVarInfoEntries = ctx.programFile.getPackageInfo(ctx.programFile.getEntryPkgName()).
                 getPackageInfoEntries();
+
         for (PackageVarInfo packVarInfo : packageVarInfoEntries) {
             // TODO: Need to change the 'contains' logic, if we allow user-defined variable names to have '$'
             if (!packVarInfo.getName().contains(META_DATA_VAR_PATTERN)) {
-                VariableDTO variableDTO = new VariableDTO(packVarInfo.getName(), GLOBAL);
-                switch (packVarInfo.getType().getTag()) {
-                    case TypeTags.INT_TAG:
-                        variableDTO.setBValue(new BInteger(programFile.globalMemArea.getIntField(pkgIndex,
-                                packVarInfo.getGlobalMemIndex())));
-                        break;
-                    case TypeTags.BYTE_TAG:
-                        variableDTO.setBValue(new BByte((byte) (programFile.globalMemArea.getBooleanField(pkgIndex,
-                                packVarInfo.getGlobalMemIndex()))));
-                        break;
-                    case TypeTags.FLOAT_TAG:
-                        variableDTO.setBValue(new BFloat(programFile.globalMemArea.getFloatField(pkgIndex,
-                                packVarInfo.getGlobalMemIndex())));
-                        break;
-                    case TypeTags.STRING_TAG:
-                        variableDTO.setBValue(new BString(programFile.globalMemArea.getStringField(pkgIndex,
-                                packVarInfo.getGlobalMemIndex())));
-                        break;
-                    case TypeTags.BOOLEAN_TAG:
-                        variableDTO.setBValue(new BBoolean(programFile.globalMemArea.getBooleanField(pkgIndex,
-                                packVarInfo.getGlobalMemIndex()) == 1));
-                        break;
-                    default:
-                        variableDTO.setBValue(programFile.globalMemArea.getRefField(pkgIndex,
-                                packVarInfo.getGlobalMemIndex()));
-                        break;
-                }
+                VariableDTO variableDTO = constructGlobalVariable(ctx, packVarInfo);
                 frameDTO.addVariable(variableDTO);
             }
         }
 
+        // Add local variables to the frame
         LocalVariableAttributeInfo localVarAttrInfo = (LocalVariableAttributeInfo) ctx.workerInfo.
                 getAttributeInfo(AttributeInfo.Kind.LOCAL_VARIABLES_ATTRIBUTE);
 
-        localVarAttrInfo.getLocalVariables().forEach(l -> {
+        localVarAttrInfo.getLocalVariables().forEach(variableInfo -> {
             // TODO: Need to change the 'contains' logic, if we allow user-defined variable names to have '$'
-            if (!l.getVariableName().contains(META_DATA_VAR_PATTERN)) {
-                VariableDTO variableDTO = new VariableDTO(l.getVariableName(), LOCAL);
-                switch (l.getVariableType().getTag()) {
-                    case TypeTags.INT_TAG:
-                        variableDTO.setBValue(new BInteger(ctx.workerLocal.longRegs[l.getVariableIndex()]));
-                        break;
-                    case TypeTags.BYTE_TAG:
-                        variableDTO.setBValue(new BByte((byte) ctx.workerLocal.intRegs[l.getVariableIndex()]));
-                        break;
-                    case TypeTags.FLOAT_TAG:
-                        variableDTO.setBValue(new BFloat(ctx.workerLocal.doubleRegs[l.getVariableIndex()]));
-                        break;
-                    case TypeTags.STRING_TAG:
-                        variableDTO.setBValue(new BString(ctx.workerLocal.stringRegs[l.getVariableIndex()]));
-                        break;
-                    case TypeTags.BOOLEAN_TAG:
-                        variableDTO.setBValue(new BBoolean(ctx.workerLocal.intRegs[l.getVariableIndex()] == 1));
-                        break;
-                    default:
-                        variableDTO.setBValue(ctx.workerLocal.refRegs[l.getVariableIndex()]);
-                        break;
-                }
+            if (!variableInfo.getVariableName().contains(META_DATA_VAR_PATTERN)) {
+
+                VariableDTO variableDTO = constructLocalVariable(ctx, variableInfo);
 
                 // Show only the variables within the current scope
-                if ((l.getScopeStartLineNumber() < callingLine.getLineNumber()) &&
-                        (callingLine.getLineNumber() <= l.getScopeEndLineNumber())) {
+                if ((variableInfo.getScopeStartLineNumber() < callingLine.getLineNumber()) &&
+                        (callingLine.getLineNumber() <= variableInfo.getScopeEndLineNumber())) {
                     frameDTO.addVariable(variableDTO);
                 }
             }
         });
         return message;
+    }
+
+    /**
+     * Method to construct a @{@link VariableDTO} that represents a global variable.
+     *
+     * @param ctx         Current context.
+     * @param packVarInfo Package variable info.
+     * @return Constructed global variable.
+     */
+    public static VariableDTO constructGlobalVariable(WorkerExecutionContext ctx, PackageVarInfo packVarInfo) {
+        int pkgIndex = ctx.callableUnitInfo.getPackageInfo().pkgIndex;
+        VariableDTO variableDTO = new VariableDTO(packVarInfo.getName(), GLOBAL);
+
+        switch (packVarInfo.getType().getTag()) {
+            case TypeTags.INT_TAG:
+                variableDTO.setBValue(new BInteger(ctx.programFile.globalMemArea.getIntField(pkgIndex,
+                        packVarInfo.getGlobalMemIndex())));
+                break;
+            case TypeTags.BYTE_TAG:
+                variableDTO.setBValue(new BByte((byte) (ctx.programFile.globalMemArea.getBooleanField(pkgIndex,
+                        packVarInfo.getGlobalMemIndex()))));
+                break;
+            case TypeTags.FLOAT_TAG:
+                variableDTO.setBValue(new BFloat(ctx.programFile.globalMemArea.getFloatField(pkgIndex,
+                        packVarInfo.getGlobalMemIndex())));
+                break;
+            case TypeTags.STRING_TAG:
+                variableDTO.setBValue(new BString(ctx.programFile.globalMemArea.getStringField(pkgIndex,
+                        packVarInfo.getGlobalMemIndex())));
+                break;
+            case TypeTags.BOOLEAN_TAG:
+                variableDTO.setBValue(new BBoolean(ctx.programFile.globalMemArea.getBooleanField(pkgIndex,
+                        packVarInfo.getGlobalMemIndex()) == 1));
+                break;
+            default:
+                variableDTO.setBValue(ctx.programFile.globalMemArea.getRefField(pkgIndex,
+                        packVarInfo.getGlobalMemIndex()));
+                break;
+        }
+        return variableDTO;
+    }
+
+    /**
+     * Method to construct a @{@link VariableDTO} that represents a local variable.
+     *
+     * @param ctx          Current context.
+     * @param variableInfo Local variable info.
+     * @return Constructed local variable.
+     */
+    public static VariableDTO constructLocalVariable(WorkerExecutionContext ctx, LocalVariableInfo variableInfo) {
+        VariableDTO variableDTO = new VariableDTO(variableInfo.getVariableName(), LOCAL);
+
+        switch (variableInfo.getVariableType().getTag()) {
+            case TypeTags.INT_TAG:
+                variableDTO.setBValue(new BInteger(ctx.workerLocal.longRegs[variableInfo.getVariableIndex()]));
+                break;
+            case TypeTags.BYTE_TAG:
+                variableDTO.setBValue(new BByte((byte) ctx.workerLocal.intRegs[variableInfo.getVariableIndex()]));
+                break;
+            case TypeTags.FLOAT_TAG:
+                variableDTO.setBValue(new BFloat(ctx.workerLocal.doubleRegs[variableInfo.getVariableIndex()]));
+                break;
+            case TypeTags.STRING_TAG:
+                variableDTO.setBValue(new BString(ctx.workerLocal.stringRegs[variableInfo.getVariableIndex()]));
+                break;
+            case TypeTags.BOOLEAN_TAG:
+                variableDTO.setBValue(new BBoolean(ctx.workerLocal.intRegs[variableInfo.getVariableIndex()] == 1));
+                break;
+            default:
+                variableDTO.setBValue(ctx.workerLocal.refRegs[variableInfo.getVariableIndex()]);
+                break;
+        }
+        return variableDTO;
     }
 
     /**

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/Debugger.java
@@ -70,7 +70,6 @@ public class Debugger {
     private static final String META_DATA_VAR_PATTERN = "$";
     private static final String GLOBAL = "Global";
     private static final String LOCAL = "Local";
-    private static final String TYPE_JSON = "json";
 
     public Debugger(ProgramFile programFile) {
         this.programFile = programFile;
@@ -403,7 +402,8 @@ public class Debugger {
         for (PackageVarInfo packVarInfo : packageVarInfoEntries) {
             // TODO: Need to change the 'contains' logic, if we allow user-defined variable names to have '$'
             if (!packVarInfo.getName().contains(META_DATA_VAR_PATTERN)) {
-                VariableDTO variableDTO = constructGlobalVariable(ctx, packVarInfo);
+                int pkgIndex = ctx.callableUnitInfo.getPackageInfo().pkgIndex;
+                VariableDTO variableDTO = constructGlobalVariable(ctx, packVarInfo, pkgIndex);
                 if (variableDTO.getValue() != null || packVarInfo.getType().getTag() == TypeTags.JSON_TAG) {
                     frameDTO.addVariable(variableDTO);
                 }
@@ -436,8 +436,8 @@ public class Debugger {
      * @param packVarInfo Package variable info.
      * @return Constructed global variable.
      */
-    public static VariableDTO constructGlobalVariable(WorkerExecutionContext ctx, PackageVarInfo packVarInfo) {
-        int pkgIndex = ctx.callableUnitInfo.getPackageInfo().pkgIndex;
+    public static VariableDTO constructGlobalVariable(WorkerExecutionContext ctx, PackageVarInfo packVarInfo,
+                                                      int pkgIndex) {
         VariableDTO variableDTO = new VariableDTO(packVarInfo.getName(), GLOBAL);
         BType varType = packVarInfo.getType();
 
@@ -469,7 +469,6 @@ public class Debugger {
         }
         return variableDTO;
     }
-
 
     /**
      * Method to construct a @{@link VariableDTO} that represents a local variable.

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
@@ -60,7 +60,7 @@ public class ExpressionEvaluator {
     public String evaluateVariable(WorkerExecutionContext ctx, LineNumberInfo currentExecLine, String variableName) {
         int currentExecLineNum = currentExecLine.getLineNumber();
 
-        String defaultMessage = constructJsonResults(false, "cannot find local variable '" + variableName + "'");
+        String defaultMessage = constructJsonResults(false, "cannot find variable '" + variableName + "'");
 
         // Check local variables
         List<LocalVariableInfo> localVars = getLocalVariables(ctx);

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.util.debugger;
+
+import org.ballerinalang.bre.bvm.WorkerExecutionContext;
+import org.ballerinalang.util.codegen.LineNumberInfo;
+import org.ballerinalang.util.codegen.LocalVariableInfo;
+import org.ballerinalang.util.codegen.PackageVarInfo;
+import org.ballerinalang.util.codegen.attributes.AttributeInfo;
+import org.ballerinalang.util.codegen.attributes.LocalVariableAttributeInfo;
+import org.ballerinalang.util.debugger.dto.VariableDTO;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ExpressionEvaluator {
+
+    public String evaluateVariable(WorkerExecutionContext ctx, LineNumberInfo currentExecLine, String variableName) {
+        int currentExecLineNum = currentExecLine.getLineNumber();
+
+        List<PackageVarInfo> globalVars = getPackageVariables(ctx);
+        for (PackageVarInfo var : globalVars) {
+            if (var.getName().equals(variableName)) {
+                VariableDTO variableDTO = Debugger.constructGlobalVariable(ctx, var);
+                return variableDTO.getValue();
+            }
+        }
+
+        List<LocalVariableInfo> localVars = getLocalVariables(ctx);
+        for (LocalVariableInfo var : localVars) {
+            if (var.getVariableName().equals(variableName) && (var.getScopeStartLineNumber() < currentExecLineNum) &&
+                    (currentExecLineNum <= var.getScopeEndLineNumber())) {
+                VariableDTO variableDTO = Debugger.constructLocalVariable(ctx, var);
+                return variableDTO.getValue();
+            }
+        }
+
+        // Return default message if the specified variable not found in the current scope
+        return "Cannot find local variable '" + variableName + "'";
+    }
+
+    private List<LocalVariableInfo> getLocalVariables(WorkerExecutionContext ctx) {
+        LocalVariableAttributeInfo localVarAttrInfo = (LocalVariableAttributeInfo) ctx.workerInfo.
+                getAttributeInfo(AttributeInfo.Kind.LOCAL_VARIABLES_ATTRIBUTE);
+        return localVarAttrInfo.getLocalVariables();
+    }
+
+    private List<PackageVarInfo> getPackageVariables(WorkerExecutionContext ctx) {
+        PackageVarInfo[] packageVars = ctx.programFile.getPackageInfo(ctx.programFile.getEntryPkgName()).
+                getPackageInfoEntries();
+        return Arrays.asList(packageVars);
+    }
+}

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
@@ -45,7 +45,7 @@ public class ExpressionEvaluator {
     private static final String RESULTS = "results";
     private static final String SUCCESS = "success";
     private static final String FAILURE = "failure";
-    private static final String INTERNAL_ERROR  = "{ \"status\": \"failure\", \"results\": \"internal error\" }";
+    private static final String INTERNAL_ERROR  = "{\"status\":\"failure\", \"results\":\"internal error\"}";
 
     /**
      * Method to evaluate a variable.

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
@@ -45,7 +45,7 @@ public class ExpressionEvaluator {
     private static final String RESULTS = "results";
     private static final String SUCCESS = "success";
     private static final String FAILURE = "failure";
-    private static final String INTERNAL_ERROR  = "{\"status\":\"failure\", \"results\":\"internal error\"}";
+    private static final String INTERNAL_ERROR = "{\"status\":\"failure\", \"results\":\"internal error\"}";
 
     /**
      * Method to evaluate a variable.

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/ExpressionEvaluator.java
@@ -29,8 +29,21 @@ import org.ballerinalang.util.debugger.dto.VariableDTO;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * {@code ExpressionEvaluator} Handles expression evaluation related actions.
+ *
+ * @since 0.981
+ */
 public class ExpressionEvaluator {
 
+    /**
+     * Method to evaluate a variable.
+     *
+     * @param ctx             Current worker execution context.
+     * @param currentExecLine Current execution line.
+     * @param variableName    Name of the variable to be evaluated.
+     * @return Evaluated results.
+     */
     public String evaluateVariable(WorkerExecutionContext ctx, LineNumberInfo currentExecLine, String variableName) {
         int currentExecLineNum = currentExecLine.getLineNumber();
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/VMDebugClientHandler.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/VMDebugClientHandler.java
@@ -105,6 +105,11 @@ public class VMDebugClientHandler implements DebugClientHandler {
         pushMessageToClient(message);
     }
 
+    @Override
+    public void sendExpressionResults(MessageDTO message) {
+        pushMessageToClient(message);
+    }
+
     /**
      * Push message to client.
      *

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/CommandDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/CommandDTO.java
@@ -31,6 +31,8 @@ public class CommandDTO {
 
     private String threadId;
 
+    private String variableName;
+
     private List<BreakPointDTO> points;
 
     public String getCommand() {
@@ -55,5 +57,13 @@ public class CommandDTO {
 
     public void setPoints(List<BreakPointDTO> points) {
         this.points = points;
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+
+    public void setVariableName(String variableName) {
+        this.variableName = variableName;
     }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/MessageDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/MessageDTO.java
@@ -84,7 +84,7 @@ public class MessageDTO {
     @Override
     public String toString() {
         StringBuilder br = new StringBuilder();
-        if(location != null) {
+        if (location != null) {
             br.append("====BreakPointInfo {").append(location.toString()).append("}====\n");
         }
         br.append("Frames ->\n");

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/MessageDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/MessageDTO.java
@@ -84,7 +84,9 @@ public class MessageDTO {
     @Override
     public String toString() {
         StringBuilder br = new StringBuilder();
-        br.append("====BreakPointInfo {").append(location.toString()).append("}====\n");
+        if(location != null) {
+            br.append("====BreakPointInfo {").append(location.toString()).append("}====\n");
+        }
         br.append("Frames ->\n");
         for (FrameDTO frame : frames) {
             br.append("    ").append(frame.toString()).append("\n");

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
@@ -74,7 +74,10 @@ public class VariableDTO {
 
     private String getStringValue(BValue bValue) {
         String bValueString;
-        if (bValue instanceof BValueType || bValue instanceof BXML || bValue.getType().getTag() == TypeTags.JSON) {
+        if (bValue == null) {
+            bValueString = null;
+        } else if (bValue instanceof BValueType || bValue instanceof BXML ||
+                bValue.getType().getTag() == TypeTags.JSON) {
             bValueString = bValue.stringValue();
         } else if (bValue instanceof BNewArray) {
             BNewArray bArray = (BNewArray) bValue;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/VariableDTO.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.util.debugger.dto;
 
+import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BNewArray;
 import org.ballerinalang.model.values.BValue;
@@ -63,6 +64,11 @@ public class VariableDTO {
             return;
         }
         type = bValue.getType().toString();
+        value = getStringValue(bValue);
+    }
+
+    public void setBValue(BValue bValue, BType bType) {
+        type = bType.toString();
         value = getStringValue(bValue);
     }
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/util/DebugMsgUtil.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/util/DebugMsgUtil.java
@@ -64,6 +64,7 @@ public class DebugMsgUtil {
     private static final String VALUE = "value";
     private static final String COMMAND = "command";
     private static final String POINTS = "points";
+    private static final String EXPRESSION = "expression";
 
     /**
      * Method to generate json message from the MessageDTO object instance.
@@ -96,11 +97,12 @@ public class DebugMsgUtil {
     public static CommandDTO buildCommandDTO(String jsonStr) {
         BRefType<?> node = JsonParser.parse(jsonStr);
         CommandDTO commandDTO = new CommandDTO();
-        
+
         if (node.getType().getTag() == TypeTags.JSON_TAG) {
             BMap<String, BRefType<?>> json = (BMap) node;
             commandDTO.setCommand(json.get(COMMAND) == null ? null : json.get(COMMAND).stringValue());
             commandDTO.setThreadId(json.get(THREAD_ID) == null ? null : json.get(THREAD_ID).stringValue());
+            commandDTO.setVariableName(json.get(EXPRESSION) == null ? null : json.get(EXPRESSION).stringValue());
             commandDTO.setPoints(buildBreakPoints(json.get(POINTS)));
         }
         return commandDTO;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -465,10 +465,11 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 5);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(packagePath, file, 5, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(packagePath, file, 5, RESUME, 1, null));
 
         List<VariableDTO> variables = new ArrayList<>();
-        variables.add(Util.createVariable("self", "Local", createObject("Apple", packagePath)));
+        String objName = "Apple";
+        variables.add(Util.createVariable("self", "Local", createObject(objName, packagePath)));
         ExpectedResults expRes = new ExpectedResults(debugPoints, 1, 0, variables, false);
         VMDebuggerUtil.startDebug("test-src/debugger/multi-package/main.bal", breakPoints, expRes);
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -40,7 +40,9 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.ballerinalang.test.utils.debug.Step.RESUME;
 import static org.ballerinalang.test.utils.debug.Step.STEP_IN;
@@ -74,13 +76,16 @@ public class VMDebuggerTest {
                                                                3, 9, 17, 29, 30, 33, 35, 37, 42, 43, 44, 45, 46, 47);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 3, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 17, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 42, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 43, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 3, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 17, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 42, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 43, RESUME, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("p", "10");
+        debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 7, 0, new ArrayList<>(), false);
 
@@ -102,27 +107,38 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 5, 8, 41);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 12, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 15, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 16, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 20, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 25, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 12, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 15, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 16, STEP_IN, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("x", "15");
+        expMap1.put("y", "5");
+        expMap1.put("z", "0");
+        expMap1.put("a", "6");
+        debugPoints.add(Util.createDebugPoint(".", FILE, 20, STEP_IN, 1, expMap1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 25, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap2 = new HashMap<>();
+        expMap2.put("p", "10");
+        expMap2.put("r", "100");
+        expMap2.put("s", "large");
+        debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1, expMap2));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 21, 0, new ArrayList<>(), false);
 
@@ -134,9 +150,15 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 26);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_OUT, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("p", "10");
+        expMap1.put("q", "5");
+        expMap1.put("r", "100");
+        expMap1.put("s", "large");
+        debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 3, 0, new ArrayList<>(), false);
 
@@ -148,12 +170,12 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 3);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 3, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 6, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 9, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 10, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 3, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 6, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 9, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 10, RESUME, 1, null));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 6, 0, new ArrayList<>(), false);
 
@@ -165,14 +187,14 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 26);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 41, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, RESUME, 1, null));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 8, 0, new ArrayList<>(), false);
 
@@ -184,10 +206,16 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 13, 14, 20, 22);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 5));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 20, RESUME, 4));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 22, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 5, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 20, RESUME, 4, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("x", "15");
+        expMap1.put("y", "5");
+        expMap1.put("z", "100");
+        expMap1.put("a", "10");
+        debugPoints.add(Util.createDebugPoint(".", FILE, 22, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 11, 0, new ArrayList<>(), false);
 
@@ -200,7 +228,10 @@ public class VMDebuggerTest {
                                                                     "while-statement.bal", 5);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", "while-statement.bal", 5, RESUME, 5));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("args", "Array[2] [\"Hello\", \"World\"]");
+        debugPoints.add(Util.createDebugPoint(".", "while-statement.bal", 5, RESUME, 5, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
         variables.add(Util.createVariable("i", "Local", new BInteger(4)));
@@ -219,22 +250,26 @@ public class VMDebuggerTest {
         String file = "try-catch-finally.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 19, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 27, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 33, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 34, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 45, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 50, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 55, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 56, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 58, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 60, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 19, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 27, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 33, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 34, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 45, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 50, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 55, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 56, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 58, STEP_OVER, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("path", "start insideTry insideInnerTry onError innerTestErrorCatch:test innerFinally " +
+                "TestErrorCatch Finally ");
+        debugPoints.add(Util.createDebugPoint(".", file, 60, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 16, 0, new ArrayList<>(), false);
 
@@ -249,17 +284,28 @@ public class VMDebuggerTest {
         String file = "test-worker.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 3, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 18, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 19, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 48, RESUME, 5));
-        debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 3, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("a", "Cannot find local variable 'a'");
+        expMap1.put("p", "15");
+        expMap1.put("q", "5");
+        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1, expMap1));
+        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 18, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 19, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 48, RESUME, 5, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap2 = new HashMap<>();
+        expMap2.put("a", "0");
+        expMap2.put("p", "15");
+        expMap2.put("q", "5");
+        expMap2.put("b", "100");
+        debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1, expMap2));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 15, 0, new ArrayList<>(), false);
 
@@ -274,21 +320,26 @@ public class VMDebuggerTest {
         String file = "test-package-init.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 5, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 5, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("val1", "60");
+        expMap1.put("val2", "20");
+        expMap1.put("cal", "80");
+        debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
         variables.add(Util.createVariable("val1", "Global", new BInteger(60)));
@@ -309,43 +360,43 @@ public class VMDebuggerTest {
         String file = "test_object_and_match.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 7, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 23, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 8, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 37, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 51, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 40, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 11, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 42, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 48, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 16, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 66, RESUME, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 54, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 67, STEP_OUT, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 7, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 23, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 8, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 37, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 51, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 40, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 11, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 42, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 48, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 66, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 54, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 67, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1, null));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 37, 0, new ArrayList<>(), false);
 
@@ -358,8 +409,14 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 10);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 11, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1, null));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("gInt", "5");
+        expMap1.put("gBool", "true");
+        expMap1.put("y", "25");
+        expMap1.put("foo", "Record Foo {count:5, last:\"last\"}");
+        debugPoints.add(Util.createDebugPoint(".", file, 11, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
         variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));
@@ -378,7 +435,14 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 9);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1));
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        expMap1.put("gStr", "str");
+        expMap1.put("gByte", "255");
+        expMap1.put("x", "10");
+        expMap1.put("z", "15");
+        expMap1.put("args", "Array[2] [\"Hello\", \"World\"]");
+        debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
         variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -56,6 +56,8 @@ import static org.ballerinalang.test.utils.debug.Util.createBreakNodeLocations;
 public class VMDebuggerTest {
 
     private static final String FILE = "test-debug.bal";
+    private static final String SUCCESS = "success";
+    private static final String FAILURE = "failure";
     private PrintStream original;
 
     @BeforeClass
@@ -76,15 +78,16 @@ public class VMDebuggerTest {
                                                                3, 9, 17, 29, 30, 33, 35, 37, 42, 43, 44, 45, 46, 47);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 3, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 17, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 42, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 43, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 3, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 17, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 42, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 43, RESUME, 1));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("p", "10");
+        populateExpressionMap(expMap1, "p", SUCCESS, "10");
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 7, 0, new ArrayList<>(), false);
@@ -107,37 +110,40 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 5, 8, 41);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 12, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 15, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 16, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 12, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 15, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 16, STEP_IN, 1));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("x", "15");
-        expMap1.put("y", "5");
-        expMap1.put("z", "0");
-        expMap1.put("a", "6");
+        populateExpressionMap(expMap1, "x", SUCCESS, "15");
+        populateExpressionMap(expMap1, "y", SUCCESS, "5");
+        populateExpressionMap(expMap1, "z", SUCCESS, "0");
+        populateExpressionMap(expMap1, "a", SUCCESS, "6");
+        populateExpressionMap(expMap1, "k", FAILURE, "cannot find local variable 'k'");
         debugPoints.add(Util.createDebugPoint(".", FILE, 20, STEP_IN, 1, expMap1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 25, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 25, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN, 1));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap2 = new HashMap<>();
-        expMap2.put("p", "10");
-        expMap2.put("r", "100");
-        expMap2.put("s", "large");
+        populateExpressionMap(expMap2, "p", SUCCESS, "10");
+        populateExpressionMap(expMap2, "r", SUCCESS, "100");
+        populateExpressionMap(expMap2, "s", SUCCESS, "large");
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1, expMap2));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 21, 0, new ArrayList<>(), false);
@@ -150,14 +156,15 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 26);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_OUT, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_OUT, 1));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("p", "10");
-        expMap1.put("q", "5");
-        expMap1.put("r", "100");
-        expMap1.put("s", "large");
+        populateExpressionMap(expMap1, "p", SUCCESS, "10");
+        populateExpressionMap(expMap1, "q", SUCCESS, "5");
+        populateExpressionMap(expMap1, "r", SUCCESS, "100");
+        populateExpressionMap(expMap1, "s", SUCCESS, "large");
         debugPoints.add(Util.createDebugPoint(".", FILE, 9, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 3, 0, new ArrayList<>(), false);
@@ -170,12 +177,12 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 3);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 3, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 6, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 9, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 10, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 3, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 5, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 6, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 9, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 10, RESUME, 1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 6, 0, new ArrayList<>(), false);
 
@@ -187,14 +194,14 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 26);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 41, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 30, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, RESUME, 1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 8, 0, new ArrayList<>(), false);
 
@@ -206,15 +213,16 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 13, 14, 20, 22);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 5, null));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 20, RESUME, 4, null));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 13, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 5));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 20, RESUME, 4));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("x", "15");
-        expMap1.put("y", "5");
-        expMap1.put("z", "100");
-        expMap1.put("a", "10");
+        populateExpressionMap(expMap1, "x", SUCCESS, "15");
+        populateExpressionMap(expMap1, "y", SUCCESS, "5");
+        populateExpressionMap(expMap1, "z", SUCCESS, "100");
+        populateExpressionMap(expMap1, "a", SUCCESS, "10");
         debugPoints.add(Util.createDebugPoint(".", FILE, 22, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 11, 0, new ArrayList<>(), false);
@@ -230,7 +238,7 @@ public class VMDebuggerTest {
         List<DebugPoint> debugPoints = new ArrayList<>();
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("args", "Array[2] [\"Hello\", \"World\"]");
+        populateExpressionMap(expMap1, "args", SUCCESS, "Array[2] [\\\"Hello\\\", \\\"World\\\"]");
         debugPoints.add(Util.createDebugPoint(".", "while-statement.bal", 5, RESUME, 5, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
@@ -244,31 +252,31 @@ public class VMDebuggerTest {
 
     @Test(description = "Testing try catch finally scenario for path")
     public void testTryCatchScenarioForPath() {
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".",
-                                                                    "try-catch-finally.bal", 19);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "try-catch-finally.bal", 19);
 
         String file = "try-catch-finally.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 19, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 27, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 33, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 34, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 45, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 50, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 55, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 56, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 58, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 19, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 27, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 33, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 34, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 45, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 50, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 55, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 56, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 58, STEP_OVER, 1));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("path", "start insideTry insideInnerTry onError innerTestErrorCatch:test innerFinally " +
-                "TestErrorCatch Finally ");
+        populateExpressionMap(expMap1, "path", SUCCESS, "start insideTry insideInnerTry onError " +
+                "innerTestErrorCatch:test innerFinally TestErrorCatch Finally ");
         debugPoints.add(Util.createDebugPoint(".", file, 60, RESUME, 1, expMap1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 16, 0, new ArrayList<>(), false);
@@ -278,33 +286,34 @@ public class VMDebuggerTest {
 
     @Test(description = "Testing debug paths in workers")
     public void testDebuggingWorkers() {
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".",
-                                                                    "test-worker.bal", 3, 9, 10, 18, 19, 23, 48);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test-worker.bal", 3, 9, 10, 18, 19, 23, 48);
 
         String file = "test-worker.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 3, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 3, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("a", "Cannot find local variable 'a'");
-        expMap1.put("p", "15");
-        expMap1.put("q", "5");
+        populateExpressionMap(expMap1, "a", FAILURE, "cannot find local variable 'a'");
+        populateExpressionMap(expMap1, "p", SUCCESS, "15");
+        populateExpressionMap(expMap1, "q", SUCCESS, "5");
         debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1, expMap1));
-        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 18, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 19, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 48, RESUME, 5, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 18, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 19, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 48, RESUME, 5));
+
         // Key: expression, Value: expected results
         Map<String, String> expMap2 = new HashMap<>();
-        expMap2.put("a", "0");
-        expMap2.put("p", "15");
-        expMap2.put("q", "5");
-        expMap2.put("b", "100");
+        populateExpressionMap(expMap2, "a", SUCCESS, "0");
+        populateExpressionMap(expMap2, "p", SUCCESS, "15");
+        populateExpressionMap(expMap2, "q", SUCCESS, "5");
+        populateExpressionMap(expMap2, "b", SUCCESS, "100");
         debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1, expMap2));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 15, 0, new ArrayList<>(), false);
@@ -320,25 +329,25 @@ public class VMDebuggerTest {
         String file = "test-package-init.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 5, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 5, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 17, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 23, RESUME, 1));
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("val1", "60");
-        expMap1.put("val2", "20");
-        expMap1.put("cal", "80");
+        populateExpressionMap(expMap1, "val1", SUCCESS, "60");
+        populateExpressionMap(expMap1, "val2", SUCCESS, "20");
+        populateExpressionMap(expMap1, "cal", SUCCESS, "80");
         debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
@@ -360,43 +369,43 @@ public class VMDebuggerTest {
         String file = "test_object_and_match.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 7, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 23, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 8, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 37, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 51, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 40, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 11, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 42, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 15, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 48, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 16, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 66, RESUME, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 54, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 67, STEP_OUT, 1, null));
-        debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 7, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 23, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 8, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 37, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 51, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 40, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 11, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 42, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 44, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 14, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 15, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 48, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 66, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 54, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 67, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 37, 0, new ArrayList<>(), false);
 
@@ -409,13 +418,13 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 10);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1, null));
+        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1));
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("gInt", "5");
-        expMap1.put("gBool", "true");
-        expMap1.put("y", "25");
-        expMap1.put("foo", "Record Foo {count:5, last:\"last\"}");
+        populateExpressionMap(expMap1, "gInt", SUCCESS, "5");
+        populateExpressionMap(expMap1, "gBool", SUCCESS, "true");
+        populateExpressionMap(expMap1, "y", SUCCESS, "25");
+        populateExpressionMap(expMap1, "foo", SUCCESS, "Record Foo {count:5, last:\\\"last\\\"}");
         debugPoints.add(Util.createDebugPoint(".", file, 11, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
@@ -437,11 +446,11 @@ public class VMDebuggerTest {
         List<DebugPoint> debugPoints = new ArrayList<>();
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        expMap1.put("gStr", "str");
-        expMap1.put("gByte", "255");
-        expMap1.put("x", "10");
-        expMap1.put("z", "15");
-        expMap1.put("args", "Array[2] [\"Hello\", \"World\"]");
+        populateExpressionMap(expMap1, "gStr", SUCCESS, "str");
+        populateExpressionMap(expMap1, "gByte", SUCCESS, "255");
+        populateExpressionMap(expMap1, "x", SUCCESS, "10");
+        populateExpressionMap(expMap1, "z", SUCCESS, "15");
+        populateExpressionMap(expMap1, "args", SUCCESS, "Array[2] [\\\"Hello\\\", \\\"World\\\"]");
         debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
@@ -465,7 +474,7 @@ public class VMDebuggerTest {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 5);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(packagePath, file, 5, RESUME, 1, null));
+        debugPoints.add(Util.createDebugPoint(packagePath, file, 5, RESUME, 1));
 
         List<VariableDTO> variables = new ArrayList<>();
         String objName = "Apple";
@@ -488,5 +497,10 @@ public class VMDebuggerTest {
         bObjectType.setFields(new BField[0]);
         objectTypeInfo.setType(bObjectType);
         return new BMap(bObjectType);
+    }
+
+    private void populateExpressionMap(Map<String, String> expMap, String expression, String status, String expected) {
+        String jsonResults = "{\"status\":\"" + status + "\", \"results\":\"" + expected + "\"}";
+        expMap.put(expression, jsonResults);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -75,7 +75,7 @@ public class VMDebuggerTest {
     @Test(description = "Testing Resume with break points.")
     public void testResume() {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE,
-                                                               3, 9, 17, 29, 30, 33, 35, 37, 42, 43, 44, 45, 46, 47);
+                3, 9, 17, 29, 30, 33, 35, 37, 42, 43, 44, 45, 46, 47);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", FILE, 3, RESUME, 1));
@@ -123,7 +123,7 @@ public class VMDebuggerTest {
         populateExpressionMap(expMap1, "y", SUCCESS, "5");
         populateExpressionMap(expMap1, "z", SUCCESS, "0");
         populateExpressionMap(expMap1, "a", SUCCESS, "6");
-        populateExpressionMap(expMap1, "k", FAILURE, "cannot find local variable 'k'");
+        populateExpressionMap(expMap1, "k", FAILURE, "cannot find variable 'k'");
         debugPoints.add(Util.createDebugPoint(".", FILE, 20, STEP_IN, 1, expMap1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1));
@@ -233,7 +233,7 @@ public class VMDebuggerTest {
     @Test(description = "Testing while statement resume")
     public void testWhileStatementResume() {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".",
-                                                                    "while-statement.bal", 5);
+                "while-statement.bal", 5);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         // Key: expression, Value: expected results
@@ -297,7 +297,7 @@ public class VMDebuggerTest {
 
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
-        populateExpressionMap(expMap1, "a", FAILURE, "cannot find local variable 'a'");
+        populateExpressionMap(expMap1, "a", FAILURE, "cannot find variable 'a'");
         populateExpressionMap(expMap1, "p", SUCCESS, "15");
         populateExpressionMap(expMap1, "q", SUCCESS, "5");
         debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1, expMap1));
@@ -323,8 +323,7 @@ public class VMDebuggerTest {
 
     @Test(description = "Testing debug paths in package init")
     public void testDebuggingPackageInit() {
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".",
-                                                                    "test-package-init.bal", 3, 9);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test-package-init.bal", 3, 9);
 
         String file = "test-package-init.bal";
 
@@ -363,8 +362,7 @@ public class VMDebuggerTest {
 
     @Test(description = "Testing debug match statement and objects")
     public void testDebuggingMatchAndObject() {
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".",
-                                                                    "test_object_and_match.bal", 3, 48, 66, 54);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test_object_and_match.bal", 3, 48, 66, 54);
 
         String file = "test_object_and_match.bal";
 
@@ -415,25 +413,26 @@ public class VMDebuggerTest {
     @Test(description = "Testing global variables availability in debug hit message")
     public void testGlobalVarAvailability() {
         String file = "test_variables.bal";
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 10);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 13);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, STEP_OVER, 1));
         // Key: expression, Value: expected results
         Map<String, String> expMap1 = new HashMap<>();
         populateExpressionMap(expMap1, "gInt", SUCCESS, "5");
         populateExpressionMap(expMap1, "gBool", SUCCESS, "true");
         populateExpressionMap(expMap1, "y", SUCCESS, "25");
         populateExpressionMap(expMap1, "foo", SUCCESS, "Record Foo {count:5, last:\\\"last\\\"}");
-        debugPoints.add(Util.createDebugPoint(".", file, 11, RESUME, 1, expMap1));
+        debugPoints.add(Util.createDebugPoint(".", file, 14, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
         variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));
         variables.add(Util.createVariable("gStr", "Global", new BString("str")));
         variables.add(Util.createVariable("gBool", "Global", new BBoolean(true)));
         variables.add(Util.createVariable("gByte", "Global", new BByte((byte) 255)));
+        variables.add(Util.createVariable("gNewStr", "Global", new BString("ABCDEFG HIJ")));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 2, 4, variables, false);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 2, 7, variables, false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
     }
@@ -441,7 +440,7 @@ public class VMDebuggerTest {
     @Test(description = "Testing local variables scopes")
     public void testLocalVarScope() {
         String file = "test_variables.bal";
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 9);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 12);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
         // Key: expression, Value: expected results
@@ -451,36 +450,87 @@ public class VMDebuggerTest {
         populateExpressionMap(expMap1, "x", SUCCESS, "10");
         populateExpressionMap(expMap1, "z", SUCCESS, "15");
         populateExpressionMap(expMap1, "args", SUCCESS, "Array[2] [\\\"Hello\\\", \\\"World\\\"]");
-        debugPoints.add(Util.createDebugPoint(".", file, 9, RESUME, 1, expMap1));
+        debugPoints.add(Util.createDebugPoint(".", file, 12, RESUME, 1, expMap1));
 
         List<VariableDTO> variables = new ArrayList<>();
         variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));
         variables.add(Util.createVariable("gStr", "Global", new BString("str")));
         variables.add(Util.createVariable("gBool", "Global", new BBoolean(true)));
         variables.add(Util.createVariable("gByte", "Global", new BByte((byte) 255)));
+        variables.add(Util.createVariable("gNewStr", "Global", new BString("ABCDEFG HIJ")));
         variables.add(Util.createVariable("args", "Local", new BStringArray(new String[]{"Hello", "World"})));
         variables.add(Util.createVariable("x", "Local", new BInteger(10)));
         variables.add(Util.createVariable("z", "Local", new BInteger(15)));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 1, 4, variables, true);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 1, 7, variables, false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Testing local variables scopes")
+    @Test(description = "Test debugging when multi-packages available")
     public void testMultiPackage() {
         String file = "apple.bal";
         String packagePath = "abc/fruits:0.0.1";
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 5);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 9);
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(packagePath, file, 5, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(packagePath, file, 9, RESUME, 1));
 
         List<VariableDTO> variables = new ArrayList<>();
         String objName = "Apple";
         variables.add(Util.createVariable("self", "Local", createObject(objName, packagePath)));
+
         ExpectedResults expRes = new ExpectedResults(debugPoints, 1, 0, variables, false);
+
         VMDebuggerUtil.startDebug("test-src/debugger/multi-package/main.bal", breakPoints, expRes);
+    }
+
+    @Test(description = "Test evaluating global variables from other packages")
+    public void testEvaluatingOtherPackageGlobalVars() {
+        String file = "apple.bal";
+        String packagePath = "abc/fruits:0.0.1";
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 9);
+
+        List<DebugPoint> debugPoints = new ArrayList<>();
+        // Key: expression, Value: expected results
+        Map<String, String> expMap1 = new HashMap<>();
+        populateExpressionMap(expMap1, "abc/fruits:0.0.1:gInt", SUCCESS, "10");
+        populateExpressionMap(expMap1, "abc/fruits:0.0.1:gApple", SUCCESS, "Object Apple {}");
+        populateExpressionMap(expMap1, "abc/vegetables:0.0.1:gInt", FAILURE,
+                "cannot find variable 'abc/vegetables:0.0.1:gInt'");
+        debugPoints.add(Util.createDebugPoint(packagePath, file, 9, RESUME, 1, expMap1));
+
+        List<VariableDTO> variables = new ArrayList<>();
+        String objName = "Apple";
+        variables.add(Util.createVariable("self", "Local", createObject(objName, packagePath)));
+
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 1, 0, variables, false);
+
+        VMDebuggerUtil.startDebug("test-src/debugger/multi-package/main.bal", breakPoints, expRes);
+    }
+
+    @Test(description = "Test ignoring non-nullable global variables with null values")
+    public void testGlobalVariableNullability() {
+        String file = "test_variables.bal";
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 31);
+
+        List<DebugPoint> debugPoints = new ArrayList<>();
+        debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 32, RESUME, 1));
+
+        List<VariableDTO> variables = new ArrayList<>();
+        variables.add(Util.createVariable("gInt", "Global", new BInteger(5)));
+        variables.add(Util.createVariable("gStr", "Global", new BString("str")));
+        variables.add(Util.createVariable("gBool", "Global", new BBoolean(true)));
+        variables.add(Util.createVariable("gNewStr", "Global", new BString("")));
+        variables.add(Util.createVariable("gByte", "Global", new BByte((byte) 0)));
+
+        // Expected global variables count should be 6 in this case
+        // Reason: Variable 'gPerson' is not yet initialized. Thus, its current value is null
+        // But this is a non-nullable variable and hence we omit this when adding variables to the frame
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 2, 6, variables, false);
+
+        VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
     }
 
     /**

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/DebugPoint.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/DebugPoint.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.utils.debug;
 
 import org.ballerinalang.util.debugger.dto.BreakPointDTO;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -34,10 +35,13 @@ public class DebugPoint {
 
     private AtomicInteger noOfHits;
 
-    DebugPoint(BreakPointDTO expBreakPoint, Step nextStep, int noOfHits) {
+    private Map<String, String> expressionsMap;
+
+    DebugPoint(BreakPointDTO expBreakPoint, Step nextStep, int noOfHits, Map<String, String> expressionsMap) {
         this.expBreakPoint = expBreakPoint;
         this.nextStep = nextStep;
         this.noOfHits = new AtomicInteger(noOfHits);
+        this.expressionsMap = expressionsMap;
     }
 
     boolean match(BreakPointDTO breakPoint) {
@@ -55,6 +59,10 @@ public class DebugPoint {
 
     int decrementAndGetHits() {
         return noOfHits.decrementAndGet();
+    }
+
+    Map<String, String> getExpressionsMap() {
+        return expressionsMap;
     }
 
     @Override

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/TestDebugClientHandler.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/TestDebugClientHandler.java
@@ -116,6 +116,10 @@ public class TestDebugClientHandler implements DebugClientHandler {
     }
 
     @Override
+    public void sendExpressionResults(MessageDTO message) {
+    }
+
+    @Override
     public void sendCustomMsg(MessageDTO message) {
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/Util.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/Util.java
@@ -35,6 +35,11 @@ public class Util {
         return new DebugPoint(new BreakPointDTO(packagePath, fileName, lineNo), nextStep, noOfHits, expressionsMap);
     }
 
+    public static DebugPoint createDebugPoint(String packagePath, String fileName, int lineNo, Step nextStep,
+                                              int noOfHits) {
+        return createDebugPoint(packagePath, fileName, lineNo, nextStep, noOfHits, null);
+    }
+
     public static BreakPointDTO[] createBreakNodeLocations(String packagePath, String fileName, int... lineNos) {
         BreakPointDTO[] breakPointDTOS = new BreakPointDTO[lineNos.length];
         int i = 0;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/Util.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/Util.java
@@ -21,6 +21,8 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.util.debugger.dto.BreakPointDTO;
 import org.ballerinalang.util.debugger.dto.VariableDTO;
 
+import java.util.Map;
+
 /**
  * Test Util class with helper methods.
  *
@@ -29,8 +31,8 @@ import org.ballerinalang.util.debugger.dto.VariableDTO;
 public class Util {
 
     public static DebugPoint createDebugPoint(String packagePath, String fileName, int lineNo, Step nextStep,
-                                              int noOfHits) {
-        return new DebugPoint(new BreakPointDTO(packagePath, fileName, lineNo), nextStep, noOfHits);
+                                              int noOfHits, Map<String, String> expressionsMap) {
+        return new DebugPoint(new BreakPointDTO(packagePath, fileName, lineNo), nextStep, noOfHits, expressionsMap);
     }
 
     public static BreakPointDTO[] createBreakNodeLocations(String packagePath, String fileName, int... lineNos) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/VMDebuggerUtil.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/utils/debug/VMDebuggerUtil.java
@@ -28,6 +28,7 @@ import org.testng.Assert;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.util.BLangConstants.COLON;
@@ -68,6 +69,15 @@ public class VMDebuggerUtil {
             int hits = debugPoint.decrementAndGetHits();
             Assert.assertTrue(hits >= 0, "Invalid number of hits for same point - "
                     + debugPoint.getExpBreakPoint() + " remaining hit count - " + hits);
+
+            Map<String, String> expressionsMap = debugPoint.getExpressionsMap();
+            if (expressionsMap != null) {
+                expressionsMap.forEach((expression, expResults) -> {
+                    String value = evaluateExpression(debugger, debugHit.getThreadId(), expression);
+                    Assert.assertEquals(value, expResults, "Evaluated value mismatch with expected results");
+                });
+            }
+
             hitCount++;
             executeDebuggerCmd(debugger, debugHit.getThreadId(), debugPoint.getNextStep());
         }
@@ -104,6 +114,11 @@ public class VMDebuggerUtil {
             default:
                 throw new IllegalStateException("Unknown Command");
         }
+    }
+
+    private static String evaluateExpression(Debugger debugManager, String workerId, String expression) {
+        // TODO: Replace the below with `evaluateExpression` method once the expression evaluation feature is done
+        return debugManager.evaluateVariable(workerId, expression);
     }
 
     private static TestDebugger setupProgram(String programArg, BreakPointDTO[] breakPoints) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/multi-package/fruits/apple.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/multi-package/fruits/apple.bal
@@ -1,4 +1,8 @@
 import ballerina/io;
+
+int gInt = 10;
+Apple gApple = new;
+
 public type Apple object {
     public new(){}
     public function print () {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_variables.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_variables.bal
@@ -1,6 +1,9 @@
 int gInt = 5;
 string gStr = "str";
 boolean gBool = true;
+string gNewStr = callFunc();
+json gJson = null;
+Person gPerson = new;
 byte gByte = 255;
 
 public function main(string... args) {
@@ -22,3 +25,9 @@ type Person object {
     public Person? parent,
     private string email = "default@abc.com",
 };
+
+function callFunc() returns (string) {
+    string newStr = "ABCDEFG";
+    newStr = newStr + " HIJ";
+    return newStr;
+}


### PR DESCRIPTION
## Purpose
This PR resembles PR https://github.com/ballerina-platform/ballerina-lang/pull/10091 with all the modifications suggested during the code review. This resolves https://github.com/ballerina-platform/ballerina-lang/issues/10090.

Added features/Modifications:
- Adds variable evaluation feature to the Ballerina debugger
- Prevents showing null values for global variables that are non-nullable
- Allows users to evaluate variables from different packages as well (By specifying `packagePath:VariableName`)
- New testcases to cover the above-mentioned scenarios

Addressed review comments:
- Return array instead of List in 'getPackageVariables' method
- Global variables of different packages need to be handled 
- When placing debug points in the global variable declaration lines, avoid showing null values for the global variables when evaluating them
- Response message needs to include a status indicating whether the variable is found or not
- Avoid passing null to the debug points in many places by overloading the 'createDebugPoint' method  