### PR TITLE
Update examples path in vscode plugin

### DIFF
--- a/tool-plugins/vscode/src/examples/index.ts
+++ b/tool-plugins/vscode/src/examples/index.ts
@@ -60,7 +60,7 @@ function showExamples(context: ExtensionContext, langClient: ExtendedLangClient)
                 const url = JSON.parse(message.url);
                 const ballerinaHome = BallerinaExtension.getBallerinaHome();
                 if (ballerinaHome) {
-                    const folderPath = path.join(ballerinaHome, 'docs', 'examples', url);
+                    const folderPath = path.join(ballerinaHome, 'examples', url);
                     const filePath = path.join(folderPath, `${url.replace(/-/g, '_')}.bal`);
                     workspace.openTextDocument(Uri.file(filePath)).then(doc => {
                         window.showTextDocument(doc);


### PR DESCRIPTION
## Purpose
Examples are packed in this /examples instead of /docs/examples now in the distribution
