### PR TITLE
Filter packages that only contain ballerina source files when compiling

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -38,7 +38,6 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
-import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 import org.wso2.ballerinalang.programfile.CompiledBinaryFile;
 import org.wso2.ballerinalang.programfile.ProgramFileWriter;
 import org.wso2.ballerinalang.util.RepoUtils;
@@ -114,13 +113,6 @@ public class LauncherUtils {
                     sourcePath.getParent() != null) {
                 throw createLauncherException("you are trying to run a ballerina file inside a package within a " +
                                                       "project. Try running 'ballerina run <package-name>'");
-            }
-            // Checks if the source path is a package
-            if (Files.isDirectory(fullPath)) {
-                // Checks if the package contains ballerina source files
-                if (!ProjectDirs.containsSourceFiles(fullPath)) {
-                    throw createLauncherException("no ballerina source files found in package " + sourcePath);
-                }
             }
             programFile = compile(sourceRootPath, sourcePath, offline);
         } else {

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -106,6 +106,11 @@ public class LauncherUtils {
                                               "folder or use --sourceroot to specify the project path and run the " +
                                               "package");
             }
+            if (Files.isRegularFile(fullPath) && !srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX)) {
+                throw createLauncherException("only packages, " + BLANG_SRC_FILE_SUFFIX + " and " +
+                                                      BLANG_EXEC_FILE_SUFFIX + " files can be used with the " +
+                                                      "'ballerina run' command.");
+            }
             // If we are trying to run a bal file inside a package from inside a project directory an error is thrown.
             // To differentiate between top level bals and bals inside packages we need to check if the parent of the
             // sourcePath given is null. If it is null then its a top level bal else its a bal inside a package

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -38,6 +38,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
+import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 import org.wso2.ballerinalang.programfile.CompiledBinaryFile;
 import org.wso2.ballerinalang.programfile.ProgramFileWriter;
 import org.wso2.ballerinalang.util.RepoUtils;
@@ -97,8 +98,7 @@ public class LauncherUtils {
 
         if (srcPathStr.endsWith(BLANG_EXEC_FILE_SUFFIX)) {
             programFile = BLangProgramLoader.read(sourcePath);
-        } else if (Files.isRegularFile(fullPath) &&
-                srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX) &&
+        } else if (Files.isRegularFile(fullPath) && srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX) &&
                 !RepoUtils.hasProjectRepo(sourceRootPath)) {
             programFile = compile(fullPath.getParent(), fullPath.getFileName(), offline);
         } else if (Files.isDirectory(sourceRootPath)) {
@@ -114,6 +114,13 @@ public class LauncherUtils {
                     sourcePath.getParent() != null) {
                 throw createLauncherException("you are trying to run a ballerina file inside a package within a " +
                                                       "project. Try running 'ballerina run <package-name>'");
+            }
+            // Checks if the source path is a package
+            if (Files.isDirectory(fullPath)) {
+                // Checks if the package contains ballerina source files
+                if (!ProjectDirs.containsSourceFiles(fullPath)) {
+                    throw createLauncherException("no ballerina source files found in package " + sourcePath);
+                }
             }
             programFile = compile(sourceRootPath, sourcePath, offline);
         } else {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -17,14 +17,17 @@
  */
 package org.ballerinalang.packerina;
 
+import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.testerina.util.Utils;
 import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
+import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -89,14 +92,14 @@ public class BuilderUtils {
                 outStream.println();
                 compiler.write(packages);
             } else {
-                outStream.println("No ballerina source files found to compile");
+                throw new BLangCompilerException("no ballerina source files found to compile");
             }
         } else {
             if (packages.size() > 0) {
                 Utils.testWithBuild(sourceRootPath, null);
                 compiler.write(packages);
             } else {
-                outStream.println("No ballerina source files found to compile");
+                throw new BLangCompilerException("no ballerina source files found to compile");
             }
         }
     }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -24,10 +24,8 @@ import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
-import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -22,7 +22,6 @@ import org.ballerinalang.launcher.BLauncherCmd;
 import org.ballerinalang.launcher.LauncherUtils;
 import org.ballerinalang.packerina.BuilderUtils;
 import org.ballerinalang.util.BLangConstants;
-import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -148,14 +147,6 @@ public class BuildCommand implements BLauncherCmd {
                     throw LauncherUtils.createLauncherException("you are trying to build a ballerina file inside a " +
                                                                         "package within a project. Try running " +
                                                                         "'ballerina build <package-name>'");
-                }
-                // Checks if the source path is a package
-                if (Files.isDirectory(resolvedFullPath)) {
-                    // Checks if the package contains ballerina source files
-                    if (!ProjectDirs.containsSourceFiles(resolvedFullPath)) {
-                        throw LauncherUtils.createLauncherException("no ballerina source files found in package "
-                                                                            + pkgName);
-                    }
                 }
             } else {
                 // Invalid source file provided

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -138,7 +138,7 @@ public class BuildCommand implements BLauncherCmd {
                     throw LauncherUtils.createLauncherException("did you mean to build the package ? If so build " +
                                                                         "from the project folder");
                 }
-                if (Files.isRegularFile(resolvedFullPath) && !sourcePath.endsWith(BLANG_SRC_FILE_SUFFIX)) {
+                if (Files.isRegularFile(resolvedFullPath) && !sourcePath.toString().endsWith(BLANG_SRC_FILE_SUFFIX)) {
                     throw LauncherUtils.createLauncherException("only packages and " + BLANG_SRC_FILE_SUFFIX + " " +
                                                                 "files can be used with the 'ballerina build' " +
                                                                         "command.");

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -22,6 +22,7 @@ import org.ballerinalang.launcher.BLauncherCmd;
 import org.ballerinalang.launcher.LauncherUtils;
 import org.ballerinalang.packerina.BuilderUtils;
 import org.ballerinalang.util.BLangConstants;
+import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
@@ -144,11 +145,17 @@ public class BuildCommand implements BLauncherCmd {
                 Path parentPath = sourcePath.getParent();
                 if (Files.isRegularFile(resolvedFullPath) && sourcePath.toString().endsWith(BLANG_SRC_FILE_SUFFIX) &&
                         parentPath != null) {
-                    Path fileName = parentPath.getFileName();
-                    String srcPkgName = fileName != null ? fileName.toString() : "";
                     throw LauncherUtils.createLauncherException("you are trying to build a ballerina file inside a " +
                                                                         "package within a project. Try running " +
                                                                         "'ballerina build <package-name>'");
+                }
+                // Checks if the source path is a package
+                if (Files.isDirectory(resolvedFullPath)) {
+                    // Checks if the package contains ballerina source files
+                    if (!ProjectDirs.containsSourceFiles(resolvedFullPath)) {
+                        throw LauncherUtils.createLauncherException("no ballerina source files found in package "
+                                                                            + pkgName);
+                    }
                 }
             } else {
                 // Invalid source file provided

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -138,6 +138,11 @@ public class BuildCommand implements BLauncherCmd {
                     throw LauncherUtils.createLauncherException("did you mean to build the package ? If so build " +
                                                                         "from the project folder");
                 }
+                if (Files.isRegularFile(resolvedFullPath) && !sourcePath.endsWith(BLANG_SRC_FILE_SUFFIX)) {
+                    throw LauncherUtils.createLauncherException("only packages and " + BLANG_SRC_FILE_SUFFIX + " " +
+                                                                "files can be used with the 'ballerina build' " +
+                                                                        "command.");
+                }
                 // If we are trying to run a bal file inside a package from a project directory an error is thrown.
                 // To differentiate between top level bals and bals inside packages we need to check if the parent of
                 // the sourcePath given is null. If it is null then its a top level bal else its a bal inside a package

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -77,6 +77,9 @@ public class Compiler {
     }
 
     public BLangPackage compile(String sourcePackage, boolean isBuild) {
+        if (!isBuild && !this.sourceDirectoryManager.checkIfSourcesExists(sourcePackage)) {
+            throw new BLangCompilerException("no ballerina source files found in package " + sourcePackage);
+        }
         PackageID packageID = this.sourceDirectoryManager.getPackageID(sourcePackage);
         if (packageID == null) {
             throw ProjectDirs.getPackageNotFoundError(sourcePackage);
@@ -90,6 +93,9 @@ public class Compiler {
     }
 
     public BLangPackage build(String sourcePackage) {
+        if (!this.sourceDirectoryManager.checkIfSourcesExists(sourcePackage)) {
+            throw new BLangCompilerException("no ballerina source files found in package " + sourcePackage);
+        }
         outStream.println("Compiling source");
         BLangPackage bLangPackage = compile(sourcePackage, true);
         if (bLangPackage.diagCollector.hasErrors()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
@@ -89,6 +89,7 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
         try {
             this.packageNames = Files.list(projectDirPath)
                     .filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+                    .filter(ProjectDirs::containsSourceFiles)
                     .map(ProjectDirs::getLastComp)
                     .filter(dirName -> !isSpecialDirectory(dirName))
                     .map(Path::toString)

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -140,5 +141,15 @@ public class SourceDirectoryManager {
     private Name getOrgName(Manifest manifest) {
         return manifest.getName() == null || manifest.getName().isEmpty() ?
                 Names.ANON_ORG : names.fromString(manifest.getName());
+    }
+
+    /**
+     * Check if sources exists in the package.
+     *
+     * @param pkg package name
+     * @return true if ballerina sources exists, else false
+     */
+    boolean checkIfSourcesExists(String pkg) {
+        return ProjectDirs.containsSourceFiles(this.sourceDirectory.getPath().resolve(pkg));
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirs.java
@@ -20,11 +20,15 @@ package org.wso2.ballerinalang.compiler.util;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.model.elements.PackageID;
 
+import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_SOURCE_EXT;
 
@@ -60,5 +64,23 @@ public class ProjectDirs {
         }
 
         return new BLangCompilerException("cannot find package '" + sourcePackage + "'");
+    }
+
+    /**
+     * Checks if the package contains ballerina source files.
+     *
+     * @param pkgPath package path
+     * @return true if source files exists else false
+     */
+    public static boolean containsSourceFiles(Path pkgPath) {
+        List<Path> sourceFiles = new ArrayList<>();
+        try {
+            sourceFiles = Files.find(pkgPath, Integer.MAX_VALUE, (path, attrs) ->
+                    path.toString().endsWith(ProjectDirConstants.BLANG_SOURCE_EXT)).collect(Collectors.toList());
+        } catch (IOException ignored) {
+            // Here we are trying to check if there are source files inside the package to be compiled. If an error
+            // occurs when trying to visit the files inside the package then we simply return the empty list created.
+        }
+        return sourceFiles.size() > 0;
     }
 }

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageBuildTestCase.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.packaging;
+
+import org.ballerinalang.test.BaseTest;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.test.utils.PackagingTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * Integration test cases for building packages.
+ */
+public class PackageBuildTestCase extends BaseTest {
+    private static final String ORG_NAME = "integrationtests";
+    private static final String VERSION = "0.0.1";
+    private static final String[] EMPTY_PROJECT_OPTS = {"\n", ORG_NAME + "\n", "\n", "f\n"};
+    private static final String[] SINGLE_PKG_PROJECT_OPTS = {"\n", ORG_NAME + "\n", "\n", "m\n", "foo\n", "f\n"};
+    private Path tempProjectDirectory;
+    private Map<String, String> envVariables;
+
+    @BeforeClass()
+    public void setUp() throws IOException {
+        tempProjectDirectory = Files.createTempDirectory("bal-test-integration-build-package-project-");
+        envVariables = PackagingTestUtils.getEnvVariables();
+    }
+
+
+    /**
+     * Building all packages in the project.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building all packages in the project")
+    public void testBuild() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("firstTestProject");
+        initProject(projectPath, SINGLE_PKG_PROJECT_OPTS);
+
+        // Create an empty directory
+        createEmptyDir(projectPath);
+
+        // Create another directory with a text file
+        createDirWithTextFile(projectPath);
+
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{},
+                          projectPath.toString());
+
+        Path genPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                    ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "foo", VERSION);
+        Assert.assertTrue(Files.exists(projectPath.resolve(genPkgPath)));
+        Assert.assertTrue(Files.exists(projectPath.resolve(genPkgPath).resolve("foo" + ".zip")));
+
+        Path emptyPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                      ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "emptypkg", VERSION);
+        Assert.assertTrue(Files.notExists(projectPath.resolve(emptyPkgPath).resolve("emptypkg" + ".zip")));
+
+        Path otherPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                      ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "otherpkg", VERSION);
+        Assert.assertTrue(Files.notExists(projectPath.resolve(otherPkgPath).resolve("otherpkg" + ".zip")));
+    }
+
+    /**
+     * Building all packages in the project with one source package and another package with text files.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building all packages in the project with one source package and another package with " +
+            "text files")
+    public void testBuildWithFirstPkgCombination() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("secondTestProject");
+        initProject(projectPath, SINGLE_PKG_PROJECT_OPTS);
+
+        // Create another directory with a text file
+        createDirWithTextFile(projectPath);
+
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{},
+                          projectPath.toString());
+
+        Path genPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                    ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "foo", VERSION);
+        Assert.assertTrue(Files.exists(projectPath.resolve(genPkgPath)));
+        Assert.assertTrue(Files.exists(projectPath.resolve(genPkgPath).resolve("foo" + ".zip")));
+
+        Path otherPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                      ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "otherpkg", VERSION);
+        Assert.assertTrue(Files.notExists(projectPath.resolve(otherPkgPath).resolve("otherpkg" + ".zip")));
+    }
+
+    /**
+     * Building all packages in the project with one source package and another empty package.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building all packages in the project with one source package and another empty package")
+    public void testBuildWithSecPkgCombination() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("thirdTestProject");
+        initProject(projectPath, SINGLE_PKG_PROJECT_OPTS);
+
+        // Create empty directory
+        createEmptyDir(projectPath.resolve("emptypkg"));
+
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{},
+                          projectPath.toString());
+
+        Path genPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                    ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "foo", VERSION);
+        Assert.assertTrue(Files.exists(projectPath.resolve(genPkgPath)));
+        Assert.assertTrue(Files.exists(projectPath.resolve(genPkgPath).resolve("foo" + ".zip")));
+
+        Path emptyPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
+                                      ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "emptypkg", VERSION);
+        Assert.assertTrue(Files.notExists(projectPath.resolve(emptyPkgPath).resolve("emptypkg" + ".zip")));
+    }
+
+    /**
+     * Building an empty package in a project.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building empty package")
+    public void testBuildWithEmptyPkg() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("thirdTestProject");
+        initProject(projectPath, EMPTY_PROJECT_OPTS);
+
+        // Create empty directory
+        createEmptyDir(projectPath.resolve("emptypkg"));
+
+        LogLeecher clientLeecher = new LogLeecher("error: no ballerina source files found in package emptypkg");
+        balClient.runMain("build", new String[]{"emptypkg"}, envVariables, new String[0],
+                          new LogLeecher[]{clientLeecher}, projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Building a package with text files in a project.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building a package with text files")
+    public void testBuildWithOtherPkg() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("fourthTestProject");
+        initProject(projectPath, EMPTY_PROJECT_OPTS);
+
+        // Create empty directory
+        createDirWithTextFile(projectPath);
+
+        LogLeecher clientLeecher = new LogLeecher("error: no ballerina source files found in package otherpkg");
+        balClient.runMain("build", new String[]{"otherpkg"}, envVariables, new String[0],
+                          new LogLeecher[]{clientLeecher}, projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Building a package with text files in a project and an empty package.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building a package with text files and an empty package")
+    public void testBuildWithEmptyAndOtherPkg() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("fifthTestProject");
+        initProject(projectPath, EMPTY_PROJECT_OPTS);
+
+        // Create an empty directory
+        createEmptyDir(projectPath.resolve("emptypkg"));
+        // Create a directory with a text file
+        createDirWithTextFile(projectPath);
+
+        LogLeecher clientLeecher = new LogLeecher("error: no ballerina source files found to compile");
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{clientLeecher},
+                          projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Building an empty project without any packages.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building an empty project without any packages")
+    public void testBuildEmptyProject() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("emptyProject");
+        initProject(projectPath, EMPTY_PROJECT_OPTS);
+        LogLeecher clientLeecher = new LogLeecher("error: no ballerina source files found to compile");
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{clientLeecher},
+                          projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Init project.
+     *
+     * @param projectPath project path
+     * @throws IOException            if an I/O exception occurs when creating directories
+     * @throws BallerinaTestException
+     */
+    private void initProject(Path projectPath, String[] options) throws IOException, BallerinaTestException {
+        Files.createDirectories(projectPath);
+        String[] clientArgsForInit = {"-i"};
+        balClient.runMain("init", clientArgsForInit, envVariables, options, new LogLeecher[0],
+                          projectPath.toString());
+    }
+
+    /**
+     * Create an empty directory.
+     *
+     * @param path path of the directory to be created
+     * @throws IOException
+     */
+    private void createEmptyDir(Path path) throws IOException {
+        Files.createDirectories(path.resolve("emptypkg"));
+    }
+
+    /**
+     * Create directory with a text file.
+     *
+     * @param path path of the directory to be created
+     * @throws IOException
+     */
+    private void createDirWithTextFile(Path path) throws IOException {
+        Files.createDirectories(path.resolve("otherpkg"));
+        Files.createFile(path.resolve("otherpkg").resolve("hello.txt"));
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        PackagingTestUtils.deleteFiles(tempProjectDirectory);
+    }
+}

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageBuildTestCase.java
@@ -217,7 +217,7 @@ public class PackageBuildTestCase extends BaseTest {
      *
      * @param projectPath project path
      * @throws IOException            if an I/O exception occurs when creating directories
-     * @throws BallerinaTestException
+     * @throws BallerinaTestException if an exception occurs when running the command
      */
     private void initProject(Path projectPath, String[] options) throws IOException, BallerinaTestException {
         Files.createDirectories(projectPath);
@@ -230,7 +230,7 @@ public class PackageBuildTestCase extends BaseTest {
      * Create an empty directory.
      *
      * @param path path of the directory to be created
-     * @throws IOException
+     * @throws IOException if an I/O exception occurs when creating directories
      */
     private void createEmptyDir(Path path) throws IOException {
         Files.createDirectories(path.resolve("emptypkg"));
@@ -240,7 +240,7 @@ public class PackageBuildTestCase extends BaseTest {
      * Create directory with a text file.
      *
      * @param path path of the directory to be created
-     * @throws IOException
+     * @throws IOException if an I/O exception occurs when creating directories
      */
     private void createDirWithTextFile(Path path) throws IOException {
         Files.createDirectories(path.resolve("otherpkg"));

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageBuildTestCase.java
@@ -51,7 +51,6 @@ public class PackageBuildTestCase extends BaseTest {
         envVariables = PackagingTestUtils.getEnvVariables();
     }
 
-
     /**
      * Building all packages in the project.
      *
@@ -68,8 +67,8 @@ public class PackageBuildTestCase extends BaseTest {
         // Create another directory with a text file
         createDirWithTextFile(projectPath);
 
-        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{},
-                          projectPath.toString());
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{}, projectPath.
+                                                                                                            toString());
 
         Path genPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
                                     ProjectDirConstants.DOT_BALLERINA_REPO_DIR_NAME, ORG_NAME, "foo", VERSION);

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageRunTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageRunTestCase.java
@@ -87,7 +87,7 @@ public class PackageRunTestCase extends BaseTest {
      *
      * @param projectPath project path
      * @throws IOException            if an I/O exception occurs when creating directories
-     * @throws BallerinaTestException
+     * @throws BallerinaTestException if an exception occurs when running the command
      */
     private void initProject(Path projectPath) throws IOException, BallerinaTestException {
         Files.createDirectories(projectPath);
@@ -100,7 +100,7 @@ public class PackageRunTestCase extends BaseTest {
      * Create directory with a text file.
      *
      * @param path path of the directory to be created
-     * @throws IOException
+     * @throws IOException if an I/O exception occurs when creating directories
      */
     private void createDirWithTextFile(Path path) throws IOException {
         Files.createDirectories(path.resolve("otherpkg"));

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageRunTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackageRunTestCase.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.packaging;
+
+import org.ballerinalang.test.BaseTest;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.test.utils.PackagingTestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Integration test cases for running packages.
+ */
+public class PackageRunTestCase extends BaseTest {
+    private Path tempProjectDirectory;
+    private Map<String, String> envVariables;
+
+    @BeforeClass()
+    public void setUp() throws IOException {
+        tempProjectDirectory = Files.createTempDirectory("bal-test-integration-run-package-project-");
+        envVariables = PackagingTestUtils.getEnvVariables();
+    }
+
+    /**
+     * Running an empty package in a project.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test running an empty package")
+    public void testRunWithEmptyPkg() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("firstTestProject");
+        initProject(projectPath);
+
+        // Create empty directory
+        Files.createDirectories(projectPath.resolve("emptypkg"));
+
+        LogLeecher clientLeecher = new LogLeecher("error: no ballerina source files found in package emptypkg");
+        balClient.runMain("run", new String[]{"emptypkg"}, envVariables, new String[0],
+                          new LogLeecher[]{clientLeecher}, projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Running a package with text files in a project.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test running a package with text files")
+    public void testRunWithOtherPkg() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("secondTestProject");
+        initProject(projectPath);
+
+        // Create empty directory
+        createDirWithTextFile(projectPath);
+
+        LogLeecher clientLeecher = new LogLeecher("error: no ballerina source files found in package otherpkg");
+        balClient.runMain("run", new String[]{"otherpkg"}, envVariables, new String[0],
+                          new LogLeecher[]{clientLeecher}, projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Init project.
+     *
+     * @param projectPath project path
+     * @throws IOException            if an I/O exception occurs when creating directories
+     * @throws BallerinaTestException
+     */
+    private void initProject(Path projectPath) throws IOException, BallerinaTestException {
+        Files.createDirectories(projectPath);
+        String[] options = {"\n", "integrationtests\n", "\n", "f\n"};
+        balClient.runMain("init", new String[]{"-i"}, envVariables, options, new LogLeecher[0],
+                          projectPath.toString());
+    }
+
+    /**
+     * Create directory with a text file.
+     *
+     * @param path path of the directory to be created
+     * @throws IOException
+     */
+    private void createDirWithTextFile(Path path) throws IOException {
+        Files.createDirectories(path.resolve("otherpkg"));
+        Files.createFile(path.resolve("otherpkg").resolve("hello.txt"));
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        PackagingTestUtils.deleteFiles(tempProjectDirectory);
+    }
+}

--- a/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
@@ -28,13 +28,15 @@
             <class name="org.ballerinalang.test.packaging.BalRunWithConfigTestCase"/>
             <class name="org.ballerinalang.test.packaging.DocGenTestCase"/>
             <class name="org.ballerinalang.test.packaging.ListDependencyTestCase"/>
+            <class name="org.ballerinalang.test.packaging.RepoHierarchyTestCase"/>
+            <class name="org.ballerinalang.test.packaging.PackageBuildTestCase"/>
+            <class name="org.ballerinalang.test.packaging.PackageRunTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingInitTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingNegativeTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>
             <class name="org.ballerinalang.test.packaging.RunTopLevelBalInProjectTestCase"/>
             <class name="org.ballerinalang.test.packaging.SingleBalBuildTestCase"/>
             <class name="org.ballerinalang.test.packaging.TestExecutionTestCase"/>
-            <class name="org.ballerinalang.test.packaging.RepoHierarchyTestCase"/>
             <class name="org.ballerinalang.test.grpc.ServicePackagingTestCase"/>
         </classes>
     </test>

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/launch/LaunchTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/launch/LaunchTest.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 public class LaunchTest {
 
     @Test(expectedExceptions = {BLangCompilerException.class },
-            expectedExceptionsMessageRegExp = "cannot find package 'xxxx'")
+            expectedExceptionsMessageRegExp = "no ballerina source files found in package xxxx")
     public void testRunNonExistingPackage() {
         CompileResult result = BCompileUtil.compile(this, "test-src/launch/", "xxxx");
         Assert.assertEquals(result.getErrorCount(), 0);


### PR DESCRIPTION
## Purpose
> This PR will filter packages that only contain ballerina source files when compiling

## Automation tests
 - Integration tests
   > Added test cases

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes