### PR TITLE
Fix transaction cleanup for committed transactions

### DIFF
--- a/stdlib/transactions/src/main/ballerina/transactions/commons.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/commons.bal
@@ -66,6 +66,7 @@ function cleanupTransactions() returns error? {
                         if (commitSuccessful) {
                             twopcTxn.state = TXN_STATE_COMMITTED;
                             log:printInfo("Auto-committed participated  transaction: " + participatedTxnId);
+                            removeParticipatedTransaction(participatedTxnId);
                         } else {
                             log:printError("Auto-commit of participated transaction: " + participatedTxnId + " failed");
                         }
@@ -85,8 +86,11 @@ function cleanupTransactions() returns error? {
                     // Commit the transaction since prepare hasn't been received
                     var result = twopcTxn.twoPhaseCommit();
                     match result {
-                        string str => log:printInfo("Auto-committed initiated transaction: " + twopcTxn.transactionId +
+                        string str => {
+                            log:printInfo("Auto-committed initiated transaction: " + twopcTxn.transactionId +
                                 ". Result: " + str);
+                            removeInitiatedTransaction(twopcTxn.transactionId);
+                        }
                         error err => log:printError("Auto-commit of participated transaction: " +
                                 twopcTxn.transactionId + " failed", err = err);
                     }


### PR DESCRIPTION
## Purpose
When performing scheduled transaction cleanup (cleanupTransactions), if an error was not returned from twoPhaseCommit, we should remove the particular transaction from initiatedTransactions or participatedTransactions.