### PR TITLE
Update HTTP/2 to HTTP/1.1 fallback test case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2205,7 +2205,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.237</transport.http.version>
+        <transport.http.version>6.0.240</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2BaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2BaseTest.java
@@ -36,7 +36,7 @@ public class Http2BaseTest extends BaseTest {
 
     @BeforeGroups(value = "http2-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
-        int[] requiredPorts = new int[]{7090, 9090, 9092, 9093, 9094, 9095};
+        int[] requiredPorts = new int[]{7090, 9090, 9092, 9093, 9094, 9095, 9096};
 
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "http2").getAbsolutePath();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2ToHttp1FallbackTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2ToHttp1FallbackTestCase.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.service.http2;
 
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.HttpsClientRequest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,6 +34,17 @@ public class Http2ToHttp1FallbackTestCase extends Http2BaseTest {
     @Test(description = "Test HTTP/2.0 to HTTP/1.1 server fallback scenario")
     public void testFallback() throws IOException {
         HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9095, "hello"));
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        String responseData = response.getData();
+        Assert.assertTrue(responseData.contains("1.1"), responseData);
+    }
+
+    @Test(description = "Test HTTP/2.0 to HTTP/1.1 server fallback scenario with SSL enabled")
+    public void testFallbackWithSSL() throws IOException {
+        String serviceUrl = "https://localhost:9096/hello";
+        String serverHome = serverInstance.getServerHome();
+        HttpResponse response = HttpsClientRequest.doGet(serviceUrl, serverHome);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         String responseData = response.getData();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2ToHttp1FallbackTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2ToHttp1FallbackTestCase.java
@@ -37,7 +37,7 @@ public class Http2ToHttp1FallbackTestCase extends Http2BaseTest {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         String responseData = response.getData();
-        Assert.assertTrue(responseData.contains("1.1"), responseData);
+        Assert.assertEquals("Version: 1.1", responseData, "HTTP/2.0 to HTTP/1.1 server fallback scenario failed");
     }
 
     @Test(description = "Test HTTP/2.0 to HTTP/1.1 server fallback scenario with SSL enabled")
@@ -48,6 +48,7 @@ public class Http2ToHttp1FallbackTestCase extends Http2BaseTest {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         String responseData = response.getData();
-        Assert.assertTrue(responseData.contains("1.1"), responseData);
+        Assert.assertEquals("Version: 1.1", responseData,
+                "HTTP/2.0 to HTTP/1.1 server fallback scenario with SSL enabled failed");
     }
 }

--- a/tests/ballerina-integration-test/src/test/resources/http2/http2services/03_http_2.0_to_http_1.0_fallback_test.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http2/http2services/03_http_2.0_to_http_1.0_fallback_test.bal
@@ -16,15 +16,42 @@
 
 import ballerina/http;
 
-endpoint http:Listener helloWorldEP {
+endpoint http:Listener serviceEndpointWithoutSSL {
     port: 9095,
     httpVersion: "2.0"
+};
+
+endpoint http:Listener serviceEndpointWithSSL {
+    port: 9096,
+    httpVersion: "2.0",
+    secureSocket: {
+        keyStore: {
+            path: "${ballerina.home}/bre/security/ballerinaKeystore.p12",
+            password: "ballerina"
+        }
+    }
 };
 
 @http:ServiceConfig {
     basePath: "/hello"
 }
-service helloWorld bind helloWorldEP {
+service helloWorldWithoutSSL bind serviceEndpointWithoutSSL {
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/"
+    }
+    sayHelloGet(endpoint caller, http:Request req) {
+        http:Response res = new;
+        res.setTextPayload("Version: " + untaint req.httpVersion);
+        _ = caller->respond(res);
+    }
+}
+
+@http:ServiceConfig {
+    basePath: "/hello"
+}
+service helloWorldWithSSL bind serviceEndpointWithSSL {
 
     @http:ResourceConfig {
         methods: ["GET"],

--- a/tests/ballerina-integration-test/src/test/resources/http2/http2services/03_http_2.0_to_http_1.0_fallback_test.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http2/http2services/03_http_2.0_to_http_1.0_fallback_test.bal
@@ -42,9 +42,7 @@ service helloWorldWithoutSSL bind serviceEndpointWithoutSSL {
         path: "/"
     }
     sayHelloGet(endpoint caller, http:Request req) {
-        http:Response res = new;
-        res.setTextPayload("Version: " + untaint req.httpVersion);
-        _ = caller->respond(res);
+        _ = caller->respond("Version: " + untaint req.httpVersion);
     }
 }
 
@@ -58,8 +56,6 @@ service helloWorldWithSSL bind serviceEndpointWithSSL {
         path: "/"
     }
     sayHelloGet(endpoint caller, http:Request req) {
-        http:Response res = new;
-        res.setTextPayload("Version: " + untaint req.httpVersion);
-        _ = caller->respond(res);
+        _ = caller->respond("Version: " + untaint req.httpVersion);
     }
 }


### PR DESCRIPTION
## Purpose
This PR update HTTP/2 to HTTP/1.1 fallback test case when SSL is enabled.
Depends on: https://github.com/wso2/transport-http/pull/271
Refers to: https://github.com/ballerina-platform/ballerina-lang/issues/10936