### PR TITLE
Improve assertions

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/EndpointTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/EndpointTest.java
@@ -37,17 +37,17 @@ public class EndpointTest {
         CompileResult testEndpointsInFunction = BCompileUtil.compile("test-src/endpoint/testEndpointInFunction.bal");
 
         BValue[] returns = BRunUtil.invoke(testEndpointsInFunction, "test1");
-        Assert.assertTrue(returns.length == 1);
+        Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "init:DummyEndpoint;start:DummyEndpoint;" +
                 "getClient:DummyEndpoint;invoke1:DummyClient;getClient:DummyEndpoint;invoke2:DummyClient;t2");
 
         returns = BRunUtil.invoke(testEndpointsInFunction, "test2");
-        Assert.assertTrue(returns.length == 1);
+        Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "init:DummyEndpoint;start:DummyEndpoint;<test2Caller>" +
                 "getClient:DummyEndpoint;invoke1:DummyClient;getClient:DummyEndpoint;invoke2:DummyClient;t2");
 
         returns = BRunUtil.invoke(testEndpointsInFunction, "test3");
-        Assert.assertTrue(returns.length == 1);
+        Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "<test3>init:DummyEndpoint;start:DummyEndpoint;" +
                 "getClient:DummyEndpoint;invoke1:DummyClient;getClient:DummyEndpoint;invoke2:DummyClient;t2");
 
@@ -63,7 +63,7 @@ public class EndpointTest {
         CompileResult testEndpointsInFunction = BCompileUtil.compile("test-src/endpoint/testEndpointWithService.bal");
 
         BValue[] returns = BRunUtil.invoke(testEndpointsInFunction, "test1");
-        Assert.assertTrue(returns.length == 1);
+        Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "init:DummyEndpoint;register:DummyEndpoint;start:DummyEndpoint;" +
                 "<test1>");
     }
@@ -73,7 +73,7 @@ public class EndpointTest {
         CompileResult testEndpointsInFunction = BCompileUtil.compile("test-src/endpoint/test_anonymous_endpoint.bal");
 
         BValue[] returns = BRunUtil.invoke(testEndpointsInFunction, "test1");
-        Assert.assertTrue(returns.length == 1);
+        Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "init:DummyEndpoint;register:DummyEndpoint;start:DummyEndpoint;" +
                 "<test1>");
     }
@@ -120,5 +120,4 @@ public class EndpointTest {
         BAssertUtil.validateError(compileResult, 0, "action invocation as an expression not allowed here", 25, 9);
         BAssertUtil.validateError(compileResult, 1, "action invocation as an expression not allowed here", 27, 17);
     }
-
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/AnnotationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/AnnotationTest.java
@@ -35,13 +35,13 @@ public class AnnotationTest {
     @Test
     public void testSensitive() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSensitiveNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 39);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 3, 50);
     }
@@ -49,14 +49,14 @@ public class AnnotationTest {
     @Test
     public void testSensitiveDefaultArgs() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-default-args.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSensitiveDefaultArgsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-default-args-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 56);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 3, 81);
     }
@@ -64,23 +64,23 @@ public class AnnotationTest {
     @Test
     public void testSensitiveRestArgs() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-rest-args.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSensitiveRestArgsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-rest-args-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 30);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 3, 29);
     }
 
     @Test
-    public void testSensitiveRestParamsWithVaryingInvocationArgs () {
+    public void testSensitiveRestParamsWithVaryingInvocationArgs() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-rest-params-with-varying-invocation-args.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class AnnotationTest {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/" +
                         "sensitive-rest-params-with-varying-invocation-args-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'restParams'", 2, 46);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'restParams'", 3, 68);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'restParams'", 4, 82);
@@ -98,7 +98,7 @@ public class AnnotationTest {
     public void testSensitiveDefaultParamsWithUnorderedArgs() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-default-params-with-unordered-args.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class AnnotationTest {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/" +
                         "sensitive-default-params-with-unordered-args-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'defaultableInput2'", 2, 43);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'defaultableInput2'", 3, 61);
     }
@@ -115,7 +115,7 @@ public class AnnotationTest {
     @Test
     public void testTainted() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/tainted.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 20);
     }
 
@@ -124,7 +124,6 @@ public class AnnotationTest {
     @Test
     public void testUntainted() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/untainted.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
-
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ConflictTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ConflictTest.java
@@ -35,14 +35,14 @@ public class ConflictTest {
     @Test
     public void testRecursion() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/recursion.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testRecursionWithinAttachedExternalFunctions() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/recursions/recursion-within-attached-external-function.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     // Test cyclic function invocations.
@@ -50,6 +50,6 @@ public class ConflictTest {
     @Test
     public void testCyclicCall() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/cyclic-call.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/RecursionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/RecursionTest.java
@@ -34,14 +34,14 @@ public class RecursionTest {
     public void testRecursiveFunctionCallingSensitiveFunction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "recursive-function-calling-sensitive-function.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testRecursiveFunctionCallingSensitiveFunctionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "recursive-function-calling-sensitive-function-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'inputData'", 2, 21);
     }
 
@@ -49,7 +49,7 @@ public class RecursionTest {
     public void testRecursiveFunctionAlteringSensitiveStatusCallingSensitiveFunction1Negative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "cyclic-call-altering-sensitive-status-calling-sensitive-function-1-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 12, 20);
     }
 
@@ -57,14 +57,14 @@ public class RecursionTest {
     public void testRecursiveFunctionAlteringSensitiveStatusCallingSensitiveFunction2Negative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "cyclic-call-altering-sensitive-status-calling-sensitive-function-2-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 18, 20);
     }
 
     @Test
     public void testMultipleRecursionsNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/multiple-recursions.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 17, 20);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -32,26 +32,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testReturn() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/returns.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testReturnNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/returns-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 20);
     }
 
     @Test
     public void testVariable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/variables.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testVariableNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/variables-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 5, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 9, 20);
     }
@@ -59,26 +59,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testReceiver() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/receiver.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testReceiverNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/receiver-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 3, 20);
     }
 
     @Test
     public void testRecord() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/record.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testRecordNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/record-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 8);
+        Assert.assertEquals(result.getDiagnostics().length, 8);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 9, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 13, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 17, 20);
@@ -92,13 +92,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testArray() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/array.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testArrayNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/array-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 6);
+        Assert.assertEquals(result.getDiagnostics().length, 6);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 4, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 13, 20);
@@ -110,13 +110,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testJson() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/json.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testJsonNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/json-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 8);
+        Assert.assertEquals(result.getDiagnostics().length, 8);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 4, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 12, 20);
@@ -130,13 +130,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testMap() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/map.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMapNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/map-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 8);
+        Assert.assertEquals(result.getDiagnostics().length, 8);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 4, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 12, 20);
@@ -150,13 +150,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testXML() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/xml.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testXMLNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/xml-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 5);
+        Assert.assertEquals(result.getDiagnostics().length, 5);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 7, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 10, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 13, 20);
@@ -167,26 +167,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testBasicWorker() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/basic-worker.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testBasicWorkerNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/basic-worker-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 3, 24);
     }
 
     @Test
     public void testIfCondition() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/if-condition.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testIfConditionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/if-condition-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 16, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 24, 20);
@@ -196,13 +196,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testTernaryExpr() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/ternary.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTernaryExprNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/ternary-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 3, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 6, 20);
     }
@@ -210,19 +210,19 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testLambda() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/lambda.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTupleReturn() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/tuple-return.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTupleReturnNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/tuple-return-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 6, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 7, 20);
     }
@@ -230,26 +230,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testStringTemplate() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/string-template.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testStringTemplateNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/string-template-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 4, 20);
     }
 
     @Test
     public void testIterable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/iterable.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testIterableNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/iterable-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 3, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 5, 59);
     }
@@ -257,14 +257,14 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testIterableWitinIterable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/iterable-within-iterable.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testIterableWitinIterableNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/iterable-within-iterable-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 7, 40);
         BAssertUtil.validateError(result, 1, "tainted value passed to global variable 'globalVar'", 10, 34);
     }
@@ -272,13 +272,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testForEach() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/foreach.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testForEachNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/foreach-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 5, 24);
     }
 
@@ -286,27 +286,27 @@ public class TaintedStatusPropagationTest {
     public void testMultipleInvocationLevels() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/multiple-invocation-levels.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMultipleInvocationLevelsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/multiple-invocation-levels-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'normalInput'", 2, 20);
     }
 
     @Test
     public void testCast() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/cast.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCastNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/cast-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 4, 20);
     }
 
@@ -314,14 +314,14 @@ public class TaintedStatusPropagationTest {
     public void testChainedInvocations() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/chained-invocations.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testChainedInvocationsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/chained-invocations-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 2, 20);
     }
 
@@ -329,34 +329,34 @@ public class TaintedStatusPropagationTest {
     public void testWithoutUserDataNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/without-user-data-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 7, 20);
     }
 
     @Test
     public void testGlobalVariables() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/global-variables.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testGlobalVariablesNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/global-variables-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to global variable 'globalVariable'", 12, 5);
     }
 
     @Test
     public void testServiceVariables() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/service-level-variables.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testServiceVariablesNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/service-level-variables-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to global variable 'serviceLevelVariable'", 19, 9);
         BAssertUtil.validateError(result, 1, "tainted value passed to global variable 'globalLevelVariable'", 20, 9);
     }
@@ -364,7 +364,7 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testHttpService() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/http-service.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 16, 24);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 17, 24);
     }
@@ -372,14 +372,14 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testCompoundAssignment() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/compound-assignment.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCompoundAssignmentNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/compound-assignment-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 5, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 9, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 14, 20);
@@ -388,13 +388,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testMatch() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/match.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMatchNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/match-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 7, 28);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 12, 28);
     }
@@ -402,13 +402,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testObjectFunction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/object-functions.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testObjectFunctionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/object-functions-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 14, 20);
     }
 
@@ -416,14 +416,14 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testObjectExternalFunction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/object-external-functions.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testObjectExternalFunctionNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/object-external-functions-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 16, 20);
     }
 
@@ -431,28 +431,28 @@ public class TaintedStatusPropagationTest {
     public void testObjectFunctionWithConstructor() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/object-functions-with-constructor.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testObjectFunctionWithConstructorNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/object-functions-with-constructor-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 20, 20);
     }
 
     @Test
     public void testSimpleWorkerInteraction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/simple-worker-interaction.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSimpleWorkerInteractionNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 11, 24);
     }
 
@@ -460,7 +460,7 @@ public class TaintedStatusPropagationTest {
     public void testSimpleBlockedWorkerInteractionNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 5, 24);
     }
 
@@ -468,41 +468,41 @@ public class TaintedStatusPropagationTest {
     public void testSimpleWorkerInteractionWithTupleAssignment() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-with-tuple-assignment.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSimpleWorkerInteractionWithTupleAssignmentNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "simple-worker-interaction-with-tuple-assignment-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 13, 24);
     }
 
     @Test
     public void testForkJoin() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/fork-join.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testForkJoinNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/fork-join-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 10, 24);
     }
 
     @Test
     public void testInOutParameters() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/in-out-param-basic.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testInOutParametersNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "in-out-param-basic-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 5);
+        Assert.assertEquals(result.getDiagnostics().length, 5);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 28, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'secureIn'", 32, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 36, 20);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/UntaintTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/UntaintTest.java
@@ -45,13 +45,13 @@ public class UntaintTest {
     @Test
     public void testUntaint() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/expressions/untaint.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testUntaintVariable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/expressions/untaint-variable-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'secureIn'", 5, 20);
     }
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/HttpClientTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/HttpClientTest.java
@@ -32,13 +32,13 @@ public class HttpClientTest {
     @Test
     public void testHttpClient() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/httpclient.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testHttpClientNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/httpclient-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'headerName'", 13, 19);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'path'", 15, 42);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'secureIn'", 21, 37);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -32,13 +32,13 @@ public class IOTest {
     @Test
     public void testCharacterIO() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/character-io.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCharacterIONegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/character-io-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'path'", 9, 54);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'numberOfChars'", 16, 31);
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'sensitiveValue'", 19,

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/SQLTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/SQLTest.java
@@ -34,14 +34,14 @@ public class SQLTest {
     public void testSelectWithUntaintedQuery() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-untainted-query.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSelectWithTaintedQueryNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-tainted-query-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'args'", 4, 40);
     }
 
@@ -50,14 +50,14 @@ public class SQLTest {
     public void testSelectWithUntaintedQueryProducingTaintedReturn() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSelectWithUntaintedQueryProducingTaintedReturnNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'anyValue'", 28, 50);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
@@ -176,7 +176,7 @@ public class BMapValueTest {
     @Test(description = "Testing map value access in variableDefStmt")
     void testInvalidGrammar1() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/map/map-value-validator-1-negative.bal");
-        Assert.assertTrue(compileResult.getDiagnostics().length == 1);
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "incompatible types: expected 'string', found 'any'");
     }
@@ -184,7 +184,7 @@ public class BMapValueTest {
     @Test(description = "Testing map value access in assignStmt")
     void testInvalidGrammar2() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/map/map-value-validator-2-negative.bal");
-        Assert.assertTrue(compileResult.getDiagnostics().length == 1);
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "incompatible types: expected 'string', found 'any'");
     }
@@ -192,7 +192,7 @@ public class BMapValueTest {
     @Test(description = "Testing map value access in binary expression")
     void testInvalidGrammar3() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/map/map-value-validator-3-negative.bal");
-        Assert.assertTrue(compileResult.getDiagnostics().length == 1);
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "operator '+' not defined for 'any' and 'int'");
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
@@ -90,7 +90,7 @@ public class MapAccessExprTest {
     @Test(description = "Test nested map access")
     public void testNestedMapAccess() {
         CompileResult incorrectCompileResult = BCompileUtil.compile("test-src/types/map/nested-map-access.bal");
-        Assert.assertTrue(incorrectCompileResult.getDiagnostics().length == 2);
+        Assert.assertEquals(incorrectCompileResult.getDiagnostics().length, 2);
         Assert.assertEquals(incorrectCompileResult.getDiagnostics()[0].getMessage(),
                 "invalid operation: type 'any' does not support field access");
         Assert.assertEquals(incorrectCompileResult.getDiagnostics()[1].getMessage(),
@@ -195,7 +195,7 @@ public class MapAccessExprTest {
         Assert.assertEquals(((BBoolean) returns[1]).value(), new Boolean(false));
         Assert.assertEquals(((BBoolean) returns[2]).value(), new Boolean(false));
     }
-    
+
     @Test(description = "Test concurrent map access.")
     public void testMapConcurrentAccess() {
         BValue[] args = {};
@@ -206,7 +206,7 @@ public class MapAccessExprTest {
 
         Assert.assertEquals(((BInteger) returns[0]).value(), new Long(1));
     }
-    
+
     @Test(description = "Test concurrent map get keys.")
     public void testConcurrentMapGetKeys() {
         BValue[] args = {};


### PR DESCRIPTION
## Purpose
This PR simplifies assertions where `Assert.assertTrue()` has been used. Without this simplification, values are compared 2 times as well.

1. returns.length == X
2. Assert.assertTrue

This can be simplified by using `Assert.assertEquals()`.

One other advantage is that we get more meaningful error message like `Expected X but got Y`. Otherwise we will get `Expected true but got false` where we cannot directly see what are the values which are being compared.