### PR TITLE
Fix output on --printreturn

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -142,8 +142,8 @@ public class LauncherUtils {
     public static void runMain(ProgramFile programFile, String functionName, String[] args, boolean printReturn) {
         try {
             BValue[] entryFuncResult = BLangProgramRunner.runEntryFunc(programFile, functionName, args);
-            if (printReturn && entryFuncResult != null && entryFuncResult.length >= 1) {
-                outStream.println(entryFuncResult[0] == null ? "()" : entryFuncResult[0].stringValue());
+            if (printReturn && entryFuncResult != null && entryFuncResult.length >= 1 && entryFuncResult[0] != null) {
+                outStream.print(entryFuncResult[0].stringValue());
             }
         } catch (BLangUsageException | BallerinaException e) {
             throw createUsageException(makeFirstLetterLowerCase(e.getLocalizedMessage()));


### PR DESCRIPTION
## Purpose
This PR fixes the value printed to the standard out stream when the `--printreturn` flag is set, by avoiding printing anything (no `()`) on nil/no return and preventing appending a new line.