### PR TITLE
Fix FO client response payload dropping issue

### DIFF
--- a/stdlib/http/src/main/ballerina/http/resiliency/failover_connector.bal
+++ b/stdlib/http/src/main/ballerina/http/resiliency/failover_connector.bal
@@ -307,6 +307,7 @@ function performFailoverAction (string path, Request request, HttpOperation requ
         currentIndex = currentIndex + 1;
         var endpointResponse = invokeEndpoint(path, failoverRequest, requestAction, failoverClient);
         if (endpointResponse is Response) {
+            inResponse = endpointResponse;
             int httpStatusCode = endpointResponse.statusCode;
             // Check whether HTTP status code of the response falls into configued `failoverCodes`
             if (failoverCodeIndex[httpStatusCode] == true) {


### PR DESCRIPTION
## Purpose
With the type guard refactoring, response payload is getting dropped when using the failover client. This is to fix that issue in the failover client.
