### PR TITLE
Update weak cipher to support newer java versions

### DIFF
--- a/tests/ballerina-integration-test/src/test/resources/http/httpservices/27_mutual_ssl_server_with_default_ciphers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http/httpservices/27_mutual_ssl_server_with_default_ciphers.bal
@@ -48,6 +48,7 @@ service<http:Service> strongService bind strongCipher {
         io:println("successful");
     }
 }
+
 endpoint http:Listener weakCipher {
     port: 9227,
     secureSocket: {
@@ -59,7 +60,7 @@ endpoint http:Listener weakCipher {
             path: "${ballerina.home}/bre/security/ballerinaTruststore.p12",
             password: "ballerina"
         },
-        ciphers: ["TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"]
+        ciphers: ["TLS_RSA_WITH_AES_256_CBC_SHA"]
     }
 };
 

--- a/tests/ballerina-integration-test/src/test/resources/mutualSSL/ssl_client_with_weak_cipher.bal
+++ b/tests/ballerina-integration-test/src/test/resources/mutualSSL/ssl_client_with_weak_cipher.bal
@@ -30,7 +30,7 @@ public function main(string... args) {
                 path: "${ballerina.home}/bre/security/ballerinaTruststore.p12",
                 password: "ballerina"
             },
-            ciphers: ["TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"]
+            ciphers: ["TLS_RSA_WITH_AES_256_CBC_SHA"]
         }
     };
     http:Request req = new;


### PR DESCRIPTION
## Purpose
Previously used weak cipher for tests is now disabled by the JDK. So update to another weak cipher which is considered weak by ourself, but not from the JDK.