### PR TITLE
Track relative file path instead of filename in compilation unit

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
@@ -29,10 +29,18 @@ public class FileSystemSourceInput implements CompilerInput {
 
     @Override
     public String getEntryName() {
-        Path fileName = path.getFileName();
-        return packageRoot != null ?
-                new File(packageRoot.toString()).toURI().relativize(new File(path.toString()).toURI()).getPath() :
-                (fileName != null ? fileName.toString() : path.toString());
+        // For non-default packages, we need to return the file path relative to the package root
+        // This is to distinguish files with the same name but in different folders
+        // For default package, returning only the filename is sufficient
+        if (packageRoot != null) {
+            File pkgRoot = new File(packageRoot.toString());
+            File file = new File(path.toString());
+            // Find the file path relative to the package root
+            return pkgRoot.toURI().relativize(file.toURI()).getPath();
+        } else {
+            Path fileName = path.getFileName();
+            return fileName != null ? fileName.toString() : path.toString();
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
@@ -3,6 +3,7 @@ package org.wso2.ballerinalang.compiler.packaging.converters;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.repository.CompilerInput;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,15 +16,24 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_COM
 public class FileSystemSourceInput implements CompilerInput {
 
     private final Path path;
+    private Path rootPath;
 
+    @Deprecated
     public FileSystemSourceInput(Path path) {
         this.path = path;
+    }
+
+    public FileSystemSourceInput(Path filePath, Path rootPath) {
+        this.path = filePath;
+        this.rootPath = rootPath;
     }
 
     @Override
     public String getEntryName() {
         Path fileName = path.getFileName();
-        return fileName == null ? path.toString() : fileName.toString();
+        return rootPath != null ?
+                new File(rootPath.toString()).toURI().relativize(new File(path.toString()).toURI()).getPath() :
+                (fileName != null ? fileName.toString() : path.toString());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
@@ -18,7 +18,6 @@ public class FileSystemSourceInput implements CompilerInput {
     private final Path path;
     private Path packageRoot;
 
-    @Deprecated
     public FileSystemSourceInput(Path path) {
         this.path = path;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
@@ -16,23 +16,23 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_COM
 public class FileSystemSourceInput implements CompilerInput {
 
     private final Path path;
-    private Path rootPath;
+    private Path packageRoot;
 
     @Deprecated
     public FileSystemSourceInput(Path path) {
         this.path = path;
     }
 
-    public FileSystemSourceInput(Path filePath, Path rootPath) {
+    public FileSystemSourceInput(Path filePath, Path packageRoot) {
         this.path = filePath;
-        this.rootPath = rootPath;
+        this.packageRoot = packageRoot;
     }
 
     @Override
     public String getEntryName() {
         Path fileName = path.getFileName();
-        return rootPath != null ?
-                new File(rootPath.toString()).toURI().relativize(new File(path.toString()).toURI()).getPath() :
+        return packageRoot != null ?
+                new File(packageRoot.toString()).toURI().relativize(new File(path.toString()).toURI()).getPath() :
                 (fileName != null ? fileName.toString() : path.toString());
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -123,7 +123,7 @@ public class PathConverter implements Converter<Path> {
         }
     
         if (Files.isRegularFile(path)) {
-            return Stream.of(new FileSystemSourceInput(path, root));
+            return Stream.of(new FileSystemSourceInput(path, root.resolve(Paths.get(pkgId.name.value))));
         } else {
             return Stream.of();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -123,7 +123,7 @@ public class PathConverter implements Converter<Path> {
         }
     
         if (Files.isRegularFile(path)) {
-            return Stream.of(new FileSystemSourceInput(path));
+            return Stream.of(new FileSystemSourceInput(path, root));
         } else {
             return Stream.of();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 public class PathConverter implements Converter<Path> {
 
     private final Path root;
+    private static final String DEFAULT_PKG_PATH = ".";
 
     public PathConverter(Path root) {
         this.root = root;
@@ -123,7 +124,11 @@ public class PathConverter implements Converter<Path> {
         }
     
         if (Files.isRegularFile(path)) {
-            return Stream.of(new FileSystemSourceInput(path, root.resolve(Paths.get(pkgId.name.value))));
+            return Stream.of(
+                    DEFAULT_PKG_PATH.equals(pkgId.name.value) ?
+                            new FileSystemSourceInput(path) :
+                            new FileSystemSourceInput(path, root.resolve(Paths.get(pkgId.name.value)))
+            );
         } else {
             return Stream.of();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -44,7 +44,6 @@ import java.util.stream.Stream;
 public class PathConverter implements Converter<Path> {
 
     private final Path root;
-    private static final String DEFAULT_PKG_PATH = ".";
 
     public PathConverter(Path root) {
         this.root = root;
@@ -125,7 +124,7 @@ public class PathConverter implements Converter<Path> {
     
         if (Files.isRegularFile(path)) {
             return Stream.of(
-                    DEFAULT_PKG_PATH.equals(pkgId.name.value) ?
+                    Names.DEFAULT_PACKAGE.getValue().equals(pkgId.name.value) ?
                             new FileSystemSourceInput(path) :
                             new FileSystemSourceInput(path, root.resolve(Paths.get(pkgId.name.value)))
             );

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSInMemorySourceEntry.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSInMemorySourceEntry.java
@@ -31,8 +31,8 @@ import java.nio.file.Path;
 class LSInMemorySourceEntry extends FileSystemSourceInput {
 
     private WorkspaceDocumentManager documentManager;
-    LSInMemorySourceEntry(Path path, PackageID pkgId, WorkspaceDocumentManager documentManager) {
-        super(path);
+    LSInMemorySourceEntry(Path path, Path root, PackageID pkgId, WorkspaceDocumentManager documentManager) {
+        super(path, root);
         this.documentManager = documentManager;
     }
 

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSInMemorySourceEntry.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSInMemorySourceEntry.java
@@ -24,6 +24,7 @@ import org.wso2.ballerinalang.compiler.packaging.converters.FileSystemSourceInpu
 
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * LSInMemorySourceEntry.
@@ -32,7 +33,7 @@ class LSInMemorySourceEntry extends FileSystemSourceInput {
 
     private WorkspaceDocumentManager documentManager;
     LSInMemorySourceEntry(Path path, Path root, PackageID pkgId, WorkspaceDocumentManager documentManager) {
-        super(path, root);
+        super(path, root.resolve(Paths.get(pkgId.name.value)));
         this.documentManager = documentManager;
     }
 

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSPathConverter.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSPathConverter.java
@@ -30,15 +30,17 @@ import java.util.stream.Stream;
  */
 public class LSPathConverter extends PathConverter {
     private WorkspaceDocumentManager documentManager;
+    private final Path root;
     
     public LSPathConverter(Path root, WorkspaceDocumentManager documentManager) {
         super(root);
+        this.root = root;
         this.documentManager = documentManager;
     }
 
     @Override
     public Stream<CompilerInput> finalize(Path path, PackageID id) {
         // Returns an In-memory source entry with backing-off capability to read from the FileSystem
-        return Stream.of(new LSInMemorySourceEntry(path, id, documentManager));
+        return Stream.of(new LSInMemorySourceEntry(path, root, id, documentManager));
     }
 }

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSPathConverter.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/workspace/repository/LSPathConverter.java
@@ -30,17 +30,15 @@ import java.util.stream.Stream;
  */
 public class LSPathConverter extends PathConverter {
     private WorkspaceDocumentManager documentManager;
-    private final Path root;
-    
+
     public LSPathConverter(Path root, WorkspaceDocumentManager documentManager) {
         super(root);
-        this.root = root;
         this.documentManager = documentManager;
     }
 
     @Override
     public Stream<CompilerInput> finalize(Path path, PackageID id) {
         // Returns an In-memory source entry with backing-off capability to read from the FileSystem
-        return Stream.of(new LSInMemorySourceEntry(path, root, id, documentManager));
+        return Stream.of(new LSInMemorySourceEntry(path, this.start(), id, documentManager));
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -469,7 +469,7 @@ public class VMDebuggerTest {
 
     @Test(description = "Test debugging when multi-packages available")
     public void testMultiPackage() {
-        String file = "apple.bal";
+        String file = "fruits/apple.bal";
         String packagePath = "abc/fruits:0.0.1";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 9);
 
@@ -487,7 +487,7 @@ public class VMDebuggerTest {
 
     @Test(description = "Test evaluating global variables from other packages")
     public void testEvaluatingOtherPackageGlobalVars() {
-        String file = "apple.bal";
+        String file = "fruits/apple.bal";
         String packagePath = "abc/fruits:0.0.1";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 9);
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -469,7 +469,7 @@ public class VMDebuggerTest {
 
     @Test(description = "Test debugging when multi-packages available")
     public void testMultiPackage() {
-        String file = "fruits/apple.bal";
+        String file = "apple.bal";
         String packagePath = "abc/fruits:0.0.1";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 9);
 
@@ -487,7 +487,7 @@ public class VMDebuggerTest {
 
     @Test(description = "Test evaluating global variables from other packages")
     public void testEvaluatingOtherPackageGlobalVars() {
-        String file = "fruits/apple.bal";
+        String file = "apple.bal";
         String packagePath = "abc/fruits:0.0.1";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(packagePath, file, 9);
 


### PR DESCRIPTION
## Purpose
This PR fixes https://github.com/ballerina-platform/ballerina-lang/issues/8042. Currently, the filename is obtained from the `FileSystemSourceInput`. Changing it to the relative file path from the package root fixes the following issues. 

 Eg: Consider following package structure
```
.
├── .ballerina
├── Ballerina.toml
└──  test
    ├── inside
    │   └── abc.bal    
    ├── main.bal
    └── abc.bal    
```

1. Two files in the same package but different folders logged with the same name when printing errors

Logged errors
```
error: test:0.0.0::abc.bal:6:1: invalid token '}'
error: test:0.0.0::abc.bal:8:1: invalid token '}'
```
2. No way to distinguish the files with same name when debugging

3. Compilation units having the same file name cannot be identified separately

