### PR TITLE
Add default auth store provider for SecureListener

### DIFF
--- a/stdlib/http/src/main/ballerina/http/secure_listener.bal
+++ b/stdlib/http/src/main/ballerina/http/secure_listener.bal
@@ -146,8 +146,9 @@ public type AuthProvider record {
 };
 
 function SecureListener::init(SecureEndpointConfiguration c) {
-    addAuthFiltersForSecureListener(c, self.instanceId);
-    self.httpListener.init(c);
+    self.config = c;
+    addAuthFiltersForSecureListener(self.config, self.instanceId);
+    self.httpListener.init(self.config);
 }
 
 # Add authn and authz filters
@@ -229,7 +230,10 @@ function createAuthFiltersForSecureListener(SecureEndpointConfiguration config, 
             }
         }
         () => {
-            // No auth providers configured.
+            // if no auth providers are specified, create a config based auth store provider
+            // as default auth store provider
+            auth:ConfigAuthStoreProvider configAuthStoreProvider = new;
+            authStoreProvider = <auth:AuthStoreProvider>configAuthStoreProvider;
         }
     }
     HttpAuthzHandler authzHandler = new(authStoreProvider, positiveAuthzCache, negativeAuthzCache);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/auth/ConfigAuthProviderTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/auth/ConfigAuthProviderTest.java
@@ -122,6 +122,15 @@ public class ConfigAuthProviderTest {
         Assert.assertEquals(groups.get(0), "scope1");
     }
 
+    @Test(description = "Test case for identify default auth store provider")
+    public void testDefaultAuthStoreProvider() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testDefaultAuthStoreProvider");
+        Assert.assertTrue(returns != null);
+        String defaultAuthStore = ((BMap) ((BMap) returns[0]).get("authzHandler")).get("authStoreProvider").getType()
+                .getName();
+        Assert.assertEquals(defaultAuthStore, "ConfigAuthStoreProvider");
+    }
+
     @AfterClass
     public void tearDown() throws IOException {
         Files.deleteIfExists(secretCopyPath);

--- a/tests/ballerina-unit-test/src/test/resources/test-src/auth/config_auth_provider_test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/auth/config_auth_provider_test.bal
@@ -1,4 +1,5 @@
 import ballerina/auth;
+import ballerina/http;
 
 function testCreateConfigAuthProvider() returns (auth:ConfigAuthStoreProvider) {
     auth:ConfigAuthStoreProvider configAuthStoreProvider = new;
@@ -28,4 +29,11 @@ function testReadScopesOfNonExistingUser() returns (string[]) {
 function testReadScopesOfUser() returns (string[]) {
     auth:ConfigAuthStoreProvider configAuthStoreProvider = new;
     return configAuthStoreProvider.getScopes("ishara");
+}
+
+function testDefaultAuthStoreProvider() returns http:Filter {
+    endpoint http:SecureListener secureEP {
+        port: 9090
+    };
+    return secureEP.config.filters[1];
 }


### PR DESCRIPTION
When the developer doesn't provide any auth provider configurations into the secure listener. Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/11152

## Purpose
 Initialize the authorization handler with a default auth store when the developer doesn't provide any auth provider

## Automation tests
 - Unit tests 
   > yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes