### PR TITLE
Support Json serialization for  BFloat and HashSet Data

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/JsonSerializer.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/JsonSerializer.java
@@ -20,6 +20,7 @@ import org.ballerinalang.model.util.JsonGenerator;
 import org.ballerinalang.model.util.JsonParser;
 import org.ballerinalang.model.util.serializer.providers.bvalue.ArrayListBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.BBooleanBValueProvider;
+import org.ballerinalang.model.util.serializer.providers.bvalue.BFloatBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.BIntegerBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.BMapBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.BRefValueArrayBValueProvider;
@@ -30,6 +31,7 @@ import org.ballerinalang.model.util.serializer.providers.bvalue.BallerinaBrokerB
 import org.ballerinalang.model.util.serializer.providers.bvalue.ClassBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.ConcurrentHashMapBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.DateTimeBValueProviders;
+import org.ballerinalang.model.util.serializer.providers.bvalue.HashSetBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.InetSocketAddressBValueProvider;
 import org.ballerinalang.model.util.serializer.providers.bvalue.NumericBValueProviders;
 import org.ballerinalang.model.values.BRefType;
@@ -60,8 +62,10 @@ public class JsonSerializer implements ObjectToJsonSerializer {
         bValueProvider.register(new BallerinaBrokerByteBufBValueProvider());
         bValueProvider.register(new ConcurrentHashMapBValueProvider());
         bValueProvider.register(new BIntegerBValueProvider());
+        bValueProvider.register(new BFloatBValueProvider());
         bValueProvider.register(new BBooleanBValueProvider());
         bValueProvider.register(new ArrayListBValueProvider());
+        bValueProvider.register(new HashSetBValueProvider());
         bValueProvider.register(new BTypeBValueProviders.BObjectTypeBValueProvider());
         bValueProvider.register(new BTypeBValueProviders.BRecordTypeBValueProvider());
         bValueProvider.register(new BTypeBValueProviders.BAnyTypeBValueProvider());

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/BFloatBValueProvider.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/BFloatBValueProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.model.util.serializer.providers.bvalue;
+
+import org.ballerinalang.model.util.serializer.BPacket;
+import org.ballerinalang.model.util.serializer.BValueDeserializer;
+import org.ballerinalang.model.util.serializer.BValueSerializer;
+import org.ballerinalang.model.util.serializer.SerializationBValueProvider;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+
+/**
+ * Class implements @{@link SerializationBValueProvider} to provide the mapping between {@link BFloat} and
+ * {@link BValue} representation of it.
+ *
+ * @since 0.982.1
+ */
+public class BFloatBValueProvider implements SerializationBValueProvider<BFloat> {
+    @Override
+    public String typeName() {
+        return getType().getSimpleName();
+    }
+
+    @Override
+    public Class<?> getType() {
+        return BFloat.class;
+    }
+
+    @Override
+    public BPacket toBValue(BFloat bFloat, BValueSerializer serializer) {
+        return BPacket.from(typeName(), bFloat);
+    }
+
+    @Override
+    public BFloat toObject(BPacket packet, BValueDeserializer bValueDeserializer) {
+        return (BFloat) packet.getValue();
+    }
+}

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/BFloatBValueProvider.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/BFloatBValueProvider.java
@@ -28,7 +28,7 @@ import org.ballerinalang.model.values.BValue;
  * Class implements @{@link SerializationBValueProvider} to provide the mapping between {@link BFloat} and
  * {@link BValue} representation of it.
  *
- * @since 0.982.1
+ * @since 0.983.0
  */
 public class BFloatBValueProvider implements SerializationBValueProvider<BFloat> {
     @Override

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/HashSetBValueProvider.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/HashSetBValueProvider.java
@@ -35,7 +35,7 @@ import java.util.HashSet;
  * Class implements @{@link SerializationBValueProvider} to provide the mapping between {@link HashSet} and
  * {@link BValue} representation of it.
  *
- * @since 0.982.1
+ * @since 0.983.0
  */
 public class HashSetBValueProvider implements SerializationBValueProvider<HashSet> {
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/HashSetBValueProvider.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/serializer/providers/bvalue/HashSetBValueProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.model.util.serializer.providers.bvalue;
+
+import org.ballerinalang.model.types.BArrayType;
+import org.ballerinalang.model.types.BTypes;
+import org.ballerinalang.model.util.serializer.BPacket;
+import org.ballerinalang.model.util.serializer.BValueDeserializer;
+import org.ballerinalang.model.util.serializer.BValueSerializer;
+import org.ballerinalang.model.util.serializer.JsonSerializerConst;
+import org.ballerinalang.model.util.serializer.SerializationBValueProvider;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BRefType;
+import org.ballerinalang.model.values.BRefValueArray;
+import org.ballerinalang.model.values.BValue;
+
+import java.util.HashSet;
+
+/**
+ * Class implements @{@link SerializationBValueProvider} to provide the mapping between {@link HashSet} and
+ * {@link BValue} representation of it.
+ *
+ * @since 0.982.1
+ */
+public class HashSetBValueProvider implements SerializationBValueProvider<HashSet> {
+
+    @Override
+    public String typeName() {
+        return getType().getName();
+    }
+
+    @Override
+    public Class<?> getType() {
+        return HashSet.class;
+    }
+
+    @Override
+    public BPacket toBValue(HashSet set, BValueSerializer serializer) {
+        BRefValueArray array = new BRefValueArray(new BArrayType(BTypes.typeAny));
+        for (Object item : set) {
+            array.append((BRefType) serializer.toBValue(item, null));
+        }
+        return BPacket
+                .from(typeName(), array)
+                .put(JsonSerializerConst.LENGTH_TAG, new BInteger(set.size()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public HashSet toObject(BPacket packet, BValueDeserializer bValueDeserializer) {
+        BInteger length = (BInteger) packet.get(JsonSerializerConst.LENGTH_TAG);
+        BRefValueArray array = (BRefValueArray) packet.getValue();
+        HashSet set = new HashSet((int) length.intValue());
+        for (int i = 0; i < array.size(); i++) {
+            set.add(bValueDeserializer.deserialize(array.get(i), null));
+        }
+        return set;
+    }
+}

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/SerializationBValueProviderTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/SerializationBValueProviderTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.util.serializer.BValueTree;
 import org.ballerinalang.model.util.serializer.JsonSerializer;
 import org.ballerinalang.model.util.serializer.providers.bvalue.NumericBValueProviders;
 import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
@@ -35,7 +36,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 
 import static org.ballerinalang.model.util.serializer.JsonSerializerConst.VALUE_TAG;
 
@@ -138,5 +141,23 @@ public class SerializationBValueProviderTest {
         String serialize = serializer.serialize(new BString(null));
         BString deserialize = serializer.deserialize(serialize, BString.class);
         Assert.assertNull(deserialize.stringValue());
+    }
+
+    @Test(description = "test BFloat serialization")
+    public void testBFloatValueProvider() {
+        BFloat bFloat = new BFloat(1.023456789);
+        JsonSerializer serializer = new JsonSerializer();
+        String json = serializer.serialize(bFloat);
+        BFloat deserialize = serializer.deserialize(json, BFloat.class);
+        Assert.assertEquals(bFloat, deserialize);
+    }
+
+    @Test(description = "test HashSet serialization")
+    public void testHashSetValueProvider() {
+        HashSet<String> hashSet = new HashSet<>(Arrays.asList("abcdef1234", "ghijkl7890"));
+        JsonSerializer serializer = new JsonSerializer();
+        String json = serializer.serialize(hashSet);
+        HashSet deserialize = serializer.deserialize(json, HashSet.class);
+        Assert.assertEquals(deserialize, hashSet);
     }
 }


### PR DESCRIPTION
## Purpose
Support serializing Bfloats and Hash Sets.

## Goals
> We store ballerina float data as BFloats. We need to keep some worker context data in hash sets. So we need to serialize and deserialize functionality to both BFloats and HashSets.
## Approach
> Write Bvalue providers for each type.


## Automation tests
 - Unit tests 
   > Yes
