### PR TITLE
Fix issue when building and testing a module in a project which contains only test sources

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
@@ -216,19 +216,7 @@ public class CompilerDriver {
         if (compilerPhase.compareTo(nextPhase) < 0) {
             return true;
         }
-        if (pkgNode.containsTestablePkg()) {
-            // There can be an edge case where the compilation unit nodes in the package node can be empty but the
-            // testable package can have one or many. This has to be treated separately. Check if the package node
-            // is empty and then execute the condition.
-            if (pkgNode.getCompilationUnits().isEmpty()) {
-                return checkNextPhase(nextPhase) && dlog.errorCount > 0;
-            }
-            // Both the package node and testable node contains compilation unit nodes, check for the compilation unit
-            // nodes in the package. At this point the compilation unit nodes of the testable package will never be
-            // empty.
-            return checkNextPhase(nextPhase) && (dlog.errorCount > 0 || pkgNode.getCompilationUnits().isEmpty());
-        }
-        return (checkNextPhase(nextPhase)) && (dlog.errorCount > 0 || pkgNode.getCompilationUnits().isEmpty());
+        return (checkNextPhase(nextPhase) && dlog.errorCount > 0);
     }
 
     private boolean checkNextPhase(CompilerPhase nextPhase) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
@@ -221,8 +221,8 @@ public class CompilerDriver {
             // testable package can have one or many. This has to be treated separately. Check if the package node
             // is empty and then execute the condition.
             if (pkgNode.getCompilationUnits().isEmpty()) {
-                return checkNextPhase(nextPhase) && (dlog.errorCount > 0 || pkgNode.getTestablePkg()
-                                                                                   .getCompilationUnits().isEmpty());
+                return checkNextPhase(nextPhase) &&
+                        (dlog.errorCount > 0 || pkgNode.getTestablePkg().getCompilationUnits().isEmpty());
             }
             // Both the package node and testable node contains compilation unit nodes, check for both the compilation
             // unit nodes in the package and testable node

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
@@ -221,13 +221,12 @@ public class CompilerDriver {
             // testable package can have one or many. This has to be treated separately. Check if the package node
             // is empty and then execute the condition.
             if (pkgNode.getCompilationUnits().isEmpty()) {
-                return checkNextPhase(nextPhase) &&
-                        (dlog.errorCount > 0 || pkgNode.getTestablePkg().getCompilationUnits().isEmpty());
+                return checkNextPhase(nextPhase) && dlog.errorCount > 0;
             }
-            // Both the package node and testable node contains compilation unit nodes, check for both the compilation
-            // unit nodes in the package and testable node
-            return checkNextPhase(nextPhase) && (dlog.errorCount > 0 || pkgNode.getCompilationUnits().isEmpty() ||
-                    pkgNode.getTestablePkg().getCompilationUnits().isEmpty());
+            // Both the package node and testable node contains compilation unit nodes, check for the compilation unit
+            // nodes in the package. At this point the compilation unit nodes of the testable package will never be
+            // empty.
+            return checkNextPhase(nextPhase) && (dlog.errorCount > 0 || pkgNode.getCompilationUnits().isEmpty());
         }
         return (checkNextPhase(nextPhase)) && (dlog.errorCount > 0 || pkgNode.getCompilationUnits().isEmpty());
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
@@ -217,7 +217,15 @@ public class CompilerDriver {
             return true;
         }
         if (pkgNode.containsTestablePkg()) {
-            // We have to check both the compilation unit nodes in the package and testable node
+            // There can be an edge case where the compilation unit nodes in the package node can be empty but the
+            // testable package can have one or many. This has to be treated separately. Check if the package node
+            // is empty and then execute the condition.
+            if (pkgNode.getCompilationUnits().isEmpty()) {
+                return checkNextPhase(nextPhase) && (dlog.errorCount > 0 || pkgNode.getTestablePkg()
+                                                                                   .getCompilationUnits().isEmpty());
+            }
+            // Both the package node and testable node contains compilation unit nodes, check for both the compilation
+            // unit nodes in the package and testable node
             return checkNextPhase(nextPhase) && (dlog.errorCount > 0 || pkgNode.getCompilationUnits().isEmpty() ||
                     pkgNode.getTestablePkg().getCompilationUnits().isEmpty());
         }

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleBuildTestCase.java
@@ -212,6 +212,78 @@ public class ModuleBuildTestCase extends BaseTest {
     }
 
     /**
+     * Building a project with a module only with tests.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test building a project with a module only with tests")
+    public void testBuildOnlyWithTest() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("testModuleBuild");
+        initProject(projectPath, SINGLE_PKG_PROJECT_OPTS);
+
+        // Delete the source files in the module
+        Files.deleteIfExists(projectPath.resolve("foo").resolve("main.bal"));
+
+        String msg = "Compiling source\n" +
+                    "    integrationtests/foo:0.0.1\n" +
+                    "\n" +
+                    "Running tests\n" +
+                    "    integrationtests/foo:0.0.1\n" +
+                    "I'm the before suite function!\n" +
+                    "I'm the before function!\n" +
+                    "I'm in test function!\n" +
+                    "I'm the after function!\n" +
+                    "I'm the after suite function!\n" +
+                    "\t[pass] testFunction\n" +
+                    "\n" +
+                    "\t1 passing\n" +
+                    "\t0 failing\n" +
+                    "\t0 skipped\n" +
+                    "\n" +
+                    "Generating executable\n" +
+                    "    ./target/foo.balx";
+        LogLeecher clientLeecher = new LogLeecher(msg);
+
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{clientLeecher},
+                          projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Executing tests in a project with a module only with tests.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     */
+    @Test(description = "Test executing tests in a project with a module only with tests")
+    public void testExecOnlyWithTest() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("testModule");
+        initProject(projectPath, SINGLE_PKG_PROJECT_OPTS);
+
+        // Delete the source files in the module
+        Files.deleteIfExists(projectPath.resolve("foo").resolve("main.bal"));
+
+        String msg = "Compiling tests\n" +
+                "    integrationtests/foo:0.0.1\n" +
+                "\n" +
+                "Running tests\n" +
+                "    integrationtests/foo:0.0.1\n" +
+                "I'm the before suite function!\n" +
+                "I'm the before function!\n" +
+                "I'm in test function!\n" +
+                "I'm the after function!\n" +
+                "I'm the after suite function!\n" +
+                "\t[pass] testFunction\n" +
+                "\n" +
+                "\t1 passing\n" +
+                "\t0 failing\n" +
+                "\t0 skipped\n";
+        LogLeecher clientLeecher = new LogLeecher(msg);
+
+        balClient.runMain("test", new String[0], envVariables, new String[0], new LogLeecher[]{clientLeecher},
+                          projectPath.toString());
+        clientLeecher.waitForText(3000);
+    }
+    /**
      * Init project.
      *
      * @param projectPath project path

--- a/tests/ballerina-tools-integration-test/src/test/resources/testModule/foo/tests/main_test.bal
+++ b/tests/ballerina-tools-integration-test/src/test/resources/testModule/foo/tests/main_test.bal
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/test;
+import ballerina/io;
+
+# Before Suite Function
+
+@test:BeforeSuite
+function beforeSuiteFunc () {
+    io:println("I'm the before suite function!");
+}
+
+# Before test function
+
+function beforeFunc () {
+    io:println("I'm the before function!");
+}
+
+# Test function
+
+@test:Config{
+    before:"beforeFunc",
+    after:"afterFunc"
+}
+function testFunction () {
+    io:println("I'm in test function!");
+    test:assertTrue(true , msg = "Failed!");
+}
+
+# After test function
+
+function afterFunc () {
+    io:println("I'm the after function!");
+}
+
+# After Suite Function
+
+@test:AfterSuite
+function afterSuiteFunc () {
+    io:println("I'm the after suite function!");
+}


### PR DESCRIPTION
## Purpose
> This PR will fix the issue when building and testing a module in a project which contains only test sources

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/11186

## User stories
> If a user tries to build or test a module inside a project which contains only test sources, the test sources should be compiled and the tests should be executed.

## Automation tests
 - Integration tests
   > Added for the build and test command

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
