### PR TITLE
Add command showDocs to vscode plugin

### DIFF
--- a/composer/distribution/package.json
+++ b/composer/distribution/package.json
@@ -14,11 +14,12 @@
   "author": "ballerina.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ballerina/diagram": "file:../diagram",
     "@ballerina/ballerina-by-examples": "file:../bbe",
     "@ballerina/theme": "file:../theme",
-    "react-dom": "^16.2.0",
-    "react": "^16.2.0"
+    "@ballerina/diagram": "file:../diagram",
+    "@ballerina/documentation": "file:../documentation",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "css-loader": "^1.0.0",

--- a/composer/distribution/package.json
+++ b/composer/distribution/package.json
@@ -8,8 +8,7 @@
     "test-coverage": "npm run test -- --coverage",
     "build": "webpack --mode=production ",
     "build-dev": "webpack --mode=development",
-    "watch": "webpack --mode=development --watch --progress --info-verbosity verbose",
-    "start:dev": "webpack-dev-server  --mode=development --progress"
+    "watch": "webpack-dev-server  --mode=development --progress"
   },
   "author": "ballerina.io",
   "license": "Apache-2.0",

--- a/composer/distribution/src/index.ts
+++ b/composer/distribution/src/index.ts
@@ -1,8 +1,10 @@
 import { renderEditableDiagram, renderStaticDiagram } from "@ballerina/diagram";
 import { renderSamplesList } from "@ballerina/ballerina-by-examples";
+import renderDocuments from "@ballerina/documentation";
 
 export {
     renderEditableDiagram,
     renderStaticDiagram,
-    renderSamplesList
+    renderSamplesList,
+    renderDocuments
 }

--- a/composer/distribution/src/index.ts
+++ b/composer/distribution/src/index.ts
@@ -1,10 +1,10 @@
 import { renderEditableDiagram, renderStaticDiagram } from "@ballerina/diagram";
 import { renderSamplesList } from "@ballerina/ballerina-by-examples";
-import renderDocuments from "@ballerina/documentation";
+import { renderDocPreview } from "@ballerina/documentation";
 
 export {
     renderEditableDiagram,
     renderStaticDiagram,
     renderSamplesList,
-    renderDocuments
+    renderDocPreview
 }

--- a/composer/distribution/src/types.d.ts
+++ b/composer/distribution/src/types.d.ts
@@ -5,5 +5,5 @@ declare module '@ballerina/diagram' {
 }
 
 declare module '@ballerina/documentation' {
-    export function render(ast: any, el: any): void;
+    export function renderDocPreview(ast: any, el: any): void;
 }

--- a/composer/distribution/src/types.d.ts
+++ b/composer/distribution/src/types.d.ts
@@ -3,3 +3,7 @@ declare module '@ballerina/diagram' {
     export function renderEditableDiagram(target: HTMLElement | null,
         docUri: string, width: number, height: number, getAST: Function) : void;
 }
+
+declare module '@ballerina/documentation' {
+    export function render(ast: any, el: any): void;
+}

--- a/composer/documentation/.babelrc
+++ b/composer/documentation/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/composer/documentation/package.json
+++ b/composer/documentation/package.json
@@ -2,12 +2,26 @@
   "name": "@ballerina/documentation",
   "version": "0.982.1-SNAPSHOT",
   "description": "",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
-    "test-coverage": "npm run test -- --coverage",
-    "build": "echo \"Building documentation module\"",
-    "test": "echo \"Error: no test specified\""
+    "build": "babel src -d lib --copy-files",
+    "watch": "babel src -d lib --copy-files --watch"
   },
   "author": "ballerina.io",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "diff": "^3.5.0",
+    "escape-html": "^1.0.3",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "react-markdown": "^4.0.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.1.2",
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/preset-react": "^7.0.0",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2"
+  }
 }

--- a/composer/documentation/src/components/App.jsx
+++ b/composer/documentation/src/components/App.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Documentation from './Documentation';
 
-export default class App extends React.Component {
+export default class DocPreview extends React.Component {
     getDocumentationDetails(node) {
         const { markdownDocumentationAttachment: mdDoc } = node;
 
@@ -35,7 +35,6 @@ export default class App extends React.Component {
                 description: mdDoc.returnParameterDocumentation,
             };
         }
-        console.log(returnParameter);
         const documentationDetails = {
             title: node.name.value,
             description: mdDoc.documentation,

--- a/composer/documentation/src/components/App.jsx
+++ b/composer/documentation/src/components/App.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Documentation from './Documentation';
+
+export default class App extends React.Component {
+    getDocumentationDetails(node) {
+        const { markdownDocumentationAttachment: mdDoc } = node;
+
+        const parameters = {};
+        node.parameters.forEach(param => {
+            parameters[param.name.value] = {
+                name: param.name.value,
+                type: param.typeNode.typeKind,
+            };
+        });
+        node.defaultableParameters.forEach(param => {
+            parameters[param.variable.name.value] = {
+                name: param.variable.name.value,
+                type: param.variable.typeNode.typeKind,
+                defaultValue: param.variable.initialExpression.value,
+            };
+        });
+
+        const processedParameters = mdDoc.parameters.map((param) => {
+            const { name, type, defaultValue } =  parameters[param.parameterName.value];
+            const description = param.parameterDocumentation;
+            return {
+                name, type, defaultValue, description
+            };
+        });
+
+        let returnParameter;
+        if (node.returnTypeNode) {
+            returnParameter = {
+                type: node.returnTypeNode.typeKind,
+                description: mdDoc.returnParameterDocumentation,
+            };
+        }
+        console.log(returnParameter);
+        const documentationDetails = {
+            title: node.name.value,
+            description: mdDoc.documentation,
+            parameters: processedParameters,
+            returnParameter
+        };
+        return documentationDetails;
+    }
+
+    render() {
+        const docElements = [];
+        this.props.ast.topLevelNodes.forEach(node => {
+            if(node.markdownDocumentationAttachment) {
+                const docDetails = this.getDocumentationDetails(node);
+                docElements.push(
+                    <Documentation docDetails={docDetails}/>
+                );
+            }
+        });
+        return docElements;
+    }
+}

--- a/composer/documentation/src/components/Description.css
+++ b/composer/documentation/src/components/Description.css
@@ -1,0 +1,11 @@
+.added {
+    animation: newAdd 3s;
+    animation-fill-mode: forwards;
+}
+
+@keyframes newAdd {
+    from {
+        background-color: rgb(225, 225, 50);
+    }
+    to {}
+}

--- a/composer/documentation/src/components/Description.css
+++ b/composer/documentation/src/components/Description.css
@@ -1,4 +1,4 @@
-.added {
+.__added {
     animation: newAdd 3s;
     animation-fill-mode: forwards;
 }

--- a/composer/documentation/src/components/Description.jsx
+++ b/composer/documentation/src/components/Description.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown/with-html';
+import htmlParser from 'react-markdown/plugins/html-parser';
+import { diffChars } from 'diff';
+import escape from 'escape-html';
+import './Description.css';
+
+export default class Description extends React.Component {
+    constructor(props) {
+        super(props);
+        this.diff = [{
+            value: props.source,
+        }];
+    }
+
+    componentWillReceiveProps(newProps) {
+        this.diff = diffChars(this.props.source, newProps.source);
+    }
+
+    render() {
+        let source = '';
+        this.diff.forEach((part) => {
+            if (part.removed) {
+                return;
+            }
+
+            const value = escape(part.value);
+            if(part.added) {
+                source += `<span class="added">${value}</span>`;
+            } else {
+                source += value;
+            }
+        })
+
+        return <ReactMarkdown 
+            source={source}
+            escapeHtml={false}
+            className={this.props.className}
+            renderers={{
+                inlineCode: block => {
+                    return <code></code>
+                }
+            }}
+        />
+    }
+}

--- a/composer/documentation/src/components/Description.jsx
+++ b/composer/documentation/src/components/Description.jsx
@@ -26,7 +26,7 @@ export default class Description extends React.Component {
 
             const value = escape(part.value);
             if(part.added) {
-                source += `<span class="added">${value}</span>`;
+                source += `<span class="__added">${value}</span>`;
             } else {
                 source += value;
             }
@@ -38,7 +38,9 @@ export default class Description extends React.Component {
             className={this.props.className}
             renderers={{
                 inlineCode: block => {
-                    return <code></code>
+                    const value = block.value.replace(
+                        new RegExp('<span class="__added">((?:.|\s)*)<\/span>'), '$1');
+                    return <code>{value}</code>
                 }
             }}
         />

--- a/composer/documentation/src/components/Documentation.css
+++ b/composer/documentation/src/components/Documentation.css
@@ -1,0 +1,57 @@
+.documentation {
+    margin: 10px;
+    margin-bottom: 30px;
+}
+
+.documentation .title {
+    font-size: 15px;
+    margin-bottom: 5px;
+}
+
+.documentation p {
+    line-height: 1.2em;
+}
+
+.documentation .parameters {
+    width: 100%;
+}
+
+.documentation .return-parameters {
+    min-width: 100px;
+}
+
+.documentation table {
+    margin-top: 5px;
+    text-align: left;
+    font-size: 13px;
+    border-collapse: collapse;
+}
+
+.documentation table th
+{
+    border-bottom:1px solid;
+}
+
+.documentation table td
+{
+    padding-top: 3px;
+}
+
+.documentation table th,
+.documentation table td {
+    vertical-align: top;
+    border-right:1px solid;
+    border-color: #555555;
+    padding-left: 3px;
+    min-width: 100px;
+    max-width: 200px;
+}
+
+.documentation table th:last-child, 
+.documentation table td:last-child  {
+    border-right: none;
+}
+
+.documentation table td p {
+    margin: 0;
+}

--- a/composer/documentation/src/components/Documentation.jsx
+++ b/composer/documentation/src/components/Documentation.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Description from './Description';
+import './Documentation.css';
+
+const Documentation = ({ docDetails }) => {
+    const { title, description, parameters, returnParameter } = docDetails;
+    return (
+        <div className='documentation'>
+            <div className='title'><b>{title}</b></div>
+            <Description source={description} className='description' />
+            {parameters.length > 0 && (
+                <table className='parameters'>
+                    <tbody>
+                        <tr>
+                            <th>Parameter Name</th>
+                            <th>Data Type</th>
+                            <th>Default Value</th>
+                            <th>Description</th>
+                        </tr>
+                        {
+                            parameters.map((param) => {
+                                const { name, type, defaultValue, description } = param;
+                                return (
+                                    <tr>
+                                        <td>{name}</td>
+                                        <td>{type}</td>
+                                        <td>{defaultValue}</td>
+                                        <td>{<Description source={description} />}</td>
+                                    </tr>
+                                );
+                            })
+                        }
+                    </tbody>
+                </table>
+            )}
+            {returnParameter && returnParameter.type !== 'nil' && (
+                <table className='return-parameters'>
+                    <tbody>
+                        <tr>
+                            <th>Return Type</th>
+                            <th>Description</th>
+                        </tr>
+                        <tr>
+                            <td>{returnParameter.type}</td>
+                            <td>{<Description source={returnParameter.description || ""} />}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+};
+
+export default Documentation;

--- a/composer/documentation/src/index.jsx
+++ b/composer/documentation/src/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './components/App';
+
+export default function render(ast, el) {
+    console.log(el)
+    ReactDOM.render(<App ast={ast}/>, el);
+}

--- a/composer/documentation/src/index.jsx
+++ b/composer/documentation/src/index.jsx
@@ -3,6 +3,5 @@ import ReactDOM from 'react-dom';
 import App from './components/App';
 
 export default function render(ast, el) {
-    console.log(el)
     ReactDOM.render(<App ast={ast}/>, el);
 }

--- a/composer/documentation/src/index.jsx
+++ b/composer/documentation/src/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './components/App';
+import DocPreview from './components/App';
 
-export default function render(ast, el) {
-    ReactDOM.render(<App ast={ast}/>, el);
+export function renderDocPreview(ast, el) {
+    ReactDOM.render(<DocPreview ast={ast}/>, el);
 }

--- a/composer/extended-language-client/src/extended-language-client.ts
+++ b/composer/extended-language-client/src/extended-language-client.ts
@@ -100,6 +100,15 @@ export class ExtendedLangClient extends LanguageClient {
         return this.sendRequest("ballerinaExample/list", args);
     }
 
+    fetchDocs(uri: Uri): Thenable<any> {
+        const req: GetASTRequest = {
+            documentIdentifier: {
+                uri: uri.toString()
+            }
+        };
+        return this.sendRequest("ballerinaDocument/docs", req);
+    }
+
     parseFragment(args: BallerinaFragmentASTRequest): Thenable<BallerinaFragmentASTResponse> {
         return this.sendRequest("ballerinaFragment/ast", args).then((resp: any)=> resp.ast);
     }

--- a/composer/extended-language-client/src/extended-language-client.ts
+++ b/composer/extended-language-client/src/extended-language-client.ts
@@ -100,15 +100,6 @@ export class ExtendedLangClient extends LanguageClient {
         return this.sendRequest("ballerinaExample/list", args);
     }
 
-    fetchDocs(uri: Uri): Thenable<any> {
-        const req: GetASTRequest = {
-            documentIdentifier: {
-                uri: uri.toString()
-            }
-        };
-        return this.sendRequest("ballerinaDocument/docs", req);
-    }
-
     parseFragment(args: BallerinaFragmentASTRequest): Thenable<BallerinaFragmentASTResponse> {
         return this.sendRequest("ballerinaFragment/ast", args).then((resp: any)=> resp.ast);
     }

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -141,19 +141,22 @@
         "commands": [
             {
                 "command": "ballerina.showDiagram",
-                "title": "Ballerina: Show Diagram",
+                "title": "Show Diagram",
                 "icon": {
                     "dark": "./resources/images/icons/design-view-white.svg",
                     "light": "./resources/images/icons/design-view.svg"
-                }
+                },
+                "category": "Ballerina"
             },
             {
                 "command": "ballerina.showExamples",
-                "title": "Ballerina: Show Examples"
+                "title": "Show Examples",
+                "category": "Ballerina"
             },
             {
                 "command": "ballerina.showDocs",
-                "title": "Ballerina: Show Docs"
+                "title": "Open Doc Prview",
+                "category": "Ballerina"
             }
         ],
         "menus": {

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -150,6 +150,10 @@
             {
                 "command": "ballerina.showExamples",
                 "title": "Ballerina: Show Examples"
+            },
+            {
+                "command": "ballerina.showDocs",
+                "title": "Ballerina: Show Docs"
             }
         ],
         "menus": {
@@ -176,7 +180,7 @@
         "compare-versions": "^3.4.0",
         "cross-env": "^5.2.0",
         "glob": "^7.1.3",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "openport": "0.0.4",
         "ps-node": "^0.1.6",
         "request-promise": "^4.2.2",

--- a/tool-plugins/vscode/src/docs/activator.ts
+++ b/tool-plugins/vscode/src/docs/activator.ts
@@ -16,7 +16,10 @@
  * under the License.
  *
  */
-import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent } from 'vscode';
+import {
+	workspace, commands, window, Uri, ViewColumn,
+	ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent
+} from 'vscode';
 import * as _ from 'lodash';
 import { render } from './renderer';
 import { BallerinaAST, ExtendedLangClient } from '../core/extended-language-client';
@@ -29,7 +32,7 @@ let activeEditor: TextEditor | undefined;
 
 function updateWebView(ast: BallerinaAST, docUri: Uri): void {
 	if (previewPanel) {
-		previewPanel.webview.postMessage({ 
+		previewPanel.webview.postMessage({
 			command: 'update',
 			json: ast,
 			docUri: docUri.toString()
@@ -39,34 +42,34 @@ function updateWebView(ast: BallerinaAST, docUri: Uri): void {
 
 function showDocs(context: ExtensionContext, langClient: ExtendedLangClient): void {
 	const didChangeDisposable = workspace.onDidChangeTextDocument(
-			_.debounce((e: TextDocumentChangeEvent) => {
-		if (activeEditor && (e.document === activeEditor.document) &&
-			e.document.fileName.endsWith('.bal')) {
-			const docUri = e.document.uri;
-			langClient.getAST(docUri)
-				.then((resp) => {
-					if (resp.ast) {
-						updateWebView(resp.ast, docUri);
-					}
-				});
-		}
-	}, DEBOUNCE_WAIT));
+		_.debounce((e: TextDocumentChangeEvent) => {
+			if (activeEditor && (e.document === activeEditor.document) &&
+				e.document.fileName.endsWith('.bal')) {
+				const docUri = e.document.uri;
+				langClient.getAST(docUri)
+					.then((resp) => {
+						if (resp.ast) {
+							updateWebView(resp.ast, docUri);
+						}
+					});
+			}
+		}, DEBOUNCE_WAIT));
 
-	const changeActiveEditorDisposable =  window.onDidChangeActiveTextEditor(
-			(activatedEditor: TextEditor | undefined) => {
-		if (window.activeTextEditor && activatedEditor 
-					&& (activatedEditor.document === window.activeTextEditor.document) 
-					&& activatedEditor.document.fileName.endsWith('.bal')) {
-			activeEditor = window.activeTextEditor;
-			const docUri = activatedEditor.document.uri;
-			langClient.getAST(docUri)
-				.then((resp) => {
-					if (resp.ast) {
-						updateWebView(resp.ast, docUri);
-					}
-				});
-		}
-	});
+	const changeActiveEditorDisposable = window.onDidChangeActiveTextEditor(
+		(activatedEditor: TextEditor | undefined) => {
+			if (window.activeTextEditor && activatedEditor
+				&& (activatedEditor.document === window.activeTextEditor.document)
+				&& activatedEditor.document.fileName.endsWith('.bal')) {
+				activeEditor = window.activeTextEditor;
+				const docUri = activatedEditor.document.uri;
+				langClient.getAST(docUri)
+					.then((resp) => {
+						if (resp.ast) {
+							updateWebView(resp.ast, docUri);
+						}
+					});
+			}
+		});
 
 	if (previewPanel) {
 		previewPanel.reveal(ViewColumn.Two, true);
@@ -76,14 +79,14 @@ function showDocs(context: ExtensionContext, langClient: ExtendedLangClient): vo
 	previewPanel = window.createWebviewPanel(
 		'ballerinaDocs',
 		"Ballerina Docs",
-		{ viewColumn: ViewColumn.Two, preserveFocus: true } ,
+		{ viewColumn: ViewColumn.Two, preserveFocus: true },
 		{
 			enableScripts: true,
 			retainContextWhenHidden: true,
 		}
 	);
 	const editor = window.activeTextEditor;
-	if(!editor) {
+	if (!editor) {
 		return;
 	}
 	activeEditor = editor;
@@ -94,11 +97,11 @@ function showDocs(context: ExtensionContext, langClient: ExtendedLangClient): vo
 	}
 
 	langClient.getAST(editor.document.uri)
-	.then((resp) => {
-		if (resp.ast) {
-			updateWebView(resp.ast, editor.document.uri);
-		}
-	});
+		.then((resp) => {
+			if (resp.ast) {
+				updateWebView(resp.ast, editor.document.uri);
+			}
+		});
 
 	previewPanel.onDidDispose(() => {
 		previewPanel = undefined;
@@ -108,27 +111,27 @@ function showDocs(context: ExtensionContext, langClient: ExtendedLangClient): vo
 }
 
 export function activate(ballerinaExtInstance: BallerinaExtension) {
-    let context = <ExtensionContext> ballerinaExtInstance.context;
-    let langClient = <ExtendedLangClient> ballerinaExtInstance.langClient;
+	let context = <ExtensionContext>ballerinaExtInstance.context;
+	let langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
 	const docsRenderDisposable = commands.registerCommand('ballerina.showDocs', () => {
 		return ballerinaExtInstance.onReady()
-		.then(() => {
-			const { experimental } = langClient.initializeResult!.capabilities;
-			const serverProvidesAST = experimental && experimental.astProvider;
+			.then(() => {
+				const { experimental } = langClient.initializeResult!.capabilities;
+				const serverProvidesAST = experimental && experimental.astProvider;
 
-			if (!serverProvidesAST) {
-				ballerinaExtInstance.showMessageServerMissingCapability();
-				return {};
-			}
-			showDocs(context, langClient);
-		})
-		.catch((e) => {
-			if (!ballerinaExtInstance.isValidBallerinaHome()) {
-				ballerinaExtInstance.showMessageInvalidBallerinaHome();
-			} else {
-				ballerinaExtInstance.showPluginActivationError();
-			}
-		});
+				if (!serverProvidesAST) {
+					ballerinaExtInstance.showMessageServerMissingCapability();
+					return {};
+				}
+				showDocs(context, langClient);
+			})
+			.catch((e) => {
+				if (!ballerinaExtInstance.isValidBallerinaHome()) {
+					ballerinaExtInstance.showMessageInvalidBallerinaHome();
+				} else {
+					ballerinaExtInstance.showPluginActivationError();
+				}
+			});
 	});
 
 	context.subscriptions.push(docsRenderDisposable);

--- a/tool-plugins/vscode/src/docs/activator.ts
+++ b/tool-plugins/vscode/src/docs/activator.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent } from 'vscode';
+import * as _ from 'lodash';
+import { render } from './renderer';
+import { BallerinaAST, ExtendedLangClient } from '../core/extended-language-client';
+import { BallerinaExtension } from '../core';
+
+const DEBOUNCE_WAIT = 500;
+
+let previewPanel: WebviewPanel | undefined;
+let activeEditor: TextEditor | undefined;
+
+function updateWebView(ast: BallerinaAST, docUri: Uri): void {
+	if (previewPanel) {
+		previewPanel.webview.postMessage({ 
+			command: 'update',
+			json: ast,
+			docUri: docUri.toString()
+		});
+	}
+}
+
+function showDocs(context: ExtensionContext, langClient: ExtendedLangClient): void {
+	const didChangeDisposable = workspace.onDidChangeTextDocument(
+			_.debounce((e: TextDocumentChangeEvent) => {
+		if (activeEditor && (e.document === activeEditor.document) &&
+			e.document.fileName.endsWith('.bal')) {
+			const docUri = e.document.uri;
+			langClient.getAST(docUri)
+				.then((resp) => {
+					if (resp.ast) {
+						updateWebView(resp.ast, docUri);
+					}
+				});
+		}
+	}, DEBOUNCE_WAIT));
+
+	const changeActiveEditorDisposable =  window.onDidChangeActiveTextEditor(
+			(activatedEditor: TextEditor | undefined) => {
+		if (window.activeTextEditor && activatedEditor 
+					&& (activatedEditor.document === window.activeTextEditor.document) 
+					&& activatedEditor.document.fileName.endsWith('.bal')) {
+			activeEditor = window.activeTextEditor;
+			const docUri = activatedEditor.document.uri;
+			langClient.getAST(docUri)
+				.then((resp) => {
+					if (resp.ast) {
+						updateWebView(resp.ast, docUri);
+					}
+				});
+		}
+	});
+
+	if (previewPanel) {
+		previewPanel.reveal(ViewColumn.Two, true);
+		return;
+	}
+	// Create and show a new webview
+	previewPanel = window.createWebviewPanel(
+		'ballerinaDocs',
+		"Ballerina Docs",
+		{ viewColumn: ViewColumn.Two, preserveFocus: true } ,
+		{
+			enableScripts: true,
+			retainContextWhenHidden: true,
+		}
+	);
+	const editor = window.activeTextEditor;
+	if(!editor) {
+		return;
+	}
+	activeEditor = editor;
+
+	const html = render(context);
+	if (previewPanel && html) {
+		previewPanel.webview.html = html;
+	}
+
+	langClient.getAST(editor.document.uri)
+	.then((resp) => {
+		if (resp.ast) {
+			updateWebView(resp.ast, editor.document.uri);
+		}
+	});
+
+	previewPanel.onDidDispose(() => {
+		previewPanel = undefined;
+		didChangeDisposable.dispose();
+		changeActiveEditorDisposable.dispose();
+	});
+}
+
+export function activate(ballerinaExtInstance: BallerinaExtension) {
+    let context = <ExtensionContext> ballerinaExtInstance.context;
+    let langClient = <ExtendedLangClient> ballerinaExtInstance.langClient;
+	const docsRenderDisposable = commands.registerCommand('ballerina.showDocs', () => {
+		return ballerinaExtInstance.onReady()
+		.then(() => {
+			const { experimental } = langClient.initializeResult!.capabilities;
+			const serverProvidesAST = experimental && experimental.astProvider;
+
+			if (!serverProvidesAST) {
+				ballerinaExtInstance.showMessageServerMissingCapability();
+				return {};
+			}
+			showDocs(context, langClient);
+		})
+		.catch((e) => {
+			if (!ballerinaExtInstance.isValidBallerinaHome()) {
+				ballerinaExtInstance.showMessageInvalidBallerinaHome();
+			} else {
+				ballerinaExtInstance.showPluginActivationError();
+			}
+		});
+	});
+
+	context.subscriptions.push(docsRenderDisposable);
+}

--- a/tool-plugins/vscode/src/docs/index.ts
+++ b/tool-plugins/vscode/src/docs/index.ts
@@ -1,0 +1,1 @@
+export * from './activator';

--- a/tool-plugins/vscode/src/docs/renderer.ts
+++ b/tool-plugins/vscode/src/docs/renderer.ts
@@ -1,0 +1,39 @@
+import { Uri, ExtensionContext } from 'vscode';
+import * as path from 'path';
+
+export function render(context: ExtensionContext): string {
+    const { extensionPath } = context;
+    const onDiskPath = Uri.file(path.join(extensionPath, 'resources', 'composer', 'composer.js'));
+    const mainJsPath = onDiskPath.with({ scheme: 'vscode-resource' });
+
+    return `
+        <!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8">
+        </head>
+        <body>
+            <div id="ballerina-documentation"/>
+            <script>
+                let astJson;
+                const el = document.getElementById("ballerina-documentation");
+                window.addEventListener('message', event => {
+                    switch (event.data.command) {
+                        case 'update':
+                            astJson = event.data.json;
+                            ballerinaComposer.renderDocuments(astJson, el);
+                            break;
+                    }
+                });
+
+                function loadedScript() {
+                    if(astJson) {
+                        ballerinaComposer.renderDocuments(astJson, el);
+                    }
+                }
+            </script>
+            <script onload="loadedScript();" src="${mainJsPath}"></script>
+        </body>
+        </html> 
+    `;
+}

--- a/tool-plugins/vscode/src/docs/renderer.ts
+++ b/tool-plugins/vscode/src/docs/renderer.ts
@@ -2,9 +2,14 @@ import { Uri, ExtensionContext } from 'vscode';
 import * as path from 'path';
 
 export function render(context: ExtensionContext): string {
-    const { extensionPath } = context;
-    const onDiskPath = Uri.file(path.join(extensionPath, 'resources', 'composer', 'composer.js'));
-    const mainJsPath = onDiskPath.with({ scheme: 'vscode-resource' });
+    let composerJsSrc;
+    if (process.env.COMPOSER_DEBUG === "true") {
+        const { extensionPath } = context;
+        const onDiskPath = Uri.file(path.join(extensionPath, 'resources', 'composer', 'composer.js'));
+        composerJsSrc = onDiskPath.with({ scheme: 'vscode-resource' });
+    } else {
+        composerJsSrc = 'http://localhost:9000/composer.js';
+    }
 
     return `
         <!doctype html>
@@ -21,7 +26,9 @@ export function render(context: ExtensionContext): string {
                     switch (event.data.command) {
                         case 'update':
                             astJson = event.data.json;
-                            ballerinaComposer.renderDocuments(astJson, el);
+                            if (ballerinaComposer) {
+                                ballerinaComposer.renderDocuments(astJson, el);
+                            }
                             break;
                     }
                 });
@@ -32,7 +39,7 @@ export function render(context: ExtensionContext): string {
                     }
                 }
             </script>
-            <script onload="loadedScript();" src="${mainJsPath}"></script>
+            <script onload="loadedScript();" src="${composerJsSrc}"></script>
         </body>
         </html> 
     `;

--- a/tool-plugins/vscode/src/docs/renderer.ts
+++ b/tool-plugins/vscode/src/docs/renderer.ts
@@ -4,11 +4,11 @@ import * as path from 'path';
 export function render(context: ExtensionContext): string {
     let composerJsSrc;
     if (process.env.COMPOSER_DEBUG === "true") {
+        composerJsSrc = 'http://localhost:9000/composer.js';
+    } else {
         const { extensionPath } = context;
         const onDiskPath = Uri.file(path.join(extensionPath, 'resources', 'composer', 'composer.js'));
         composerJsSrc = onDiskPath.with({ scheme: 'vscode-resource' });
-    } else {
-        composerJsSrc = 'http://localhost:9000/composer.js';
     }
 
     return `
@@ -26,7 +26,7 @@ export function render(context: ExtensionContext): string {
                     switch (event.data.command) {
                         case 'update':
                             astJson = event.data.json;
-                            if (ballerinaComposer) {
+                            if (window.ballerinaComposer) {
                                 ballerinaComposer.renderDocuments(astJson, el);
                             }
                             break;
@@ -35,7 +35,7 @@ export function render(context: ExtensionContext): string {
 
                 function loadedScript() {
                     if(astJson) {
-                        ballerinaComposer.renderDocuments(astJson, el);
+                        ballerinaComposer.renderDocPreview(astJson, el);
                     }
                 }
             </script>

--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -18,9 +18,10 @@
  *
  */
 import { ExtensionContext } from 'vscode';
+import { ballerinaExtInstance } from './core';
 import { activate as activateDiagram } from './diagram'; 
 import { activate as activateBBE } from './bbe';
-import { ballerinaExtInstance } from './core';
+import { activate as activateDocs } from './docs';
 import { activateDebugConfigProvider } from './debugger';
 
 export function activate(context: ExtensionContext): void {
@@ -33,4 +34,5 @@ export function activate(context: ExtensionContext): void {
 	activateBBE(ballerinaExtInstance);
 	// Enable Ballerina Debug Config Provider
 	activateDebugConfigProvider(ballerinaExtInstance);
+	activateDocs(ballerinaExtInstance);
 }


### PR DESCRIPTION
## Purpose
This command can be used to view markdown documentations in a bal file

![image](https://user-images.githubusercontent.com/3872221/47362021-0f7b4780-d6f1-11e8-9f9d-1aed9df348c1.png)
