### PR TITLE
[WebSub] Register topics irrespective of topicRegistrationRequired

### DIFF
--- a/stdlib/websub/src/main/ballerina/websub/commons.bal
+++ b/stdlib/websub/src/main/ballerina/websub/commons.bal
@@ -563,10 +563,18 @@ function WebSubHub::publishUpdate(string topic, string|xml|json|byte[]|io:Readab
 }
 
 function WebSubHub::registerTopic(string topic) returns error? {
+    if (!hubTopicRegistrationRequired) {
+        error e = { message: "Remote topic registration not allowed/not required at the Hub" };
+        return e;
+    }
     return registerTopicAtHub(topic);
 }
 
 function WebSubHub::unregisterTopic(string topic) returns error? {
+    if (!hubTopicRegistrationRequired) {
+        error e = { message: "Remote topic unregistration not allowed/not required at the Hub" };
+        return e;
+    }
     return unregisterTopicAtHub(topic);
 }
 

--- a/stdlib/websub/src/main/ballerina/websub/hub_service.bal
+++ b/stdlib/websub/src/main/ballerina/websub/hub_service.bal
@@ -87,7 +87,7 @@ service<http:Service> hubService {
                 error e => log:printError("Error responding to subscription change request", err = e);
                 () => {
                     if (validSubscriptionChangeRequest) {
-                        verifyIntent(callback, topic, params);
+                        verifyIntentAndAddSubscription(callback, topic, params);
                     }
                 }
             }
@@ -288,7 +288,7 @@ function validateSubscriptionChangeRequest(string mode, string topic, string cal
 # + callback - The callback URL of the new subscription/unsubscription request
 # + topic - The topic specified in the new subscription/unsubscription request
 # + params - Parameters specified in the new subscription/unsubscription request
-function verifyIntent(string callback, string topic, map<string> params) {
+function verifyIntentAndAddSubscription(string callback, string topic, map<string> params) {
     endpoint http:Client callbackEp {
         url:callback,
         secureSocket: hubClientSecureSocket
@@ -332,6 +332,12 @@ function verifyIntent(string callback, string topic, map<string> params) {
                             subscriptionDetails.leaseSeconds = leaseSeconds * 1000;
                             subscriptionDetails.createdAt = createdAt;
                             subscriptionDetails.secret = params[HUB_SECRET] but { () => "" };
+                            if (!isTopicRegistered(topic)) {
+                                match(registerTopicAtHub(topic)) {
+                                    error e => log:printError("Error registering topic for subscription: " + e.message);
+                                    () => {}
+                                }
+                            }
                             addSubscription(subscriptionDetails);
                         } else {
                             removeSubscription(topic, callback);
@@ -437,9 +443,7 @@ function changeSubscriptionInDatabase(string mode, SubscriptionDetails subscript
 # Function to initiate set up activities on startup/restart.
 function setupOnStartup() {
     if (hubPersistenceEnabled) {
-        if (hubTopicRegistrationRequired) {
-            addTopicRegistrationsOnStartup();
-        }
+        addTopicRegistrationsOnStartup();
         addSubscriptionsOnStartup(); //TODO:verify against topics
     }
     return;

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/hub/Hub.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/hub/Hub.java
@@ -81,9 +81,6 @@ public class Hub {
     }
 
     public void registerTopic(String topic, boolean loadingOnStartUp) throws BallerinaWebSubException {
-        if (!hubTopicRegistrationRequired) {
-            throw new BallerinaWebSubException("Remote topic registration not allowed/not required at the Hub");
-        }
         if (isTopicRegistered(topic)) {
             throw new BallerinaWebSubException("Topic registration not allowed at the Hub: topic already exists");
         } else if (topic == null || topic.isEmpty()) {
@@ -99,9 +96,6 @@ public class Hub {
     }
 
     public void unregisterTopic(String topic) throws BallerinaWebSubException {
-        if (!hubTopicRegistrationRequired) {
-            throw new BallerinaWebSubException("Remote topic unregistration not allowed/not required at the Hub");
-        }
         if (topic == null || !isTopicRegistered(topic)) {
             throw new BallerinaWebSubException("Topic unavailable/invalid for unregistration at Hub");
         } else {


### PR DESCRIPTION
## Purpose
This PR introduces logic to register topics internally at the hub even when topic registration is not required for publishers/subscribers, to maintain an explicit list of topics registered.