### PR TITLE
Allow {} as a map constructor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -385,9 +385,7 @@ public class TypeChecker extends BLangNodeVisitor {
             // Change the expected type to map,
             expType = symTable.mapType;
         }
-        if (expTypeTag == TypeTags.ANY
-                || (expTypeTag == TypeTags.MAP && recordLiteral.keyValuePairs.isEmpty())
-                || expTypeTag == TypeTags.OBJECT) {
+        if (expTypeTag == TypeTags.ANY || expTypeTag == TypeTags.OBJECT) {
             dlog.error(recordLiteral.pos, DiagnosticCode.INVALID_RECORD_LITERAL, originalExpType);
             resultType = symTable.errType;
             return;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
@@ -159,4 +159,12 @@ public class MapInitializerExprTest {
         Assert.assertEquals(mapValue.get("key1").stringValue(), "Cat");
         Assert.assertEquals(mapValue.get("key2").stringValue(), "Dog");
     }
+
+    @Test
+    public void testEmptyMap() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testEmptyMap", new BValue[] {});
+
+        Assert.assertTrue(returns[0] instanceof BMap<?, ?>, "empty map initialization with {}");
+        Assert.assertEquals(((BMap) returns[0]).size(), 0, "empty map initialization");
+    }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
@@ -165,6 +165,6 @@ public class MapInitializerExprTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testEmptyMap", new BValue[] {});
 
         Assert.assertTrue(returns[0] instanceof BMap<?, ?>, "empty map initialization with {}");
-        Assert.assertEquals(((BMap) returns[0]).size(), 0, "empty map initialization");
+        Assert.assertEquals(((BMap) returns[0]).size(), 0, "incorrect empty map size");
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/map/map-initializer-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/map/map-initializer-expr.bal
@@ -44,3 +44,13 @@ function mapInitWithIdentifiersTest() returns (map) {
 function getKey() returns (string) {
 	return "key2";
 }
+
+function testEmptyMap() returns (map) {
+    map emptyMap = {};
+    mapFunction({});
+    return emptyMap;
+}
+
+function mapFunction(map m) {
+
+}


### PR DESCRIPTION

> Allow empty maps as a map constructor. This is allowed according to the spec dated 2018/07/12.
Following syntax won't give an error after this change.
```
function testEmptyMap() returns (map) {
    map emptyMap = {};
    mapFunction({});
    return emptyMap;
}

function mapFunction(map m) {}
```
