### PR TITLE
Remove word Java from error messages

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVMErrors.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVMErrors.java
@@ -374,7 +374,7 @@ public class BLangVMErrors {
 
         String msg = msgBVal.stringValue();
         if (msgBVal != null && !msg.isEmpty()) {
-            errorMsg = errorMsg + ", message: " + makeFirstLetterLowerCase(msg);
+            errorMsg = errorMsg + ", message: " + removeJava(makeFirstLetterLowerCase(msg));
         }
 
         return errorMsg;
@@ -387,5 +387,12 @@ public class BLangVMErrors {
         char c[] = s.toCharArray();
         c[0] = Character.toLowerCase(c[0]);
         return new String(c);
+    }
+
+    private static String removeJava(String s) {
+        if (s == null) {
+            return null;
+        }
+        return s.replaceAll("java", "runtime");
     }
 }


### PR DESCRIPTION
Word Java in error messages is replaced with word runtime.
FIxes https://github.com/ballerina-platform/ballerina-lang/issues/10679.
