### PR TITLE
Fix table literal data row whitespace not capturing issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1057,6 +1057,9 @@ public class BLangPackageBuilder {
         List<ExpressionNode> argExprList = exprNodeListStack.pop();
         BLangTableLiteral tableLiteral = this.tableLiteralNodes.peek();
         tableLiteral.addWS(ws);
+        if (commaWsStack.size() > 0) {
+            tableLiteral.addWS(commaWsStack.pop());
+        }
         tableLiteral.tableDataRows = argExprList.stream().map(expr -> (BLangExpression) expr)
                 .collect(Collectors.toList());
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/sourcegen/SourceGenTest.java
@@ -111,9 +111,7 @@ public class SourceGenTest {
      */
     static class FileVisitor extends SimpleFileVisitor<Path> {
         private List<File> files;
-        private String[] ignoredFiles = {"table_queries.bal", "table.bal", "csv_io.bal",
-                "channels_correlation.bal", "channels_workers.bal", "grpc_bidirectional_streaming_client.bal",
-                "symbolic_string_literal.bal", "table_literal_syntax.bal", "compensate-stmt.bal",
+        private String[] ignoredFiles = {"grpc_bidirectional_streaming_client.bal", "compensate-stmt.bal",
                 "function-with-two-rest-params.bal", "redundant-compression-config.bal",
                 "taintchecking/annotations/lambda.bal", "high_loc.bal", "test_objects.bal",
                 "lang/annotations/variable-as-attribute-value.bal", "lang/annotations/constant-as-attribute-value.bal",

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTable.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTable.bal
@@ -69,4 +69,28 @@ function name1() {
             {1, 26, 3000.50, "jui", false}
         ]
     };
+
+    Person p2 = {
+        id: 1,
+        age: 26,
+        salary: 3000.50,
+        name: "marcus",
+        married: false
+    };
+
+    Person p3 = {
+        id: 1,
+        age: 26,
+        salary: 3000.50,
+        name: "jui",
+        married: false
+    };
+
+    table<Person> dt8 = table {
+        {primarykey id, primarykey age, salary, name, married},
+        [
+            p2,
+            p3
+        ]
+    };
 }

--- a/language-server/modules/langserver-core/src/test/resources/formatting/table.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/table.bal
@@ -59,4 +59,13 @@ function name1() {
                   {1, 26, 3000.50, "jui", false}
             ]
     };
+
+    Person p2 = {id:1, age:26, salary:3000.50, name:"marcus", married:false};
+
+        Person p3 = {id:1, age:26, salary:3000.50, name:"jui", married:false};
+
+    table<Person> dt8 = table {
+   {primarykey id, primarykey age, salary, name, married},
+           [ p2,p3]
+    };
 }


### PR DESCRIPTION
## Purpose
This commit will fix the issue of not capturing whitespaces when the table data row is represented with expressions.