### PR TITLE
Fix else if node arrow overlapping in diagram

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1276,9 +1276,6 @@ class SizingUtil {
         const viewState = node.viewState;
         const components = viewState.components;
         const dropZoneHeight = TreeUtil.isBlock(node.parent) ? this.config.statement.gutter.v : 0;
-        const parentBlockGutter = ((node.elseStatement) &&
-            (node.elseStatement.statements) &&
-            (node.elseStatement.statements.length > 0)) ? this.config.statement.height : 0;
         const nodeBodyViewState = node.body.viewState;
 
         // flow chart if width and height is different to normal block node width and height
@@ -1307,7 +1304,7 @@ class SizingUtil {
         viewState.components['statement-box'].w = bodyWidth;
         viewState.bBox.h = viewState.components['statement-box'].h +
             viewState.components['drop-zone'].h +
-            components['block-header'].h + parentBlockGutter;
+            components['block-header'].h + this.config.statement.height;
         viewState.bBox.w = bodyWidth;
 
         components['block-header'].setOpaque(true);


### PR DESCRIPTION
## Purpose
> Fixed if/else/else if arrow overlapping issue

**_Issue:_**

![image](https://user-images.githubusercontent.com/7569427/46340887-693da400-c654-11e8-890e-0d6221adc63b.png)

![image](https://user-images.githubusercontent.com/7569427/46340906-7a86b080-c654-11e8-9dc0-308cbc074fd5.png)

**_Solution:_**

![image](https://user-images.githubusercontent.com/7569427/46340948-9b4f0600-c654-11e8-9a45-a6e45c9ed210.png)

![image](https://user-images.githubusercontent.com/7569427/46340934-8c685380-c654-11e8-89ef-a3ae10f6be08.png)

## Related PRs
> #10527