### PR TITLE
Update diagram representation of if/else, while, foreach nodes

### DIFF
--- a/composer/modules/web/scss/modules/ballerina-editor.scss
+++ b/composer/modules/web/scss/modules/ballerina-editor.scss
@@ -111,6 +111,11 @@
     font-weight: 300;
 }
 
+.flowchart-true-text-bg,
+.flowchart-false-text-bg {
+    fill: $white;
+}
+
 .client-line-header,
 .statement-title-rect,
 .flowchart-background-empty-rect,

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
@@ -98,6 +98,9 @@ class IfStatementDecorator extends React.Component {
         const viewState = model.viewState;
         const titleH = this.context.designer.config.flowChartControlStatement.heading.height;
         const titleW = this.context.designer.config.flowChartControlStatement.heading.width;
+        const decisionLabelH = this.context.designer.config.flowChartControlStatement.decision.height;
+        const decisionLabelW = this.context.designer.config.flowChartControlStatement.decision.width;
+        const decisionLabelRadius = this.context.designer.config.flowChartControlStatement.decision.radius;
         const statementBBox = viewState.components['statement-box'];
         const displayExpression = viewState.components.expression;
         const gapLeft = this.context.designer.config.flowChartControlStatement.gap.left;
@@ -161,6 +164,13 @@ class IfStatementDecorator extends React.Component {
         const p12X = p8X;
         const p12Y = p8Y + this.context.designer.config.flowChartControlStatement.heading.gap;
 
+        const decisionTrueLabelPositionX = (p8X - (decisionLabelW / 2));
+        const decisionTrueLabelPositionY = (((p8Y + p12Y) / 2) - (decisionLabelH / 2));
+        const decisionFalseLabelPositionX = (p3X + 2);
+        const decisionFalseLabelPositionY = (p3Y - (decisionLabelH / 2));
+        const expressionPositionX = (bBox.x + (viewState.components.expression.w / 2)) + 18;
+        const expressionPositionY = (p2Y + 22);
+
         this.conditionBox = new SimpleBBox(p2X, (p2Y - (this.context.designer.config.statement.height / 2)),
             statementBBox.w, this.context.designer.config.statement.height);
 
@@ -208,31 +218,49 @@ class IfStatementDecorator extends React.Component {
                     className={statementRectClass}
                 />
                 <text
-                    x={p9X}
-                    y={p9Y + 14}
+                    x={p8X}
+                    y={p2Y}
                     className='statement-title-text'
                 >
                     if
                 </text>
                 {expression &&
                     <text
-                        x={p8X}
-                        y={p2Y}
+                        x={expressionPositionX}
+                        y={expressionPositionY}
                         className='condition-text'
                     >
                         {displayExpression.text}
                     </text>
                 }
+                <rect
+                    x={decisionTrueLabelPositionX}
+                    y={decisionTrueLabelPositionY}
+                    width={decisionLabelW}
+                    height={decisionLabelH}
+                    rx={decisionLabelRadius}
+                    ry={decisionLabelRadius}
+                    className='flowchart-true-text-bg'
+                />
                 <text
-                    x={p12X - 4}
-                    y={(p8Y + p12Y) / 2}
+                    x={p8X + 12}
+                    y={((p8Y + p12Y) / 2) + 4}
                     className='flowchart-true-text'
                 >
                     true
                 </text>
+                <rect
+                    x={decisionFalseLabelPositionX}
+                    y={decisionFalseLabelPositionY}
+                    width={decisionLabelW}
+                    height={decisionLabelH}
+                    rx={decisionLabelRadius}
+                    ry={decisionLabelRadius}
+                    className='flowchart-false-text-bg'
+                />
                 <text
-                    x={p3X + 4}
-                    y={p3Y - 4}
+                    x={p3X + 8}
+                    y={p3Y + 4}
                     className='flowchart-false-text'
                 >
                     false

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/while-statement-decorator.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/while-statement-decorator.jsx
@@ -93,6 +93,9 @@ class WhileStatementDecorator extends React.Component {
         const viewState = model.viewState;
         const titleH = this.context.designer.config.flowChartControlStatement.heading.height;
         const titleW = this.context.designer.config.flowChartControlStatement.heading.width;
+        const decisionLabelH = this.context.designer.config.flowChartControlStatement.decision.height;
+        const decisionLabelW = this.context.designer.config.flowChartControlStatement.decision.width;
+        const decisionLabelRadius = this.context.designer.config.flowChartControlStatement.decision.radius;
         const statementBBox = viewState.components['statement-box'];
         const displayExpression = viewState.components.expression;
         const gapLeft = viewState.bBox.leftMargin;
@@ -161,6 +164,13 @@ class WhileStatementDecorator extends React.Component {
         const p12X = p8X;
         const p12Y = p8Y + this.context.designer.config.flowChartControlStatement.heading.gap;
 
+        const decisionTrueLabelPositionX = (p8X - (decisionLabelW / 2));
+        const decisionTrueLabelPositionY = (((p8Y + p12Y) / 2) - (decisionLabelH / 2));
+        const decisionFalseLabelPositionX = (p3X + 2);
+        const decisionFalseLabelPositionY = (p3Y - (decisionLabelH / 2));
+        const expressionPositionX = (bBox.x + (viewState.components.expression.w / 2)) + 18;
+        const expressionPositionY = (p2Y + 22);
+
         this.conditionBox = new SimpleBBox(p2X, (p2Y - (this.context.designer.config.statement.height / 2)),
             statementBBox.w, this.context.designer.config.statement.height);
 
@@ -212,8 +222,8 @@ class WhileStatementDecorator extends React.Component {
                 />
                 { TreeUtil.isWhile(this.props.model) &&
                 <text
-                    x={p9X}
-                    y={p9Y + 14}
+                    x={p8X}
+                    y={p2Y}
                     className='statement-title-text'
                 >
                     while
@@ -230,8 +240,8 @@ class WhileStatementDecorator extends React.Component {
                 }
                 { TreeUtil.isWhile(this.props.model) && expression &&
                     <text
-                        x={p8X}
-                        y={p2Y}
+                        x={expressionPositionX}
+                        y={expressionPositionY}
                         className='condition-text'
                     >
                         {displayExpression.text}
@@ -246,16 +256,34 @@ class WhileStatementDecorator extends React.Component {
                         {displayExpression.text}
                     </text>
                 }
+                <rect
+                    x={decisionTrueLabelPositionX}
+                    y={decisionTrueLabelPositionY}
+                    width={decisionLabelW}
+                    height={decisionLabelH}
+                    rx={decisionLabelRadius}
+                    ry={decisionLabelRadius}
+                    className='flowchart-true-text-bg'
+                />
                 <text
-                    x={p12X - 4}
-                    y={(p8Y + p12Y) / 2}
+                    x={p8X + 12}
+                    y={((p8Y + p12Y) / 2) + 4}
                     className='flowchart-true-text'
                 >
                     true
                 </text>
+                <rect
+                    x={decisionFalseLabelPositionX}
+                    y={decisionFalseLabelPositionY}
+                    width={decisionLabelW}
+                    height={decisionLabelH}
+                    rx={decisionLabelRadius}
+                    ry={decisionLabelRadius}
+                    className='flowchart-false-text-bg'
+                />
                 <text
-                    x={p3X + 4}
-                    y={p3Y - 4}
+                    x={p3X + 8}
+                    y={p3Y + 4}
                     className='flowchart-false-text'
                 >
                     false

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
@@ -167,7 +167,7 @@ export const blockStatement = {
 
 export const flowChartControlStatement = {
     heading: {
-        width: (statement.width * (3 / 4)),
+        width: (statement.width * (1 / 2)),
         height: (3 * statement.height),
         paramPaddingX: 5,
         paramSeparatorOffsetX: 20,
@@ -176,6 +176,11 @@ export const flowChartControlStatement = {
     },
     gutter: {
         h: statement.height,
+    },
+    decision: {
+        width: 40,
+        height: 17,
+        radius: 0,
     },
     body: {
         padding: {

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
@@ -35,7 +35,7 @@ class PositioningUtil {
         viewState.components['statement-box'].y = viewState.bBox.y + viewState.components['drop-zone'].h;
         viewState.components.text.x = viewState.components['statement-box'].x + this.config.statement.gutter.h;
         viewState.components.text.y = viewState.components['statement-box'].y +
-            (viewState.components['statement-box'].h / 2);
+            (viewState.components['statement-box'].h / 2) + this.config.statement.gutter.h;
 
         if (TreeUtil.statementIsInvocation(node)) {
             // Set the view state property to manipulate at the action invocation decorator

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1320,7 +1320,7 @@ class SizingUtil {
         // we will calculate the width of the expression and adjust the block statement
         if (expression) {
             components.expression = this.getTextWidth(expression.getSource(true), 0,
-                this.config.flowChartControlStatement.heading.width - 20);
+                node.viewState.bBox.w - 20);
         }
 
         // end of if block sizing
@@ -1792,7 +1792,7 @@ class SizingUtil {
         // we will calculate the width of the expression and adjust the block statement
         if (expression) {
             components.expression = this.getTextWidth(expression.getSource(true, true), 0,
-                                        this.config.flowChartControlStatement.heading.width - 5);
+                node.viewState.bBox.w - 20);
         }
     }
 

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1277,6 +1277,9 @@ class SizingUtil {
         const viewState = node.viewState;
         const components = viewState.components;
         const dropZoneHeight = TreeUtil.isBlock(node.parent) ? this.config.statement.gutter.v : 0;
+        const parentBlockGutter = ((node.elseStatement) &&
+            (node.elseStatement.statements) &&
+            (node.elseStatement.statements.length > 0)) ? this.config.statement.height : 0;
         const nodeBodyViewState = node.body.viewState;
 
         // flow chart if width and height is different to normal block node width and height
@@ -1303,9 +1306,9 @@ class SizingUtil {
         viewState.components['drop-zone'].w = bodyWidth;
         viewState.components['statement-box'].h = bodyHeight;
         viewState.components['statement-box'].w = bodyWidth;
-        viewState.bBox.h = viewState.components['statement-box'].h
-                            + viewState.components['drop-zone'].h
-                            + components['block-header'].h;
+        viewState.bBox.h = viewState.components['statement-box'].h +
+            viewState.components['drop-zone'].h +
+            components['block-header'].h + parentBlockGutter;
         viewState.bBox.w = bodyWidth;
 
         components['block-header'].setOpaque(true);
@@ -1317,7 +1320,7 @@ class SizingUtil {
         // we will calculate the width of the expression and adjust the block statement
         if (expression) {
             components.expression = this.getTextWidth(expression.getSource(true), 0,
-                                        this.config.flowChartControlStatement.heading.width - 5);
+                this.config.flowChartControlStatement.heading.width - 20);
         }
 
         // end of if block sizing


### PR DESCRIPTION
## Purpose
> Fix some UX issues in  `if/else` & `while`, `foreach` representation
> Fix statement positioning gap when there is a if/else or loop statement

_**Issue:**_

![image](https://user-images.githubusercontent.com/7569427/45966894-f88dfa80-c049-11e8-8db5-1d0b2b70409f.png)

_**Solution:**_

![image](https://user-images.githubusercontent.com/7569427/45966961-27a46c00-c04a-11e8-81d8-537c8432285c.png)