### PR TITLE
Fix isValidBallerinaHome bug in VSCode plugin

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -233,7 +233,7 @@ export class BallerinaExtension {
 
 
     isValidBallerinaHome(homePath: string = this.ballerinaHome): boolean {
-        if (fs.existsSync(path.join(homePath))) {
+        if (fs.existsSync(path.join(homePath,'bin','ballerina'))) {
             return true;
         }
         return false;

--- a/tool-plugins/vscode/test/core/ballerina-extention.test.ts
+++ b/tool-plugins/vscode/test/core/ballerina-extention.test.ts
@@ -36,7 +36,7 @@ suite("Ballerina Extension Core Tests", function () {
 
     test("Test isValidBallerinaHome", function () {
         assert.equal(ballerinaExtInstance.isValidBallerinaHome(testBallerinaHome), true);
-        assert.equal(ballerinaExtInstance.isValidBallerinaHome(testBallerinaHome + '../'), false);
+        assert.equal(ballerinaExtInstance.isValidBallerinaHome(__dirname), false);
     });
 
     test("Test autoDitectBallerinaHome", function () {


### PR DESCRIPTION
There is a negative test failure in VSCode isValidBallerinaHome function this PR fixes that.