### PR TITLE
Fix throwing error when reading corrupted / incomplete zip files

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipError;
 
 /**
  * Provide functions to convert a patten to a stream of zip paths.
@@ -74,7 +75,7 @@ public class ZipConverter extends PathConverter {
             // we are accessing the same zip/jar for the second time sometimes that filesystem might already exist.
             // Since we have no way to check if a filesystem is already created for a particular zip/jar, we have
             // ignored this exception.
-        } catch (IOException e) {
+        } catch (IOException | ZipError e) {
             throw new BLangCompilerException("Error loading balo " + uri.getPath(), e);
         }
     }


### PR DESCRIPTION
## Purpose
> Fix throwing error when reading corrupted / incomplete zip files.
> 
> This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/11273