### PR TITLE
Add support for little endian byte order 

### DIFF
--- a/stdlib/io/src/main/ballerina/io/writable_data_channel.bal
+++ b/stdlib/io/src/main/ballerina/io/writable_data_channel.bal
@@ -19,8 +19,9 @@
 # BIG_ENDIAN - specifies the bytes to be in the order of most significant byte first
 #
 # LITTLE_ENDIAN - specifies the byte order to be the least significant byte first
-public type ByteOrder "BE";
+public type ByteOrder "BE"|"LE";
 @final public ByteOrder BIG_ENDIAN = "BE";
+@final public ByteOrder LITTLE_ENDIAN = "LE";
 
 # Represents a WritableDataChannel for writing data.
 public type WritableDataChannel object {

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DataChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DataChannel.java
@@ -57,9 +57,9 @@ public class DataChannel implements IOChannel {
     }
 
     /**
-     * Reverse the array of a given bytebuffer.
+     * Reverse the underlying array of the given ByteBuffer.
      *
-     * @param buffer the content of the byte in it's native byte order.
+     * @param buffer byte content in it's native order.
      */
     private byte[] reverse(ByteBuffer buffer) {
         byte[] contentArr = buffer.array();
@@ -155,8 +155,8 @@ public class DataChannel implements IOChannel {
      * Converts var long to a fixed size long.
      *
      * @param value  var long value.
-     * @param nBytes number of bytes in varlong.
-     * @return corresponding long converted through varlong.
+     * @param nBytes number of bytes in VarLong.
+     * @return corresponding long converted through VarLong.
      */
     private long convertVarLongToFixedLong(long value, int nBytes) {
         int nBits = nBytes * Representation.VARIABLE.getBase() - 1;

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DataChannel.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/DataChannel.java
@@ -42,7 +42,6 @@ public class DataChannel implements IOChannel {
      */
     private static final long BIT_64_LONG_MAX = 0xFFFFFFFFFFFFFFFFL;
 
-
     public DataChannel(Channel channel, ByteOrder order) {
         this.channel = channel;
         this.order = order;
@@ -58,7 +57,7 @@ public class DataChannel implements IOChannel {
     }
 
     /**
-     * Reverse the byte array.
+     * Reverse the array of a given bytebuffer.
      *
      * @param buffer the content of the byte in it's native byte order.
      */
@@ -75,8 +74,8 @@ public class DataChannel implements IOChannel {
     /**
      * Recursively read bytes until the buffer is filled.
      *
-     * @param buffer         buffer which holds the byte[]
-     * @param representation specifies the representation
+     * @param buffer         buffer which holds the byte[].
+     * @param representation specifies the representation.
      * @throws IOException during i/o error.
      */
     private void readFull(ByteBuffer buffer, Representation representation) throws IOException {
@@ -207,7 +206,7 @@ public class DataChannel implements IOChannel {
     }
 
     /**
-     * Reverse the buffer content.
+     * Reverse the buffer content based on little-endian byte order.
      *
      * @param content original content which contains the byte[] information.
      * @return content which is reversed.
@@ -266,7 +265,7 @@ public class DataChannel implements IOChannel {
      * Writes the given content to the channel.
      *
      * @param buffer         buffer which holds the content.
-     * @param representation whether this a var/fix int
+     * @param representation whether this a var/fix int.
      * @throws IOException occurs during i/o error.
      */
     private void write(ByteBuffer buffer, Representation representation) throws IOException {

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/Representation.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/Representation.java
@@ -41,7 +41,7 @@ public enum Representation {
      */
     VARIABLE(-1, IOConstants.PROTO_BUF_BASE),
     /**
-     * If representation could not be used.
+     * If representation is none.
      */
     NONE(-1, -1);
 

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/Representation.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/channels/base/Representation.java
@@ -39,7 +39,11 @@ public enum Representation {
     /**
      * Represents a variable value which does not have a size defined.
      */
-    VARIABLE(-1, IOConstants.PROTO_BUF_BASE);
+    VARIABLE(-1, IOConstants.PROTO_BUF_BASE),
+    /**
+     * If representation could not be used.
+     */
+    NONE(-1, -1);
 
     private int numberOfBytes;
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
@@ -47,7 +47,7 @@ public class DataChannelTest {
         currentDirectoryPath = System.getProperty("user.dir") + "/target";
     }
 
-    @Test(description = "read and write fixed size integers", dataProvider = "endianness")
+    @Test(description = "read and write fixed size integers", dataProvider = "Endianness")
     public void processFixedInteger(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/integer.bin";
         //Will initialize the channel
@@ -63,7 +63,7 @@ public class DataChannelTest {
         Assert.assertEquals(value, ((BInteger) result[0]).intValue());
     }
 
-    @Test(description = "read and write var integers", dataProvider = "endianness")
+    @Test(description = "read and write var integers", dataProvider = "Endianness")
     public void processVarInteger(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/varint.bin";
         //Will initialize the channel
@@ -77,7 +77,7 @@ public class DataChannelTest {
         Assert.assertEquals(value, ((BInteger) result[0]).intValue());
     }
 
-    @Test(description = "read and write fixed size float values", dataProvider = "endianness")
+    @Test(description = "read and write fixed size float values", dataProvider = "Endianness")
     public void processFixedFloat(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/float.bin";
         //Will initialize the channel
@@ -91,7 +91,7 @@ public class DataChannelTest {
         Assert.assertEquals(value, ((BFloat) result[0]).floatValue());
     }
 
-    @Test(description = "read and write bool", dataProvider = "endianness")
+    @Test(description = "read and write bool", dataProvider = "Endianness")
     public void processBool(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/boolean.bin";
         BValue[] args = {new BBoolean(false), new BString(sourceToWrite), new BString(order.toString())};
@@ -103,7 +103,7 @@ public class DataChannelTest {
         Assert.assertEquals(false, ((BBoolean) result[0]).booleanValue());
     }
 
-    @Test(description = "read and write string", dataProvider = "endianness")
+    @Test(description = "read and write string", dataProvider = "Endianness")
     public void processString(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/string.bin";
         String content = "Ballerina";

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
@@ -47,12 +47,14 @@ public class DataChannelTest {
         currentDirectoryPath = System.getProperty("user.dir") + "/target";
     }
 
-    @Test(description = "read and write fixed size integers", dataProvider = "Endianness")
+    @Test(description = "read and write fixed size integers", dataProvider = "endianness")
     public void processFixedInteger(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/integer.bin";
         //Will initialize the channel
         int value = 123;
-        BValue[] args = {new BInteger(value), new BString(sourceToWrite), new BString(order.toString())};
+        BValue[] args = {new BInteger(value),
+                new BString(sourceToWrite),
+                new BString(order.toString())};
         BRunUtil.invokeStateful(dataChannel, "testWriteFixedSignedInt", args);
 
         BValue[] args2 = {new BString(sourceToWrite), new BString(order.toString())};
@@ -61,7 +63,7 @@ public class DataChannelTest {
         Assert.assertEquals(value, ((BInteger) result[0]).intValue());
     }
 
-    @Test(description = "read and write var integers")
+    @Test(description = "read and write var integers", dataProvider = "endianness")
     public void processVarInteger(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/varint.bin";
         //Will initialize the channel
@@ -75,7 +77,7 @@ public class DataChannelTest {
         Assert.assertEquals(value, ((BInteger) result[0]).intValue());
     }
 
-    @Test(description = "read and write fixed size float values")
+    @Test(description = "read and write fixed size float values", dataProvider = "endianness")
     public void processFixedFloat(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/float.bin";
         //Will initialize the channel
@@ -89,7 +91,7 @@ public class DataChannelTest {
         Assert.assertEquals(value, ((BFloat) result[0]).floatValue());
     }
 
-    @Test(description = "read and write bool")
+    @Test(description = "read and write bool", dataProvider = "endianness")
     public void processBool(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/boolean.bin";
         BValue[] args = {new BBoolean(false), new BString(sourceToWrite), new BString(order.toString())};
@@ -101,7 +103,7 @@ public class DataChannelTest {
         Assert.assertEquals(false, ((BBoolean) result[0]).booleanValue());
     }
 
-    @Test(description = "read and write string")
+    @Test(description = "read and write string", dataProvider = "endianness")
     public void processString(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/string.bin";
         String content = "Ballerina";
@@ -118,9 +120,8 @@ public class DataChannelTest {
     }
 
     @DataProvider(name = "Endianness")
-    public static Object[][] endianness() {
+    public Object[][] endianness() {
         return new Object[][]{{ByteOrder.BIG_ENDIAN}, {ByteOrder.LITTLE_ENDIAN}};
-
     }
 
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/data/DataChannelTest.java
@@ -29,7 +29,10 @@ import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.nio.ByteOrder;
 
 /**
  * Test data io operations.
@@ -44,71 +47,80 @@ public class DataChannelTest {
         currentDirectoryPath = System.getProperty("user.dir") + "/target";
     }
 
-    @Test(description = "read and write fixed size integers")
-    public void processFixedInteger() {
+    @Test(description = "read and write fixed size integers", dataProvider = "Endianness")
+    public void processFixedInteger(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/integer.bin";
         //Will initialize the channel
         int value = 123;
-        BValue[] args = {new BInteger(value), new BString(sourceToWrite)};
+        BValue[] args = {new BInteger(value), new BString(sourceToWrite), new BString(order.toString())};
         BRunUtil.invokeStateful(dataChannel, "testWriteFixedSignedInt", args);
 
-        BValue[] args2 = {new BString(sourceToWrite)};
+        BValue[] args2 = {new BString(sourceToWrite), new BString(order.toString())};
         BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadFixedSignedInt", args2);
 
         Assert.assertEquals(value, ((BInteger) result[0]).intValue());
     }
 
     @Test(description = "read and write var integers")
-    public void processVarInteger() {
+    public void processVarInteger(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/varint.bin";
         //Will initialize the channel
         int value = 2;
-        BValue[] args = {new BInteger(value), new BString(sourceToWrite)};
+        BValue[] args = {new BInteger(value), new BString(sourceToWrite), new BString(order.toString())};
         BRunUtil.invokeStateful(dataChannel, "testWriteVarInt", args);
 
-        BValue[] args2 = {new BString(sourceToWrite)};
+        BValue[] args2 = {new BString(sourceToWrite), new BString(order.toString())};
         BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadVarInt", args2);
 
         Assert.assertEquals(value, ((BInteger) result[0]).intValue());
     }
 
     @Test(description = "read and write fixed size float values")
-    public void processFixedFloat() {
+    public void processFixedFloat(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/float.bin";
         //Will initialize the channel
         double value = 1359494.69;
-        BValue[] args = {new BFloat(value), new BString(sourceToWrite)};
+        BValue[] args = {new BFloat(value), new BString(sourceToWrite), new BString(order.toString())};
         BRunUtil.invokeStateful(dataChannel, "testWriteFixedFloat", args);
 
-        BValue[] args2 = {new BString(sourceToWrite)};
+        BValue[] args2 = {new BString(sourceToWrite), new BString(order.toString())};
         BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadFixedFloat", args2);
 
         Assert.assertEquals(value, ((BFloat) result[0]).floatValue());
     }
 
     @Test(description = "read and write bool")
-    public void processBool() {
+    public void processBool(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/boolean.bin";
-        BValue[] args = {new BBoolean(false), new BString(sourceToWrite)};
+        BValue[] args = {new BBoolean(false), new BString(sourceToWrite), new BString(order.toString())};
         BRunUtil.invokeStateful(dataChannel, "testWriteBool", args);
 
-        BValue[] args2 = {new BString(sourceToWrite)};
+        BValue[] args2 = {new BString(sourceToWrite), new BString(order.toString())};
         BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadBool", args2);
 
         Assert.assertEquals(false, ((BBoolean) result[0]).booleanValue());
     }
 
     @Test(description = "read and write string")
-    public void processString() {
+    public void processString(ByteOrder order) {
         String sourceToWrite = currentDirectoryPath + "/string.bin";
         String content = "Ballerina";
         String encoding = "UTF-8";
-        BValue[] args = {new BString(sourceToWrite), new BString(content), new BString(encoding)};
+        BValue[] args = {new BString(sourceToWrite), new BString(content), new BString(encoding),
+                new BString(order.toString())};
         BRunUtil.invokeStateful(dataChannel, "testWriteString", args);
 
-        BValue[] args2 = {new BString(sourceToWrite), new BInteger(content.getBytes().length), new BString(encoding)};
+        BValue[] args2 = {new BString(sourceToWrite), new BInteger(content.getBytes().length), new BString(encoding),
+                new BString(order.toString())};
         BValue[] result = BRunUtil.invokeStateful(dataChannel, "testReadString", args2);
 
         Assert.assertEquals(content, result[0].stringValue());
     }
+
+    @DataProvider(name = "Endianness")
+    public static Object[][] endianness() {
+        return new Object[][]{{ByteOrder.BIG_ENDIAN}, {ByteOrder.LITTLE_ENDIAN}};
+
+    }
+
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/io/data_io.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/io/data_io.bal
@@ -1,75 +1,75 @@
 import ballerina/io;
 
-function testWriteFixedSignedInt(int value, string path, io:ByteOrder bOrder) {
+function testWriteFixedSignedInt(int value, string path, io:ByteOrder byteOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch, bOrder);
+    io:WritableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     var result = dataChannel.writeInt64(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadFixedSignedInt(string path, io:ByteOrder bOrder) returns int|error {
+function testReadFixedSignedInt(string path, io:ByteOrder byteOrder) returns int|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch, bOrder);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     int result = check dataChannel.readInt64();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteVarInt(int value, string path, io:ByteOrder bOrder) {
+function testWriteVarInt(int value, string path, io:ByteOrder byteOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch, bOrder);
+    io:WritableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     var result = dataChannel.writeVarInt(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadVarInt(string path, io:ByteOrder bOrder) returns int|error {
+function testReadVarInt(string path, io:ByteOrder byteOrder) returns int|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch, bOrder);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     int result = check dataChannel.readVarInt();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteFixedFloat(float value, string path, io:ByteOrder bOrder) {
+function testWriteFixedFloat(float value, string path, io:ByteOrder byteOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch, bOrder);
+    io:WritableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     var result = dataChannel.writeFloat64(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadFixedFloat(string path, io:ByteOrder bOrder) returns float|error {
+function testReadFixedFloat(string path, io:ByteOrder byteOrder) returns float|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch, bOrder);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     float result = check dataChannel.readFloat64();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteBool(boolean value, string path, io:ByteOrder bOrder) {
+function testWriteBool(boolean value, string path, io:ByteOrder byteOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch, bOrder);
+    io:WritableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     var result = dataChannel.writeBool(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadBool(string path, io:ByteOrder bOrder) returns boolean|error {
+function testReadBool(string path, io:ByteOrder byteOrder) returns boolean|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch, bOrder);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     boolean result = check dataChannel.readBool();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteString(string path, string content, string encoding, io:ByteOrder bOrder) {
+function testWriteString(string path, string content, string encoding, io:ByteOrder byteOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch, bOrder);
+    io:WritableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     var result = check dataChannel.writeString(content, encoding);
     var closeResult = dataChannel.close();
 }
 
-function testReadString(string path, int nBytes, string encoding, io:ByteOrder bOrder) returns string|error {
+function testReadString(string path, int nBytes, string encoding, io:ByteOrder byteOrder) returns string|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch, bOrder);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder = byteOrder);
     string result = check dataChannel.readString(nBytes, encoding);
     var closeResult = dataChannel.close();
     return result;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/io/data_io.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/io/data_io.bal
@@ -1,75 +1,75 @@
 import ballerina/io;
 
-function testWriteFixedSignedInt(int value, string path) {
+function testWriteFixedSignedInt(int value, string path, io:ByteOrder bOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch);
+    io:WritableDataChannel dataChannel = new(ch, bOrder);
     var result = dataChannel.writeInt64(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadFixedSignedInt(string path) returns int|error {
+function testReadFixedSignedInt(string path, io:ByteOrder bOrder) returns int|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder);
     int result = check dataChannel.readInt64();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteVarInt(int value, string path) {
+function testWriteVarInt(int value, string path, io:ByteOrder bOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch);
+    io:WritableDataChannel dataChannel = new(ch, bOrder);
     var result = dataChannel.writeVarInt(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadVarInt(string path) returns int|error {
+function testReadVarInt(string path, io:ByteOrder bOrder) returns int|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder);
     int result = check dataChannel.readVarInt();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteFixedFloat(float value, string path) {
+function testWriteFixedFloat(float value, string path, io:ByteOrder bOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch);
+    io:WritableDataChannel dataChannel = new(ch, bOrder);
     var result = dataChannel.writeFloat64(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadFixedFloat(string path) returns float|error {
+function testReadFixedFloat(string path, io:ByteOrder bOrder) returns float|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder);
     float result = check dataChannel.readFloat64();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteBool(boolean value, string path) {
+function testWriteBool(boolean value, string path, io:ByteOrder bOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch);
+    io:WritableDataChannel dataChannel = new(ch, bOrder);
     var result = dataChannel.writeBool(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadBool(string path) returns boolean|error {
+function testReadBool(string path, io:ByteOrder bOrder) returns boolean|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder);
     boolean result = check dataChannel.readBool();
     var closeResult = dataChannel.close();
     return result;
 }
 
-function testWriteString(string path, string content, string encoding) {
+function testWriteString(string path, string content, string encoding, io:ByteOrder bOrder) {
     io:WritableByteChannel ch = io:openWritableFile(path);
-    io:WritableDataChannel dataChannel = new(ch);
+    io:WritableDataChannel dataChannel = new(ch, bOrder);
     var result = check dataChannel.writeString(content, encoding);
     var closeResult = dataChannel.close();
 }
 
-function testReadString(string path, int nBytes, string encoding) returns string|error {
+function testReadString(string path, int nBytes, string encoding, io:ByteOrder bOrder) returns string|error {
     io:ReadableByteChannel ch = io:openReadableFile(path);
-    io:ReadableDataChannel dataChannel = new(ch);
+    io:ReadableDataChannel dataChannel = new(ch, bOrder);
     string result = check dataChannel.readString(nBytes, encoding);
     var closeResult = dataChannel.close();
     return result;


### PR DESCRIPTION
## Purpose
Support little endian format. This will fix #9337

## Goals
- Introduce interpretation of little endian byte order
- Add the relevant test cases

## Approach
Currently ballerina data-io supports only Big-Endian format. However, when dealing with serialized data used in formats such as protobuf it is required that the data is interpreted in Little-Endian format. 

The following is a sample usage of using Little-Endian format

```
    io:ReadableByteChannel ch = io:openReadableFile(path);
    io:ReadableDataChannel dataChannel = new(ch, bOrder = "LE");
    int result = check dataChannel.readInt64();
    var closeResult = dataChannel.close();
    return result;
```