### PR TITLE
Cleanup resources of the native StdLibs when BVM shutting down

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/BLangProgramRunner.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/BLangProgramRunner.java
@@ -18,7 +18,9 @@
 package org.ballerinalang;
 
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.NativeUnitLoader;
 import org.ballerinalang.persistence.RecoveryTask;
+import org.ballerinalang.runtime.threadpool.ThreadPoolFactory;
 import org.ballerinalang.util.codegen.FunctionInfo;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.ProgramFile;
@@ -26,6 +28,8 @@ import org.ballerinalang.util.debugger.Debugger;
 import org.ballerinalang.util.exceptions.BLangUsageException;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.program.BLangFunctions;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
 import static org.ballerinalang.util.cli.ArgumentParser.extractEntryFuncArgs;
@@ -80,6 +84,10 @@ public class BLangProgramRunner {
                     debugger.notifyExit();
                 }
                 BLangFunctions.invokePackageStopFunctions(programFile);
+                // Notify native units
+                NativeUnitLoader.getInstance().notifyAllShutdownHooks(1000L, TimeUnit.MILLISECONDS);
+                // Notify worker executor
+                ThreadPoolFactory.getInstance().getWorkerExecutor().shutdownNow();
             }
         }
         return entryFuncResult;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.docgen.docs;
 
 import org.apache.commons.io.FileUtils;
+import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.config.ConfigRegistry;
@@ -298,12 +299,11 @@ public class BallerinaDocGenerator {
             try {
                 generatePackageDocsFromBallerina(sourceRoot, source, packageFilter, isNative, offline);
 
-            } catch (IOException e) {
+            } catch (IOException | BLangCompilerException e) {
                 out.println(String.format("docerina: API documentation generation failed for %s: %s", source, e
                         .getMessage()));
                 log.error(String.format("API documentation generation failed for %s", source), e);
                 // we continue, as there may be other valid packages.
-                continue;
             }
         }
         return BallerinaDocDataHolder.getInstance().getPackageMap();

--- a/stdlib/task/src/main/java/org/ballerinalang/stdlib/task/timer/Timer.java
+++ b/stdlib/task/src/main/java/org/ballerinalang/stdlib/task/timer/Timer.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.stdlib.task.timer;
 
 import org.ballerinalang.bre.Context;
+import org.ballerinalang.natives.NativeUnitLoader;
 import org.ballerinalang.stdlib.task.SchedulingException;
 import org.ballerinalang.stdlib.task.TaskExecutor;
 import org.ballerinalang.stdlib.task.TaskIdGenerator;
@@ -57,10 +58,13 @@ public class Timer {
         final Runnable schedulerFunc = () -> {
             callTriggerFunction(ctx, onTriggerFunction, onErrorFunction);
         };
-        
         executorService.scheduleWithFixedDelay(schedulerFunc, delay, interval, TimeUnit.MILLISECONDS);
         TaskRegistry.getInstance().addTimer(this);
         //BLangScheduler.workerCountUp();
+        NativeUnitLoader.getInstance().addShutdownHook(() -> {
+            executorService.shutdownNow();
+            return 0;
+        });
     }
 
     /**


### PR DESCRIPTION
## Purpose
Initial issue raised with the `ballerina doc` command where the command breaks when there's a non-package folder in the source root. 

In that case, PackageLoader tries to load `<non-package-folder>` through the ballerina central. This process involves executing `packaging_pull.balx` through the `BLangProgramRunner`. 

Finally, even though we can make to recover from the package not found exception (thrown as `BLangCompilerException`), still the JVM process won't get killed due to non-daemon threads(eg. nioEventLoop) spawned while executing the `packaging_pull.balx`.

Please refer #10568 for a detailed explanation on this.

## Approach
As a solution; implemented a ballerina shutdown hook mechanism to signal native StdLibs to clean up their resources properly. Shutdown hook for the DefaultHttpWsConnectorFactory includes a retry mechanism due to the fact that `DefaultHttpWsConnectorFactory.shutdown()` is not atomic and throws `java.lang.InterruptedException` in some cases; keeping the system in an inconsistent state. Thus, the retry mechanism will make sure all boss, worker and client thread groups closed properly.

This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/10568