### PR TITLE
Fix issue related to named arguments in windows in ballerina streams

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/StreamingCodeDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/StreamingCodeDesugar.java
@@ -918,9 +918,10 @@ public class StreamingCodeDesugar extends BLangNodeVisitor {
         BLangFieldBasedAccess nextProcessMethodAccess = createFieldBasedAccessForProcessFunc(window.pos,
                 nextProcessInvokableSymbol, nextProcessSimpleVarRef);
 
+        BLangInvocation invocation = (BLangInvocation) window.getFunctionInvocation();
         BInvokableSymbol windowInvokableSymbol = (BInvokableSymbol) symResolver.
                 resolvePkgSymbol(window.pos, env, names.fromString(STREAMS_STDLIB_PACKAGE_NAME)).
-                scope.lookup(new Name(((BLangInvocation) window.getFunctionInvocation()).name.value)).symbol;
+                scope.lookup(new Name(invocation.name.value)).symbol;
 
         BType windowInvokableType = windowInvokableSymbol.type.getReturnType();
 
@@ -931,12 +932,17 @@ public class StreamingCodeDesugar extends BLangNodeVisitor {
 
         List<BLangExpression> args = new ArrayList<>();
         args.add(nextProcessMethodAccess);
-        args.addAll(((BLangInvocation) window.getFunctionInvocation()).argExprs);
-
+        args.addAll(invocation.argExprs);
         BLangInvocation windowInvocation = ASTBuilderUtil.
                 createInvocationExprForMethod(window.pos, windowInvokableSymbol, args,
                         symResolver);
+
         windowInvocation.argExprs = args;
+        windowInvocation.requiredArgs = invocation.requiredArgs;
+        windowInvocation.requiredArgs.add(0, nextProcessMethodAccess);
+        windowInvocation.restArgs = invocation.restArgs;
+        windowInvocation.namedArgs = invocation.namedArgs;
+
         BLangVariable windowInvokableTypeVariable = ASTBuilderUtil.createVariable(window.pos,
                 getVariableName(WINDOW_FUNC_REFERENCE), windowInvokableType, windowInvocation,
                 windowInvokableTypeVarSymbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1311,6 +1311,17 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         if (!isSiddhiRuntimeEnabled && (isGroupByAvailable || isWindowAvailable)) {
             for (BLangExpression arg : invocationExpr.argExprs) {
                 typeChecker.checkExpr(arg, env);
+                switch (arg.getKind()) {
+                    case NAMED_ARGS_EXPR:
+                        invocationExpr.namedArgs.add(arg);
+                        break;
+                    case REST_ARGS_EXPR:
+                        invocationExpr.restArgs.add(arg);
+                        break;
+                    default:
+                        invocationExpr.requiredArgs.add(arg);
+                        break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Purpose
Fixes #10613 

Consider the below code.
```
from teacherStream window externalTimeBatch(Teacher.timeStamp, 1000, startTime = 1000, timeout = 2000) 
select name, age => (TeacherOutput[] t) {
     outPutStream.publish(t); 
}
```
This is failing in the current implementation because the defaultable arguments are not picked up. This PR fixes the above issue.