### PR TITLE
Migrate table type tests for new error and typeguard changes

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableUtils.java
@@ -23,10 +23,12 @@ import org.ballerinalang.bre.bvm.BLangVMErrors;
 import org.ballerinalang.model.types.BArrayType;
 import org.ballerinalang.model.types.BField;
 import org.ballerinalang.model.types.BStructureType;
+import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BBooleanArray;
 import org.ballerinalang.model.values.BByteArray;
+import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BFloatArray;
 import org.ballerinalang.model.values.BIntArray;
@@ -35,8 +37,6 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.util.codegen.PackageInfo;
-import org.ballerinalang.util.codegen.StructureTypeInfo;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.io.ByteArrayInputStream;
@@ -50,9 +50,8 @@ import java.sql.Types;
  * @since 0.970.0
  */
 public class TableUtils {
-    private static final String TABLE_OPERATION_ERROR = "error";
-    private static final String TABLE_PACKAGE_PATH = BLangConstants.BALLERINA_BUILTIN_PKG;
-    private static final String EXCEPTION_OCCURRED = "Exception occurred";
+    private static final String TABLE_OPERATION_ERROR = "TableError";
+    private static final String DEFAULT_ERROR_DETAIL_MESSAGE = "Error occurred during table manipulation";
 
     public static String generateInsertDataStatment(String tableName, BMap<?, ?> constrainedType) {
         StringBuilder sbSql = new StringBuilder();
@@ -175,21 +174,16 @@ public class TableUtils {
     }
 
     /**
-     * Creates an instance of {@code {@link BStruct}} of the type error.
+     * Creates an instance of {@code {@link BError}} representing an error.
      *
      * @param context The context
      * @param throwable The Throwable object to be used
      * @return error value
      */
-    public static BMap<?, ?> createTableOperationError(Context context, Throwable throwable) {
-        PackageInfo tableLibPackage = context.getProgramFile().getPackageInfo(TABLE_PACKAGE_PATH);
-        StructureTypeInfo errorStructInfo = tableLibPackage.getStructInfo(TABLE_OPERATION_ERROR);
-        BMap<String, BValue> tableOperationError = new BMap<>(errorStructInfo.getType());
-        if (throwable.getMessage() == null) {
-            tableOperationError.put(BLangVMErrors.ERROR_MESSAGE_FIELD, new BString(EXCEPTION_OCCURRED));
-        } else {
-            tableOperationError.put(BLangVMErrors.ERROR_MESSAGE_FIELD, new BString(throwable.getMessage()));
-        }
-        return tableOperationError;
+    public static BError createTableOperationError(Context context, Throwable throwable) {
+        String detail = throwable.getMessage() != null ? throwable.getMessage() : DEFAULT_ERROR_DETAIL_MESSAGE;
+        BMap<String, BValue> tableErrorDetail = new BMap<>();
+        tableErrorDetail.put("message", new BString(detail));
+        return BLangVMErrors.createError(context, true, BTypes.typeError, TABLE_OPERATION_ERROR, tableErrorDetail);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -41,7 +41,6 @@ import org.ballerinalang.test.utils.SQLDBUtils;
 import org.ballerinalang.test.utils.SQLDBUtils.DBType;
 import org.ballerinalang.test.utils.SQLDBUtils.FileBasedTestDatabase;
 import org.ballerinalang.test.utils.SQLDBUtils.TestDatabase;
-import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;
@@ -69,11 +68,11 @@ public class TableTest {
     private static final String TABLE_TEST = "TableTest";
 
     private static final String TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD =
-            ".*Trying to assign a Nil value to a non-nillable field.*";
+            "Trying to assign a Nil value to a non-nillable field";
     private static final String INVALID_UNION_FIELD_ASSIGNMENT =
-            ".*Corresponding Union type in the record is not an assignable nillable type.*";
+            "Corresponding Union type in the record is not an assignable nillable type";
     private static final String TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_ARRAY_FIELD =
-            ".*Trying to assign an array containing NULL values to an array of a non-nillable element type.*";
+            "Trying to assign an array containing NULL values to an array of a non-nillable element type";
     private static final double DELTA = 0.01;
 
     @BeforeClass
@@ -404,11 +403,15 @@ public class TableTest {
         BValue[] returns = BRunUtil.invoke(result, "testXmlWithNull");
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(returns[0] instanceof BXML);
-        String expected = "<results><result><INT_TYPE>0</INT_TYPE><LONG_TYPE>0</LONG_TYPE><FLOAT_TYPE>0.0</FLOAT_TYPE>"
+        String expected1 = "<results><result><INT_TYPE>0</INT_TYPE><LONG_TYPE>0</LONG_TYPE><FLOAT_TYPE>0.0</FLOAT_TYPE>"
                 + "<DOUBLE_TYPE>0.0</DOUBLE_TYPE><BOOLEAN_TYPE>false</BOOLEAN_TYPE>"
                 + "<STRING_TYPE xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\">"
                 + "</STRING_TYPE></result></results>";
-        Assert.assertEquals(returns[0].stringValue(), expected);
+        String expected2 = "<results><result><INT_TYPE>0</INT_TYPE><LONG_TYPE>0</LONG_TYPE><FLOAT_TYPE>0.0"
+                + "</FLOAT_TYPE><DOUBLE_TYPE>0.0</DOUBLE_TYPE><BOOLEAN_TYPE>false</BOOLEAN_TYPE><STRING_TYPE "
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                + "xsi:nil=\"true\"/></result></results>";
+        Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
     @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.")
@@ -654,12 +657,10 @@ public class TableTest {
         Assert.assertEquals((returns[0]).stringValue(), "data cannot be deleted from a table returned from a database");
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test performing operation over a closed table",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*trying to perform an operation over a closed table.*")
+    @Test(groups = TABLE_TEST, description = "Test performing operation over a closed table")
     public void tableGetNextInvalid() {
-        BRunUtil.invoke(result, "tableGetNextInvalid");
+        BValue[] returns = BRunUtil.invoke(result, "tableGetNextInvalid");
+        Assert.assertTrue((returns[0]).stringValue().contains("Trying to perform an operation over a closed table"));
     }
     
     //Nillable mapping tests
@@ -786,333 +787,270 @@ public class TableTest {
     }
 
     //Nillable mapping negative tests
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable int field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable int field")
     public void testAssignNilToNonNillableInt() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableInt");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableInt");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable long field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable long field")
     public void testAssignNilToNonNillableLong() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableLong");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableLong");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable float field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable float field")
     public void testAssignNilToNonNillableFloat() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableFloat");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableFloat");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable double field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable double field")
     public void testAssignNilToNonNillableDouble() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDouble");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDouble");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable boolean field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable boolean field")
     public void testAssignNilToNonNillableBoolean() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableBoolean");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableBoolean");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable string field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable string field")
     public void testAssignNilToNonNillableString() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableString");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableString");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable numeric field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable numeric field")
     public void testAssignNilToNonNillableNumeric() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableNumeric");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableNumeric");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable small-int field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable small-int field")
     public void testAssignNilToNonNillableSmallint() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableSmallint");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableSmallint");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable tiny-int field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable tiny-int field")
     public void testAssignNilToNonNillableTinyInt() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableTinyInt");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableTinyInt");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable decimal field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable decimal field")
     public void testAssignNilToNonNillableDecimal() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDecimal");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDecimal");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable real field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable real field")
     public void testAssignNilToNonNillableReal() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableReal");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableReal");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable clob field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable clob field")
     public void testAssignNilToNonNillableClob() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableClob");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableClob");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable blob field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable blob field")
     public void testAssignNilToNonNillableBlob() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableBlob");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableBlob");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable binary field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable binary field")
     public void testAssignNilToNonNillableBinary() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableBinary");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableBinary");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable date field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable date field")
     public void testAssignNilToNonNillableDate() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDate");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDate");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable time field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable time field")
     public void testAssignNilToNonNillableTime() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableTime");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableTime");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable datetime field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable datetime field")
     public void testAssignNilToNonNillableDateTime() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDateTime");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableDateTime");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          description = "Test mapping nil to non-nillable timestamp field",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+    @Test(groups = TABLE_TEST, description = "Test mapping nil to non-nillable timestamp field")
     public void testAssignNilToNonNillableTimeStamp() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableTimeStamp");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNilToNonNillableTimeStamp");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionInt() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionInt");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionInt");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionLong() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionLong");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionLong");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionFloat() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionFloat");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionFloat");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionDouble() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDouble");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDouble");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionBoolean() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionBoolean");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionBoolean");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionString() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionString");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionString");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionNumeric() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionNumeric");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionNumeric");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionSmallint() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionSmallint");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionSmallint");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionTinyInt() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionTinyInt");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionTinyInt");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionDecimal() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDecimal");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDecimal");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionReal() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionReal");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionReal");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionClob() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionClob");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionClob");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionBlob() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionBlob");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionBlob");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionBinary() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionBinary");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionBinary");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionDate() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDate");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDate");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionTime() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionTime");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionTime");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionDateTime() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDateTime");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionDateTime");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = TABLE_TEST,
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = TABLE_TEST)
     public void testAssignToInvalidUnionTimeStamp() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionTimeStamp");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignToInvalidUnionTimeStamp");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-
     @Test(groups = {TABLE_TEST},
-          description = "Test mapping a null array to non-nillable type with non-nillable element type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+          description = "Test mapping a null array to non-nillable type with non-nillable element type.")
     public void testAssignNullArrayToNonNillableWithNonNillableElements() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNullArrayToNonNillableWithNonNillableElements");
+        BValue[] returns = BRunUtil
+                .invoke(nillableMappingNegativeResult, "testAssignNullArrayToNonNillableWithNonNillableElements");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
     @Test(groups = {TABLE_TEST},
-          description = "Test mapping a null array to non-nillable type with nillable element type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD)
+          description = "Test mapping a null array to non-nillable type with nillable element type.")
     public void testAssignNullArrayToNonNillableTypeWithNillableElements() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignNullArrayToNonNillableTypeWithNillableElements");
+        BValue[] returns = BRunUtil
+                .invoke(nillableMappingNegativeResult, "testAssignNullArrayToNonNillableTypeWithNillableElements");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_FIELD));
     }
 
     @Test(groups = {TABLE_TEST},
-          description = "Test mapping a null array to non-nillable type with non-nillable element type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_ARRAY_FIELD)
+          description = "Test mapping a null array to non-nillable type with non-nillable element type.")
     public void testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() {
-        BRunUtil.invoke(nillableMappingNegativeResult,
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult,
                 "testAssignNullElementArrayToNonNillableTypeWithNonNillableElements");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_ARRAY_FIELD));
     }
 
     @Test(groups = {TABLE_TEST},
-          description = "Test mapping a null element array to nillable type with non-nillable element type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_ARRAY_FIELD)
+          description = "Test mapping a null element array to nillable type with non-nillable element type.")
     public void testAssignNullElementArrayToNillableTypeWithNonNillableElements() {
-        BRunUtil.invoke(nillableMappingNegativeResult,
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult,
                 "testAssignNullElementArrayToNillableTypeWithNonNillableElements");
+        Assert.assertTrue(returns[0].stringValue().contains(TRYING_TO_ASSIGN_NIL_TO_NON_NILLABLE_ARRAY_FIELD));
     }
 
-    @Test(groups = {TABLE_TEST},
-          description = "Test mapping an array to invalid union type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = {TABLE_TEST}, description = "Test mapping an array to invalid union type.")
     public void testAssignInvalidUnionArray() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignInvalidUnionArray");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignInvalidUnionArray");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = {TABLE_TEST},
-          description = "Test mapping an array to invalid union type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = {TABLE_TEST}, description = "Test mapping an array to invalid union type.")
     public void testAssignInvalidUnionArray2() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignInvalidUnionArray2");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignInvalidUnionArray2");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
-    @Test(groups = {TABLE_TEST},
-          description = "Test mapping an array to invalid union type.",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = INVALID_UNION_FIELD_ASSIGNMENT)
+    @Test(groups = {TABLE_TEST}, description = "Test mapping an array to invalid union type.")
     public void testAssignInvalidUnionArrayElement() {
-        BRunUtil.invoke(nillableMappingNegativeResult, "testAssignInvalidUnionArrayElement");
+        BValue[] returns = BRunUtil.invoke(nillableMappingNegativeResult, "testAssignInvalidUnionArrayElement");
+        Assert.assertTrue(returns[0].stringValue().contains(INVALID_UNION_FIELD_ASSIGNMENT));
     }
 
     @AfterSuite

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping_negative.bal
@@ -137,80 +137,79 @@ type ResultMapNillableTypeNonNillableElements record {
     string[]? STRING_ARRAY;
 };
 
-function testAssignNilToNonNillableInt() {
-    testAssignNilToNonNillableField("int_type", NonNillableInt);
+function testAssignNilToNonNillableInt() returns string {
+    return testAssignNilToNonNillableField("int_type", NonNillableInt);
 }
 
-function testAssignNilToNonNillableLong() {
-    testAssignNilToNonNillableField("long_type", NonNillableLong);
+function testAssignNilToNonNillableLong() returns string {
+    return testAssignNilToNonNillableField("long_type", NonNillableLong);
 }
 
-function testAssignNilToNonNillableFloat() {
-    testAssignNilToNonNillableField("float_type", NonNillableFloat);
+function testAssignNilToNonNillableFloat() returns string {
+    return testAssignNilToNonNillableField("float_type", NonNillableFloat);
 }
 
-function testAssignNilToNonNillableDouble() {
-    testAssignNilToNonNillableField("double_type", NonNillableDouble);
+function testAssignNilToNonNillableDouble() returns string {
+    return testAssignNilToNonNillableField("double_type", NonNillableDouble);
 }
 
-function testAssignNilToNonNillableBoolean() {
-    testAssignNilToNonNillableField("boolean_type", NonNillableBoolean);
+function testAssignNilToNonNillableBoolean() returns string {
+    return testAssignNilToNonNillableField("boolean_type", NonNillableBoolean);
 }
 
-function testAssignNilToNonNillableString() {
-    testAssignNilToNonNillableField("string_type", NonNillableString);
+function testAssignNilToNonNillableString() returns string {
+    return testAssignNilToNonNillableField("string_type", NonNillableString);
 }
 
-function testAssignNilToNonNillableNumeric() {
-    testAssignNilToNonNillableField("numeric_type", NonNillableNumeric);
+function testAssignNilToNonNillableNumeric() returns string {
+    return testAssignNilToNonNillableField("numeric_type", NonNillableNumeric);
 }
 
-function testAssignNilToNonNillableTinyInt() {
-    testAssignNilToNonNillableField("tinyint_type", NonNillableTinyInt);
+function testAssignNilToNonNillableTinyInt() returns string {
+    return testAssignNilToNonNillableField("tinyint_type", NonNillableTinyInt);
 }
 
-function testAssignNilToNonNillableSmallint() {
-    testAssignNilToNonNillableField("smallint_type", NonNillableSmallInt);
+function testAssignNilToNonNillableSmallint() returns string {
+    return testAssignNilToNonNillableField("smallint_type", NonNillableSmallInt);
 }
 
-function testAssignNilToNonNillableDecimal() {
-    testAssignNilToNonNillableField("decimal_type", NonNillableDecimal);
+function testAssignNilToNonNillableDecimal() returns string {
+    return testAssignNilToNonNillableField("decimal_type", NonNillableDecimal);
 }
 
-function testAssignNilToNonNillableReal() {
-    testAssignNilToNonNillableField("real_type", NonNillableReal);
+function testAssignNilToNonNillableReal() returns string {
+    return testAssignNilToNonNillableField("real_type", NonNillableReal);
 }
 
-function testAssignNilToNonNillableClob() {
-    testAssignNilToNonNillableField("clob_type", NonNillableClob);
+function testAssignNilToNonNillableClob() returns string {
+    return testAssignNilToNonNillableField("clob_type", NonNillableClob);
 }
 
-function testAssignNilToNonNillableBlob() {
-    testAssignNilToNonNillableField("blob_type", NonNillableBlob);
+function testAssignNilToNonNillableBlob() returns string {
+    return testAssignNilToNonNillableField("blob_type", NonNillableBlob);
 }
 
-function testAssignNilToNonNillableBinary() {
-    testAssignNilToNonNillableField("binary_type", NonNillableBinary);
+function testAssignNilToNonNillableBinary() returns string {
+    return testAssignNilToNonNillableField("binary_type", NonNillableBinary);
 }
 
-function testAssignNilToNonNillableDate() {
-    testAssignNilToNonNillableField("date_type", NonNillableDate);
+function testAssignNilToNonNillableDate() returns string {
+    return testAssignNilToNonNillableField("date_type", NonNillableDate);
 }
 
-function testAssignNilToNonNillableTime() {
-    testAssignNilToNonNillableField("time_type", NonNillableTime);
+function testAssignNilToNonNillableTime() returns string {
+    return testAssignNilToNonNillableField("time_type", NonNillableTime);
 }
 
-function testAssignNilToNonNillableDateTime() {
-    testAssignNilToNonNillableField("datetime_type", NonNillableDateTime);
+function testAssignNilToNonNillableDateTime() returns string {
+    return testAssignNilToNonNillableField("datetime_type", NonNillableDateTime);
 }
 
-function testAssignNilToNonNillableTimeStamp() {
-    testAssignNilToNonNillableField("timestamp_type", NonNillableTimeStamp);
+function testAssignNilToNonNillableTimeStamp() returns string {
+    return testAssignNilToNonNillableField("timestamp_type", NonNillableTimeStamp);
 }
 
-function testAssignNilToNonNillableField(string field, typedesc
-    recordType) {
+function testAssignNilToNonNillableField(string field, typedesc recordType) returns string {
     endpoint h2:Client testDB {
         path: "./target/tempdb/",
         name: "TEST_DATA_TABLE_H2",
@@ -218,10 +217,8 @@ function testAssignNilToNonNillableField(string field, typedesc
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
     string dbTable;
     int rowId;
-
     if (field == "blob_type") {
         dbTable = "DataTypeTableNillableBlob";
         rowId = 4;
@@ -229,119 +226,119 @@ function testAssignNilToNonNillableField(string field, typedesc
         dbTable = "DataTypeTableNillable";
         rowId = 2;
     }
-
     table dt = check testDB->select("SELECT " + field + " from " + dbTable + " where row_id=?", recordType, rowId);
-
-    try {
-        while (dt.hasNext()) {
-            var rs = dt.getNext();
+    string errorMessage = "";
+    while (dt.hasNext()) {
+        var ret = trap dt.getNext();
+        if (ret is error) {
+            errorMessage = <string> ret.reason();
         }
-    } finally {
-        testDB.stop();
     }
+    testDB.stop();
+    return errorMessage;
 }
 
-function testAssignToInvalidUnionInt() {
-    testAssignToInvalidUnionField("int_type");
+function testAssignToInvalidUnionInt() returns string {
+    return testAssignToInvalidUnionField("int_type");
 }
 
-function testAssignToInvalidUnionLong() {
-    testAssignToInvalidUnionField("long_type");
+function testAssignToInvalidUnionLong() returns string {
+    return testAssignToInvalidUnionField("long_type");
 }
 
-function testAssignToInvalidUnionFloat() {
-    testAssignToInvalidUnionField("float_type");
+function testAssignToInvalidUnionFloat() returns string {
+    return testAssignToInvalidUnionField("float_type");
 }
 
-function testAssignToInvalidUnionDouble() {
-    testAssignToInvalidUnionField("double_type");
+function testAssignToInvalidUnionDouble() returns string {
+    return testAssignToInvalidUnionField("double_type");
 }
 
-function testAssignToInvalidUnionBoolean() {
-    testAssignToInvalidUnionField("boolean_type");
+function testAssignToInvalidUnionBoolean() returns string {
+    return testAssignToInvalidUnionField("boolean_type");
 }
 
-function testAssignToInvalidUnionString() {
-    testAssignToInvalidUnionField("string_type");
+function testAssignToInvalidUnionString() returns string {
+    return testAssignToInvalidUnionField("string_type");
 }
 
-function testAssignToInvalidUnionNumeric() {
-    testAssignToInvalidUnionField("numeric_type");
+function testAssignToInvalidUnionNumeric() returns string {
+    return testAssignToInvalidUnionField("numeric_type");
 }
 
-function testAssignToInvalidUnionTinyInt() {
-    testAssignToInvalidUnionField("tinyint_type");
+function testAssignToInvalidUnionTinyInt() returns string {
+    return testAssignToInvalidUnionField("tinyint_type");
 }
 
-function testAssignToInvalidUnionSmallint() {
-    testAssignToInvalidUnionField("smallint_type");
+function testAssignToInvalidUnionSmallint() returns string {
+    return testAssignToInvalidUnionField("smallint_type");
 }
 
-function testAssignToInvalidUnionDecimal() {
-    testAssignToInvalidUnionField("decimal_type");
+function testAssignToInvalidUnionDecimal() returns string {
+    return testAssignToInvalidUnionField("decimal_type");
 }
 
-function testAssignToInvalidUnionReal() {
-    testAssignToInvalidUnionField("real_type");
+function testAssignToInvalidUnionReal() returns string {
+    return testAssignToInvalidUnionField("real_type");
 }
 
-function testAssignToInvalidUnionClob() {
-    testAssignToInvalidUnionField("clob_type");
+function testAssignToInvalidUnionClob() returns string {
+    return testAssignToInvalidUnionField("clob_type");
 }
 
-function testAssignToInvalidUnionBlob() {
-    testAssignToInvalidUnionField("blob_type");
+function testAssignToInvalidUnionBlob() returns string {
+    return testAssignToInvalidUnionField("blob_type");
 }
 
-function testAssignToInvalidUnionBinary() {
-    testAssignToInvalidUnionField("binary_type");
+function testAssignToInvalidUnionBinary() returns string {
+    return testAssignToInvalidUnionField("binary_type");
 }
 
-function testAssignToInvalidUnionDate() {
-    testAssignToInvalidUnionField("date_type");
+function testAssignToInvalidUnionDate() returns string {
+    return testAssignToInvalidUnionField("date_type");
 }
 
-function testAssignToInvalidUnionTime() {
-    testAssignToInvalidUnionField("time_type");
+function testAssignToInvalidUnionTime() returns string {
+    return testAssignToInvalidUnionField("time_type");
 }
 
-function testAssignToInvalidUnionDateTime() {
-    testAssignToInvalidUnionField("datetime_type");
+function testAssignToInvalidUnionDateTime() returns string {
+    return testAssignToInvalidUnionField("datetime_type");
 }
 
-function testAssignToInvalidUnionTimeStamp() {
-    testAssignToInvalidUnionField("timestamp_type");
+function testAssignToInvalidUnionTimeStamp() returns string {
+    return testAssignToInvalidUnionField("timestamp_type");
 }
 
-function testAssignNullArrayToNonNillableWithNonNillableElements() {
-    testAssignArrayToInvalidField(ResultMap, 3);
+function testAssignNullArrayToNonNillableWithNonNillableElements() returns string {
+    return testAssignArrayToInvalidField(ResultMap, 3);
 }
 
-function testAssignNullArrayToNonNillableTypeWithNillableElements() {
-    testAssignArrayToInvalidField(ResultMapNonNillableTypeNillableElements, 3);
+function testAssignNullArrayToNonNillableTypeWithNillableElements() returns string {
+    return testAssignArrayToInvalidField(ResultMapNonNillableTypeNillableElements, 3);
 }
 
-function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() {
-    testAssignArrayToInvalidField(ResultMap, 2);
+function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() returns string {
+    return testAssignArrayToInvalidField(ResultMap, 2);
 }
 
-function testAssignNullElementArrayToNillableTypeWithNonNillableElements() {
-    testAssignArrayToInvalidField(ResultMapNillableTypeNonNillableElements, 2);
+function testAssignNullElementArrayToNillableTypeWithNonNillableElements() returns string {
+    return testAssignArrayToInvalidField(ResultMapNillableTypeNonNillableElements, 2);
 }
 
-function testAssignInvalidUnionArray() {
-    testInvalidUnionForArrays(InvalidUnionArray);
+function testAssignInvalidUnionArray() returns string {
+    return testInvalidUnionForArrays(InvalidUnionArray);
 }
 
-function testAssignInvalidUnionArrayElement() {
-    testInvalidUnionForArrays(InvalidUnionArrayElement);
+function testAssignInvalidUnionArrayElement() returns string {
+    return testInvalidUnionForArrays(InvalidUnionArrayElement);
 }
 
-function testAssignInvalidUnionArray2() {
-    testInvalidUnionForArrays(InvalidUnionArray2);
+function testAssignInvalidUnionArray2() returns string {
+    return testInvalidUnionForArrays(InvalidUnionArray2);
 }
 
-function testAssignToInvalidUnionField(string field) {
+function testAssignToInvalidUnionField(string field) returns string {
     endpoint h2:Client testDB {
         path: "./target/tempdb/",
         name: "TEST_DATA_TABLE_H2",
@@ -362,17 +359,18 @@ function testAssignToInvalidUnionField(string field) {
     }
 
     table dt = check testDB->select("SELECT " + field + " from " + dbTable + " where row_id=?", InvalidUnion, rowId);
-
-    try {
-        while (dt.hasNext()) {
-            var rs = <InvalidUnion>dt.getNext();
+    string errorMessage = "";
+    while (dt.hasNext()) {
+        var ret = trap <InvalidUnion>dt.getNext();
+        if (ret is error) {
+            errorMessage = ret.reason();
         }
-    } finally {
-        testDB.stop();
     }
+    testDB.stop();
+    return errorMessage;
 }
 
-function testAssignArrayToInvalidField(typedesc invalidType, int id) {
+function testAssignArrayToInvalidField(typedesc invalidType, int id) returns string {
     endpoint h2:Client testDB {
         path: "./target/tempdb/",
         name: "TEST_DATA_TABLE_H2",
@@ -383,17 +381,18 @@ function testAssignArrayToInvalidField(typedesc invalidType, int id) {
 
     table dt = check testDB->select("SELECT int_array, long_array, float_array, boolean_array,
               string_array from ArrayTypes where row_id = ?", invalidType, id);
-
-    try {
-        while (dt.hasNext()) {
-            var rs = dt.getNext();
+    string errorMessage = "";
+    while (dt.hasNext()) {
+        var ret = trap dt.getNext();
+        if (ret is error) {
+            errorMessage = ret.reason();
         }
-    } finally {
-        testDB.stop();
     }
+    testDB.stop();
+    return errorMessage;
 }
 
-function testInvalidUnionForArrays(typedesc invalidUnion) {
+function testInvalidUnionForArrays(typedesc invalidUnion) returns string {
     endpoint h2:Client testDB {
         path: "./target/tempdb/",
         name: "TEST_DATA_TABLE_H2",
@@ -401,14 +400,14 @@ function testInvalidUnionForArrays(typedesc invalidUnion) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
     table dt = check testDB->select("SELECT int_array from ArrayTypes where row_id = 1", invalidUnion);
-
-    try {
-        while (dt.hasNext()) {
-            var rs = dt.getNext();
+    string message = "";
+    while (dt.hasNext()) {
+        var ret = trap dt.getNext();
+        if (ret is error) {
+            message = <string> ret.reason();
         }
-    } finally {
-        testDB.stop();
     }
+    testDB.stop();
+    return message;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -137,17 +137,13 @@ function testToJson() returns (json) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable WHERE row_id = 1", ());
-        json result = check <json>dt;
-        // Converting to string to make sure the json is built before returning.
-        _ = result.toString();
-        return result;
-    } finally {
-        testDB.stop();
-    }
+    json result = check <json>dt;
+    // Converting to string to make sure the json is built before returning.
+    _ = result.toString();
+    testDB.stop();
+    return result;
 }
 
 function testToXml() returns (xml) {
@@ -158,18 +154,14 @@ function testToXml() returns (xml) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                    boolean_type, string_type from DataTable WHERE row_id = 1", ());
 
-        xml convertedVal = check <xml>dt;
-        // Converting to string to make sure the xml is built before returning.
-        _ = io:sprintf("%s", convertedVal);
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    xml convertedVal = check <xml>dt;
+    // Converting to string to make sure the xml is built before returning.
+    _ = io:sprintf("%s", convertedVal);
+    testDB.stop();
+    return convertedVal;
 }
 
 function testToXmlMultipleConsume() returns (xml) {
@@ -181,16 +173,13 @@ function testToXmlMultipleConsume() returns (xml) {
         poolOptions: { maximumPoolSize: 1 }
     };
 
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
         boolean_type, string_type from DataTable WHERE row_id = 1", ());
 
-        xml result = check <xml>dt;
-        io:println(result);
-        return result;
-    } finally {
-        testDB.stop();
-    }
+    xml result = check <xml>dt;
+    io:println(result);
+    testDB.stop();
+    return result;
 }
 
 function testToXmlWithAdd() returns (xml) {
@@ -201,21 +190,17 @@ function testToXmlWithAdd() returns (xml) {
         password: "",
         poolOptions: { maximumPoolSize: 2 }
     };
+    table dt1 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", ());
+    xml result1 = check <xml>dt1;
 
-    try {
-        table dt1 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", ());
-        xml result1 = check <xml>dt1;
+    table dt2 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", ());
+    xml result2 = check <xml>dt2;
 
-        table dt2 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", ());
-        xml result2 = check <xml>dt2;
+    xml result = result1 + result2;
 
-        xml result = result1 + result2;
-
-        table dt3 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", ());
-        return result;
-    } finally {
-        testDB.stop();
-    }
+    table dt3 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", ());
+    testDB.stop();
+    return result;
 }
 
 function testToJsonMultipleConsume() returns (json) {
@@ -226,17 +211,13 @@ function testToJsonMultipleConsume() returns (json) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
         boolean_type, string_type from DataTable WHERE row_id = 1", ());
 
-        json result = check <json>dt;
-        io:println(result);
-        return result;
-    } finally {
-        testDB.stop();
-    }
+    json result = check <json>dt;
+    io:println(result);
+    testDB.stop();
+    return result;
 }
 
 
@@ -248,19 +229,15 @@ function toXmlComplex() returns (xml) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
+    table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
                     float_array, double_type, boolean_type, string_type, double_array, boolean_array, string_array
                     from MixTypes where row_id =1", ());
 
-        xml convertedVal = check <xml>dt;
-        // Converting to string to make sure the xml is built before returning.
-        _ = io:sprintf("%s", convertedVal);
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    xml convertedVal = check <xml>dt;
+    // Converting to string to make sure the xml is built before returning.
+    _ = io:sprintf("%s", convertedVal);
+    testDB.stop();
+    return convertedVal;
 }
 
 function testToXmlComplexWithStructDef() returns (xml) {
@@ -271,19 +248,15 @@ function testToXmlComplexWithStructDef() returns (xml) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
+    table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
                     float_array, double_type, boolean_type, string_type, double_array, boolean_array, string_array
                     from MixTypes where row_id =1", TestTypeData);
 
-        xml convertedVal = check <xml>dt;
-        // Converting to string to make sure the xml is built before returning.
-        _ = io:sprintf("%s", convertedVal);
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    xml convertedVal = check <xml>dt;
+    // Converting to string to make sure the xml is built before returning.
+    _ = io:sprintf("%s", convertedVal);
+    testDB.stop();
+    return convertedVal;
 }
 
 
@@ -295,19 +268,16 @@ function testToJsonComplex() returns (json) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
+    table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
                     float_array, double_type, boolean_type, string_type, double_array, boolean_array, string_array
                     from MixTypes where row_id =1", ());
 
-        json convertedVal = check <json>dt;
-        // Converting to string to make sure the json is built before returning.
-        _ = convertedVal.toString();
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    json convertedVal = check <json>dt;
+    // Converting to string to make sure the json is built before returning.
+    _ = convertedVal.toString();
+    testDB.stop();
+
+    return convertedVal;
 }
 
 function testToJsonComplexWithStructDef() returns (json) {
@@ -318,19 +288,16 @@ function testToJsonComplexWithStructDef() returns (json) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
+    table dt = check testDB->select("SELECT int_type, int_array, long_type, long_array, float_type,
                     float_array, double_type, boolean_type, string_type, double_array, boolean_array, string_array
                     from MixTypes where row_id =1", TestTypeData);
 
-        json convertedVal = check <json>dt;
-        // Converting to string to make sure the json is built before returning.
-        _ = convertedVal.toString();
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    json convertedVal = check <json>dt;
+    // Converting to string to make sure the json is built before returning.
+    _ = convertedVal.toString();
+    testDB.stop();
+
+    return convertedVal;
 }
 
 function testJsonWithNull() returns (json) {
@@ -341,18 +308,15 @@ function testJsonWithNull() returns (json) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable WHERE row_id = 2", ());
 
-        json convertedVal = check <json>dt;
-        // Converting to string to make sure the json is built before returning.
-        _ = convertedVal.toString();
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    json convertedVal = check <json>dt;
+    // Converting to string to make sure the json is built before returning.
+    _ = convertedVal.toString();
+    testDB.stop();
+
+    return convertedVal;
 }
 
 function testXmlWithNull() returns (xml) {
@@ -363,18 +327,15 @@ function testXmlWithNull() returns (xml) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                    boolean_type, string_type from DataTable WHERE row_id = 2", ());
 
-        xml convertedVal = check <xml>dt;
-        // Converting to string to make sure the xml is built before returning.
-        _ = io:sprintf("%s", convertedVal);
-        return convertedVal;
-    } finally {
-        testDB.stop();
-    }
+    xml convertedVal = check <xml>dt;
+    // Converting to string to make sure the xml is built before returning.
+    _ = io:sprintf("%s", convertedVal);
+    testDB.stop();
+
+    return convertedVal;
 }
 
 function testToXmlWithinTransaction() returns (string, int) {
@@ -388,17 +349,15 @@ function testToXmlWithinTransaction() returns (string, int) {
 
     int returnValue = 0;
     string resultXml;
-    try {
-        transaction {
-            table dt = check testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
+    transaction {
+        table dt = check testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
 
-            var result = check <xml>dt;
-            resultXml = io:sprintf("%s", result);
-        }
-        return (resultXml, returnValue);
-    } finally {
-        testDB.stop();
+        var result = check <xml>dt;
+        resultXml = io:sprintf("%s", result);
     }
+    testDB.stop();
+
+    return (resultXml, returnValue);
 }
 
 function testToJsonWithinTransaction() returns (string, int) {
@@ -412,17 +371,14 @@ function testToJsonWithinTransaction() returns (string, int) {
 
     int returnValue = 0;
     string result;
-    try {
-        transaction {
-            table dt = check testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
+    transaction {
+        table dt = check testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
 
-            var j = check <json>dt;
-            result = io:sprintf("%s", j);
-        }
-        return (result, returnValue);
-    } finally {
-        testDB.stop();
+        var j = check <json>dt;
+        result = io:sprintf("%s", j);
     }
+    testDB.stop();
+    return (result, returnValue);
 }
 
 function testGetPrimitiveTypes() returns (int, int, float, float, boolean, string) {
@@ -1213,12 +1169,11 @@ function testComplexTypeInsertAndRetrieval() returns (int, int, string,
     while (dt.hasNext()) {
         var result = check <ResultComplexTypes>dt.getNext();
         string blobType;
-        match result.BLOB_TYPE {
-            byte[] b => {
-                expected[i] = b;
-                blobType = "nonNil";
-            }
-            () => blobType = "nil";
+        if (result.BLOB_TYPE is byte[]) {
+            expected[i] = result.BLOB_TYPE;
+            blobType = "nonNil";
+        } else if (result.BLOB_TYPE is ()) {
+            blobType = "nil";
         }
         str = str + result.ROW_ID + "|" + blobType + "|" + (result.CLOB_TYPE but { () => "nil" }) + "|";
         i += 1;
@@ -1236,24 +1191,21 @@ function testJsonXMLConversionwithDuplicateColumnNames() returns (json,
         password: "",
         poolOptions: { maximumPoolSize: 2 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT dt1.row_id, dt1.int_type, dt2.row_id, dt2.int_type from DataTable dt1 left
+    table dt = check testDB->select("SELECT dt1.row_id, dt1.int_type, dt2.row_id, dt2.int_type from DataTable dt1 left
             join DataTableRep dt2 on dt1.row_id = dt2.row_id WHERE dt1.row_id = 1", ());
-        json j = check <json>dt;
-        // Converting to string to make sure the json is built before returning.
-        _ = j.toString();
+    json j = check <json>dt;
+    // Converting to string to make sure the json is built before returning.
+    _ = j.toString();
 
-        table dt2 = check testDB->select("SELECT dt1.row_id, dt1.int_type, dt2.row_id, dt2.int_type from DataTable dt1 left
+    table dt2 = check testDB->select("SELECT dt1.row_id, dt1.int_type, dt2.row_id, dt2.int_type from DataTable dt1 left
             join DataTableRep dt2 on dt1.row_id = dt2.row_id WHERE dt1.row_id = 1", ());
-        xml x = check <xml>dt2;
+    xml x = check <xml>dt2;
 
-        // Converting to string to make sure the xml is built before returning.
-        _ = io:sprintf("%s", x);
-        return (j, x);
-    } finally {
-        testDB.stop();
-    }
+    // Converting to string to make sure the xml is built before returning.
+    _ = io:sprintf("%s", x);
+    testDB.stop();
+
+    return (j, x);
 }
 
 function testStructFieldNotMatchingColumnName() returns (int, int, int,
@@ -1360,17 +1312,15 @@ function testTableAddInvalid() returns string {
 
     table dt = check testDB->select("SELECT int_type from DataTableRep", ResultPrimitiveInt);
 
-    string s;
-    try {
-        ResultPrimitiveInt row = { INT_TYPE: 443 };
-        var ret = dt.add(row);
-        match (ret) {
-            error e => s = e.message;
-            () => s = "nil";
-        }
-    } finally {
-        testDB.stop();
+    string s = "";
+    ResultPrimitiveInt row = { INT_TYPE: 443 };
+    var ret = trap dt.add(row);
+    if (ret is error) {
+        s = <string> ret.detail().message;
+    } else if (ret is ()) {
+        s = "nil";
     }
+    testDB.stop();
     return s;
 }
 
@@ -1384,21 +1334,19 @@ function testTableRemoveInvalid() returns string {
     };
 
     table dt = check testDB->select("SELECT int_type from DataTableRep", ResultPrimitiveInt);
-    string s;
-    try {
-        ResultPrimitiveInt row = { INT_TYPE: 443 };
-        var ret = dt.remove(isDelete);
-        match (ret) {
-            int count => s = <string>count;
-            error e => s = e.message;
-        }
-    } finally {
-        testDB.stop();
+    string s = "";
+    ResultPrimitiveInt row = { INT_TYPE: 443 };
+    var ret = trap dt.remove(isDelete);
+    if (ret is int) {
+        s = <string> ret;
+    } else if (ret is error) {
+        s = <string> ret.detail().message;
     }
+    testDB.stop();
     return s;
 }
 
-function tableGetNextInvalid() {
+function tableGetNextInvalid() returns string {
     endpoint h2:Client testDB {
         path: "./target/tempdb/",
         name: "TEST_DATA_TABLE_H2",
@@ -1406,14 +1354,15 @@ function tableGetNextInvalid() {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT * from DataTable WHERE row_id = 1", ());
-        dt.close();
-        any data = dt.getNext();
-    } finally {
-        testDB.stop();
+    table dt = check testDB->select("SELECT * from DataTable WHERE row_id = 1", ());
+    dt.close();
+    var ret = trap dt.getNext();
+    testDB.stop();
+    string retVal = "";
+    if (ret is error) {
+        retVal = <string> ret.reason();
     }
+    return retVal;
 }
 
 function isDelete(ResultPrimitiveInt p) returns (boolean) {
@@ -1428,17 +1377,13 @@ function testToJsonAndAccessFromMiddle() returns (json, int) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable", ());
-        json result = check <json>dt;
+    json result = check <json>dt;
 
-        json j = result[1];
-        return (result, result.length());
-    } finally {
-        testDB.stop();
-    }
+    json j = result[1];
+    testDB.stop();
+    return (result, result.length());
 }
 
 function testToJsonAndIterate() returns (json, int) {
@@ -1449,22 +1394,17 @@ function testToJsonAndIterate() returns (json, int) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable", ());
-        json result = check <json>dt;
-        json j = [];
-        int i = 0;
-        foreach row in result {
-            j[i] = row;
-            i += 1;
-        }
-
-        return (j, j.length());
-    } finally {
-        testDB.stop();
+    json result = check <json>dt;
+    json j = [];
+    int i = 0;
+    foreach row in result {
+        j[i] = row;
+        i += 1;
     }
+    testDB.stop();
+    return (j, j.length());
 }
 
 function testToJsonAndSetAsChildElement() returns json {
@@ -1475,16 +1415,12 @@ function testToJsonAndSetAsChildElement() returns json {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable", ());
-        json result = check <json>dt;
-        json j = { status: "SUCCESS", resp: { value: result } };
-        return j;
-    } finally {
-        testDB.stop();
-    }
+    json result = check <json>dt;
+    json j = { status: "SUCCESS", resp: { value: result } };
+    testDB.stop();
+    return j;
 }
 
 function testToJsonAndLengthof() returns (int, int) {
@@ -1495,21 +1431,16 @@ function testToJsonAndLengthof() returns (int, int) {
         password: "",
         poolOptions: { maximumPoolSize: 1 }
     };
-
-    try {
-        table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
+    table dt = check testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable", ());
-        json result = check <json>dt;
+    json result = check <json>dt;
 
-        // get the length before accessing
-        int beforeLen = result.length();
+    // get the length before accessing
+    int beforeLen = result.length();
 
-        // get the length after accessing
-        json j = result[0];
-        int afterLen = result.length();
-
-        return (beforeLen, afterLen);
-    } finally {
-        testDB.stop();
-    }
+    // get the length after accessing
+    json j = result[0];
+    int afterLen = result.length();
+    testDB.stop();
+    return (beforeLen, afterLen);
 }


### PR DESCRIPTION
## Purpose
$Subject

Note: "testComplexTypeInsertAndRetrieval" test function makes the compilation fail with the following error.
```bash
Compilation Failed:
ERROR: .::table_type.bal:1173:27:: incompatible types: expected 'byte[]', found 'byte[]?'
```
This needs to be fixed. Rest of the code gets compiled without any issue and all tests except for this one passes.