### PR TITLE
Fix index out of bound exception when componsating

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -892,7 +892,7 @@ public class CPU {
         List<BClosure> closureVars = fp.getClosureVars();
         if (closureVars.isEmpty()) {
             //compensate functions has no args apart from closure vars, no return as well
-            return BLangFunctions.invokeCallable(functionInfo, ctx, new int[0], new int[0], false);
+            return BLangFunctions.invokeCallable(functionInfo, ctx, new int[0], new int[1], false);
         }
 
         int[] newArgRegs = new int[closureVars.size()];
@@ -937,7 +937,7 @@ public class CPU {
             }
         }
 
-        return BLangFunctions.invokeCallable(functionInfo, ctx, newArgRegs, new int[0], false);
+        return BLangFunctions.invokeCallable(functionInfo, ctx, newArgRegs, new int[1], false);
     }
 
     private static int expandLongRegs(WorkerData sf, BFunctionPointer fp) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Instruction.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Instruction.java
@@ -325,22 +325,23 @@ public class Instruction {
     public static class InstructionCompensate extends Instruction {
         public String scopeName;
         public ArrayList<String> childScopes = new ArrayList<>();
+        public int retRegIndex;
 
-        InstructionCompensate(int opcode, String scopeName, ArrayList<String> childScopes) {
+        InstructionCompensate(int opcode, String scopeName, ArrayList<String> childScopes, int retRegIndex) {
             super(opcode);
             this.scopeName = scopeName;
             this.childScopes = childScopes;
+            this.retRegIndex = retRegIndex;
         }
 
         @Override
-
         public String toString() {
             StringJoiner sj = new StringJoiner(" ");
             sj.add(String.valueOf(scopeName));
             for (String child : childScopes) {
                 sj.add(child);
             }
-            return Mnemonics.getMnem(opcode) + " " + sj.toString();
+            return Mnemonics.getMnem(opcode) + " " + sj.toString() + " " + retRegIndex;
         }
     }
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -252,6 +252,10 @@ public class Mnemonics {
         mnemonics[InstructionCodes.XML2S] = "xml2s";
         mnemonics[InstructionCodes.LOCK] = "lock";
         mnemonics[InstructionCodes.UNLOCK] = "unlock";
+
+        mnemonics[InstructionCodes.SCOPE_END] = "scope_end";
+        mnemonics[InstructionCodes.COMPENSATE] = "compensate";
+        mnemonics[InstructionCodes.LOOP_COMPENSATE] = "loop_compensate";
     }
 
     public static String getMnem(int opcode) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1496,7 +1496,8 @@ public class PackageInfoReader {
                     for (int count = 0; count < childCount; count++) {
                         childScopeMap.add(((UTF8CPEntry) packageInfo.getCPEntry(codeStream.readInt())).getValue());
                     }
-                    packageInfo.addInstruction(new InstructionCompensate(opcode, name, childScopeMap));
+                    int retRegIndex = codeStream.readInt();
+                    packageInfo.addInstruction(new InstructionCompensate(opcode, name, childScopeMap, retRegIndex));
                     break;
                 default:
                     throw new ProgramFileFormatException("unknown opcode " + opcode +

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1384,8 +1384,8 @@ public class CodeGenerator extends BLangNodeVisitor {
         Stack children = childScopesMap.get(compensate.scopeName.getValue());
 
         int i = 0;
-        //scopeName, child count, children
-        Operand[] operands = new Operand[2 + children.size()];
+        //scopeName, child count, children, NIL return
+        Operand[] operands = new Operand[3 + children.size()];
 
         int scopeNameCPIndex = addUTF8CPEntry(currentPkgInfo, compensate.invocation.name.value);
         operands[i++] = getOperand(scopeNameCPIndex);
@@ -1396,6 +1396,8 @@ public class CodeGenerator extends BLangNodeVisitor {
             int childNameCP = currentPkgInfo.addCPEntry(new UTF8CPEntry(childName));
             operands[i++] = getOperand(childNameCP);
         }
+        // compensation block is modeled as an anonymous function, which require a return reg
+        operands[i++] = getRegIndex(TypeTags.NIL);
 
         emit(InstructionCodes.COMPENSATE, operands);
         emit(InstructionCodes.LOOP_COMPENSATE, jumpAddr);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1380,11 +1380,11 @@ public class CodeGenerator extends BLangNodeVisitor {
 
     public void visit(BLangCompensate compensate) {
         Operand jumpAddr = getOperand(nextIP());
-        //Add child function refs
+        // Add child function refs.
         Stack children = childScopesMap.get(compensate.scopeName.getValue());
 
         int i = 0;
-        //scopeName, child count, children, NIL return
+        // Operands: scopeName, child count, children, NIL return.
         Operand[] operands = new Operand[3 + children.size()];
 
         int scopeNameCPIndex = addUTF8CPEntry(currentPkgInfo, compensate.invocation.name.value);
@@ -1396,7 +1396,7 @@ public class CodeGenerator extends BLangNodeVisitor {
             int childNameCP = currentPkgInfo.addCPEntry(new UTF8CPEntry(childName));
             operands[i++] = getOperand(childNameCP);
         }
-        // compensation block is modeled as an anonymous function, which require a return reg
+        // Compensation block is modeled as an anonymous function, which require a return reg.
         operands[i++] = getRegIndex(TypeTags.NIL);
 
         emit(InstructionCodes.COMPENSATE, operands);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangScope.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangScope.java
@@ -25,7 +25,6 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 
 import java.util.Stack;
-import java.util.StringJoiner;
 
 /**
  * Implementation of the Scope block.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangScope.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangScope.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 
 import java.util.Stack;
+import java.util.StringJoiner;
 
 /**
  * Implementation of the Scope block.
@@ -85,5 +86,10 @@ public class BLangScope extends BLangStatement implements ScopeNode {
 
     public void setCompensationFunction(BLangLambdaFunction compensationFunction) {
         this.compensationFunction = compensationFunction;
+    }
+
+    @Override
+    public String toString() {
+        return "scope " + this.name + " {" + this.scopeBody.toString() + "}";
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -242,6 +242,11 @@ public class Mnemonics {
         mnemonics[InstructionCodes.XML2S] = "xml2s";
         mnemonics[InstructionCodes.LOCK] = "lock";
         mnemonics[InstructionCodes.UNLOCK] = "unlock";
+
+        mnemonics[InstructionCodes.SCOPE_END] = "scope_end";
+        mnemonics[InstructionCodes.COMPENSATE] = "compensate";
+        mnemonics[InstructionCodes.LOOP_COMPENSATE] = "loop_compensate";
+
     }
 
     public static String getMnem(int opcode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -246,7 +246,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.SCOPE_END] = "scope_end";
         mnemonics[InstructionCodes.COMPENSATE] = "compensate";
         mnemonics[InstructionCodes.LOOP_COMPENSATE] = "loop_compensate";
-
     }
 
     public static String getMnem(int opcode) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compensation/CompensationsStmtTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compensation/CompensationsStmtTest.java
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License, 
- * Version 2.0 (the "License"); you may not use this file except 
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -18,7 +18,12 @@ package org.ballerinalang.test.statements.compensation;
 
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BRefType;
+import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,5 +52,34 @@ public class CompensationsStmtTest {
     @Test(description = "Test nested scopes and scopes in loops")
     public void compensationStmtTest() {
         Assert.assertEquals(result.getErrorCount(), 0);
+    }
+
+    @Test(description = "Test compensation block execution")
+    public void testCompensationBlockExecution() {
+        Boolean compensateStatus = executeOtherFuncAndGetStatus(true);
+        Assert.assertTrue(compensateStatus);
+
+        compensateStatus = executeOtherFuncAndGetStatus(false);
+        Assert.assertFalse(compensateStatus);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Boolean executeOtherFuncAndGetStatus(boolean doExecCompensate) {
+        BBoolean bCompensate = new BBoolean(doExecCompensate);
+        BValue[] returns = BRunUtil.invoke(result, "OtherFunc", new BValue[]{bCompensate});
+        BMap<String, BRefType> status = (BMap<String, BRefType>) returns[0];
+        return (Boolean) status.get("compensated").value();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(description = "Test compensation block execution of nested scopes")
+    public void testCompensationBlockExecutionNestedScopes() {
+        BValue[] returns = BRunUtil.invoke(result, "testNestedScopes");
+        BMap<String, BRefType> resultMap = (BMap<String, BRefType>) returns[0];
+        Boolean compensatedA = (Boolean) resultMap.get("scopeACompensated").value();
+        Boolean compensatedB = (Boolean) resultMap.get("scopeBCompensated").value();
+
+        Assert.assertTrue(compensatedA, "ScopeA was not compensated");
+        Assert.assertTrue(compensatedB, "Inner ScopeB was not compensated");
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/statements/compensation/compensate-stmt.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/statements/compensation/compensate-stmt.bal
@@ -1,19 +1,55 @@
-function testNestedScopes() returns (int) {
+import ballerina/io;
+
+public type CompensationStatus record {
+    boolean scopeACompensated;
+    boolean scopeBCompensated;
+};
+
+public type R record {
+    boolean compensated;
+};
+
+public function main(string... argv) {
+    var r = testNestedScopes();
+    io:println(r);
+}
+
+function testNestedScopes() returns (CompensationStatus) {
     int a = 2;
+    CompensationStatus st = {scopeACompensated:false, scopeBCompensated:false};
+    CompensationStatus st2 = {scopeACompensated:false, scopeBCompensated:false};
+
 
     scope scopeA {
         scope scopeB {
             string s = "abc";
             a = 5;
         } compensation {
-            //compensate
+            st.scopeACompensated = true;
         }
     } compensation {
-
+        st.scopeBCompensated = true;
     }
     a = 3;
     compensate scopeA;
-    return a;
+    return st;
+}
+
+public function OtherFunc(boolean comp) returns (R) {
+    int b = 0;
+    string s = "s";
+    R status = { compensated: false };
+    scope scp {
+
+    } compensation {
+        s = s + "2";
+        status.compensated = true;
+    }
+    
+    if (comp) {
+        compensate scp;
+    }
+    return status;
 }
 
 function testLoopScopes() returns (int) {
@@ -21,8 +57,8 @@ function testLoopScopes() returns (int) {
 
     int k = 1;
     while (k < 5) {
-        scope scopeA {
-            scope scopeB {
+        scope ScopeA {
+            scope ScopeB {
                 a = 5;
             } compensation {
                 string abc = "abc";
@@ -32,7 +68,7 @@ function testLoopScopes() returns (int) {
         }
         k = k +2;
 
-        compensate scopeA;
+        compensate ScopeA;
     }
     a = 3;
 


### PR DESCRIPTION
## Purpose
This PR fixes the exception that is thrown when compensation action is returning to caller.

## Approach
Compensation block is modeled as a lambda function and when executing it we need to provide the return registry index even though the lambda is a void function.

An index to empty slot from the callers `workerLocal` is passed to the `compensate` instruction.
So that it doesn't overwrite live workerLocals.




