### PR TITLE
Remove error status code functions

### DIFF
--- a/stdlib/http/src/main/ballerina/http/http_connection.bal
+++ b/stdlib/http/src/main/ballerina/http/http_connection.bal
@@ -94,10 +94,11 @@ public type Connection object {
 
     # Sends the outbound response to the caller with the status 201 Created.
     #
+    # + uri - Represents the most specific URI for the newly created resource
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ByteChannel`
     #             or `mime:Entity[]`. This message is optional.
     # + return - Returns an `error` if failed to respond
-    public function created(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
+    public function created(string uri, Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
                                                                                             returns error?;
 
     # Sends the outbound response to the caller with the status 202 Accepted.
@@ -107,29 +108,6 @@ public type Connection object {
     # + return - Returns an `error` if failed to respond
     public function accepted(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
                                                                                             returns error?;
-
-    # Sends the outbound response to the caller with the status 204 No Content. If the given response contains a body
-    # that will be removed.
-    #
-    # + message - Outbound response is optional
-    # + return - Returns an `error` if failed to respond
-    public function noContent(Response|() message = ()) returns error?;
-
-    # Sends the outbound response to the caller with the status 400 Bad Request.
-    #
-    # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ByteChannel`
-    #             or `mime:Entity[]`. This message is optional.
-    # + return - Returns an `error` if failed to respond
-    public function badRequest(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
-                                                                                                returns error?;
-
-    # Sends the outbound response to the caller with the status 500 Internal Server Error.
-    #
-    # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ByteChannel`
-    #             or `mime:Entity[]`. This message is optional.
-    # + return - Returns an `error` if failed to respond
-    public function internalServerError(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
-                                                                                                        returns error?;
 };
 
 extern function nativeRespond(Connection connection, Response response) returns error?;
@@ -197,10 +175,13 @@ function Connection::ok(Response|string|xml|json|byte[]|io:ByteChannel|mime:Enti
     return self.respond(response);
 }
 
-function Connection::created(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
+function Connection::created(string uri, Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
                                                                                             returns error? {
     Response response = buildResponse(message);
     response.statusCode = CREATED_201;
+    if (uri.length() > 0) {
+        response.setHeader(LOCATION, uri);
+    }
     return self.respond(response);
 }
 
@@ -208,29 +189,5 @@ function Connection::accepted(Response|string|xml|json|byte[]|io:ByteChannel|mim
                                                                                             returns error? {
     Response response = buildResponse(message);
     response.statusCode = ACCEPTED_202;
-    return self.respond(response);
-}
-
-function Connection::noContent(Response|() message = ()) returns error? {
-    Response newResponse = new;
-    match message {
-        () => {}
-        Response response => {newResponse = response;}
-    }
-    newResponse.statusCode = NO_CONTENT_204;
-    return self.respond(newResponse);
-}
-
-function Connection::badRequest(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
-                                                                                            returns error? {
-    Response response = buildResponse(message);
-    response.statusCode = BAD_REQUEST_400;
-    return self.respond(response);
-}
-
-function Connection::internalServerError(Response|string|xml|json|byte[]|io:ByteChannel|mime:Entity[]|() message = ())
-                                                                                            returns error? {
-    Response response = buildResponse(message);
-    response.statusCode = INTERNAL_SERVER_ERROR_500;
     return self.respond(response);
 }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpStatusCodeTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpStatusCodeTestCase.java
@@ -65,8 +65,8 @@ public class HttpStatusCodeTestCase extends HttpBaseTest {
         assertEquals(response.getResponseCode(), 201, "Response code mismatched");
         assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
-        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString())
-                , newResourceURI, "Incorrect location header value");
+        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString()), newResourceURI,
+                "Incorrect location header value");
         assertEquals(response.getData(), "Created Response", "Message content mismatched");
     }
 
@@ -75,8 +75,8 @@ public class HttpStatusCodeTestCase extends HttpBaseTest {
         HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
                 "code/createdWithoutBody"));
         assertEquals(response.getResponseCode(), 201, "Response code mismatched");
-        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString())
-                , newResourceURI, "Incorrect location header value");
+        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString()), newResourceURI,
+                "Incorrect location header value");
         assertEquals(response.getData(), "", "Message body should be empty");
     }
 
@@ -85,8 +85,8 @@ public class HttpStatusCodeTestCase extends HttpBaseTest {
         HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
                 "code/createdWithEmptyURI"));
         assertEquals(response.getResponseCode(), 201, "Response code mismatched");
-        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString())
-                , null, "No location header should be received");
+        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString()), null,
+                "No location header should be received");
         assertEquals(response.getData(), "", "Message body should be empty");
     }
 

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpStatusCodeTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpStatusCodeTestCase.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertEquals;
 public class HttpStatusCodeTestCase extends HttpBaseTest {
 
     private final int servicePort = 9223;
+    private final String newResourceURI = "/newResourceURI";
 
     @Test(description = "Test ballerina ok() function with entity body")
     public void testOKWithBody() throws IOException {
@@ -64,6 +65,8 @@ public class HttpStatusCodeTestCase extends HttpBaseTest {
         assertEquals(response.getResponseCode(), 201, "Response code mismatched");
         assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString())
+                , newResourceURI, "Incorrect location header value");
         assertEquals(response.getData(), "Created Response", "Message content mismatched");
     }
 
@@ -72,6 +75,18 @@ public class HttpStatusCodeTestCase extends HttpBaseTest {
         HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
                 "code/createdWithoutBody"));
         assertEquals(response.getResponseCode(), 201, "Response code mismatched");
+        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString())
+                , newResourceURI, "Incorrect location header value");
+        assertEquals(response.getData(), "", "Message body should be empty");
+    }
+
+    @Test(description = "Test ballerina created() function with an empty URI")
+    public void testCreatedWithEmptyURI() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
+                "code/createdWithEmptyURI"));
+        assertEquals(response.getResponseCode(), 201, "Response code mismatched");
+        assertEquals(response.getHeaders().get(HttpHeaderNames.LOCATION.toString())
+                , null, "No location header should be received");
         assertEquals(response.getData(), "", "Message body should be empty");
     }
 
@@ -91,57 +106,5 @@ public class HttpStatusCodeTestCase extends HttpBaseTest {
                 "code/acceptedWithoutBody"));
         assertEquals(response.getResponseCode(), 202, "Response code mismatched");
         assertEquals(response.getData(), "", "Message body should be empty");
-    }
-
-    @Test(description = "Test ballerina noContent() function with entity body")
-    public void testNoContentWithBody() throws IOException {
-        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
-                "code/noContentWithBody"));
-        assertEquals(response.getResponseCode(), 204, "Response code mismatched");
-        assertEquals(response.getHeaders().get("x-custom-header")
-                , "custom-header-value", "Content-Type mismatched");
-        assertEquals(response.getData(), "", "Message body should be empty");
-    }
-
-    @Test(description = "Test ballerina noContent() function without entity body")
-    public void testNoContentWithoutBody() throws IOException {
-        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
-                "code/noContentWithoutBody"));
-        assertEquals(response.getResponseCode(), 204, "Response code mismatched");
-        assertEquals(response.getData(), "", "Message body should be empty");
-    }
-
-    @Test(description = "Test ballerina badRequest() function with entity body")
-    public void testBadRequestWithBody() throws IOException {
-        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
-                "code/badRequestWithBody"));
-        assertEquals(response.getResponseCode(), 400, "Response code mismatched");
-        assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
-                , TestConstant.CONTENT_TYPE_XML, "Content-Type mismatched");
-        assertEquals(response.getData(), "<test>Bad Request</test>", "Message content mismatched");
-    }
-
-    @Test(description = "Test ballerina badRequest() function without entity body", expectedExceptions =
-            IOException.class, expectedExceptionsMessageRegExp = "Server returned HTTP response code: 400 .*")
-    public void testBadRequestWithoutBody() throws IOException {
-        HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort, "code/badRequestWithoutBody"), true);
-    }
-
-    @Test(description = "Test ballerina badRequest() function with entity body")
-    public void testInternalServerErrWithBody() throws IOException {
-        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
-                "code/serverErrWithBody"));
-        assertEquals(response.getResponseCode(), 500, "Response code mismatched");
-        assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
-                , TestConstant.CONTENT_TYPE_XML, "Content-Type mismatched");
-        assertEquals(response.getData(), "<test>Internal Server Error Occurred</test>",
-                "Message content mismatched");
-    }
-
-    @Test(description = "Test ballerina badRequest() function without entity body",
-            expectedExceptions = IOException.class, expectedExceptionsMessageRegExp =
-            "Server returned HTTP response code: 500 .*")
-    public void testInternalServerErrWithoutBody() throws IOException {
-        HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort, "code/serverErrWithoutBody"), true);
     }
 }

--- a/tests/ballerina-integration-test/src/test/resources/http/httpservices/http-status-codes.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http/httpservices/http-status-codes.bal
@@ -42,7 +42,7 @@ service<http:Service> differentStatusCodes bind {port : 9223} {
         path:"/createdWithBody"
     }
     sendCreatedWithBody (endpoint caller, http:Request req) {
-        _ = caller -> created(message = "Created Response");
+        _ = caller -> created("/newResourceURI", message = "Created Response");
     }
 
     @http:ResourceConfig {
@@ -50,7 +50,15 @@ service<http:Service> differentStatusCodes bind {port : 9223} {
         path:"/createdWithoutBody"
     }
     sendCreatedWithoutBody (endpoint caller, http:Request req) {
-        _ = caller -> created();
+        _ = caller -> created("/newResourceURI");
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/createdWithEmptyURI"
+    }
+    sendCreatedWithEmptyURI (endpoint caller, http:Request req) {
+        _ = caller -> created("");
     }
 
     @http:ResourceConfig {
@@ -67,58 +75,5 @@ service<http:Service> differentStatusCodes bind {port : 9223} {
     }
     sendAcceptedWithoutBody (endpoint caller, http:Request req) {
         _ = caller -> accepted();
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/noContentWithBody"
-    }
-    sendNoContentWithBody (endpoint caller, http:Request req) {
-        http:Response res = new;
-        res.setHeader("x-custom-header", "custom-header-value");
-        res.setPayload(xml `<test>No Content</test>`);
-        _ = caller -> noContent(message = res); //Body will be removed
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/noContentWithoutBody"
-    }
-    sendNoContentWithoutBody (endpoint caller, http:Request req) {
-        _ = caller -> noContent();
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/badRequestWithBody"
-    }
-    sendBadRequestWithBody (endpoint caller, http:Request req) {
-        http:Response res = new;
-        res.setPayload(xml `<test>Bad Request</test>`);
-        _ = caller -> badRequest(message = res);
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/badRequestWithoutBody"
-    }
-    sendBadRequestWithoutBody (endpoint caller, http:Request req) {
-        _ = caller -> badRequest();
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/serverErrWithBody"
-    }
-    sendServerErrWithBody (endpoint caller, http:Request req) {
-        _ = caller -> internalServerError(message = xml `<test>Internal Server Error Occurred</test>`);
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/serverErrWithoutBody"
-    }
-    sendServerErrWithoutBody (endpoint caller, http:Request req) {
-        _ = caller -> internalServerError();
     }
 }

--- a/tests/ballerina-integration-test/src/test/resources/http/httpservices/http-status-codes.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http/httpservices/http-status-codes.bal
@@ -17,63 +17,63 @@
 import ballerina/http;
 
 @http:ServiceConfig {
-    basePath:"/code"
+    basePath: "/code"
 }
-service<http:Service> differentStatusCodes bind {port : 9223} {
+service<http:Service> differentStatusCodes bind { port: 9223 } {
 
     @http:ResourceConfig {
-        methods:["GET"],
-        path:"/okWithBody"
+        methods: ["GET"],
+        path: "/okWithBody"
     }
-    sendOKWithBody (endpoint caller, http:Request req) {
+    sendOKWithBody(endpoint caller, http:Request req) {
         _ = caller->ok("OK Response");
     }
 
     @http:ResourceConfig {
-        methods:["GET"],
-        path:"/okWithoutBody"
+        methods: ["GET"],
+        path: "/okWithoutBody"
     }
-    sendOKWithoutBody (endpoint caller, http:Request req) {
+    sendOKWithoutBody(endpoint caller, http:Request req) {
         _ = caller->ok(());
     }
 
     @http:ResourceConfig {
-        methods:["GET"],
-        path:"/createdWithBody"
+        methods: ["GET"],
+        path: "/createdWithBody"
     }
-    sendCreatedWithBody (endpoint caller, http:Request req) {
-        _ = caller -> created("/newResourceURI", message = "Created Response");
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/createdWithoutBody"
-    }
-    sendCreatedWithoutBody (endpoint caller, http:Request req) {
-        _ = caller -> created("/newResourceURI");
+    sendCreatedWithBody(endpoint caller, http:Request req) {
+        _ = caller->created("/newResourceURI", message = "Created Response");
     }
 
     @http:ResourceConfig {
-        methods:["GET"],
-        path:"/createdWithEmptyURI"
+        methods: ["GET"],
+        path: "/createdWithoutBody"
     }
-    sendCreatedWithEmptyURI (endpoint caller, http:Request req) {
-        _ = caller -> created("");
-    }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/acceptedWithBody"
-    }
-    sendAcceptedWithBody (endpoint caller, http:Request req) {
-        _ = caller -> accepted(message = {msg : "accepted response"});
+    sendCreatedWithoutBody(endpoint caller, http:Request req) {
+        _ = caller->created("/newResourceURI");
     }
 
     @http:ResourceConfig {
-        methods:["GET"],
-        path:"/acceptedWithoutBody"
+        methods: ["GET"],
+        path: "/createdWithEmptyURI"
     }
-    sendAcceptedWithoutBody (endpoint caller, http:Request req) {
-        _ = caller -> accepted();
+    sendCreatedWithEmptyURI(endpoint caller, http:Request req) {
+        _ = caller->created("");
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/acceptedWithBody"
+    }
+    sendAcceptedWithBody(endpoint caller, http:Request req) {
+        _ = caller->accepted(message = { msg: "accepted response" });
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/acceptedWithoutBody"
+    }
+    sendAcceptedWithoutBody(endpoint caller, http:Request req) {
+        _ = caller->accepted();
     }
 }


### PR DESCRIPTION
## Purpose
> Remove noContent(), badRequest() and internalServerError() functions from connection actions and introduce a mandatory parameter for the created action to accept the most specific newly created resource URI.

## Automation tests
 - Integration tests
   > Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
>
```ballerina
// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
//
// WSO2 Inc. licenses this file to you under the Apache License,
// Version 2.0 (the "License"); you may not use this file except
// in compliance with the License.
// You may obtain a copy of the License at
//
// http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing,
// software distributed under the License is distributed on an
// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
// KIND, either express or implied.  See the License for the
// specific language governing permissions and limitations
// under the License.

import ballerina/http;

@http:ServiceConfig {
    basePath:"/code"
}
service<http:Service> differentStatusCodes bind {port : 9223} {

    @http:ResourceConfig {
        methods:["GET"],
        path:"/okWithBody"
    }
    sendOKWithBody (endpoint caller, http:Request req) {
        _ = caller->ok("OK Response");
    }

    @http:ResourceConfig {
        methods:["GET"],
        path:"/okWithoutBody"
    }
    sendOKWithoutBody (endpoint caller, http:Request req) {
        _ = caller->ok(());
    }

    @http:ResourceConfig {
        methods:["GET"],
        path:"/createdWithBody"
    }
    sendCreatedWithBody (endpoint caller, http:Request req) {
        _ = caller -> created("/newResourceURI", message = "Created Response");
    }

    @http:ResourceConfig {
        methods:["GET"],
        path:"/createdWithoutBody"
    }
    sendCreatedWithoutBody (endpoint caller, http:Request req) {
        _ = caller -> created("/newResourceURI");
    }

    @http:ResourceConfig {
        methods:["GET"],
        path:"/createdWithEmptyURI"
    }
    sendCreatedWithEmptyURI (endpoint caller, http:Request req) {
        _ = caller -> created("");
    }

    @http:ResourceConfig {
        methods:["GET"],
        path:"/acceptedWithBody"
    }
    sendAcceptedWithBody (endpoint caller, http:Request req) {
        _ = caller -> accepted(message = {msg : "accepted response"});
    }

    @http:ResourceConfig {
        methods:["GET"],
        path:"/acceptedWithoutBody"
    }
    sendAcceptedWithoutBody (endpoint caller, http:Request req) {
        _ = caller -> accepted();
    }
}
```
