### PR TITLE
Fix isOpen value being incorrect at occasions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2223,7 +2223,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.234</transport.http.version>
+        <transport.http.version>6.0.236</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketClientConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketClientConnectorListener.java
@@ -75,4 +75,8 @@ public class WebSocketClientConnectorListener implements WebSocketConnectorListe
         WebSocketDispatcher.dispatchIdleTimeout(connectionInfo);
     }
 
+    @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        WebSocketUtil.setListenerOpenField(connectionInfo);
+    }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -255,6 +255,7 @@ public class WebSocketDispatcher {
 
     static void dispatchCloseMessage(WebSocketOpenConnectionInfo connectionInfo,
                                      WebSocketCloseMessage closeMessage) {
+        WebSocketUtil.setListenerOpenField(connectionInfo);
         WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
         WebSocketService wsService = connectionInfo.getService();
         Resource onCloseResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_CLOSE);
@@ -301,6 +302,7 @@ public class WebSocketDispatcher {
     }
 
     static void dispatchError(WebSocketOpenConnectionInfo connectionInfo, Throwable throwable) {
+        WebSocketUtil.setListenerOpenField(connectionInfo);
         WebSocketService webSocketService = connectionInfo.getService();
         Resource onErrorResource = webSocketService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_ERROR);
         if (isUnexpectedError(throwable)) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketServerConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketServerConnectorListener.java
@@ -66,7 +66,7 @@ public class WebSocketServerConnectorListener implements WebSocketConnectorListe
         HttpResource onUpgradeResource = wsService.getUpgradeResource();
         if (onUpgradeResource != null) {
             webSocketHandshaker.getHttpCarbonRequest().setProperty(HttpConstants.RESOURCES_CORS,
-                    onUpgradeResource.getCorsHeaders());
+                                                                   onUpgradeResource.getCorsHeaders());
             Resource balResource = onUpgradeResource.getBalResource();
             BValue[] signatureParams = HttpDispatcher.getSignatureParameters(onUpgradeResource, webSocketHandshaker
                     .getHttpCarbonRequest(), httpEndpointConfig);
@@ -157,13 +157,19 @@ public class WebSocketServerConnectorListener implements WebSocketConnectorListe
     @Override
     public void onMessage(WebSocketCloseMessage webSocketCloseMessage) {
         WebSocketDispatcher.dispatchCloseMessage(
-                connectionManager.removeConnectionInfo(getConnectionId(webSocketCloseMessage)), webSocketCloseMessage);
+                connectionManager.getConnectionInfo(getConnectionId(webSocketCloseMessage)), webSocketCloseMessage);
+    }
+
+    @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        WebSocketUtil.setListenerOpenField(
+                connectionManager.removeConnectionInfo(webSocketConnection.getChannelId()));
     }
 
     @Override
     public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
         WebSocketDispatcher.dispatchError(
-                connectionManager.removeConnectionInfo(webSocketConnection.getChannelId()), throwable);
+                connectionManager.getConnectionInfo(webSocketConnection.getChannelId()), throwable);
     }
 
     @Override

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -189,6 +189,11 @@ public class WebSocketUtil {
 
     }
 
+    public static void setListenerOpenField(WebSocketOpenConnectionInfo connectionInfo) {
+        connectionInfo.getWebSocketEndpoint().put(WebSocketConstants.LISTENER_IS_OPEN_FIELD,
+                                                  new BBoolean(connectionInfo.getWebSocketConnection().isOpen()));
+    }
+
     private WebSocketUtil() {
     }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Close.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Close.java
@@ -21,7 +21,6 @@ import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
 import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
@@ -30,6 +29,7 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.WebSocketConstants;
 import org.ballerinalang.net.http.WebSocketOpenConnectionInfo;
+import org.ballerinalang.net.http.WebSocketUtil;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 
 import java.util.concurrent.CountDownLatch;
@@ -65,7 +65,7 @@ public class Close implements NativeCallableUnit {
                 initiateConnectionClosure(context, statusCode, reason, connectionInfo, countDownLatch);
         waitForTimeout(context, timeoutInSecs, countDownLatch);
         closeFuture.channel().close().addListener(future -> {
-            connectionInfo.getWebSocketEndpoint().put(WebSocketConstants.LISTENER_IS_OPEN_FIELD, new BBoolean(false));
+            WebSocketUtil.setListenerOpenField(connectionInfo);
             callback.notifySuccess();
         });
 

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/IsOpenTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/IsOpenTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.service.websocket;
+
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.net.URISyntaxException;
+
+/**
+ * Test the value of isOpen in different situations.
+ * (Uses the isOpen.bal file)
+ */
+@Test(groups = "websocket-test")
+public class IsOpenTest extends WebSocketTestCommons {
+
+    private WebSocketTestClient client;
+    private static final String URL = "ws://localhost:9078";
+    private LogLeecher logLeecher;
+
+    @Test(description = "Test isOpen when close is called")
+    public void testIsOpenCloseCalled() throws InterruptedException, BallerinaTestException, URISyntaxException {
+        String expectingErrorLog = "In onText isOpen false";
+        logLeecher = new LogLeecher(expectingErrorLog);
+        serverInstance.addLogLeecher(logLeecher);
+        client = new WebSocketTestClient(URL);
+        client.handshake();
+        client.sendText("Hello World!!");
+        logLeecher.waitForText(TIMEOUT_IN_SECS * 1000);
+    }
+
+    @Test(description = "Test isOpen when a close frame is received")
+    public void testIsOpenCloseFrameReceived() throws InterruptedException, BallerinaTestException, URISyntaxException {
+        String expectingErrorLog = "In onClose isOpen true";
+        logLeecher = new LogLeecher(expectingErrorLog);
+        serverInstance.addLogLeecher(logLeecher);
+        client = new WebSocketTestClient(URL);
+        client.handshake();
+        client.sendCloseFrameWithoutCloseCode();
+        logLeecher.waitForText(TIMEOUT_IN_SECS * 1000);
+    }
+
+    @Test(description = "Test isOpen in onError resource")
+    public void testCloseInOnError() throws InterruptedException, BallerinaTestException, URISyntaxException {
+        String expectingErrorLog = "In onError isOpen false";
+        logLeecher = new LogLeecher(expectingErrorLog);
+        serverInstance.addLogLeecher(logLeecher);
+        client = new WebSocketTestClient(URL);
+        client.handshake();
+        client.sendCorruptedFrame();
+        logLeecher.waitForText(TIMEOUT_IN_SECS * 1000);
+    }
+
+    @AfterMethod
+    public void shutDown() throws InterruptedException {
+        client.shutDown();
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
@@ -43,10 +43,10 @@ public class WebSocketTestCommons extends BaseTest {
     @BeforeGroups(value = "websocket-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
         int[] requiredPorts = new int[]{
-                9079, 9081, 9082, 9083, 9084, 9085, 9086, 9087, 9088, 9089, 9090, 9091, 9092, 9093, 9094, 9095, 9096,
-                9097, 9098, 9099, 9100};
+                9078, 9079, 9081, 9082, 9083, 9084, 9085, 9086, 9087, 9088, 9089, 9090, 9091, 9092, 9093, 9094, 9095,
+                9096, 9097, 9098, 9099, 9100};
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
-                "websocket").getAbsolutePath();
+                                          "websocket").getAbsolutePath();
         serverInstance = new BServerInstance(balServer);
         serverInstance.startServer(balFile, "wsservices", requiredPorts);
     }

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -150,6 +150,7 @@
             <class name="org.ballerinalang.test.service.websocket.ClientInitializationFailureTest"/>
             <class name="org.ballerinalang.test.service.websocket.ClientCloseTest"/>
             <class name="org.ballerinalang.test.service.websocket.PushTextFailureTest"/>
+            <class name="org.ballerinalang.test.service.websocket.IsOpenTest"/>
         </classes>
     </test>
 

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/isOpen.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/isOpen.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+http:WebSocketListener listener;
+
+@http:WebSocketServiceConfig {
+    path: "/"
+}
+service<http:WebSocketService> isOpen bind { port: 9078 } {
+    onOpen(endpoint caller){
+        listener = untaint caller;
+    }
+
+    onText(endpoint caller, string text) {
+        _ = caller->close(timeoutInSecs = 0);
+        io:println("In onText isOpen " + caller.isOpen);
+    }
+
+    onClose(endpoint caller, int code, string reason) {
+        io:println("In onClose isOpen " + caller.isOpen);
+    }
+
+    onError(endpoint caller, error err) {
+        io:println("In onError isOpen " + caller.isOpen);
+    }
+}


### PR DESCRIPTION
## Purpose
This makes sure the value for `isOpen` is set correctly. Also makes sure that the connectionInfo is removed from the map correctly whenever the channel becomes inactive.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/10667
Related PR: https://github.com/wso2/transport-http/pull/265