### PR TITLE
Allow array of tuples for Testerina data providers

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -367,14 +367,15 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                         BType bType = func.getbFunction().getRetParamTypes()[0];
                         if (bType.getTag() == TypeTags.ARRAY_TAG) {
                             BArrayType bArrayType = (BArrayType) bType;
-                            if (bArrayType.getElementType().getTag() != TypeTags.ARRAY_TAG) {
+                            int tag = bArrayType.getElementType().getTag();
+                            if (!(tag == TypeTags.ARRAY_TAG || tag == TypeTags.TUPLE_TAG)) {
                                 String message = String.format("Data provider function [%s] should return an array of" +
-                                        " arrays.", dataProvider);
+                                        " arrays or an array of tuples.", dataProvider);
                                 throw new BallerinaException(message);
                             }
                         } else {
                             String message = String.format("Data provider function [%s] should return an array of " +
-                                    "arrays.", dataProvider);
+                                    "arrays or an array of tuples.", dataProvider);
                             throw new BallerinaException(message);
                         }
                     } else {
@@ -450,7 +451,7 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                     int idx = testNames.indexOf(dependsOnFn);
                     if (idx == -1) {
                         String message = String.format("Test [%s] depends on function [%s], but it couldn't be found" +
-                                ".", test.getTestFunction().getName(), dependsOnFn);
+                                                               ".", test.getTestFunction().getName(), dependsOnFn);
                         throw new BallerinaException(message);
                     }
                     dependencyMatrix[i].add(idx);

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
@@ -41,7 +41,7 @@ public class DataProviderTest {
         BTestRunner runner = new BTestRunner();
         runner.runTest(sourceRoot, new Path[]{Paths.get("data-provider-test.bal")}, new
                 ArrayList<>());
-        Assert.assertEquals(runner.getTesterinaReport().getTestSummary(".", "passed"), 5);
+        Assert.assertEquals(runner.getTesterinaReport().getTestSummary(".", "passed"), 6);
 
     }
 

--- a/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/data-provider-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/data-provider-test.bal
@@ -41,10 +41,26 @@ function testFunc3 (json fValue, json sValue, json result) {
     test:assertEquals(result, c, msg = "json data provider failed");
 }
 
+@test:Config{
+    dataProvider:"dataGen4"
+}
+function testFunc4 (int aValue, int bValue, (int, int) result) {
+    int a = 10;
+    int b = 20;
+    (int, int) c = (30, 30);
+    test:assertEquals(aValue, a, msg = "tuple data provider failed");
+    test:assertEquals(bValue, b, msg = "tuple data provider failed");
+    test:assertEquals(result, c, msg = "tuple data provider failed");
+}
+
 function dataGen2() returns (string[][]) {
     return [["1", "2", "3"]];
 }
 
 function dataGen3() returns (json[][]) {
     return [[{"a": "a"}, {"b": "b"}, {"c": "c"}]];
+}
+
+function dataGen4() returns ((int, int, (int, int))[]) {
+    return [(10, 20, (30, 30))];
 }


### PR DESCRIPTION
## Purpose
With this PR, Testerina allows writing data providers that returning array of tuples. However, this is a valid use case for scenarios where the specific testing function returning a tuple(`any[][]` doesn't helps here since you can't assign a tuple to an `any` array).

**::Let the source file be;**

```ballerina
function addition(int n1, int n2) returns (int, int) {
    return (n1 + n2, n1 - n2);
}
```
**::Then my test file should be;**

```ballerina
@test:Config{
    dataProvider:"additionDataProvider"
}
function testAddition(int n1, int n2, (int, int) expected) {
    (int, int) actual = addition (n1, n2);
    test:assertEquals(actual, expected, msg = "The value is not correct");
}

function additionDataProvider() returns ((int, int, (int, int))[]){
    return [(1, 1, (2, 0)), (4, 2, (6, 2))];
}
```
This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/10927