### PR TITLE
Add Azure pipeline config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,42 @@
+jobs:
+- job: macOS
+  pool:
+    vmImage: 'macOS 10.13'
+  timeoutInMinutes: 150
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.12.0'
+  - script: |
+      sudo ulimit -n 65535
+      mvn -v
+      mvn clean install
+    displayName: 'Build Ballerina'
+- job: Linux
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  timeoutInMinutes: 150
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.12.0'
+  - script: |
+      wget http://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+      tar xzf apache-maven-3.5.4-bin.tar.gz
+      export PATH=$(pwd)/apache-maven-3.5.4/bin:$PATH
+      mvn -v
+      mvn clean install
+    displayName: 'Build Ballerina'
+- job: Windows
+  pool:
+    vmImage: 'VS2017-Win2016'
+  timeoutInMinutes: 150
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.12.0'
+  - script: |
+      sudo ulimit -n 65535
+      mvn -v
+      mvn clean install
+    displayName: 'Build Ballerina'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ jobs:
     inputs:
       versionSpec: '8.12.0'
   - script: |
+      sudo ulimit -n 65535
       wget http://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
       tar xzf apache-maven-3.5.4-bin.tar.gz
       export PATH=$(pwd)/apache-maven-3.5.4/bin:$PATH
@@ -36,7 +37,6 @@ jobs:
     inputs:
       versionSpec: '8.12.0'
   - script: |
-      sudo ulimit -n 65535
       mvn -v
       mvn clean install
     displayName: 'Build Ballerina'


### PR DESCRIPTION
## Purpose
This PR adds [Azure pipeline](https://dev.azure.com) config to the repo. By adding Azure pipeline support in the Ballerina repo, we can build each PR in Windows, Ubuntu and MacOS. So any build failure particular to these OSs can be identified beforehand.