### PR TITLE
Migrate taint checking unit tests to new syntax

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -620,19 +620,23 @@ public class TaintAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangMatch matchStmt) {
         matchStmt.expr.accept(this);
-        matchStmt.patternClauses.forEach(clause -> clause.accept(this));
+        TaintedStatus observedTaintedStatusOfMatchExpr = this.taintedStatus;
+        matchStmt.patternClauses.forEach(clause -> {
+            this.taintedStatus = observedTaintedStatusOfMatchExpr;
+            clause.accept(this);
+        });
     }
 
     @Override
     public void visit(BLangMatch.BLangMatchStmtTypedBindingPatternClause clause) {
-        TaintedStatus observedTaintedStatus = this.taintedStatus;
-        setTaintedStatus(clause.variable.symbol, observedTaintedStatus);
+        TaintedStatus observedTaintedStatusOfMatchExpr = this.taintedStatus;
+        setTaintedStatus(clause.variable.symbol, observedTaintedStatusOfMatchExpr);
         clause.body.accept(this);
     }
 
     @Override
     public void visit(BLangMatch.BLangMatchStmtStaticBindingPatternClause clause) {
-        /*ignore*/
+        clause.body.accept(this);
     }
 
     @Override

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-external-functions-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-external-functions-negative.bal
@@ -2,7 +2,7 @@ type TestObject object {
     function testFunction (string input) returns string;
 };
 
-function TestObject::testFunction (string input) returns string {
+function TestObject.testFunction (string input) returns string {
     return input;
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-external-functions.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-external-functions.bal
@@ -2,7 +2,7 @@ type TestObject object {
     function testFunction (string input) returns string;
 };
 
-function TestObject::testFunction (string input) returns string {
+function TestObject.testFunction (string input) returns string {
     return input;
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-functions-with-constructor-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-functions-with-constructor-negative.bal
@@ -6,7 +6,7 @@ type TestObject object {
     function testFunction (string input) returns string;
 };
 
-function TestObject::testFunction (string input) returns string {
+function TestObject.testFunction (string input) returns string {
     return input;
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-functions-with-constructor.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/object-functions-with-constructor.bal
@@ -5,7 +5,7 @@ type TestObject object {
     function testFunction (string input) returns string;
 };
 
-function TestObject::testFunction (string input) returns string {
+function TestObject.testFunction (string input) returns string {
     return input;
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/recursions/recursion-within-attached-external-function.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/recursions/recursion-within-attached-external-function.bal
@@ -2,7 +2,7 @@ type TestObject object {
     function testFunction (string input) returns string;
 };
 
-function TestObject::testFunction (string input) returns @untainted string {
+function TestObject.testFunction (string input) returns @untainted string {
     TestObject testObj = new;
     return testObj.testFunction(input);
 }


### PR DESCRIPTION
## Purpose
$subject and correct taint analyzer logic for match expression, clause analysis. 