### PR TITLE
Avoid activating extension on every vscode startup

### DIFF
--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -21,7 +21,8 @@
         "Debuggers"
     ],
     "activationEvents": [
-        "*"
+        "onLanguage:ballerina",
+        "onCommand:ballerina.showExamples"
     ],
     "contributes": {
         "languages": [

--- a/tool-plugins/vscode/src/core/ballerina-extension.ts
+++ b/tool-plugins/vscode/src/core/ballerina-extension.ts
@@ -58,8 +58,8 @@ class BallerinaExtension {
         this.context = context;
     }
 
-    init(): Promise<BallerinaExtension> {
-        return new Promise((resolve, reject) => {
+    init(): void {
+        try {
             // Register pre init handlers.
             this.registerPreInitHandlers();
 
@@ -71,8 +71,7 @@ class BallerinaExtension {
                     // Ballerina home in setting is invalid show message and quit.
                     // Prompt to correct the home. // TODO add auto ditection.
                     this.showMessageInvalidBallerinaHome();
-                    // Return error
-                    reject();
+                    return;
                 }
             } else {
                 // If ballerina home is not set try to auto ditect ballerina home.
@@ -81,7 +80,7 @@ class BallerinaExtension {
                 if (!this.ballerinaHome) {
                     this.showMessageInstallBallerina();
                     log("Unable to auto ditect ballerina home.");
-                    reject();
+                    return;
                 }
             }
 
@@ -100,7 +99,6 @@ class BallerinaExtension {
             const disposeDidChange = this.langClient.onDidChangeState(stateChangeEvent => {
                 if (stateChangeEvent.newState === LS_STATE.Stopped) {
                     this.showPluginActivationError();
-                    reject();
                 }
             });
 
@@ -109,9 +107,19 @@ class BallerinaExtension {
             this.langClient.onReady().then(fullfilled => {
                 disposeDidChange.dispose();
                 this.context!.subscriptions.push(disposable);
-                resolve();
             });
-        });
+        } catch {
+            // If any failure occurs while intializing show an error messege
+            this.showPluginActivationError();
+        }
+    }
+
+    onReady(): Promise<void> {
+        if (!this.langClient) {
+            return Promise.reject('BallerinaExtension is not initialized');
+        }
+
+        return this.langClient.onReady();
     }
 
     showPluginActivationError(): any {

--- a/tool-plugins/vscode/src/examples/index.ts
+++ b/tool-plugins/vscode/src/examples/index.ts
@@ -25,67 +25,80 @@ import BallerinaExtension from '../core/ballerina-extension';
 
 let examplesPanel: WebviewPanel | undefined;
 
-export function activate(context: ExtensionContext, langClient: ExtendedLangClient) {
-    const { experimental } = langClient.initializeResult!.capabilities;
-    const serverProvidesExamples = experimental && experimental.examplesProvider;
-
-    if (!serverProvidesExamples) {
-        commands.registerCommand('ballerina.showExamples', () => {
-            BallerinaExtension.showMessageServerMissingCapability();
-        });
+function showExamples(context: ExtensionContext, langClient: ExtendedLangClient) :void {
+    if (examplesPanel) {
         return;
     }
-
-	const examplesListRenderer = commands.registerCommand('ballerina.showExamples', () => {
-		if (examplesPanel) {
-			return;
-		}
-		// Create and show a new webview
-        examplesPanel = window.createWebviewPanel(
-            'ballerinaExamples',
-            "Ballerina Examples",
-            { viewColumn: ViewColumn.One, preserveFocus: false } ,
-            {
-				enableScripts: true,
-				retainContextWhenHidden: true,
-			}
-        );
-        WebViewRPCHandler.create([
-			{
-				methodName: 'getExamples',
-				handler: (args: any[]) => {
-					return langClient.fetchExamples();
-				}
-            }], 
-            examplesPanel.webview
-        );
-        const html = render(context, langClient);
-		if (examplesPanel && html) {
-			examplesPanel.webview.html = html;
-		}
-        
-		// Handle messages from the webview
-        examplesPanel.webview.onDidReceiveMessage(message => {
-            switch (message.command) {
-                case 'openExample':
-                    const url = JSON.parse(message.url);
-                    const ballerinaHome = BallerinaExtension.getBallerinaHome();
-                    if (ballerinaHome) {
-                        const folderPath = path.join(ballerinaHome, 'docs', 'examples', url);
-                        const filePath = path.join(folderPath, `${url.replace(/-/g, '_')}.bal`);
-                        workspace.openTextDocument(Uri.file(filePath)).then(doc => {
-                            window.showTextDocument(doc);
-                         }); 
-                    }
-                    break;
-                default: 
+    // Create and show a new webview
+    examplesPanel = window.createWebviewPanel(
+        'ballerinaExamples',
+        "Ballerina Examples",
+        { viewColumn: ViewColumn.One, preserveFocus: false } ,
+        {
+            enableScripts: true,
+            retainContextWhenHidden: true,
+        }
+    );
+    WebViewRPCHandler.create([
+        {
+            methodName: 'getExamples',
+            handler: (args: any[]) => {
+                return langClient.fetchExamples();
             }
-		});
-		examplesPanel.onDidDispose(() => {
-			examplesPanel = undefined;
+        }], 
+        examplesPanel.webview
+    );
+    const html = render(context, langClient);
+    if (examplesPanel && html) {
+        examplesPanel.webview.html = html;
+    }
+    
+    // Handle messages from the webview
+    examplesPanel.webview.onDidReceiveMessage(message => {
+        switch (message.command) {
+            case 'openExample':
+                const url = JSON.parse(message.url);
+                const ballerinaHome = BallerinaExtension.getBallerinaHome();
+                if (ballerinaHome) {
+                    const folderPath = path.join(ballerinaHome, 'docs', 'examples', url);
+                    const filePath = path.join(folderPath, `${url.replace(/-/g, '_')}.bal`);
+                    workspace.openTextDocument(Uri.file(filePath)).then(doc => {
+                        window.showTextDocument(doc);
+                     }); 
+                }
+                break;
+            default: 
+        }
+    });
+    examplesPanel.onDidDispose(() => {
+        examplesPanel = undefined;
+    });
+}
+
+export function activate(context: ExtensionContext, langClient: ExtendedLangClient) {
+    const examplesListRenderer = commands.registerCommand('ballerina.showExamples', () => {
+        BallerinaExtension.onReady()
+        .then(() => {
+            const { experimental } = langClient.initializeResult!.capabilities;
+            const serverProvidesExamples = experimental && experimental.examplesProvider;
+
+            if (!serverProvidesExamples) {
+                BallerinaExtension.showMessageServerMissingCapability();
+                return;
+            }
+
+            showExamples(context, langClient);
+        })
+		.catch((e) => {
+			if (!BallerinaExtension.isValidBallerinaHome()) {
+				BallerinaExtension.showMessageInvalidBallerinaHome();
+			} else {
+				BallerinaExtension.showPluginActivationError();
+			}
 		});
     });
-	context.subscriptions.push(examplesListRenderer);
+    
+    context.subscriptions.push(examplesListRenderer);
 }
 
 

--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -23,7 +23,7 @@ import {
 } from 'vscode';
 import { } from 'vscode-debugadapter';
 import { BallerinaPluginConfig, getPluginConfig } from './config';
-import { activate as activateRenderer, errored as rendererErrored } from './renderer';
+import { activate as activateRenderer } from './renderer';
 import { activate as activateSamples } from './examples';
 import BallerinaExtension from './core/ballerina-extension';
 
@@ -46,22 +46,10 @@ const debugConfigResolver: DebugConfigurationProvider = {
 export function activate(context: ExtensionContext): void {
 
 	BallerinaExtension.setContext(context);
-	BallerinaExtension.init()
-		.then(success => {
-			// start the features.
-			activateRenderer(context, BallerinaExtension.langClient!);
-			activateSamples(context, BallerinaExtension.langClient!);
-		}, () => {
-			// If home is not valid show error on design page.
-			if (!BallerinaExtension.isValidBallerinaHome()) {
-				rendererErrored(context);
-			}
-			BallerinaExtension.showPluginActivationError();
-		})
-		.catch(error => {
-			// unknown error
-			BallerinaExtension.showPluginActivationError();
-		});
+	BallerinaExtension.init();
+	// start the features.
+	activateRenderer(context, BallerinaExtension.langClient!);
+	activateSamples(context, BallerinaExtension.langClient!);
 
 	/*if (!config.debugLog) {
 		clientOptions.outputChannel = dropOutputChannel;

--- a/tool-plugins/vscode/src/renderer/content-provider.ts
+++ b/tool-plugins/vscode/src/renderer/content-provider.ts
@@ -1,7 +1,0 @@
-import { Uri } from "vscode";
-
-export class StaticProvider {
-    provideTextDocumentContent(uri: Uri) {
-        return require(`.${uri.path}`);
-    }
-}

--- a/tool-plugins/vscode/src/renderer/index.ts
+++ b/tool-plugins/vscode/src/renderer/index.ts
@@ -18,7 +18,6 @@
  */
 import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent, Position, Range, Selection } from 'vscode';
 import * as _ from 'lodash';
-import { StaticProvider } from './content-provider';
 import { render } from './renderer';
 import { BallerinaAST, ExtendedLangClient } from '../lang-client';
 import { WebViewRPCHandler } from '../utils';
@@ -41,20 +40,11 @@ function updateWebView(ast: BallerinaAST, docUri: Uri, stale: boolean): void {
 	}
 }
 
-export function activate(context: ExtensionContext, langClient: ExtendedLangClient) {
-	const { experimental } = langClient.initializeResult!.capabilities;
-	const serverProvidesAST = experimental && experimental.astProvider;
-
-    if (!serverProvidesAST) {
-        commands.registerCommand('ballerina.showDiagram', () => {
-            BallerinaExtension.showMessageServerMissingCapability();
-        });
-        return;
-    }
-
-	workspace.onDidChangeTextDocument(_.debounce((e: TextDocumentChangeEvent) => {
-        if (activeEditor && (e.document === activeEditor.document) &&
-            e.document.fileName.endsWith('.bal')) {
+function showDiagramEditor(context: ExtensionContext, langClient: ExtendedLangClient): void {
+	const didChangeDisposable = workspace.onDidChangeTextDocument(
+			_.debounce((e: TextDocumentChangeEvent) => {
+		if (activeEditor && (e.document === activeEditor.document) &&
+			e.document.fileName.endsWith('.bal')) {
 			if (preventDiagramUpdate) {
 				return;
 			}
@@ -70,7 +60,8 @@ export function activate(context: ExtensionContext, langClient: ExtendedLangClie
 		}
 	}, DEBOUNCE_WAIT));
 
-	window.onDidChangeActiveTextEditor((activatedEditor: TextEditor | undefined) => {
+	const changeActiveEditorDisposable =  window.onDidChangeActiveTextEditor(
+			(activatedEditor: TextEditor | undefined) => {
 		if (window.activeTextEditor && activatedEditor 
 					&& (activatedEditor.document === window.activeTextEditor.document) 
 					&& activatedEditor.document.fileName.endsWith('.bal')) {
@@ -87,96 +78,109 @@ export function activate(context: ExtensionContext, langClient: ExtendedLangClie
 		}
 	});
 
-	const diagramRenderDisposable = commands.registerCommand('ballerina.showDiagram', () => {
-		if (previewPanel) {
-			previewPanel.reveal(ViewColumn.Two, true);
-			return;
+	if (previewPanel) {
+		previewPanel.reveal(ViewColumn.Two, true);
+		return;
+	}
+	// Create and show a new webview
+	previewPanel = window.createWebviewPanel(
+		'ballerinaDiagram',
+		"Ballerina Diagram",
+		{ viewColumn: ViewColumn.Two, preserveFocus: true } ,
+		{
+			enableScripts: true,
+			retainContextWhenHidden: true,
 		}
-		// Create and show a new webview
-        previewPanel = window.createWebviewPanel(
-            'ballerinaDiagram',
-            "Ballerina Diagram",
-            { viewColumn: ViewColumn.Two, preserveFocus: true } ,
-            {
-				enableScripts: true,
-				retainContextWhenHidden: true,
+	);
+	const editor = window.activeTextEditor;
+	if(!editor) {
+		return;
+	}
+	activeEditor = editor;
+	WebViewRPCHandler.create([
+		{
+			methodName: 'getAST',
+			handler: (args: any[]) => {
+				return langClient.getAST(args[0]);
 			}
-		);
-		const editor = window.activeTextEditor;
-		if(!editor) {
-            return "";
-		}
-		activeEditor = editor;
-		WebViewRPCHandler.create([
-			{
-				methodName: 'getAST',
-				handler: (args: any[]) => {
-					return langClient.getAST(args[0]);
-				}
-			},
-			{
-				methodName: 'getEndpoints',
-				handler: (args: any[]) => {
-					return langClient.getEndpoints();
-				}
-			},
-			{
-				methodName: 'parseFragment',
-				handler: (args: any[]) => {
-					return langClient.parseFragment({
-						enclosingScope: args[0].enclosingScope,
-						expectedNodeType: args[0].expectedNodeType,
-						source: args[0].source
-					});
-				}
-			},
-			{
-				methodName: 'revealRange',
-				handler: (args: any[]) => {
-					if (activeEditor) {
-						const start = new Position(args[0] - 1, args[1] - 1);
-						const end = new Position(args[2] - 1, args[3]);
-						activeEditor.revealRange(new Range(start, end));
-						activeEditor.selection = new Selection(start, end);
-					}
-					return Promise.resolve();
-				}
+		},
+		{
+			methodName: 'getEndpoints',
+			handler: (args: any[]) => {
+				return langClient.getEndpoints();
 			}
-		], previewPanel.webview);
-		const html = render(context, langClient, editor.document.uri);
-		if (previewPanel && html) {
-			previewPanel.webview.html = html;
+		},
+		{
+			methodName: 'parseFragment',
+			handler: (args: any[]) => {
+				return langClient.parseFragment({
+					enclosingScope: args[0].enclosingScope,
+					expectedNodeType: args[0].expectedNodeType,
+					source: args[0].source
+				});
+			}
+		},
+		{
+			methodName: 'revealRange',
+			handler: (args: any[]) => {
+				if (activeEditor) {
+					const start = new Position(args[0] - 1, args[1] - 1);
+					const end = new Position(args[2] - 1, args[3]);
+					activeEditor.revealRange(new Range(start, end));
+					activeEditor.selection = new Selection(start, end);
+				}
+				return Promise.resolve();
+			}
 		}
-		// Handle messages from the webview
-        previewPanel.webview.onDidReceiveMessage(message => {
-            switch (message.command) {
-				case 'astModified':
-					if (activeEditor && activeEditor.document.fileName.endsWith('.bal')) {
-						preventDiagramUpdate = true;
-						const ast = JSON.parse(message.ast);
-						langClient.triggerASTDidChange(ast, activeEditor.document.uri)
-							.then(() => {
-								preventDiagramUpdate = false;
-							});	
-					}
-                    return;
-            }
-		}, undefined, context.subscriptions);
-		previewPanel.onDidDispose(() => {
-			previewPanel = undefined;
-		});
-    });
-	context.subscriptions.push(diagramRenderDisposable);
+	], previewPanel.webview);
+	const html = render(context, langClient, editor.document.uri);
+	if (previewPanel && html) {
+		previewPanel.webview.html = html;
+	}
+	// Handle messages from the webview
+	previewPanel.webview.onDidReceiveMessage(message => {
+		switch (message.command) {
+			case 'astModified':
+				if (activeEditor && activeEditor.document.fileName.endsWith('.bal')) {
+					preventDiagramUpdate = true;
+					const ast = JSON.parse(message.ast);
+					langClient.triggerASTDidChange(ast, activeEditor.document.uri)
+						.then(() => {
+							preventDiagramUpdate = false;
+						});	
+				}
+				return;
+		}
+	}, undefined, context.subscriptions);
+
+	previewPanel.onDidDispose(() => {
+		previewPanel = undefined;
+		didChangeDisposable.dispose();
+		changeActiveEditorDisposable.dispose();
+	});
 }
 
-export function errored(context: ExtensionContext) {
-	const provider = new StaticProvider();
-	let registration = workspace.registerTextDocumentContentProvider('ballerina-static', provider);
-
+export function activate(context: ExtensionContext, langClient: ExtendedLangClient) {
 	const diagramRenderDisposable = commands.registerCommand('ballerina.showDiagram', () => {
-		let uri = Uri.parse('ballerina-static:///resources/pages/error.html');
-		commands.executeCommand('vscode.previewHtml', uri, ViewColumn.Two, 'Ballerina Diagram');
+		return BallerinaExtension.onReady()
+		.then(() => {
+			const { experimental } = langClient.initializeResult!.capabilities;
+			const serverProvidesAST = experimental && experimental.astProvider;
+
+			if (!serverProvidesAST) {
+				BallerinaExtension.showMessageServerMissingCapability();
+				return {};
+			}
+			showDiagramEditor(context, langClient);
+		})
+		.catch((e) => {
+			if (!BallerinaExtension.isValidBallerinaHome()) {
+				BallerinaExtension.showMessageInvalidBallerinaHome();
+			} else {
+				BallerinaExtension.showPluginActivationError();
+			}
+		});
 	});
 
-	context.subscriptions.push(diagramRenderDisposable, registration);
+	context.subscriptions.push(diagramRenderDisposable);
 }


### PR DESCRIPTION
## Purpose

Activate only when opening a ballerina file or running ballerina.showExamples command
As we need to register the showExamples command before language server client is ready we now activate features at extension activation. Features must only use language client after the ballerina extension is ready.

Fixes #10684