### PR TITLE
Allow assigning int literal to float type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -236,6 +236,11 @@ public class TypeChecker extends BLangNodeVisitor {
         BType literalType = symTable.getTypeFromTag(literalExpr.typeTag);
 
         Object literalValue = literalExpr.value;
+        if (TypeTags.FLOAT == expType.tag && TypeTags.INT == literalType.tag) {
+            literalType = symTable.floatType;
+            literalExpr.value = ((Long) literalValue).doubleValue();
+        }
+
         if (TypeTags.BYTE == expType.tag && TypeTags.INT == literalType.tag) {
             if (!isByteLiteralValue((Long) literalValue)) {
                 dlog.error(literalExpr.pos, DiagnosticCode.INCOMPATIBLE_TYPES, expType, literalType);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -305,10 +305,10 @@ public class TypeCastExprTest {
         CompileResult res = BCompileUtil.compile("test-src/expressions/typecast/incompatible-cast-negative.bal");
         Assert.assertEquals(res.getErrorCount(), 5);
         BAssertUtil.validateError(res, 0, "incompatible types: expected 'Person', found 'Student'", 24, 16);
-        BAssertUtil.validateError(res, 1, "incompatible types: expected 'float', found 'int'", 30, 16);
-        BAssertUtil.validateError(res, 2, "incompatible types: expected 'float', found 'int'", 30, 20);
-        BAssertUtil.validateError(res, 3, "incompatible types: expected 'float', found 'int'", 30, 23);
-        BAssertUtil.validateError(res, 4, "incompatible types: expected 'float', found 'int'", 33, 18);
+        BAssertUtil.validateError(res, 1, "incompatible types: expected 'float', found 'int'", 33, 16);
+        BAssertUtil.validateError(res, 2, "incompatible types: expected 'float', found 'int'", 33, 19);
+        BAssertUtil.validateError(res, 3, "incompatible types: expected 'float', found 'int'", 33, 22);
+        BAssertUtil.validateError(res, 4, "incompatible types: expected 'float', found 'int'", 37, 18);
     }
 
     @Test(description = "Test casting a JSON integer to a string")

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
@@ -143,6 +143,14 @@ public class BFloatValueTest {
         Assert.assertEquals(((BFloat) returns[3]).floatValue(), 12.0, "Invalid float value returned.");
     }
 
+    @Test(description = "Test int literal")
+    public void testIntLiteralAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testIntLiteralAssignment");
+        Assert.assertEquals(returns.length, 2);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 12.0, "Invalid float value returned.");
+        Assert.assertEquals(((BFloat) returns[1]).floatValue(), 15.0, "Invalid float value returned.");
+    }
+
     @Test
     public void testIntegerValue() {
         Assert.assertEquals(negativeResult.getErrorCount(), 1);

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typecast/incompatible-cast-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typecast/incompatible-cast-negative.bal
@@ -27,8 +27,12 @@ function testStructToStruct() returns (Person) {
 
 function intToFloatImpCast() {
     float[] numbers;
-    numbers = [999,95,889];
+    int a = 999;
+    int b = 95;
+    int c = 889;
+    numbers = [a, b, c];
     float val1 = 160.0;
     float val2 = <float> 160;
-    float val3 = 160;
+    int d;
+    float val3 = d;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/float/float-value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/float/float-value.bal
@@ -69,3 +69,8 @@ function testHexFloatingPointLiterals() returns (float, float, float, float) {
     float d = 0x3p2;
     return (a, b, c, d);
 }
+
+function testIntLiteralAssignment() returns (float, float) {
+    float x = 12;
+    return (x, 15);
+}


### PR DESCRIPTION
### Purpose
Allow assigning int literal to float type. i.e.
```ballerina
float x = 12; // Valid
```