### PR TITLE
Skip grpc streaming client to avoid jenkins issue

### DIFF
--- a/composer/modules/integration-tests/src/test/resources/config.json
+++ b/composer/modules/integration-tests/src/test/resources/config.json
@@ -6,7 +6,8 @@
             "table.bal",
             "csv_io.bal",
             "channels_correlation.bal",
-            "channels_workers.bal"
+            "channels_workers.bal",
+            "grpc_bidirectional_streaming_client.bal"
         ]
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
@@ -111,7 +111,7 @@ public class SourceGenTest {
     static class FileVisitor extends SimpleFileVisitor<Path> {
         private List<File> files;
         private String[] ignoredFiles = {"table_queries.bal", "table.bal", "csv_io.bal",
-                "channels_correlation.bal", "channels_workers.bal"};
+                "channels_correlation.bal", "channels_workers.bal", "grpc_bidirectional_streaming_client.bal"};
 
         FileVisitor(List<File> ballerinaFiles) {
             this.files = ballerinaFiles;


### PR DESCRIPTION
## Purpose
> This will skip the grpc_bidirectional_streaming_client.bal from been processed in source gen tests to avoid unicode issue in Jenkins. 

```
1) Ballerina Composer Test Suite
       grpc_bidirectional_streaming_client.bal
         generates source:

      AssertionError: ....
      + expected - actual

       
           io:println(connErr.message but { () => "" });
           runtime:sleep(6000);
       
      -    // Once all messages are sent, client send complete message to notify the server, I???m done.
      +    // Once all messages are sent, client send complete message to notify the server, I���m done.
           _ = ep->complete();
       }
       
       
      
      at Context.<anonymous> (src/test/js/test.js:97:44)
```