### PR TITLE
Fix renaming, references and code diagnostics fails for inner directories

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 
+import static org.ballerinalang.langserver.compiler.LSCompilerUtil.getCurrentModulePath;
 import static org.ballerinalang.langserver.compiler.LSCompilerUtil.prepareCompilerContext;
 
 /**
@@ -210,13 +211,12 @@ public class LSCompiler {
                     file -> {
                         if (isBallerinaPackage(file) || isBallerinaFile(file)) {
                             Path filePath = sourceDoc.getPath();
-                            Path fileNamePath = filePath.getFileName();
-                            final String fileName = (fileNamePath != null) ? fileNamePath.toString() : "";
-                            PackageID packageID = new PackageID(fileName);
+                            String relativeFilePath = getCurrentModulePath(filePath).relativize(filePath).toString();
+                            PackageID packageID = new PackageID(relativeFilePath);
                             CompilerContext compilerContext = prepareCompilerContext(packageID, pkgRepo, sourceDoc,
-                                    preserveWS, docManager);
-                            Compiler compiler = LSCompilerUtil.getCompiler(context, fileName, compilerContext, 
-                                    errStrategy);
+                                                                                     preserveWS, docManager);
+                            Compiler compiler = LSCompilerUtil.getCompiler(context, relativeFilePath, compilerContext,
+                                                                           errStrategy);
                             BLangPackage bLangPackage = compiler.compile(file.getName());
                             packages.add(bLangPackage);
                             LSPackageCache.getInstance(compilerContext).invalidate(bLangPackage.packageID);

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
@@ -243,6 +243,36 @@ public class LSCompilerUtil {
     }
 
     /**
+     * Returns top-level module path of a given file path.
+     *
+     * @param filePath file path
+     * @return top-level module path
+     */
+    public static Path getCurrentModulePath(Path filePath) {
+        Path projectRoot = Paths.get(LSCompilerUtil.getSourceRoot(filePath));
+        Path currentModulePath = projectRoot;
+        Path prevSourceRoot = filePath.getParent();
+        try {
+            if (prevSourceRoot == null || Files.isSameFile(prevSourceRoot, projectRoot)) {
+                return currentModulePath;
+            }
+            while (true) {
+                Path newSourceRoot = prevSourceRoot.getParent();
+                currentModulePath = prevSourceRoot;
+                if (newSourceRoot == null || newSourceRoot.toString().isEmpty() ||
+                        "/".equals(newSourceRoot.toString()) || Files.isSameFile(newSourceRoot, projectRoot)) {
+                    // We have reached the project root
+                    break;
+                }
+                prevSourceRoot = newSourceRoot;
+            }
+        } catch (IOException e) {
+            // do nothing
+        }
+        return currentModulePath;
+    }
+
+    /**
      * Check whether given directory is a project dir.
      *
      * @param root root path

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/common/LSDocument.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/common/LSDocument.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.compiler.common;
 
 import org.ballerinalang.langserver.compiler.LSCompilerUtil;
+import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -115,6 +116,15 @@ public class LSDocument {
      */
     public void setSourceRoot(String sourceRoot) {
         this.sourceRoot = sourceRoot;
+    }
+
+    /**
+     * Returns True when this source file has a ballerina project repository folder.
+     *
+     * @return True if this file has project repo, False otherwise
+     */
+    public boolean hasProjectRepo() {
+        return RepoUtils.hasProjectRepo(Paths.get(sourceRoot));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -73,6 +73,7 @@ import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -278,7 +279,8 @@ class BallerinaTextDocumentService implements TextDocumentService {
     public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
         return CompletableFuture.supplyAsync(() -> {
             String fileUri = params.getTextDocument().getUri();
-            Path refFilePath = new LSDocument(fileUri).getPath();
+            LSDocument document = new LSDocument(fileUri);
+            Path refFilePath = document.getPath();
             Path compilationPath = getUntitledFilePath(refFilePath.toString()).orElse(refFilePath);
             Optional<Lock> lock = documentManager.lockFile(compilationPath);
             List<Location> contents = new ArrayList<>();
@@ -286,10 +288,21 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 LSServiceOperationContext referenceContext = new LSServiceOperationContext();
                 referenceContext.put(DocumentServiceKeys.FILE_URI_KEY, fileUri);
                 referenceContext.put(DocumentServiceKeys.POSITION_KEY, params);
-                List<BLangPackage> bLangPackages = lsCompiler.getBLangPackage(referenceContext, documentManager, false,
-                        LSCustomErrorStrategy.class, true).getLeft();
-                // Get the current package.
-                BLangPackage currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, fileUri);
+                boolean isBallerinaProject = document.hasProjectRepo();
+                Either<List<BLangPackage>, BLangPackage> eitherBLangPackage =
+                        lsCompiler.getBLangPackage(referenceContext, documentManager, false,
+                                                   LSCustomErrorStrategy.class,
+                                                   isBallerinaProject);
+                BLangPackage currentBLangPackage;
+                List<BLangPackage> bLangPackages;
+                if (isBallerinaProject) {
+                    bLangPackages = eitherBLangPackage.getLeft();
+                    // Get the current package from multiple.
+                    currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, fileUri);
+                } else {
+                    currentBLangPackage = eitherBLangPackage.getRight();
+                    bLangPackages = Collections.singletonList(currentBLangPackage);
+                }
 
                 referenceContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                      currentBLangPackage.symbol.getName().getValue());
@@ -466,23 +479,32 @@ class BallerinaTextDocumentService implements TextDocumentService {
     @Override
     public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
         return CompletableFuture.supplyAsync(() -> {
-            Path renameFilePath = new LSDocument(params.getTextDocument().getUri()).getPath();
+            TextDocumentIdentifier identifier = params.getTextDocument();
+            LSDocument document = new LSDocument(identifier.getUri());
+            Path renameFilePath = document.getPath();
             Path compilationPath = getUntitledFilePath(renameFilePath.toString()).orElse(renameFilePath);
             Optional<Lock> lock = documentManager.lockFile(compilationPath);
             WorkspaceEdit workspaceEdit = new WorkspaceEdit();
             try {
                 LSServiceOperationContext renameContext = new LSServiceOperationContext();
-                renameContext.put(DocumentServiceKeys.FILE_URI_KEY, params.getTextDocument().getUri());
+                renameContext.put(DocumentServiceKeys.FILE_URI_KEY, identifier.getUri());
                 renameContext.put(DocumentServiceKeys.POSITION_KEY,
-                                  new TextDocumentPositionParams(params.getTextDocument(), params.getPosition()));
+                                  new TextDocumentPositionParams(identifier, params.getPosition()));
                 List<Location> contents = new ArrayList<>();
-                List<BLangPackage> bLangPackages = lsCompiler.getBLangPackage(renameContext, documentManager, false,
-                                                                              LSCustomErrorStrategy.class, true)
-                        .getLeft();
-                // Get the current package.
-                BLangPackage currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages,
-                                                                                          params.getTextDocument()
-                                                                                                  .getUri());
+                boolean isBallerinaProject = document.hasProjectRepo();
+                Either<List<BLangPackage>, BLangPackage> eitherBLangPackage =
+                        lsCompiler.getBLangPackage(renameContext, documentManager, false, LSCustomErrorStrategy.class,
+                                                   isBallerinaProject);
+                BLangPackage currentBLangPackage;
+                List<BLangPackage> bLangPackages;
+                if (isBallerinaProject) {
+                    bLangPackages = eitherBLangPackage.getLeft();
+                    // Get the current package from multiple.
+                    currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, identifier.getUri());
+                } else {
+                    currentBLangPackage = eitherBLangPackage.getRight();
+                    bLangPackages = Collections.singletonList(currentBLangPackage);
+                }
 
                 renameContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                   currentBLangPackage.symbol.getName().getValue());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
@@ -356,7 +356,7 @@ public class CommandExecutor {
 
         return applySingleTextEdit(docAttachmentInfo.getDocAttachment(), range, textDocumentIdentifier,
                 context.get(ExecuteCommandKeys.LANGUAGE_SERVER_KEY).getClient());
-        
+
     }
 
     /**
@@ -451,7 +451,7 @@ public class CommandExecutor {
                 .findAny().orElseThrow(() ->
                         new BallerinaCommandExecutionException("Error Executing Create Constructor Command"));
         List<BLangVariable> fields = ((BLangObjectTypeNode) ((BLangTypeDefinition) objectNode).typeNode).fields;
-        
+
         DiagnosticPos zeroBasedIndex = CommonUtil.toZeroBasedPosition(CommonUtil.getLastItem(fields).getPosition());
         int lastFieldLine = zeroBasedIndex.getEndLine();
         int lastFieldOffset = zeroBasedIndex.getStartColumn();
@@ -558,7 +558,7 @@ public class CommandExecutor {
      * @param line              position to be compared with
      * @return Document attachment info
      */
-    private static CommandUtil.DocAttachmentInfo getDocumentationEditForNodeByPosition(String topLevelNodeType, 
+    private static CommandUtil.DocAttachmentInfo getDocumentationEditForNodeByPosition(String topLevelNodeType,
                                                                                        BLangPackage bLangPkg,
                                                                                        int line) {
         CommandUtil.DocAttachmentInfo docAttachmentInfo = null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -22,6 +22,7 @@ import org.ballerinalang.langserver.LSGlobalContextKeys;
 import org.ballerinalang.langserver.SnippetBlock;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
+import org.ballerinalang.langserver.compiler.LSCompilerUtil;
 import org.ballerinalang.langserver.compiler.LSContext;
 import org.ballerinalang.langserver.compiler.common.LSDocument;
 import org.ballerinalang.langserver.compiler.common.modal.BallerinaPackage;
@@ -382,22 +383,20 @@ public class CommonUtil {
      */
     public static BLangPackage getCurrentPackageByFileName(List<BLangPackage> packages, String fileUri) {
         Path filePath = new LSDocument(fileUri).getPath();
-        Path fileNamePath = filePath.getFileName();
-        BLangPackage currentPackage = null;
+        String currentModule = LSCompilerUtil.getCurrentModulePath(filePath).getFileName().toString();
         try {
-            found:
             for (BLangPackage bLangPackage : packages) {
-                for (BLangCompilationUnit compilationUnit : bLangPackage.getCompilationUnits()) {
-                    if (compilationUnit.name.equals(fileNamePath.getFileName().toString())) {
-                        currentPackage = bLangPackage;
-                        break found;
-                    }
+                if (bLangPackage.packageID.sourceFileName != null &&
+                        bLangPackage.packageID.sourceFileName.value.equals(filePath.getFileName().toString())) {
+                    return bLangPackage;
+                } else if (currentModule.equals(bLangPackage.packageID.name.value)) {
+                    return bLangPackage;
                 }
             }
         } catch (NullPointerException e) {
-            currentPackage = packages.get(0);
+            return packages.get(0);
         }
-        return currentPackage;
+        return null;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.diagnostic;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.compiler.LSCompiler;
+import org.ballerinalang.langserver.compiler.LSCompilerUtil;
 import org.ballerinalang.langserver.compiler.LSPackageLoader;
 import org.ballerinalang.langserver.compiler.common.modal.BallerinaFile;
 import org.ballerinalang.langserver.compiler.common.modal.BallerinaPackage;
@@ -118,13 +119,14 @@ public class DiagnosticsHelper {
      * @return diagnostics map
      */
     private Map<String, List<Diagnostic>> getDiagnostics(BallerinaFile balFile, Path filePath) {
+        Path currentModulePath = LSCompilerUtil.getCurrentModulePath(filePath);
         List<org.ballerinalang.util.diagnostic.Diagnostic>
                 balDiagnostics = balFile.getDiagnostics().orElseGet(ArrayList::new);
         Map<String, List<Diagnostic>> diagnosticsMap = new HashMap<>();
         balDiagnostics.forEach(diag -> {
             final org.ballerinalang.util.diagnostic.Diagnostic.DiagnosticPosition position = diag.getPosition();
             String fileName = position.getSource().getCompilationUnitName();
-            String fileURI = Paths.get(filePath.getParent() + "", fileName).toUri().toString() + "";
+            String fileURI = Paths.get(currentModulePath + "", fileName).toUri().toString() + "";
 
             if (!diagnosticsMap.containsKey(fileURI)) {
                 diagnosticsMap.put(fileURI, new ArrayList<>());


### PR DESCRIPTION
## Purpose
When having inner directories for the modules; renaming, references and code diagnostics are failing.
```bash
.
├── Ballerina.toml
├── main.bal
└── module1
    ├── a.bal
    ├── dir1
    │   └── b.bal          [try to rename a symbol in this file]
    └── tests
        └── dir1
```
Fix renaming, references and code diagnostics fails for inner directories. This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/11052