### PR TITLE
Exclude maven build files (target dir) from .vsix file

### DIFF
--- a/tool-plugins/vscode/.vscodeignore
+++ b/tool-plugins/vscode/.vscodeignore
@@ -3,6 +3,7 @@
 out/test/**
 out/**/*.map
 src/**
+target
 .gitignore
 tsconfig.json
 tslint.json


### PR DESCRIPTION
This is to reduce large file size of vscode plugin distribution