### PR TITLE
Enabled vsode build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8.9.0
   - nvm use 8.9.0
-  - mvn install -B -V -pl '!tool-plugins/vscode'
+  - mvn install -B -V
 
 script: echo "Done"
 


### PR DESCRIPTION
## Purpose
> Tested the travis build by re-enabling the vscode build. 
> And it seems we couldn't reproduced the earlier build failure and tried 5 times on re-building the source. 