### PR TITLE
Add script arguments and command options for VSCode launch.json

### DIFF
--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -109,6 +109,8 @@
                                 "type": "string",
                                 "default": "${file}"
                             },
+                            "scriptArguments": [],
+                            "commandOptions": [],
                             "debugServerTimeout": {
                                 "type": "integer",
                                 "default": 5000,

--- a/tool-plugins/vscode/src/debugger/index.ts
+++ b/tool-plugins/vscode/src/debugger/index.ts
@@ -37,6 +37,8 @@ interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
 
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     script: string;
+    scriptArguments: Array<string>;
+    commandOptions: Array<string>;
     'ballerina.home': string; 
 }
 
@@ -233,6 +235,8 @@ export class BallerinaDebugSession extends LoggingDebugSession {
         }
 
         const openFile = args.script;
+        const scriptArguments = args.scriptArguments;
+        const commandOptions = args.commandOptions;
         let cwd : string | undefined = path.dirname(openFile);
         let debugTarget = path.basename(openFile);
         this._sourceRoot = cwd;
@@ -272,10 +276,24 @@ export class BallerinaDebugSession extends LoggingDebugSession {
                 return;
             }
             this._debugPort = port.toString();
-            let debugServer;
-            debugServer = this._debugServer = spawn(
+
+            let executableArgs: Array<string> = ["run"];
+            executableArgs.push('--debug');
+            executableArgs.push(<string>this._debugPort);
+
+            if (Array.isArray(commandOptions) && commandOptions.length) {
+                executableArgs = executableArgs.concat(commandOptions);
+            }
+
+            executableArgs.push(<string>this._debugTarget);
+
+            if (Array.isArray(scriptArguments) && scriptArguments.length) {
+                executableArgs = executableArgs.concat(scriptArguments);
+            }
+
+            let debugServer = this._debugServer = spawn(
                 executable,
-                ['run', '--debug', <string> this._debugPort, <string> this._debugTarget],
+                executableArgs,
                 { cwd }
             );
 


### PR DESCRIPTION
## Purpose
Need to allow adding **ballerina defined command options** such as **--observe, --config, -e** etc., and **user-defined program arguments** into the `run` or `debug` command.

This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/10662

## Samples
```yaml
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "ballerina",
            "request": "launch",
            "name": "Ballerina Debug",
            "script": "${file}",
            "scriptArguments": ["foo", "bar"],
            "commandOptions": ["-e", "b7a.log.level=DEBUG"]
        },
        {
            "type": "ballerina",
            "request": "attach",
            "name": "Ballerina Remote Debug",
            "host": "127.0.0.1",
            "port": 5000
        }
    ]
}
```