### PR TITLE
Fix arrow expression in record and object

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -514,6 +514,9 @@ public class TypeChecker extends BLangNodeVisitor {
                     }
                 }
                 if (env.node.getKind() == NodeKind.ARROW_EXPR && !(symbol.owner instanceof BPackageSymbol)) {
+                    // The owner of the variable ref should be an invokable symbol.
+                    // It's set here because the arrow expression changes to an invokable only at desugar
+                    // and is not an invokable at this phase.
                     symbol.owner = Symbols.createInvokableSymbol(SymTag.FUNCTION, 0, null,
                             env.enclPkg.packageID, null, symbol.owner);
                     SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
@@ -567,7 +570,7 @@ public class TypeChecker extends BLangNodeVisitor {
             // if enclosing env's node is arrow expression
             return env.enclEnv;
         }
-        if (env.enclInvokable == encInvokable && env.enclInvokable != null) {
+        if (env.enclInvokable != null && env.enclInvokable == encInvokable) {
             return findEnclosingInvokableEnv(env.enclEnv, encInvokable);
         }
         return env;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -513,7 +513,9 @@ public class TypeChecker extends BLangNodeVisitor {
                         ((BLangFunction) env.enclInvokable).closureVarSymbols.add((BVarSymbol) closureVarSymbol);
                     }
                 }
-                if (env.node.getKind() == NodeKind.ARROW_EXPR) {
+                if (env.node.getKind() == NodeKind.ARROW_EXPR && !(symbol.owner instanceof BPackageSymbol)) {
+                    symbol.owner = Symbols.createInvokableSymbol(SymTag.FUNCTION, 0, null,
+                            env.enclPkg.packageID, null, symbol.owner);
                     SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
                     BSymbol closureVarSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol.name,
                             SymTag.VARIABLE_NAME);
@@ -562,9 +564,10 @@ public class TypeChecker extends BLangNodeVisitor {
      */
     private SymbolEnv findEnclosingInvokableEnv(SymbolEnv env, BLangInvokableNode encInvokable) {
         if (env.enclEnv.node != null && env.enclEnv.node.getKind() == NodeKind.ARROW_EXPR) {
+            // if enclosing env's node is arrow expression
             return env.enclEnv;
         }
-        if (env.enclInvokable == encInvokable) {
+        if (env.enclInvokable == encInvokable && env.enclInvokable != null) {
             return findEnclosingInvokableEnv(env.enclEnv, encInvokable);
         }
         return env;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -163,6 +163,20 @@ public class ArrowExprTest {
         Assert.assertEquals(returns[0].stringValue(), "DoReMeFa");
     }
 
+    @Test(description = "Test arrow expression inside a record")
+    public void testArrowExprInRecord() {
+        BValue[] returns = BRunUtil.invoke(basic, "testArrowExprInRecord");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 50);
+    }
+
+    @Test(description = "Test arrow expression inside an object")
+    public void testArrowExprInObject() {
+        BValue[] returns = BRunUtil.invoke(basic, "testArrowExprInObject");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 60);
+    }
+
     @Test(description = "Test compile time errors for arrow expression")
     public void testNegativeArrowExpr() {
         int i = 0;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -155,3 +155,23 @@ function testNestedArrowExpression4() returns string {
     var lambda4 = lambda3(22, "Me");
     return lambda4(24, "Fa");
 }
+
+int k = 10;
+
+type Foo record {
+    function (int) returns int lambda = (i) => i * k;
+};
+
+type Bar object {
+    function (int) returns int lambda = (i) => i * k;
+};
+
+function testArrowExprInRecord() returns int {
+    Foo f;
+    return f.lambda(5);
+}
+
+function testArrowExprInObject() returns int {
+    Bar f = new;
+    return f.lambda(6);
+}


### PR DESCRIPTION
## Purpose
Fix assigning arrow expressions inside record and object 
```ballerina
type Foo record {
    function (int) returns int lambda = (i) => i * i;
};
```