### PR TITLE
Validate org-name and package name in ballerina init, push and install

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -49,7 +49,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -102,14 +101,14 @@ public class PushUtils {
 
         String orgName = manifest.getName();
         // Validate the org-name
-        if (!validateOrg(orgName)) {
-            throw createLauncherException("invalid organization name provided \'" + orgName + "\'." + " Only " +
+        if (!RepoUtils.validateOrg(orgName)) {
+            throw createLauncherException("invalid organization name provided \'" + orgName + "\'. Only " +
                                           "lowercase alphanumerics and underscores are allowed in an organization " +
                                           "name and the maximum length is 256 characters");
         }
         // Validate the package-name
-        if (!validatePkg(packageName)) {
-            throw createLauncherException("invalid package name provided'" + packageName + "\'." + " Only " +
+        if (!RepoUtils.validatePkg(packageName)) {
+            throw createLauncherException("invalid package name provided'" + packageName + "\'. Only " +
                                           "alphanumerics, underscores and periods are allowed in a package name and " +
                                           "the maximum length is 256 characters");
         }
@@ -392,27 +391,5 @@ public class PushUtils {
                                                 ProjectDirConstants.RESOURCE_DIR_NAME);
         String dirNameStr = dirName.toString();
         return dirNameStr.startsWith(".") || dirName.toFile().isHidden() || ignoreDirs.contains(dirNameStr);
-    }
-
-    /**
-     * Validates the org-name and package name.
-     *
-     * @param orgName The org-name
-     * @return True if valid org-name or package name, else false.
-     */
-    private static boolean validateOrg(String orgName) {
-        String validRegex = "^[a-z0-9_]*$";
-        return Pattern.matches(validRegex, orgName);
-    }
-
-    /**
-     * Validates the org-name and package name.
-     *
-     * @param pkgName The org-name or package name.
-     * @return True if valid org-name or package name, else false.
-     */
-    private static boolean validatePkg(String pkgName) {
-        String validRegex = "^[a-zA-Z0-9_.]*$";
-        return Pattern.matches(validRegex, pkgName);
     }
 }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -49,6 +49,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -100,6 +101,18 @@ public class PushUtils {
         }
 
         String orgName = manifest.getName();
+        // Validate the org-name
+        if (!validateOrg(orgName)) {
+            throw createLauncherException("invalid organization name provided " + "'" + orgName + "'." + " Only " +
+                                          "lowercase alphanumerics and underscores are allowed in an organization " +
+                                          "name and the maximum length is 256 characters");
+        }
+        // Validate the package-name
+        if (!validatePkg(packageName)) {
+            throw createLauncherException("invalid package name provided " + "'" + packageName + "'." + " Only " +
+                                          "alphanumerics, underscores and periods are allowed in a package name " +
+                                          "and the maximum length is 256 characters");
+        }
         String version = manifest.getVersion();
         String ballerinaVersion = RepoUtils.getBallerinaVersion();
         PackageID packageID = new PackageID(new Name(orgName), new Name(packageName), new Name(version));
@@ -379,5 +392,27 @@ public class PushUtils {
                                                 ProjectDirConstants.RESOURCE_DIR_NAME);
         String dirNameStr = dirName.toString();
         return dirNameStr.startsWith(".") || dirName.toFile().isHidden() || ignoreDirs.contains(dirNameStr);
+    }
+
+    /**
+     * Validates the org-name and package name.
+     *
+     * @param orgName The org-name
+     * @return True if valid org-name or package name, else false.
+     */
+    private static boolean validateOrg(String orgName) {
+        String validRegex = "^[a-z0-9_]*$";
+        return Pattern.matches(validRegex, orgName);
+    }
+
+    /**
+     * Validates the org-name and package name.
+     *
+     * @param pkgName The org-name or package name.
+     * @return True if valid org-name or package name, else false.
+     */
+    private static boolean validatePkg(String pkgName) {
+        String validRegex = "^[a-zA-Z0-9_.]*$";
+        return Pattern.matches(validRegex, pkgName);
     }
 }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -108,7 +108,7 @@ public class PushUtils {
         }
         // Validate the package-name
         if (!RepoUtils.validatePkg(packageName)) {
-            throw createLauncherException("invalid package name provided'" + packageName + "\'. Only " +
+            throw createLauncherException("invalid package name provided \'" + packageName + "\'. Only " +
                                           "alphanumerics, underscores and periods are allowed in a package name and " +
                                           "the maximum length is 256 characters");
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -103,15 +103,15 @@ public class PushUtils {
         String orgName = manifest.getName();
         // Validate the org-name
         if (!validateOrg(orgName)) {
-            throw createLauncherException("invalid organization name provided " + "'" + orgName + "'." + " Only " +
+            throw createLauncherException("invalid organization name provided \'" + orgName + "\'." + " Only " +
                                           "lowercase alphanumerics and underscores are allowed in an organization " +
                                           "name and the maximum length is 256 characters");
         }
         // Validate the package-name
         if (!validatePkg(packageName)) {
-            throw createLauncherException("invalid package name provided " + "'" + packageName + "'." + " Only " +
-                                          "alphanumerics, underscores and periods are allowed in a package name " +
-                                          "and the maximum length is 256 characters");
+            throw createLauncherException("invalid package name provided'" + packageName + "\'." + " Only " +
+                                          "alphanumerics, underscores and periods are allowed in a package name and " +
+                                          "the maximum length is 256 characters");
         }
         String version = manifest.getVersion();
         String ballerinaVersion = RepoUtils.getBallerinaVersion();

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -24,6 +24,7 @@ import org.ballerinalang.packerina.init.models.FileType;
 import org.ballerinalang.packerina.init.models.PackageMdFile;
 import org.ballerinalang.packerina.init.models.SrcFile;
 import org.ballerinalang.toml.model.Manifest;
+import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -96,9 +97,9 @@ public class InitCommand implements BLauncherCmd {
                     do {
                         out.print("Organization name: (" + defaultOrg + ") ");
                         orgName = scanner.nextLine().trim();
-                        manifest.setName(orgName.isEmpty() ? defaultOrg : orgName);
                     } while (!validateOrgName(out, orgName));
-
+                    // Set org-name
+                    manifest.setName(orgName.isEmpty() ? defaultOrg : orgName);
                     String version;
                     do {
                         out.print("Version: (" + DEFAULT_VERSION + ") ");
@@ -259,8 +260,7 @@ public class InitCommand implements BLauncherCmd {
      * @return True if valid org-name, else false.
      */
     private boolean validateOrgName(PrintStream out, String orgName) {
-        String validRegex = "^[a-z0-9_]*$";
-        boolean matches = Pattern.matches(validRegex, orgName);
+        boolean matches = RepoUtils.validateOrg(orgName);
         if (!matches) {
             out.println("--Invalid organization name: \'" + orgName + "\'." + " Organization name can only contain " +
                                 "lowercase alphanumerics and underscores and the maximum length is 256 characters");
@@ -278,8 +278,7 @@ public class InitCommand implements BLauncherCmd {
         if (pkgName.isEmpty()) {
            return true;
         }
-        String validRegex = "^[a-zA-Z0-9_.]*$";
-        boolean matches = Pattern.matches(validRegex, pkgName);
+        boolean matches = RepoUtils.validatePkg(pkgName);
         if (!matches) {
             out.println("--Invalid package name: \'" + pkgName + "\'." + " Package name can only contain " +
                                 "alphanumerics, underscores and periods and the maximum length is 256 characters");

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -262,7 +262,7 @@ public class InitCommand implements BLauncherCmd {
     private boolean validateOrgName(PrintStream out, String orgName) {
         boolean matches = RepoUtils.validateOrg(orgName);
         if (!matches) {
-            out.println("--Invalid organization name: \'" + orgName + "\'." + " Organization name can only contain " +
+            out.println("--Invalid organization name: \'" + orgName + "\'. Organization name can only contain " +
                                 "lowercase alphanumerics and underscores and the maximum length is 256 characters");
         }
         return matches;
@@ -280,7 +280,7 @@ public class InitCommand implements BLauncherCmd {
         }
         boolean matches = RepoUtils.validatePkg(pkgName);
         if (!matches) {
-            out.println("--Invalid package name: \'" + pkgName + "\'." + " Package name can only contain " +
+            out.println("--Invalid package name: \'" + pkgName + "\'. Package name can only contain " +
                                 "alphanumerics, underscores and periods and the maximum length is 256 characters");
         }
         return matches;

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -262,8 +262,8 @@ public class InitCommand implements BLauncherCmd {
         String validRegex = "^[a-z0-9_]*$";
         boolean matches = Pattern.matches(validRegex, orgName);
         if (!matches) {
-            out.println("--Invalid organization name: \"" + orgName + "\"." + " Organization name can only contain " +
-                                "lowercase alphanumerics and underscores");
+            out.println("--Invalid organization name: \'" + orgName + "\'." + " Organization name can only contain " +
+                                "lowercase alphanumerics and underscores and the maximum length is 256 characters");
         }
         return matches;
     }
@@ -281,8 +281,8 @@ public class InitCommand implements BLauncherCmd {
         String validRegex = "^[a-zA-Z0-9_.]*$";
         boolean matches = Pattern.matches(validRegex, pkgName);
         if (!matches) {
-            out.println("--Invalid package name: \"" + pkgName + "\"." + " Package name can only contain " +
-                                "alphanumerics, underscores and periods");
+            out.println("--Invalid package name: \'" + pkgName + "\'." + " Package name can only contain " +
+                                "alphanumerics, underscores and periods and the maximum length is 256 characters");
         }
         return matches;
     }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/InitCommand.java
@@ -92,10 +92,12 @@ public class InitCommand implements BLauncherCmd {
 
                     String defaultOrg = guessOrgName();
 
-                    // Get org name.
-                    out.print("Organization name: (" + defaultOrg + ") ");
-                    String orgName = scanner.nextLine().trim();
-                    manifest.setName(orgName.isEmpty() ? defaultOrg : orgName);
+                    String orgName;
+                    do {
+                        out.print("Organization name: (" + defaultOrg + ") ");
+                        orgName = scanner.nextLine().trim();
+                        manifest.setName(orgName.isEmpty() ? defaultOrg : orgName);
+                    } while (!validateOrgName(out, orgName));
 
                     String version;
                     do {
@@ -251,6 +253,22 @@ public class InitCommand implements BLauncherCmd {
     }
 
     /**
+     * Validates the org-name.
+     *
+     * @param orgName The org-name.
+     * @return True if valid org-name, else false.
+     */
+    private boolean validateOrgName(PrintStream out, String orgName) {
+        String validRegex = "^[a-z0-9_]*$";
+        boolean matches = Pattern.matches(validRegex, orgName);
+        if (!matches) {
+            out.println("--Invalid organization name: \"" + orgName + "\"." + " Organization name can only contain " +
+                                "lowercase alphanumerics and underscores");
+        }
+        return matches;
+    }
+
+    /**
      * Validates the package name.
      *
      * @param pkgName The package name.
@@ -264,7 +282,7 @@ public class InitCommand implements BLauncherCmd {
         boolean matches = Pattern.matches(validRegex, pkgName);
         if (!matches) {
             out.println("--Invalid package name: \"" + pkgName + "\"." + " Package name can only contain " +
-                                "alphanumeric, underscore and DOT");
+                                "alphanumerics, underscores and periods");
         }
         return matches;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Home repository util methods.
@@ -141,5 +142,28 @@ public class RepoUtils {
         } catch (Throwable ignore) {
         }
         return "unknown";
+    }
+
+
+    /**
+     * Validates the org-name and package name.
+     *
+     * @param orgName The org-name
+     * @return True if valid org-name or package name, else false.
+     */
+    public static boolean validateOrg(String orgName) {
+        String validRegex = "^[a-z0-9_]*$";
+        return Pattern.matches(validRegex, orgName);
+    }
+
+    /**
+     * Validates the org-name and package name.
+     *
+     * @param pkgName The org-name or package name.
+     * @return True if valid org-name or package name, else false.
+     */
+    public static boolean validatePkg(String pkgName) {
+        String validRegex = "^[a-zA-Z0-9_.]*$";
+        return Pattern.matches(validRegex, pkgName);
     }
 }

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.packaging;
 
+import org.apache.commons.io.FileUtils;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.context.LogLeecher;
@@ -330,6 +331,66 @@ public class PackagingNegativeTestCase extends BaseTest {
                           new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
     }
 
+    @Test(description = "Test pushing a package with an invalid org-name")
+    public void testPushWithInvalidOrg() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectWithInvalidOrg");
+        initProject(projectPath);
+
+        // Remove org-name from manifest
+        Path manifestFilePath = projectPath.resolve("Ballerina.toml");
+        if (Files.exists(manifestFilePath)) {
+            String content = "[project]\n org-name = \"foo-bar\"\n version = \"0.0.2\"";
+            writeToFile(manifestFilePath, content);
+        }
+        String msg = "error: invalid organization name provided 'foo-bar'. Only lowercase alphanumerics and " +
+                "underscores are allowed in an organization name and the maximum length is 256 characters";
+
+        String[] clientArgs = {packageName};
+
+        balClient.runMain("push", clientArgs, envVariables, new String[0],
+                          new LogLeecher[]{new LogLeecher(msg)}, projectPath.toString());
+    }
+
+    @Test(description = "Test installing a package with an invalid org-name",
+            dependsOnMethods = "testPushWithInvalidOrg")
+    public void testInstallWithInvalidOrg() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectWithInvalidOrg");
+        String msg = "error: invalid organization name provided 'foo-bar'. Only lowercase alphanumerics and " +
+                "underscores are allowed in an organization name and the maximum length is 256 characters";
+
+        String[] clientArgs = {packageName};
+        balClient.runMain("install", clientArgs, envVariables, new String[0], new LogLeecher[]{new LogLeecher(msg)},
+                          projectPath.toString());
+    }
+
+    @Test(description = "Test pushing a package with an invalid package name")
+    public void testPushWithInvalidPkg() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectWithInvalidPkg");
+        initProject(projectPath);
+
+        // Rename package-name
+        Path invalidPkgPath = projectPath.resolve("hello-pkg");
+        Files.createDirectories(invalidPkgPath);
+        FileUtils.copyDirectory(projectPath.resolve(packageName).toFile(), invalidPkgPath.toFile());
+        String msg = "error: invalid package name provided 'hello-pkg'. Only alphanumerics, underscores and periods " +
+                "are allowed in a package name and the maximum length is 256 characters";
+
+        String[] clientArgs = {"hello-pkg"};
+        balClient.runMain("push", clientArgs, envVariables, new String[0], new LogLeecher[]{new LogLeecher(msg)},
+                          projectPath.toString());
+    }
+
+    @Test(description = "Test installing a package with an invalid package name",
+            dependsOnMethods = "testPushWithInvalidPkg")
+    public void testInstallWithInvalidPkg() throws Exception {
+        Path projectPath = tempProjectDirectory.resolve("projectWithInvalidPkg");
+        String msg = "error: invalid package name provided 'hello-pkg'. Only alphanumerics, underscores and periods " +
+                "are allowed in a package name and the maximum length is 256 characters";
+
+        String[] clientArgs = {"hello-pkg"};
+        balClient.runMain("install", clientArgs, envVariables, new String[0], new LogLeecher[]{new LogLeecher(msg)},
+                          projectPath.toString());
+    }
     /**
      * Init project used to test the scenario.
      *


### PR DESCRIPTION
## Purpose
> This PR will add validation for the org-name and package name in ballerina init, push and install.

The following errors will be given:

- If the org-name is invalid : _**"error: invalid organization name provided 'foo-bar'. Only lowercase alphanumerics and underscores are allowed in an organization name and the maximum length is 256 characters"**_

- If the package-name is invalid : _**"error: invalid package name provided 'hello-pkg'. Only alphanumerics, underscores and periods are allowed in a package name and the maximum length is 256 characters"**_

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10638
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10675

## Automation tests
 - Integration tests
   > Added integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes