### PR TITLE
Skip channels source gen tests until support added

### DIFF
--- a/composer/modules/integration-tests/src/test/resources/config.json
+++ b/composer/modules/integration-tests/src/test/resources/config.json
@@ -9,7 +9,9 @@
             "temporal_aggregations_and_windows.bal",
             "grpc_bidirectional_streaming_client.bal",
             "table.bal",
-            "csv_io.bal"
+            "csv_io.bal",
+            "channels_correlation.bal",
+            "channels_workers.bal"
         ]
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
@@ -112,7 +112,8 @@ public class SourceGenTest {
         private List<File> files;
         private String[] ignoredFiles = {"identify_patterns.bal", "identify_trends.bal",
                 "join_multiple_streams.bal", "table_queries.bal", "temporal_aggregations_and_windows.bal",
-                "table.bal", "csv_io.bal", "grpc_bidirectional_streaming_client.bal"};
+                "table.bal", "csv_io.bal", "grpc_bidirectional_streaming_client.bal", "channels_correlation.bal",
+                "channels_workers.bal"};
 
         FileVisitor(List<File> ballerinaFiles) {
             this.files = ballerinaFiles;


### PR DESCRIPTION
## Purpose
> This will skip BBE files added to describe Ballerina channels being processed in source gen tests of composer and language server.

BBE PR: https://github.com/ballerina-platform/ballerina-examples/pull/1007