### PR TITLE
Fix array type source gen to render correctly

### DIFF
--- a/composer/modules/web/source-gen/SourceGenTemplate.java
+++ b/composer/modules/web/source-gen/SourceGenTemplate.java
@@ -918,6 +918,9 @@ public class SourceGen {
                     startingBracket = null;
                     endingBracket = null;
                     content = new StringBuilder();
+                } else if (ws.get(j).getAsJsonObject().get("text").getAsString().equals("?")) {
+                    dimensionAsString += ws.get(j).getAsJsonObject().get("ws").getAsString() +
+                            ws.get(j).getAsJsonObject().get("text").getAsString();
                 } else if (startingBracket != null) {
                     content.append(ws.get(j).getAsJsonObject().get("ws").getAsString())
                             .append(ws.get(j).getAsJsonObject().get("text").getAsString());

--- a/composer/modules/web/src/plugins/ballerina/model/tree-builder.js
+++ b/composer/modules/web/src/plugins/ballerina/model/tree-builder.js
@@ -567,6 +567,8 @@ class TreeBuilder {
                     content = "";
                     startingBracket = null;
                     endingBracket = null;
+                } else if (node.ws[j].text === '?') {
+                    node.dimensionAsString += node.ws[j].ws + node.ws[j].text;
                 } else if (startingBracket) {
                     content += node.ws[j].ws + node.ws[j].text;
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SourceGen.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SourceGen.java
@@ -7806,6 +7806,9 @@ public class SourceGen {
                     startingBracket = null;
                     endingBracket = null;
                     content = new StringBuilder();
+                } else if (ws.get(j).getAsJsonObject().get("text").getAsString().equals("?")) {
+                    dimensionAsString += ws.get(j).getAsJsonObject().get("ws").getAsString() +
+                            ws.get(j).getAsJsonObject().get("text").getAsString();
                 } else if (startingBracket != null) {
                     content.append(ws.get(j).getAsJsonObject().get("ws").getAsString())
                             .append(ws.get(j).getAsJsonObject().get("text").getAsString());


### PR DESCRIPTION
## Purpose
This PR will fix the array type source gen to render the array type correctly in all the syntax variations.
```ballerina
function name() {
    json[!...]? foo;
    json[1]? bar;
    int[1] abcd;
    int[] abc = [];
}
```

## Goals
Fix #10857