### PR TITLE
Fix issue in parsing backward slashes in configs

### DIFF
--- a/bvm/ballerina-config/pom.xml
+++ b/bvm/ballerina-config/pom.xml
@@ -45,6 +45,10 @@
             <groupId>org.ballerinalang</groupId>
             <artifactId>toml-parser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/bvm/ballerina-config/src/main/java/org/ballerinalang/bcl/parser/BConfigLangListener.java
+++ b/bvm/ballerina-config/src/main/java/org/ballerinalang/bcl/parser/BConfigLangListener.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.bcl.parser;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.ballerinalang.toml.antlr4.TomlBaseListener;
 import org.ballerinalang.toml.antlr4.TomlParser;
 
@@ -81,6 +82,7 @@ public class BConfigLangListener extends TomlBaseListener {
     @Override
     public void enterBasicString(TomlParser.BasicStringContext context) {
         String stringVal = context.basicStringValue().getText();
+        stringVal = StringEscapeUtils.unescapeJava(stringVal);
         currentValue = getResolvedStringValue(stringVal);
     }
 

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -33,6 +33,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.ballerinalang.test.context.Constant.BALLERINA_AGENT_PATH;
+import static org.ballerinalang.test.context.Constant.JACOCO_AGENT_ARG_LINE;
+
 /**
  * This class hold the server information and manage the a server instance.
  *
@@ -69,7 +72,7 @@ public class BServerInstance implements BServer {
     }
 
     private void configureAgentArgs() throws BallerinaTestException {
-        String balAgent = Paths.get(System.getProperty("ballerina.agent.path")).toString();
+        String balAgent = Paths.get(System.getProperty(BALLERINA_AGENT_PATH)).toString();
 
         if (balAgent == null || balAgent.isEmpty()) {
             throw new BallerinaTestException("Cannot start server, Ballerina agent not provided");
@@ -78,7 +81,7 @@ public class BServerInstance implements BServer {
         agentArgs = "-javaagent:" + balAgent + "=host=" + agentHost + ",port=" + agentPort
                 + ",exitStatus=1,timeout=15000,killStatus=5 ";
 
-        String jacocoArgLine = System.getProperty("jacoco.agent.argLine");
+        String jacocoArgLine = System.getProperty(JACOCO_AGENT_ARG_LINE);
         if (jacocoArgLine == null || jacocoArgLine.isEmpty()) {
             log.warn("Running integration test without jacoco test coverage");
             return;

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
@@ -68,7 +69,7 @@ public class BServerInstance implements BServer {
     }
 
     private void configureAgentArgs() throws BallerinaTestException {
-        String balAgent = System.getProperty("ballerina.agent.path");
+        String balAgent = Paths.get(System.getProperty("ballerina.agent.path")).toString();
 
         if (balAgent == null || balAgent.isEmpty()) {
             throw new BallerinaTestException("Cannot start server, Ballerina agent not provided");

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/Constant.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/Constant.java
@@ -44,4 +44,8 @@ public class Constant {
     public static final String VFS_LOCATION = "FTPLocation";
 
     public static final String PROJECT_BUILD_DIR = "project.build.directory";
+
+    public static final String BALLERINA_AGENT_PATH = "ballerina.agent.path";
+
+    public static final String JACOCO_AGENT_ARG_LINE = "jacoco.agent.argLine";
 }

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/GrpcBaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/GrpcBaseTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.service.grpc.sample;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BServerInstance;
 import org.ballerinalang.test.context.BallerinaTestException;
@@ -25,6 +26,7 @@ import org.testng.annotations.AfterGroups;
 import org.testng.annotations.BeforeGroups;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 /**
  * Base test class for GRPC integration test cases which starts/stops the grpc services as ballerina package before
@@ -35,12 +37,10 @@ public class GrpcBaseTest extends BaseTest {
 
     @BeforeGroups(value = "grpc-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
-        String privateKey = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "certsAndKeys"
-                        + File.separator + "private.key").getAbsolutePath();
-        String publicCert = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "certsAndKeys"
-                        + File.separator + "public.crt").getAbsolutePath();
+        String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                                                                   "private.key").toAbsolutePath().toString());
+        String publicCert = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                                                                   "public.crt").toAbsolutePath().toString());
         int[] requiredPorts = new int[]{9090, 9092, 9095, 9096, 9098, 9099, 9100, 9101, 8085, 9317};
 
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/GrpcMutualSslWithCertsTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/sample/GrpcMutualSslWithCertsTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.service.grpc.sample;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
@@ -28,7 +29,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -49,8 +49,8 @@ public class GrpcMutualSslWithCertsTest extends GrpcBaseTest {
         Path balFilePath = Paths.get("src", "test", "resources", "grpc", "clients", "grpc_ssl_client.bal");
         result = BCompileUtil.compile(balFilePath.toAbsolutePath().toString());
         final String serverMsg = "Hello WSO2";
-        String path = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator
-                + "certsAndKeys").getAbsolutePath();
+        String path = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys")
+                                                           .toAbsolutePath().toString());
         BString pathTocerts = new BString(path);
 
         BValue[] responses = BRunUtil.invoke(result, "testUnarySecuredBlockingWithCerts", new BValue[] {pathTocerts});

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -18,13 +18,14 @@
 
 package org.ballerinalang.test.service.http;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BServerInstance;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.testng.annotations.AfterGroups;
 import org.testng.annotations.BeforeGroups;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 /**
  * Base test class for Http integration test cases which starts/stops the http services as ballerina package before
@@ -38,14 +39,11 @@ public class HttpBaseTest extends BaseTest {
         int[] requiredPorts = new int[]{9090, 9224, 9091, 9092, 9093, 9094, 9095, 9096, 9097, 9098, 9099, 9100, 9101,
                 9102, 9103, 9104, 9105, 9106, 9107, 9108, 9109, 9110, 9111, 9112, 9113, 9114, 9115, 9116, 9117, 9118,
                 9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225};
-        String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
-                "http").getAbsolutePath();
-        String privateKey = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "certsAndKeys"
-                        + File.separator + "private.key").getAbsolutePath();
-        String publicCert = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "certsAndKeys"
-                        + File.separator + "public.crt").getAbsolutePath();
+        String balFile = Paths.get("src", "test", "resources", "http").toAbsolutePath().toString();
+        String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                                                                   "private.key").toAbsolutePath().toString());
+        String publicCert = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                                                                   "public.crt").toAbsolutePath().toString());
         String[] args = new String[] { "-e", "certificate.key=" + privateKey, "-e", "public.cert=" + publicCert };
         serverInstance = new BServerInstance(balServer);
         serverInstance.startServer(balFile, "httpservices", args, requiredPorts);

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/MutualSSLWithCerts.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/MutualSSLWithCerts.java
@@ -18,12 +18,13 @@
 
 package org.ballerinalang.test.service.http.sample;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BMainInstance;
 import org.ballerinalang.test.context.LogLeecher;
 import org.testng.annotations.Test;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 /**
  * Test mutual ssl with certificates and keys.
@@ -34,16 +35,13 @@ public class MutualSSLWithCerts extends BaseTest {
     @Test(description = "Test mutual ssl")
     public void testMutualSSLWithCerts() throws Exception {
         String serverResponse = "Response received";
-        String privateKey = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "certsAndKeys"
-                        + File.separator + "private.key").getAbsolutePath();
-        String publicCert = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "certsAndKeys"
-                        + File.separator + "public.crt").getAbsolutePath();
+        String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                                                                   "private.key").toAbsolutePath().toString());
+        String publicCert = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                                                                   "public.crt").toAbsolutePath().toString());
 
-        String balFile = new File(
-                "src" + File.separator + "test" + File.separator + "resources" + File.separator + "mutualSSL"
-                        + File.separator + "ssl_client.bal").getAbsolutePath();
+        String balFile = Paths.get("src", "test", "resources", "mutualSSL", "ssl_client.bal").toAbsolutePath()
+                .toString();
 
         String[] flags = { "-e certificate.key=" + privateKey, "-e public.cert=" + publicCert};
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/config/ConfigTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/config/ConfigTest.java
@@ -329,6 +329,14 @@ public class ConfigTest {
         Assert.assertEquals(((BFloat) returnVals[0]).floatValue(), 0.23333);
     }
 
+    @Test(description = "Test \\ in the config value string")
+    public void testBackwardSlashInString() throws IOException {
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+        BValue[] inputArg = {new BString("path.test")};
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetAsString", inputArg);
+        Assert.assertEquals(returnVals[0].stringValue(), "C:\\Users\\John");
+    }
+
     private Map<String, String> getRuntimeProperties() {
         Map<String, String> runtimeConfigs = new HashMap<>();
         runtimeConfigs.put("ballerina.http.host", "10.100.1.201");

--- a/tests/ballerina-unit-test/src/test/resources/datafiles/config/default/ballerina.conf
+++ b/tests/ballerina-unit-test/src/test/resources/datafiles/config/default/ballerina.conf
@@ -21,6 +21,7 @@ ballerina.http.host="10.100.1.205"
 ballerina.http.instances="http1,http2,http3"
 ballerina.env.Path="${env:PATH}"
 ballerina.log.format="{{timestamp}}[yyyy-MM-dd HH:mm:ss,SSS] {{level}} [{{package}}:{{unit}}] [{{file}}:{{line}}] [{{worker}}] - \"{{msg}}\" {{err}}"
+path.test="C:\\Users\\John"
 
 [http1]
 port=8085


### PR DESCRIPTION
## Purpose
> This PR is to fix the issue in the config parser in parsing strings with backward slashes. Fix #11014 

## Samples
> With this fix, the following type of strings will be properly parsed by the config parser
```
path.test="C:\\Users\\John"
```