### PR TITLE
Revamp repository hierarchy and package pulling error logs

### DIFF
--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -58,7 +58,7 @@ function createError (string errMessage) returns error {
 #
 # + args - Arguments for pulling a package
 # + return - 1 if package is not found, else 0 if package already exists or successfully pulled.
-function invokePull (string... args) returns error? {
+public function invokePull (string... args) returns error? {
     string url = args[0];
     string dirPath = args[1];
     string pkgPath = args[2];

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -52,7 +52,7 @@ type BuildLogFormatter object {
 # + fileSeparator - File separator based on the operating system
 # + terminalWidth - Width of the terminal
 # + versionRange - Supported version range
-# + return - 1 if package is not found, else 0 if package already exists or successfully pulled
+# + return - 1 error occurs, else 0 if successfully pulled
 function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, string dirPath, string pkgPath,
                       string fileSeparator, string terminalWidth, string versionRange) returns int {
     endpoint http:Client httpEndpoint = definedEndpoint;
@@ -131,7 +131,7 @@ function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, 
                 internal:Path pkgArchivePath = new(destArchivePath);
                 if (pkgArchivePath.exists()) {
                     io:println(logFormatter.formatLog("package already exists in the home repository"));
-                    return 0;
+                    return 1;
                 }
             }
 
@@ -153,7 +153,7 @@ function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, 
 
 # This function will invoke the method to pull the package. If error occurs, it is thrown.
 # + args - package pull arguments
-# + return - 1 if package is not found, else 0 if package already exists or successfully pulled
+# + return - 1 error occurs, else 0 if successfully pulled
 public function main(string... args) returns int {
     http:Client httpEndpoint;
     string host = args[4];

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -57,7 +57,7 @@ function createError (string errMessage) returns error {
 # This function pulls a package from ballerina central.
 #
 # + args - Arguments for pulling a package
-# + return - 1 if package is not found, else 0 if package already exists or successfully pulled.
+# + return - nil if no error occurred, else error.
 public function invokePull (string... args) returns error? {
     string url = args[0];
     string dirPath = args[1];
@@ -101,7 +101,7 @@ public function invokePull (string... args) returns error? {
 # + versionRange - Balo version range
 # + fileSeparator - System file separator
 # + terminalWidth - Width of the terminal
-# + return - Error if occurred
+# + return - Error if occurred, else nil
 function pullPackage(http:Client httpEndpoint, string url, string pkgPath, string dirPath, string versionRange,
                      string fileSeparator, string terminalWidth) returns error? {
     endpoint http:Client centralEndpoint = httpEndpoint;

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -43,10 +43,10 @@ type BuildLogFormatter object {
     }
 };
 
-# Handle errors when pulling a package. Build command will throw an error while non-build commands will print the error
-# and return 1.
+# Creates an error record.
+
 # + errMessage - The error message.
-# + return - 1 if from non-build commands else an error is thrown.
+# + return - Newly created error record.
 function createError (string errMessage) returns error {
     error endpointError = {
         message: logFormatter.formatLog(errMessage)

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -20,7 +20,8 @@ import ballerina/io;
 
 @final int MAX_INT_VALUE = 2147483647;
 @final string VERSION_REGEX = "(\\d+\\.)(\\d+\\.)(\\d+)";
-DefaultLogFormatter logFormatter;
+DefaultLogFormatter logFormatter = new DefaultLogFormatter();
+boolean isBuild;
 
 # This object denotes the default log formatter used when pulling a package directly.
 #
@@ -42,54 +43,103 @@ type BuildLogFormatter object {
     }
 };
 
+# Handle errors when pulling a package. Build command will throw an error while non-build commands will print the error
+# and return 1.
+# + errMessage - The error message.
+# + return - 1 if from non-build commands else an error is thrown.
+function createError (string errMessage) returns error {
+    error endpointError = {
+        message: logFormatter.formatLog(errMessage)
+    };
+    return endpointError;
+}
+
 # This function pulls a package from ballerina central.
 #
-# + definedEndpoint - Endpoint defined with the proxy configurations
-# + isBuild - True if executed for building, else false
-# + url - Url to be invoked
-# + dirPath - Path of the directory to save the pulled package
-# + pkgPath - Package path
-# + fileSeparator - File separator based on the operating system
+# + args - Arguments for pulling a package
+# + return - 1 if package is not found, else 0 if package already exists or successfully pulled.
+function invokePull (string... args) returns error? {
+    string url = args[0];
+    string dirPath = args[1];
+    string pkgPath = args[2];
+    string fileSeparator = args[3];
+    string host = args[4];
+    string port = args[5];
+    string proxyUsername = args[6];
+    string proxyPassword = args[7];
+    string terminalWidth = args[8];
+    string versionRange = args[9];
+    isBuild = untaint <boolean>args[10];
+
+    if (isBuild) {
+        logFormatter = new BuildLogFormatter();
+    }
+
+    // resolve endpoint
+    http:Client httpEndpoint;
+    if (host != "" && port != "") {
+        try {
+            httpEndpoint = defineEndpointWithProxy(url, host, port, proxyUsername, proxyPassword);
+        } catch (error err) {
+            return createError("failed to resolve host : " + host + " with port " + port);
+        }
+    } else  if (host != "" || port != "") {
+        return createError("both host and port should be provided to enable proxy");
+    } else {
+        httpEndpoint = defineEndpointWithoutProxy(url);
+    }
+
+    return pullPackage(httpEndpoint, url, pkgPath, dirPath, versionRange, fileSeparator, terminalWidth);
+}
+
+# Pulling a package
+#
+# + httpEndpoint - The endpoint to call
+# + url - Central URL
+# + pkgPath - Package Path
+# + dirPath - Directory path
+# + versionRange - Balo version range
+# + fileSeparator - System file separator
 # + terminalWidth - Width of the terminal
-# + versionRange - Supported version range
-# + return - 1 error occurs, else 0 if successfully pulled
-function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, string dirPath, string pkgPath,
-                      string fileSeparator, string terminalWidth, string versionRange) returns int {
-    endpoint http:Client httpEndpoint = definedEndpoint;
+# + return - Error if occurred
+function pullPackage(http:Client httpEndpoint, string url, string pkgPath, string dirPath, string versionRange,
+                     string fileSeparator, string terminalWidth) returns error? {
+    endpoint http:Client centralEndpoint = httpEndpoint;
+
     string fullPkgPath = pkgPath;
     string destDirPath = dirPath;
     http:Request req = new;
     req.addHeader("Accept-Encoding", "identity");
 
     http:Response httpResponse = new;
-    var result = httpEndpoint -> get(untaint versionRange, message=req);
+    var result = centralEndpoint -> get(untaint versionRange, message=req);
 
     match result {
         http:Response response => httpResponse = response;
         error e => {
-            io:println(logFormatter.formatLog("connection to the remote host failed : " + e.message));
-            return 1;
+            return createError("connection to the remote host failed : " + e.message);
         }
     }
 
     http:Response res = new;
     string statusCode = <string> httpResponse.statusCode;
     if (statusCode.hasPrefix("5")) {
-        io:println(logFormatter.formatLog("remote registry failed for url :" + url));
-        return 1;
+        return createError("remote registry failed for url :" + url);
     } else if (statusCode != "200") {
         var jsonResponse = httpResponse.getJsonPayload();
         match jsonResponse {
             json resp => {
                 if (!(statusCode == "404" && isBuild)) {
-                    io:println(logFormatter.formatLog(resp.message.toString()));
+                    return createError(resp.message.toString());
+                } else {
+                    // To ignore printing the error
+                    return createError("");
                 }
             }
             error err => {
-                io:println(logFormatter.formatLog("error occurred when pulling the package"));
+                return createError("error occurred when pulling the package");
             }
         }
-        return 1;
     } else {
         string contentLengthHeader;
         int pkgSize = MAX_INT_VALUE;
@@ -98,8 +148,7 @@ function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, 
             contentLengthHeader = httpResponse.getHeader("content-length");
             pkgSize = check <int> contentLengthHeader;
         } else {
-            io:println(logFormatter.formatLog("package size information is missing from remote repository. please retry."));
-            return 1;
+            return createError("package size information is missing from remote repository. please retry.");
         }
 
         io:ByteChannel sourceChannel = check (httpResponse.getByteChannel());
@@ -124,8 +173,7 @@ function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, 
             if (!createDirectories(destDirPath)) {
                 internal:Path pkgArchivePath = new(destArchivePath);
                 if (pkgArchivePath.exists()) {
-                    io:println(logFormatter.formatLog("package already exists in the home repository"));
-                    return 1;
+                    return createError("package already exists in the home repository");
                 }
             }
 
@@ -137,57 +185,27 @@ function pullPackage (http:Client definedEndpoint, boolean isBuild, string url, 
 
             match destDirChannel.close() {
                 error destChannelCloseError => {
-                    io:println(logFormatter.formatLog("error occured while closing the channel: " + destChannelCloseError.message));
-                    return 1;
+                    return createError("error occured while closing the channel: " + destChannelCloseError.message);
                 }
                 () => {
                     match sourceChannel.close() {
                         error sourceChannelCloseError => {
-                            io:println(logFormatter.formatLog("error occured while closing the channel: " + sourceChannelCloseError.message));
-                            return 1;
+                            return createError("error occured while closing the channel: " + sourceChannelCloseError.message);
                         }
                         () => {
-                            return 0;
+                            return ();
                         }
                     }
                 }
             }
         } else {
-            io:println(logFormatter.formatLog("package version could not be detected"));
-            return 1;
+            return createError("package version could not be detected");
         }
     }
 }
 
-# This function will invoke the method to pull the package. If error occurs, it is thrown.
-# + args - package pull arguments
-# + return - 1 error occurs, else 0 if successfully pulled
-public function main(string... args) returns int {
-    http:Client httpEndpoint;
-    string host = args[4];
-    string port = args[5];
-    boolean isBuild = <boolean>args[10];
-    if (isBuild) {
-        logFormatter = new BuildLogFormatter();
-    } else {
-        logFormatter = new DefaultLogFormatter();
-    }
-
-    if (host != "" && port != "") {
-        try {
-            httpEndpoint = defineEndpointWithProxy(args[0], host, port, args[6], args[7]);
-        } catch (error err) {
-            io:println(logFormatter.formatLog("failed to resolve host : " + host + " with port " + port));
-            return 1;
-        }
-    } else  if (host != "" || port != "") {
-        io:println(logFormatter.formatLog("both host and port should be provided to enable proxy"));
-        return 1;
-    } else {
-        httpEndpoint = defineEndpointWithoutProxy(args[0]);
-    }
-    return pullPackage(httpEndpoint, isBuild, args[0], args[1], args[2], args[3], args[8], args[9]);
-}
+# A dummy main function to generate the balx.
+public function main() {}
 
 # This function defines an endpoint with proxy configurations.
 #
@@ -197,8 +215,8 @@ public function main(string... args) returns int {
 # + username - Username of the proxy
 # + password - Password of the proxy
 # + return - Endpoint defined
-function defineEndpointWithProxy (string url, string hostname, string port, string username, string password) returns http:Client{
-    endpoint http:Client httpEndpoint {
+function defineEndpointWithProxy (string url, string hostname, string port, string username, string password) returns http:Client {
+    endpoint http:Client httpEndpointWithProxy {
         url: url,
         secureSocket:{
             trustStore:{
@@ -211,7 +229,7 @@ function defineEndpointWithProxy (string url, string hostname, string port, stri
         followRedirects: { enabled: true, maxCount: 5 },
         proxy : getProxyConfigurations(hostname, port, username, password)
     };
-    return httpEndpoint;
+    return httpEndpointWithProxy;
 }
 
 # This function defines an endpoint without proxy configurations.
@@ -219,7 +237,7 @@ function defineEndpointWithProxy (string url, string hostname, string port, stri
 # + url - URL to be invoked
 # + return - Endpoint defined
 function defineEndpointWithoutProxy (string url) returns http:Client{
-    endpoint http:Client httpEndpoint {
+    endpoint http:Client httpEndpointWithoutProxy {
         url: url,
         secureSocket:{
             trustStore:{
@@ -231,7 +249,7 @@ function defineEndpointWithoutProxy (string url) returns http:Client{
         },
         followRedirects: { enabled: true, maxCount: 5 }
     };
-    return httpEndpoint;
+    return httpEndpointWithoutProxy;
 }
 
 # This function will get the file channel.

--- a/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/BVMEmbeddedExecutor.java
+++ b/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/BVMEmbeddedExecutor.java
@@ -19,6 +19,8 @@ package org.ballerinalang.cli.utils;
 
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.spi.EmbeddedExecutor;
 
 import java.net.URI;
@@ -36,7 +38,8 @@ import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
 @JavaSPIService("org.ballerinalang.spi.EmbeddedExecutor")
 public class BVMEmbeddedExecutor implements EmbeddedExecutor {
     @Override
-    public void execute(String programArg, boolean isFunction, String... args) {
+    public long execute(String programArg, boolean isFunction, String... args) {
+        
         String balxPath = programArg;
         String functionName = MAIN_FUNCTION_NAME;
 
@@ -54,12 +57,17 @@ public class BVMEmbeddedExecutor implements EmbeddedExecutor {
         if (resource == null) {
             throw new BLangCompilerException("Missing internal modules when retrieving remote package");
         }
+        
         try {
             URI balxResource = resource.toURI();
-            // TODO: 8/5/18 return BValue[] ignored 
-            ExecutorUtils.execute(balxResource, isFunction, isFunction ? functionName : null, args);
+            BValue[] returns = ExecutorUtils.execute(balxResource, isFunction, isFunction ? functionName : null, args);
+            if (returns.length == 1 && returns[0] instanceof BInteger) {
+                return ((BInteger) returns[0]).intValue();
+            } else {
+                return 0L;
+            }
         } catch (URISyntaxException e) {
-            throw new BLangCompilerException("Error loading internal modules when retrieving remote package");
+            throw new BLangCompilerException("Error reading balx path in internal executor.");
         }
     }
 }

--- a/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/BVMEmbeddedExecutor.java
+++ b/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/BVMEmbeddedExecutor.java
@@ -39,7 +39,6 @@ import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
 public class BVMEmbeddedExecutor implements EmbeddedExecutor {
     @Override
     public long execute(String programArg, boolean isFunction, String... args) {
-        
         String balxPath = programArg;
         String functionName = MAIN_FUNCTION_NAME;
 

--- a/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/ExecutorUtils.java
+++ b/cli/ballerina-cli-utils/src/main/java/org/ballerinalang/cli/utils/ExecutorUtils.java
@@ -38,28 +38,32 @@ import java.util.Map;
  * @since 0.964
  */
 public class ExecutorUtils {
-
+    
     /**
-     * Run balx that lives within jars.
+     * Run a function in a balx that lives within jars.
      *
      * @param balxResource URI of the balx resource
-     * @param isFunction   if a function or service is to be invoked
      * @param functionName the function name, if a function is to be invoked
      * @param args         arguments passed to the function
      * @return execution results
      */
-    public static BValue[] execute(URI balxResource, boolean isFunction, String functionName, String... args) {
-        // TODO: 8/3/18 check if we can unify isFunction and functionName
+    public static BValue[] executeFunction(URI balxResource, String functionName, String... args) {
         initFileSystem(balxResource);
         Path baloFilePath = Paths.get(balxResource);
         ProgramFile programFile = readExecutableProgram(baloFilePath);
-
-        if (isFunction) {
-            return BLangProgramRunner.runEntryFunc(programFile, functionName, args);
-        } else {
-            BLangProgramRunner.runService(programFile);
-            return new BValue[]{};
-        }
+        return BLangProgramRunner.runEntryFunc(programFile, functionName, args);
+    }
+    
+    /**
+     * Run a service in a balx that lives within jars.
+     *
+     * @param balxResource URI of the balx resource
+     */
+    public static void executeService(URI balxResource) {
+        initFileSystem(balxResource);
+        Path baloFilePath = Paths.get(balxResource);
+        ProgramFile programFile = readExecutableProgram(baloFilePath);
+        BLangProgramRunner.runService(programFile);
     }
 
     /**

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -54,6 +54,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static org.ballerinalang.launcher.LauncherUtils.createLauncherException;
+import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
 
 /**
  * This class provides util methods when pushing Ballerina packages to central and home repository.
@@ -141,10 +142,10 @@ public class PushUtils {
             String msg = orgName + "/" + packageName + ":" + version + " [project repo -> central]";
             Proxy proxy = settings.getProxy();
             String baloVersionOfPkg = String.valueOf(ProgramFileConstants.VERSION_NUMBER);
-            executor.execute("packaging_push/packaging_push.balx", true, accessToken, mdFileContent,
-                             description, homepageURL, repositoryURL, apiDocURL, authors, keywords, license,
-                             resourcePath, pkgPathFromPrjtDir.toString(), msg, ballerinaVersion, proxy.getHost(),
-                             proxy.getPort(), proxy.getUserName(), proxy.getPassword(), baloVersionOfPkg);
+            executor.executeFunction("packaging_push/packaging_push.balx", MAIN_FUNCTION_NAME, accessToken,
+                    mdFileContent, description, homepageURL, repositoryURL, apiDocURL, authors, keywords, license,
+                    resourcePath, pkgPathFromPrjtDir.toString(), msg, ballerinaVersion, proxy.getHost(),
+                    proxy.getPort(), proxy.getUserName(), proxy.getPassword(), baloVersionOfPkg);
 
         } else {
             if (!installToRepo.equals("home")) {
@@ -174,7 +175,7 @@ public class PushUtils {
                                                  "\nAuto update failed. Please visit https://central.ballerina.io");
             }
             long modifiedTimeOfFileAtStart = getLastModifiedTimeOfFile(SETTINGS_TOML_FILE_PATH);
-            executor.execute("packaging_token_updater/packaging_token_updater.balx", false);
+            executor.executeFunction("packaging_token_updater/packaging_token_updater.balx", MAIN_FUNCTION_NAME);
 
             boolean waitForToken = true;
             while (waitForToken) {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/SearchUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/SearchUtils.java
@@ -23,13 +23,15 @@ import org.ballerinalang.util.EmbeddedExecutorProvider;
 import org.wso2.ballerinalang.util.RepoUtils;
 import org.wso2.ballerinalang.util.TomlParserUtils;
 
+import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
+
 /**
  * This class provides util methods when searching for Ballerina packages in the central.
  *
  * @since 0.95.2
  */
 public class SearchUtils {
-
+    
     /**
      * Search for packages in central.
      *
@@ -39,8 +41,8 @@ public class SearchUtils {
         String query = "?q=" + argument;
         EmbeddedExecutor executor = EmbeddedExecutorProvider.getInstance().getExecutor();
         Proxy proxy = TomlParserUtils.readSettings().getProxy();
-        executor.execute("packaging_search/packaging_search.balx", true, RepoUtils.getRemoteRepoURL(), query,
-                         proxy.getHost(), proxy.getPort(), proxy.getUserName(), proxy.getPassword(),
-                         RepoUtils.getTerminalWidth());
+        executor.executeFunction("packaging_search/packaging_search.balx", MAIN_FUNCTION_NAME,
+                RepoUtils.getRemoteRepoURL(), query, proxy.getHost(), proxy.getPort(), proxy.getUserName(),
+                proxy.getPassword(), RepoUtils.getTerminalWidth());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/spi/EmbeddedExecutor.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/spi/EmbeddedExecutor.java
@@ -24,6 +24,6 @@ package org.ballerinalang.spi;
  */
 public interface EmbeddedExecutor {
 
-    void execute(String balxPath, boolean isFunction, String... args);
+    long execute(String balxPath, boolean isFunction, String... args);
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/spi/EmbeddedExecutor.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/spi/EmbeddedExecutor.java
@@ -17,13 +17,28 @@
 */
 package org.ballerinalang.spi;
 
+import org.ballerinalang.util.EmbeddedExecutorError;
+
+import java.util.Optional;
+
 /**
  * This represents the Java SPI interface for the resource runner.
  *
  * @since 0.964
  */
 public interface EmbeddedExecutor {
-
-    long execute(String balxPath, boolean isFunction, String... args);
-
+    /**
+     * Executes a function of a balx file.
+     * @param programArg Path of the balx.
+     * @param functionName The name of the function.
+     * @param args The arguments for the function.
+     * @return Program execution output.
+     */
+    Optional<EmbeddedExecutorError> executeFunction(String programArg, String functionName, String... args);
+    
+    /**
+     * Executes a service of a balx file.
+     * @param balxPath Path of the balx.
+     */
+    void executeService(String balxPath);
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/EmbeddedExecutorError.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/EmbeddedExecutorError.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.util;
+
+/**
+ * Represents an error record if an error is occurred when embedded executor is running.
+ */
+public class EmbeddedExecutorError {
+    private String message;
+    private EmbeddedExecutorError cause;
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    public EmbeddedExecutorError getCause() {
+        return cause;
+    }
+    
+    public void setCause(EmbeddedExecutorError cause) {
+        this.cause = cause;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.ballerinalang.compiler.packaging.converters;
 
 import org.ballerinalang.model.elements.PackageID;
@@ -102,13 +120,14 @@ public class URIConverter implements Converter<URI> {
                     proxy.getUserName(), proxy.getPassword(), RepoUtils.getTerminalWidth(), supportedVersionRange,
                     String.valueOf(isBuild));
             if (execute == 1) {
+                // Package not found
                 return Stream.of();
             } else {
                 Patten patten = binaryRepo.calculate(packageID);
                 return patten.convertToSources(binaryRepo.getConverterInstance(), packageID);
             }
         } catch (Exception e) {
-            outStream.println(isBuild ? "    " : "" + e.getMessage());
+            outStream.println(e.getMessage());
         }
         return Stream.of();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
@@ -97,15 +97,18 @@ public class URIConverter implements Converter<URI> {
             String supportedVersionRange = "?supported-version-range=" + ProgramFileConstants.MIN_SUPPORTED_VERSION +
                     "," + ProgramFileConstants.MAX_SUPPORTED_VERSION;
             EmbeddedExecutor executor = EmbeddedExecutorProvider.getInstance().getExecutor();
-            executor.execute("packaging_pull/packaging_pull.balx", true, u.toString(), destDirPath.toString(),
-                             fullPkgPath, File.separator, proxy.getHost(), proxy.getPort(), proxy.getUserName(),
-                             proxy.getPassword(), RepoUtils.getTerminalWidth(), supportedVersionRange,
-                             String.valueOf(isBuild));
-
-            Patten patten = binaryRepo.calculate(packageID);
-            return patten.convertToSources(binaryRepo.getConverterInstance(), packageID);
+            long execute = executor.execute("packaging_pull/packaging_pull.balx", true, u.toString(),
+                    destDirPath.toString(), fullPkgPath, File.separator, proxy.getHost(), proxy.getPort(),
+                    proxy.getUserName(), proxy.getPassword(), RepoUtils.getTerminalWidth(), supportedVersionRange,
+                    String.valueOf(isBuild));
+            if (execute == 1) {
+                return Stream.of();
+            } else {
+                Patten patten = binaryRepo.calculate(packageID);
+                return patten.convertToSources(binaryRepo.getConverterInstance(), packageID);
+            }
         } catch (Exception e) {
-            outStream.println(isBuild ? "    " : "" + "Error occurred when pulling the remote artifact");
+            outStream.println(isBuild ? "    " : "" + e.getMessage());
         }
         return Stream.of();
     }


### PR DESCRIPTION
## Purpose
> Repository hierarchy is modified to visit system repository before and after visiting central. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/8314.

> Error logs are printed to the console from the ballerina implementation except for package not found as it already gets printed from BLangDiagnosticLog.

## Goals
> Visit system repo before central. Remove package not found log from package_pull ballerina implementation.

## Approach
> Modify package pull ballerina code. Change repo hierarchy.
