### PR TITLE
Avoid re-defining package when orgname is used in import

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -268,6 +268,10 @@ public class SymbolEnter extends BLangNodeVisitor {
             // means it's in 'import <pkg-name>' style
             orgName = enclPackageID.orgName;
             version = (Names.DEFAULT_VERSION.equals(enclPackageID.version)) ? new Name("") : enclPackageID.version;
+        } else if (importPkgNode.orgName.value.equals(enclPackageID.orgName.value)) {
+            // means it's in 'import <org-name>/<pkg-name>' style and <org-name> is used to import within same project
+            orgName = names.fromIdNode(importPkgNode.orgName);
+            version = (Names.DEFAULT_VERSION.equals(enclPackageID.version)) ? new Name("") : enclPackageID.version;
         } else {
             // means it's in 'import <org-name>/<pkg-name>' style
             orgName = names.fromIdNode(importPkgNode.orgName);


### PR DESCRIPTION
This is fixed in master with #10905

When there are multiple packages within the same Ballerina project, and a package within the same project is imported in another package of the project, it is not possible to use "orgname" in the import. 

```
A
 |___ example1.bal
B
 |___ example2.bal
```

Given that this project is stored within the project owned by Org "exampleOrg", following code will result in the condition explained in this issue: 

example1.bal
```ballerina
import exampleOrg/B;

public function main(string... args) {}
```

However the following code will work as expected:

example1.bal
```ballerina
import B;

public function main(string... args) {}
```

If "orgname" is used, package will get redefined with each import attempt, rather than pulling already defined and fully-compiled symbol from the package cache. Due to this behavior, any data that is added to node / symbol during compiler phases other than the define phase will be lost in the imported package symbol. 

One observable problem due to this issue is that, imported package symbol will not contain taint table attached, leading to failing taint-checking. 