### PR TITLE
Remove visiting remote repository if organization name is unavailable

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/URIConverter.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Provide functions need to covert a patten to steam of by paths, by downloading them as url .
+ * Provide functions need to covert a patten to steam of by paths, by downloading them as url.
  */
 public class URIConverter implements Converter<URI> {
 
@@ -71,7 +71,7 @@ public class URIConverter implements Converter<URI> {
             try {
                 Files.createDirectories(dirPath);
             } catch (IOException e) {
-                throw new RuntimeException("Error occured when creating the directory path " + dirPath);
+                throw new RuntimeException("Error occurred when creating the directory path " + dirPath);
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/RemoteRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/RemoteRepo.java
@@ -1,9 +1,28 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.ballerinalang.compiler.packaging.repo;
 
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.packaging.Patten;
 import org.wso2.ballerinalang.compiler.packaging.converters.Converter;
 import org.wso2.ballerinalang.compiler.packaging.converters.URIConverter;
+import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.net.URI;
 
@@ -26,6 +45,11 @@ public class RemoteRepo extends NonSysRepo<URI> {
 
     @Override
     public Patten calculateNonSysPkg(PackageID pkg) {
+        // Central requires an org name.
+        if (pkg.getOrgName().equals(Names.ANON_ORG)) {
+            return Patten.NULL;
+        }
+        
         String orgName = pkg.getOrgName().value;
         String pkgName = pkg.getName().value;
         String pkgVersion = pkg.getPackageVersion().value;


### PR DESCRIPTION
## Purpose
> Related to https://github.com/ballerina-platform/ballerina-lang/issues/10675. Allow resolving packages without organization name.

## Goals
> Resolve package imports.

## Approach
> Imports without organization names are skipped when visiting remote repository(central).
