### PR TITLE
 Set appveyor npm version to 5.6.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
   - ps: Install-Product node $env:nodejs_version
+  - cmd: npm -g install npm@5.6.0
   - cmd: SET M2_HOME=C:\maven\apache-maven-%MAVEN_VERSION%
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: mvn --version


### PR DESCRIPTION
- Set appveyor npm version to 5.6.0 
- Due to package-lock compatibility issues we have to stick to one npm version for now.