### PR TITLE
Add source gen test skip on ballerina parser error

### DIFF
--- a/composer/modules/integration-tests/src/test/js/test.js
+++ b/composer/modules/integration-tests/src/test/js/test.js
@@ -67,18 +67,24 @@ describe('Ballerina Composer Test Suite', () => {
             before(done => {
                 model = undefined;
                 content = undefined;
-                fs.readFile(testFile, 'utf8', (err, fileContent) => {
-                    parse(fileContent, testFile, parsedModel => {
-                        content = fileContent;
-                        model = parsedModel;
-                        let error;
-                        if (!model && !(sourceGenSkip.includes(path.basename(testFile)) ||
-                                renderingSkip.includes(path.basename(testFile)))) {
-                            error = new Error('Could not parse!');
-                        }
-                        done(error);
-                    });
-                })
+
+                if (sourceGenSkip.includes(path.basename(testFile)) &&
+                    renderingSkip.includes(path.basename(testFile))) {
+                    done();
+                } else {
+                    fs.readFile(testFile, 'utf8', (err, fileContent) => {
+                        parse(fileContent, testFile, parsedModel => {
+                            content = fileContent;
+                            model = parsedModel;
+                            let error;
+
+                            if (!model) {
+                                error = new Error('Could not parse!');
+                            }
+                            done(error);
+                        });
+                    })
+                }
             });
 
             it('renders', function () {
@@ -100,7 +106,7 @@ describe('Ballerina Composer Test Suite', () => {
                 expect(generatedSource).to.equal(content);
             });
 
-            if (process.env.DEBUG == "true") {
+            if (process.env.DEBUG === "true") {
                 it('debug print', () => {
                     const tree = testEnv.buildTree(model);
                     debugPrint(tree);

--- a/composer/modules/integration-tests/src/test/js/test.js
+++ b/composer/modules/integration-tests/src/test/js/test.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
@@ -40,7 +40,7 @@ describe('Ballerina Composer Test Suite', () => {
     }
 
     let backEndProcess;
-    
+
     before(function (beforeAllDone) {
         this.timeout(10000);
         const targetPath = path.join(global.targetPath, 'lib', `composer-server.jar`);
@@ -63,7 +63,7 @@ describe('Ballerina Composer Test Suite', () => {
         describe(path.basename(testFile), () => {
             let model;
             let content;
-            
+
             before(done => {
                 model = undefined;
                 content = undefined;
@@ -72,7 +72,8 @@ describe('Ballerina Composer Test Suite', () => {
                         content = fileContent;
                         model = parsedModel;
                         let error;
-                        if (!model) {
+                        if (!model && !(sourceGenSkip.includes(path.basename(testFile)) ||
+                                renderingSkip.includes(path.basename(testFile)))) {
                             error = new Error('Could not parse!');
                         }
                         done(error);
@@ -81,7 +82,7 @@ describe('Ballerina Composer Test Suite', () => {
             });
 
             it('renders', function () {
-                if(renderingSkip.includes(path.basename(testFile))) {
+                if (renderingSkip.includes(path.basename(testFile))) {
                     this.skip();
                     return;
                 }
@@ -90,7 +91,7 @@ describe('Ballerina Composer Test Suite', () => {
             });
 
             it('generates source', function () {
-                if(sourceGenSkip.includes(path.basename(testFile))) {
+                if (sourceGenSkip.includes(path.basename(testFile))) {
                     this.skip();
                     return;
                 }

--- a/composer/modules/integration-tests/src/test/resources/config.json
+++ b/composer/modules/integration-tests/src/test/resources/config.json
@@ -1,28 +1,44 @@
 {
-    "skip": {
-        "rendering": [],
-        "source-gen": [
-            "table_queries.bal",
-            "table.bal",
-            "csv_io.bal",
-            "channels_correlation.bal",
-            "channels_workers.bal",
-            "grpc_bidirectional_streaming_client.bal",
-            "xml_test.bal",
-            "xml.bal",
-            "xml_access_test.bal",
-            "xml-access.bal",
-            "xml_attributes_test.bal",
-            "xml_attributes.bal",
-            "xml_functions_test.bal",
-            "xml_functions.bal",
-            "xml_io.bal",
-            "xml_literal_test.bal",
-            "xml_literal.bal",
-            "xml_namespaces_test.bal",
-            "xml_namespaces.bal",
-            "xml_namespaces_test.bal",
-            "xml_to_json_conversion.bal"
-        ]
-    }
+  "skip": {
+    "rendering": [
+      "xml_test.bal",
+      "xml.bal",
+      "xml_access_test.bal",
+      "xml-access.bal",
+      "xml_attributes_test.bal",
+      "xml_attributes.bal",
+      "xml_functions_test.bal",
+      "xml_functions.bal",
+      "xml_io.bal",
+      "xml_literal_test.bal",
+      "xml_literal.bal",
+      "xml_namespaces_test.bal",
+      "xml_namespaces.bal",
+      "xml_namespaces_test.bal",
+      "xml_to_json_conversion.bal"
+    ],
+    "source-gen": [
+      "table_queries.bal",
+      "table.bal",
+      "csv_io.bal",
+      "channels_correlation.bal",
+      "channels_workers.bal",
+      "grpc_bidirectional_streaming_client.bal",
+      "xml_test.bal",
+      "xml.bal",
+      "xml_access_test.bal",
+      "xml-access.bal",
+      "xml_attributes_test.bal",
+      "xml_attributes.bal",
+      "xml_functions_test.bal",
+      "xml_functions.bal",
+      "xml_io.bal",
+      "xml_literal_test.bal",
+      "xml_literal.bal",
+      "xml_namespaces_test.bal",
+      "xml_namespaces.bal",
+      "xml_namespaces_test.bal",
+      "xml_to_json_conversion.bal"
+    ]
+  }
 }


### PR DESCRIPTION
## Purpose
This will add functionality for the source gen test runner to skip the tests given on the config even on the when the files doesn't get parse properly. 

User needs to add names of the files with a parser errors on to the config.json under both "rendering" and "source-gen" sections to skip those file being parsed.