### PR TITLE
Fix error when trying to get the access token for Ballerina Central the first time you perform a ballerina push

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -23,6 +23,7 @@ import org.ballerinalang.spi.EmbeddedExecutor;
 import org.ballerinalang.toml.model.Manifest;
 import org.ballerinalang.toml.model.Proxy;
 import org.ballerinalang.toml.model.Settings;
+import org.ballerinalang.util.BLangConstants;
 import org.ballerinalang.util.EmbeddedExecutorProvider;
 import org.wso2.ballerinalang.compiler.packaging.Patten;
 import org.wso2.ballerinalang.compiler.packaging.converters.Converter;
@@ -54,7 +55,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static org.ballerinalang.launcher.LauncherUtils.createLauncherException;
-import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
 
 /**
  * This class provides util methods when pushing Ballerina modules to central and home repository.
@@ -154,10 +154,11 @@ public class PushUtils {
             String msg = orgName + "/" + packageName + ":" + version + " [project repo -> central]";
             Proxy proxy = settings.getProxy();
             String baloVersionOfPkg = String.valueOf(ProgramFileConstants.VERSION_NUMBER);
-            executor.executeFunction("packaging_push/packaging_push.balx", MAIN_FUNCTION_NAME, accessToken,
-                    mdFileContent, description, homepageURL, repositoryURL, apiDocURL, authors, keywords, license,
-                    resourcePath, pkgPathFromPrjtDir.toString(), msg, ballerinaVersion, proxy.getHost(),
-                    proxy.getPort(), proxy.getUserName(), proxy.getPassword(), baloVersionOfPkg);
+            executor.executeFunction("packaging_push/packaging_push.balx", BLangConstants.MAIN_FUNCTION_NAME,
+                                     accessToken, mdFileContent, description, homepageURL, repositoryURL, apiDocURL,
+                                     authors, keywords, license, resourcePath, pkgPathFromPrjtDir.toString(), msg,
+                                     ballerinaVersion, proxy.getHost(), proxy.getPort(), proxy.getUserName(),
+                                     proxy.getPassword(), baloVersionOfPkg);
 
         } else {
             if (!installToRepo.equals("home")) {
@@ -187,7 +188,7 @@ public class PushUtils {
                                                  "\nAuto update failed. Please visit https://central.ballerina.io");
             }
             long modifiedTimeOfFileAtStart = getLastModifiedTimeOfFile(SETTINGS_TOML_FILE_PATH);
-            executor.executeFunction("packaging_token_updater/packaging_token_updater.balx", MAIN_FUNCTION_NAME);
+            executor.executeService("packaging_token_updater/packaging_token_updater.balx");
 
             boolean waitForToken = true;
             while (waitForToken) {


### PR DESCRIPTION
## Purpose
>  Fixes https://github.com/ballerina-platform/ballerina-lang/issues/11219

## Goals
> The access token of a first time user will be automatically updated after he/she logs into to Ballerina Central

## Automation tests
 Tests cannot be written for this scenario as the default browser is opened automatically during this process for the user to sign up to Ballerina Central.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes