### PR TITLE
Fix channels with json keys, key value ordering issue

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/channels/ChannelRegistry.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/channels/ChannelRegistry.java
@@ -17,6 +17,7 @@
 package org.ballerinalang.channels;
 
 import org.ballerinalang.bre.bvm.WorkerExecutionContext;
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 
 import java.util.HashMap;
@@ -59,7 +60,14 @@ public class ChannelRegistry {
         //add channel if absent
         addChannel(channel);
         Map<String, LinkedList<PendingContext>> channelEntries = channelList.get(channel);
-        String keyVal = key != null ? key.stringValue() : null;
+        String keyVal = null;
+        if (key != null) {
+            if (key instanceof BMap) {
+                keyVal = DatabaseUtils.sortBMap(((BMap) key).getMap());
+            } else {
+                keyVal = key.stringValue();
+            }
+        }
         LinkedList<PendingContext> ctxList = channelEntries.computeIfAbsent(keyVal,
                 bValue -> new LinkedList<>());
 
@@ -79,7 +87,14 @@ public class ChannelRegistry {
     public PendingContext pollOnChannel(String channel, BValue key) {
         //add channel if absent
         addChannel(channel);
-        String keyVal = key != null ? key.stringValue() : null;
+        String keyVal = null;
+        if (key != null) {
+            if (key instanceof BMap) {
+                keyVal = DatabaseUtils.sortBMap(((BMap) key).getMap());
+            } else {
+                keyVal = key.stringValue();
+            }
+        }
         LinkedList<PendingContext> pendingCtxs = channelList.get(channel).get(keyVal);
         if (pendingCtxs != null) {
             return pendingCtxs.poll();

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/channels/DatabaseUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/channels/DatabaseUtils.java
@@ -340,8 +340,7 @@ public class DatabaseUtils {
      */
     public static String sortBMap(LinkedHashMap map) {
 
-        TreeMap<String, String> result =
-                new TreeMap<>();
+        TreeMap<String, String> result = new TreeMap<>();
         result.putAll(map);
         return result.toString();
     }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/channels/DatabaseUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/channels/DatabaseUtils.java
@@ -29,6 +29,7 @@ import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BByte;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -41,7 +42,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.TreeMap;
 
 /**
  * Utility methods for storing/fetching channel messages.
@@ -66,12 +69,12 @@ public class DatabaseUtils {
             stmt = con.prepareStatement(ChannelConstants.INSERT);
             stmt.setString(1, channelName);
             if (keyType != null) {
-                setParam(stmt, key, keyType, 2);
+                setParam(stmt, key, keyType, 2, true);
             } else {
                 stmt.setNull(2, Types.VARCHAR);
             }
 
-            setParam(stmt, value, valType, 3);
+            setParam(stmt, value, valType, 3, false);
             stmt.execute();
         } catch (SQLException e) {
             throw new BallerinaException("error in saving received channel message " + e.getMessage(), e);
@@ -100,7 +103,7 @@ public class DatabaseUtils {
 
             if (keyType != null) {
                 prpStmt = con.prepareStatement(ChannelConstants.SELECT);
-                setParam(prpStmt, key, keyType, 2);
+                setParam(prpStmt, key, keyType, 2, true);
             } else {
                 prpStmt = con.prepareStatement(ChannelConstants.SELECT_NULL);
             }
@@ -299,7 +302,8 @@ public class DatabaseUtils {
 
     }
 
-    private static void setParam(PreparedStatement stmt, BValue value, BType bType, int index) throws SQLException {
+    private static void setParam(PreparedStatement stmt, BValue value, BType bType, int index, boolean isKey)
+            throws SQLException {
 
         int type = bType.getTag();
 
@@ -320,7 +324,25 @@ public class DatabaseUtils {
                 stmt.setByte(index, ((BByte) value).byteValue());
                 break;
             default:
-                stmt.setString(index, value.toString());
+                if (isKey && value instanceof BMap) {
+                    stmt.setString(index, sortBMap(((BMap) value).getMap()));
+                } else {
+                    stmt.setString(index, value.toString());
+                }
+
         }
+    }
+
+    /**
+     * Sort a given map to the keys' order and return string value of the map.
+     * @param map the map to be sorted
+     * @return string value of the sorted map
+     */
+    public static String sortBMap(LinkedHashMap map) {
+
+        TreeMap<String, String> result =
+                new TreeMap<>();
+        result.putAll(map);
+        return result.toString();
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/channels/channel-worker-interactions.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/channels/channel-worker-interactions.bal
@@ -10,7 +10,7 @@ function workerWithChannels() returns json {
     }
 
     worker w2 {
-        json key = {"id":50, name:"john"};
+        json key = {name:"john", "id":50};
         json msg = {"payment":10000};
         msg -> chn, key;
     }
@@ -18,7 +18,7 @@ function workerWithChannels() returns json {
 
 function sendBeforeReceive() returns json {
     worker w2 {
-        json key = {"id":50, name:"john"};
+        json key = {name:"john", "id":50};
         json msg = {"payment":10000};
         msg -> chn, key;
     }


### PR DESCRIPTION
With this fix, two json objects with different key-value pair ordering but the same key-value pairs are
considered as equal. This is one of the improvements captured in https://github.com/ballerina-platform/ballerina-lang/issues/10388