### PR TITLE
[WebSub] Introduce functions to retrieve topic/subscriber details

### DIFF
--- a/stdlib/websub/src/main/ballerina/websub/commons.bal
+++ b/stdlib/websub/src/main/ballerina/websub/commons.bal
@@ -345,7 +345,6 @@ public type Notification object {
     public function getFormParams() returns map<string>|error {
         return request.getFormParams();
     }
-
 };
 
 # Function to retrieve hub and topic URLs from the `http:response` from a publisher to a discovery request.
@@ -526,6 +525,16 @@ public type WebSubHub object {
     # + return - `error` if an error occurred with unregistration
     public function unregisterTopic(string topic) returns error?;
 
+    # Retrieves an array of topics which registered in the Hub.
+    #
+    # + return - An array of available topics
+    public extern function getAvailableTopics() returns string[];
+
+    # Retrieves an array of registered subscriber details for a given topic.
+    #
+    # + topic - The topic to ............
+    # + return - An array of subscribers
+    public extern function getTopicSubscribers(string topic) returns SubscriberDetails[];
 };
 
 function WebSubHub::stop() returns boolean {
@@ -586,7 +595,7 @@ public function addWebSubLinkHeader(http:Response response, string[] hubs, strin
     response.setHeader("Link", hubLinkHeader + "<" + topic + ">; rel=\"self\"");
 }
 
-# Struct to represent Subscription Details retrieved from the database.
+# Record to represent Subscription Details retrieved from the database.
 #
 # + topic - The topic for which the subscription is added
 # + callback - The callback specified for the particular subscription
@@ -637,5 +646,17 @@ public type HubStartedUpError record {
     string message;
     error? cause;
     WebSubHub startedUpHub;
+    !...
+};
+
+# Record to represent Subscriber Details.
+#
+# + callback - The callback specified for the particular subscription
+# + leaseSeconds - The lease second period specified for the particular subscription
+# + createdAt - The time at which the subscription was created
+public type SubscriberDetails record {
+    string callback;
+    int leaseSeconds;
+    int createdAt;
     !...
 };

--- a/stdlib/websub/src/main/ballerina/websub/commons.bal
+++ b/stdlib/websub/src/main/ballerina/websub/commons.bal
@@ -525,16 +525,16 @@ public type WebSubHub object {
     # + return - `error` if an error occurred with unregistration
     public function unregisterTopic(string topic) returns error?;
 
-    # Retrieves an array of topics which registered in the Hub.
+    # Retrieves topics currently recognized by the Hub.
     #
     # + return - An array of available topics
     public extern function getAvailableTopics() returns string[];
 
-    # Retrieves an array of registered subscriber details for a given topic.
+    # Retrieves details of subscribers registered to receive updates for a particular topic.
     #
-    # + topic - The subscriber details required topic
-    # + return - An array of subscribers
-    public extern function getTopicSubscribers(string topic) returns SubscriberDetails[];
+    # + topic - The topic for which details need to be retrieved
+    # + return - An array of subscriber details
+    public extern function getSubscribers(string topic) returns SubscriberDetails[];
 };
 
 function WebSubHub::stop() returns boolean {

--- a/stdlib/websub/src/main/ballerina/websub/commons.bal
+++ b/stdlib/websub/src/main/ballerina/websub/commons.bal
@@ -532,7 +532,7 @@ public type WebSubHub object {
 
     # Retrieves an array of registered subscriber details for a given topic.
     #
-    # + topic - The topic to ............
+    # + topic - The subscriber details required topic
     # + return - An array of subscribers
     public extern function getTopicSubscribers(string topic) returns SubscriberDetails[];
 };

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
@@ -81,7 +81,10 @@ public class WebSubSubscriberConstants {
     // SubscriptionDetails struct field names
     public static final String SUBSCRIPTION_DETAILS_TOPIC = "topic";
     public static final String SUBSCRIPTION_DETAILS_CALLBACK = "callback";
-    public static final String SUBSCRIPTION_DETAILS_SECRET = "sceret";
+    public static final String SUBSCRIPTION_DETAILS_SECRET = "secret";
+    public static final String SUBSCRIPTION_DETAILS_LEASE_SECONDS = "leaseSeconds";
+    public static final String SUBSCRIPTION_DETAILS_CREATE_AT = "createdAt";
+    public static final String SUBSCRIPTION_DETAILS = "SubscriberDetails";
 
     // IntentVerificationRequest
     public static final String VERIFICATION_REQUEST_MODE = "mode";

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
@@ -83,7 +83,7 @@ public class WebSubSubscriberConstants {
     public static final String SUBSCRIPTION_DETAILS_CALLBACK = "callback";
     public static final String SUBSCRIPTION_DETAILS_SECRET = "secret";
     public static final String SUBSCRIPTION_DETAILS_LEASE_SECONDS = "leaseSeconds";
-    public static final String SUBSCRIPTION_DETAILS_CREATE_AT = "createdAt";
+    public static final String SUBSCRIPTION_DETAILS_CREATED_AT = "createdAt";
     public static final String SUBSCRIPTION_DETAILS = "SubscriberDetails";
 
     // IntentVerificationRequest

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/hub/Hub.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/hub/Hub.java
@@ -89,7 +89,7 @@ public class Hub {
         } else if (topic == null || topic.isEmpty()) {
             throw new BallerinaWebSubException("Topic unavailable/invalid for registration at Hub");
         } else {
-            getTopics().add(topic);
+            topics.add(topic);
             if (hubPersistenceEnabled && !loadingOnStartUp) {
                 BValue[] args = { new BString("register"), new BString(topic) };
                 BLangFunctions.invokeCallable(hubProgramFile.getPackageInfo(WEBSUB_PACKAGE)
@@ -105,7 +105,7 @@ public class Hub {
         if (topic == null || !isTopicRegistered(topic)) {
             throw new BallerinaWebSubException("Topic unavailable/invalid for unregistration at Hub");
         } else {
-            getTopics().remove(topic);
+            topics.remove(topic);
             if (hubPersistenceEnabled) {
                 BValue[] args = { new BString("unregister"), new BString(topic) };
                 BLangFunctions.invokeCallable(hubProgramFile.getPackageInfo(WEBSUB_PACKAGE)
@@ -115,7 +115,7 @@ public class Hub {
     }
 
     public boolean isTopicRegistered(String topic) {
-        return getTopics().contains(topic);
+        return topics.contains(topic);
     }
 
     /**
@@ -130,7 +130,7 @@ public class Hub {
             //TODO: Revisit to check if this needs to be returned as an error, currently not required since this check
             // is performed at Ballerina level
             logger.error("Hub Service not started: subscription failed");
-        } else if (!getTopics().contains(topic) && hubTopicRegistrationRequired) {
+        } else if (!topics.contains(topic) && hubTopicRegistrationRequired) {
             logger.warn("Subscription request ignored for unregistered topic[" + topic + "]");
         } else {
             if (getSubscribers().contains(new HubSubscriber("", topic, callback, null))) {
@@ -184,7 +184,7 @@ public class Hub {
     public void publish(String topic, BMap<String, BValue> content) throws BallerinaWebSubException {
         if (!started) {
             throw new BallerinaWebSubException("Hub Service not started: publish failed");
-        } else if (!getTopics().contains(topic) && hubTopicRegistrationRequired) {
+        } else if (!topics.contains(topic) && hubTopicRegistrationRequired) {
             throw new BallerinaWebSubException("Publish call ignored for unregistered topic[" + topic + "]");
         } else {
             brokerInstance.publish(topic, new BallerinaBrokerByteBuf(content));
@@ -300,16 +300,16 @@ public class Hub {
     }
 
     /**
-     * Retrieve available topics of the Hub
+     * Retrieve available topics of the Hub.
      *
-     * @return the list of topics
+     * @return the array of topics
      */
-    public List<String> getTopics() {
-        return topics;
+    public String[] getTopics() {
+        return topics.toArray(new String[0]);
     }
 
     /**
-     * Retrieve subscribers list
+     * Retrieve subscribers list.
      *
      * @return the list of subscribers
      */

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/hub/HubSubscriber.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/hub/HubSubscriber.java
@@ -37,7 +37,7 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACK
  *
  * @since 0.965.0
  */
-class HubSubscriber extends Consumer {
+public class HubSubscriber extends Consumer {
 
     private final String queue;
     private final String topic;
@@ -56,7 +56,7 @@ class HubSubscriber extends Consumer {
         ProgramFile programFile = Hub.getInstance().getHubProgramFile();
         BValue content =
                 ((BallerinaBrokerByteBuf) (message.getContentChunks().get(0).getByteBuf()).unwrap()).getValue();
-        BValue[] args = {new BString(callback), subscriptionDetails, content};
+        BValue[] args = {new BString(getCallback()), getSubscriptionDetails(), content};
         BLangFunctions.invokeCallable(programFile.getPackageInfo(WEBSUB_PACKAGE)
                                      .getFunctionInfo("distributeContent"), args);
     }
@@ -85,13 +85,25 @@ class HubSubscriber extends Consumer {
     public boolean equals(Object subscriberObject) {
         if (subscriberObject instanceof HubSubscriber) {
             HubSubscriber subscriber = (HubSubscriber) subscriberObject;
-            return subscriber.topic.equals(topic) && subscriber.callback.equals(callback);
+            return subscriber.getTopic().equals(getTopic()) && subscriber.getCallback().equals(getCallback());
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(topic, callback);
+        return Objects.hash(getTopic(), getCallback());
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getCallback() {
+        return callback;
+    }
+
+    public BMap<String, BValue> getSubscriptionDetails() {
+        return subscriptionDetails;
     }
 }

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetAvailableTopics.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetAvailableTopics.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.websub.nativeimpl;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BLangVMErrors;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.websub.BallerinaWebSubException;
+import org.ballerinalang.net.websub.hub.Hub;
+
+import java.util.List;
+
+/**
+ * Extern function to retrieve an array of topics which registered in the Hub.
+ *
+ * @since 0.983.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "websub",
+        functionName = "getAvailableTopics",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "WebSubHub", structPackage = "ballerina/websub"),
+        returnType = {@ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.STRING)},
+        isPublic = true
+)
+public class GetAvailableTopics extends BlockingNativeCallableUnit {
+
+    @Override
+    public void execute(Context context) {
+        BStringArray topicArray = new BStringArray();
+        List<String> topics = Hub.getInstance().getTopics();
+        int i = 0;
+        for (String topic : topics) {
+            topicArray.add(i++, topic);
+        }
+        context.setReturnValues(topicArray);
+    }
+}

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetAvailableTopics.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetAvailableTopics.java
@@ -19,22 +19,16 @@
 package org.ballerinalang.net.websub.nativeimpl;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BLangVMErrors;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStringArray;
-import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.websub.BallerinaWebSubException;
 import org.ballerinalang.net.websub.hub.Hub;
 
-import java.util.List;
-
 /**
- * Extern function to retrieve an array of topics which registered in the Hub.
+ * Extern function to retrieve topics currently recognized by the Hub.
  *
  * @since 0.983.0
  */
@@ -49,12 +43,7 @@ public class GetAvailableTopics extends BlockingNativeCallableUnit {
 
     @Override
     public void execute(Context context) {
-        BStringArray topicArray = new BStringArray();
-        List<String> topics = Hub.getInstance().getTopics();
-        int i = 0;
-        for (String topic : topics) {
-            topicArray.add(i++, topic);
-        }
-        context.setReturnValues(topicArray);
+        String[] topics = Hub.getInstance().getTopics();
+        context.setReturnValues(new BStringArray(topics));
     }
 }

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetSubscribers.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetSubscribers.java
@@ -22,7 +22,6 @@ import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BLangVMStructs;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BValue;
@@ -35,31 +34,28 @@ import org.ballerinalang.net.websub.hub.HubSubscriber;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructureTypeInfo;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS;
-import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS_CREATE_AT;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS_CREATED_AT;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS_LEASE_SECONDS;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
 
 /**
- * Extern function to retrieve an array of registered subscriber details for a given topic.
+ * Extern function to retrieve details of subscribers registered to receive updates for a particular topic.
  *
  * @since 0.983.0
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "websub",
-        functionName = "getTopicSubscribers",
+        functionName = "getSubscribers",
         args = {@Argument(name = "topic", type = TypeKind.STRING)},
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = "WebSubHub", structPackage = "ballerina/websub"),
-        returnType = @ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.RECORD, structType = "SubscriberDetails",
-                                 structPackage = "ballerina/websub"),
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "WebSubHub", structPackage = WEBSUB_PACKAGE),
+        returnType = @ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.RECORD,
+                                 structType = SUBSCRIPTION_DETAILS, structPackage = WEBSUB_PACKAGE),
         isPublic = true
 )
-public class GetTopicSubscribers extends BlockingNativeCallableUnit {
+public class GetSubscribers extends BlockingNativeCallableUnit {
 
     @Override
     public void execute(Context context) {
@@ -75,7 +71,7 @@ public class GetTopicSubscribers extends BlockingNativeCallableUnit {
                 BMap<String, BValue> subscriberDetail = BLangVMStructs.createBStruct(
                         structInfo, subscriber.getCallback(),
                         subscriber.getSubscriptionDetails().get(SUBSCRIPTION_DETAILS_LEASE_SECONDS),
-                        subscriber.getSubscriptionDetails().get(SUBSCRIPTION_DETAILS_CREATE_AT));
+                        subscriber.getSubscriptionDetails().get(SUBSCRIPTION_DETAILS_CREATED_AT));
                 subscriberDetailArray.append(subscriberDetail);
             }
         }

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetTopicSubscribers.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetTopicSubscribers.java
@@ -28,12 +28,16 @@ import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.websub.hub.Hub;
 import org.ballerinalang.net.websub.hub.HubSubscriber;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructureTypeInfo;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS;
@@ -50,6 +54,7 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACK
         orgName = "ballerina", packageName = "websub",
         functionName = "getTopicSubscribers",
         args = {@Argument(name = "topic", type = TypeKind.STRING)},
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "WebSubHub", structPackage = "ballerina/websub"),
         returnType = @ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.RECORD, structType = "SubscriberDetails",
                                  structPackage = "ballerina/websub"),
         isPublic = true

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetTopicSubscribers.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/GetTopicSubscribers.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.websub.nativeimpl;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BLangVMStructs;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BRefValueArray;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.websub.hub.Hub;
+import org.ballerinalang.net.websub.hub.HubSubscriber;
+import org.ballerinalang.util.codegen.PackageInfo;
+import org.ballerinalang.util.codegen.StructureTypeInfo;
+
+import java.util.List;
+
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS_CREATE_AT;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SUBSCRIPTION_DETAILS_LEASE_SECONDS;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
+
+/**
+ * Extern function to retrieve an array of registered subscriber details for a given topic.
+ *
+ * @since 0.983.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "websub",
+        functionName = "getTopicSubscribers",
+        args = {@Argument(name = "topic", type = TypeKind.STRING)},
+        returnType = @ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.RECORD, structType = "SubscriberDetails",
+                                 structPackage = "ballerina/websub"),
+        isPublic = true
+)
+public class GetTopicSubscribers extends BlockingNativeCallableUnit {
+
+    @Override
+    public void execute(Context context) {
+        String topic = context.getStringArgument(0);
+        List<HubSubscriber> subscribers = Hub.getInstance().getSubscribers();
+
+        final PackageInfo packageInfo = context.getProgramFile().getPackageInfo(WEBSUB_PACKAGE);
+        final StructureTypeInfo structInfo = packageInfo.getStructInfo(SUBSCRIPTION_DETAILS);
+        BRefValueArray subscriberDetailArray = new BRefValueArray(structInfo.getType());
+
+        for (HubSubscriber subscriber : subscribers) {
+            if (subscriber.getTopic().equals(topic)) {
+                BMap<String, BValue> subscriberDetail = BLangVMStructs.createBStruct(
+                        structInfo, subscriber.getCallback(),
+                        subscriber.getSubscriptionDetails().get(SUBSCRIPTION_DETAILS_LEASE_SECONDS),
+                        subscriber.getSubscriptionDetails().get(SUBSCRIPTION_DETAILS_CREATE_AT));
+                subscriberDetailArray.append(subscriberDetail);
+            }
+        }
+        context.setReturnValues(subscriberDetailArray);
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websub/WebSubCoreFunctionalityTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websub/WebSubCoreFunctionalityTestCase.java
@@ -218,6 +218,17 @@ public class WebSubCoreFunctionalityTestCase extends WebSubBaseTest {
         Assert.assertEquals(response.getData(), "validation failed for notification");
     }
 
+    @Test(dependsOnMethods = "testSubscriptionAndExplicitIntentVerification")
+    public void testHubTopicSubscriberDetailsRetrieval() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
+        HttpResponse response = HttpClientRequest.doPost(
+                webSubSubscriber.getServiceURLHttp(8181, "websubTwo"), "{\"dummy\":\"body\"}",
+                headers);
+        Assert.assertEquals(response.getResponseCode(), 404);
+        Assert.assertEquals(response.getData(), "validation failed for notification");
+    }
+
     @AfterClass
     public void teardown() throws Exception {
         webSubSubscriber.removeAllLeechers();

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
@@ -81,7 +81,7 @@ service<http:Service> publisher bind publisherServiceEP {
     topicInfo(endpoint caller, http:Request req) {
         if (req.hasHeader("x-topic")) {
             string topicName = req.getHeader("x-topic");
-            websub:SubscriberDetails[] details = webSubHub.getTopicSubscribers(topicName);
+            websub:SubscriberDetails[] details = webSubHub.getSubscribers(topicName);
             json j = check <json> details[0];
             caller->respond(j) but {
                 error e => log:printError("Error responding on topicInfo request", err = e)

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
@@ -77,6 +77,29 @@ service<http:Service> publisher bind publisherServiceEP {
             };
         }
     }
+
+    topicInfo(endpoint caller, http:Request req) {
+        if (req.hasHeader("x-topic")) {
+            string topicName = req.getHeader("x-topic");
+            websub:SubscriberDetails[] details = webSubHub.getTopicSubscribers(topicName);
+            json j = check <json> details[0];
+            caller->respond(j) but {
+                error e => log:printError("Error responding on topicInfo request", err = e)
+            };
+        } else {
+            map allTopics;
+            int index=1;
+            string [] availableTopics = webSubHub.getAvailableTopics();
+            foreach topic in availableTopics {
+                allTopics["Topic_" + index] = topic;
+                index += 1;
+            }
+            json j = check <json> allTopics;
+            caller->respond(j) but {
+                error e => log:printError("Error responding on topicInfo request", err = e)
+            };
+        }
+    }
 }
 
 service<http:Service> publisherTwo bind publisherServiceEP {


### PR DESCRIPTION
## Purpose
> Functions on the WebSubHub object provides the following information:
```ballerina
public extern function getAvailableTopics() returns string[];
```
- retrieve currently registered topics, or topics for which subscriptions are added
```ballerina
public extern function getSubscribers(string topic) returns SubscriberDetails[];
```
- subscriber details (callback URL, lease seconds, registered time) for a particular topic
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10637
## Goals
> Retrieve topic and/or subscriber details from the WebSubHub object 

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > Added

## Samples
```ballerina
     string [] availableTopics = webSubHub.getAvailableTopics();
     websub:SubscriberDetails[] details = webSubHub.getSubscribers(topicName);
```