### PR TITLE
Fix VSCode debugger does not exit on errors

### DIFF
--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -107,7 +107,8 @@
                         "properties": {
                             "script": {
                                 "type": "string",
-                                "default": "${file}"
+                                "default": "${file}",
+                                "description": "Path of the script that need to be executed (e.g. ${workspaceRoot}/main.bal)"
                             },
                             "debugServerTimeout": {
                                 "type": "integer",

--- a/tool-plugins/vscode/src/debugger/index.ts
+++ b/tool-plugins/vscode/src/debugger/index.ts
@@ -295,8 +295,8 @@ export class BallerinaDebugSession extends LoggingDebugSession {
             });
 
             debugServer.stderr.on('data', (data) => {
-                if (`${data}`.indexOf('compilation contains errors') > -1) {
-                    this.terminate('Failed to compile.');
+                if (`${data}`.startsWith("error:")) {
+                    this.terminate(`${data}`);
                 } else {
                     this.sendEvent(new OutputEvent(`${data}`));
                 }


### PR DESCRIPTION
## Purpose
> For the launch.json we `"script": "${file}"` element as the script path. Most of the time when we are in **wrong script**(that doesn't have a main function) or when we are in **another file**(such as launch.json); VSCode Debug fails with following errors;
> ```
> error: cannot find package '.vscode'
> error: cannot find package '.ballerina'
> ```
> This PR fixes;
> 1. VSCode debugger not terminated when ballerina run command fails with errors. 
> 2. Added a description for the script parameter to let the ordinary users know that a **main ballerina script** can be configured through; `script : {workspaceRoot}/main.bal` configuration in `launch.json`.
> 
> Thus this PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/10661