### PR TITLE
[IntelliJ Plugin] Remove BBE submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "tool-plugins/intellij/src/test/resources/BBE"]
-	path = tool-plugins/intellij/src/test/resources/BBE
-	url = https://github.com/ballerina-platform/ballerina-examples.git
 [submodule "tool-plugins/vscode/grammar/ballerina-grammar"]
 	path = tool-plugins/vscode/grammar/ballerina-grammar
 	url = https://github.com/ballerina-platform/ballerina-grammar.git

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
@@ -197,9 +197,9 @@ public class CommandExecutor {
                 remainingTextToReplace = fileContent;
             }
 
-            String editText = (pos != null ? "\r\n" : "") + "import " + pkgName + ";"
-                    + (remainingTextToReplace.startsWith("\n") || remainingTextToReplace.startsWith("\r") ? "" : "\r\n")
-                    + remainingTextToReplace;
+            String editText = (pos != null ? CommonUtil.LINE_SEPARATOR : "") + "import " + pkgName + ";"
+                    + (remainingTextToReplace.startsWith("\n") || remainingTextToReplace.startsWith("\r")
+                    ? "" : CommonUtil.LINE_SEPARATOR) + remainingTextToReplace;
             Range range = new Range(new Position(endLine, endCol + 1), new Position(totalLines + 1, lastCharCol));
 
             return applySingleTextEdit(editText, range, textDocumentIdentifier,

--- a/tool-plugins/intellij/src/test/java/io/ballerina/lexer/BallerinaLexerTest.java
+++ b/tool-plugins/intellij/src/test/java/io/ballerina/lexer/BallerinaLexerTest.java
@@ -40,7 +40,7 @@ import static io.netty.util.internal.StringUtil.EMPTY_STRING;
 public class BallerinaLexerTest extends LexerTestCase {
 
     private String getTestDataDirectoryPath() {
-        return "src/test/resources/BBE/examples";
+        return "../../examples";
     }
 
     private String getExpectedResultDirectoryPath() {

--- a/tool-plugins/intellij/src/test/java/io/ballerina/parsing/BallerinaParsingTest.java
+++ b/tool-plugins/intellij/src/test/java/io/ballerina/parsing/BallerinaParsingTest.java
@@ -44,7 +44,7 @@ public class BallerinaParsingTest extends ParsingTestCase {
 
     @Override
     protected String getTestDataPath() {
-        return "src/test/resources/BBE/examples";
+        return "../../examples";
     }
 
     private String getExpectedResultPath() {


### PR DESCRIPTION
## Purpose
This PR removes BBE submodule, which has been used as a test resource for lexer and parser related tests in IntelliJ plugin.

