### PR TITLE
Process the testable package separately when executing the compiler extensions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/plugins/AbstractCompilerPlugin.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/plugins/AbstractCompilerPlugin.java
@@ -23,12 +23,13 @@ import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.AnnotationNode;
 import org.ballerinalang.model.tree.EndpointNode;
 import org.ballerinalang.model.tree.FunctionNode;
-import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.model.tree.ResourceNode;
 import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.TypeDefinition;
 import org.ballerinalang.model.tree.VariableNode;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -44,7 +45,11 @@ public abstract class AbstractCompilerPlugin implements CompilerPlugin {
     public abstract void init(DiagnosticLog diagnosticLog);
 
     @Override
-    public void process(PackageNode packageNode) {
+    public void process(BLangPackage packageNode) {
+    }
+
+    @Override
+    public void process(BLangTestablePackage packageNode) {
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/plugins/CompilerPlugin.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/plugins/CompilerPlugin.java
@@ -23,12 +23,13 @@ import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.AnnotationNode;
 import org.ballerinalang.model.tree.EndpointNode;
 import org.ballerinalang.model.tree.FunctionNode;
-import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.model.tree.ResourceNode;
 import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.TypeDefinition;
 import org.ballerinalang.model.tree.VariableNode;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.nio.file.Path;
@@ -64,7 +65,16 @@ public interface CompilerPlugin {
      *
      * @param packageNode package node
      */
-    void process(PackageNode packageNode);
+    void process(BLangPackage packageNode);
+
+    /**
+     * Processes a testable package node.
+     * <p>
+     * Ballerina compiler invokes this method for each and every testable package node in the AST.
+     *
+     * @param testablePackageNode package node
+     */
+    void process(BLangTestablePackage testablePackageNode);
 
     /**
      * Processes a list of annotations attached to a service node.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -114,6 +114,8 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
     public BLangPackage runPlugins(BLangPackage pkgNode) {
         this.defaultPos = pkgNode.pos;
         loadPlugins();
+        // Process the package node for each plugin in the plugin list
+        pluginList.forEach(plugin -> plugin.process(pkgNode));
         pkgNode.accept(this);
         return pkgNode;
     }
@@ -123,14 +125,14 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
             return;
         }
 
-        pluginList.forEach(plugin -> plugin.process(pkgNode));
-
         // Then visit each top-level element sorted using the compilation unit
         pkgNode.topLevelNodes.forEach(topLevelNode -> ((BLangNode) topLevelNode).accept(this));
 
         pkgNode.completedPhases.add(CompilerPhase.COMPILER_PLUGIN);
         pkgNode.getTestablePkgs().forEach(testablePackage -> {
             this.defaultPos = testablePackage.pos;
+            // Process the testable package node for each plugin in the plugin list
+            pluginList.forEach(plugin -> plugin.process(testablePackage));
             visit((BLangPackage) testablePackage);
         });
     }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -90,10 +90,6 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
     }
 
     @Override
-    public void process(PackageNode packageNode) {
-    }
-
-    @Override
     public void process(FunctionNode functionNode, List<AnnotationAttachmentNode> annotations) {
         if (!enabled) {
             return;

--- a/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/ABCCompilerPlugin.java
+++ b/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/ABCCompilerPlugin.java
@@ -30,6 +30,7 @@ import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.TypeDefinition;
 import org.ballerinalang.model.tree.VariableNode;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ public class ABCCompilerPlugin extends AbstractCompilerPlugin {
     }
 
     @Override
-    public void process(PackageNode packageNode) {
+    public void process(BLangPackage packageNode) {
         addEvent(TestEvent.Kind.PKG_NODE, packageNode.toString(), 1);
     }
 

--- a/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/ABCCompilerPlugin.java
+++ b/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/ABCCompilerPlugin.java
@@ -24,7 +24,6 @@ import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.AnnotationNode;
 import org.ballerinalang.model.tree.FunctionNode;
-import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.model.tree.ResourceNode;
 import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.TypeDefinition;


### PR DESCRIPTION
## Purpose
> $subject since processing the testable package is not needed for some extensions like k8s and docker

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
> K8s and Docker have to override the method given to process the bLangPackage in the AbstractCompilerPluginRunner in their extensions