### PR TITLE
Fix native function parameter tainted status tracking

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -95,8 +95,10 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Stack;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.semantics.model.Scope.NOT_FOUND_ENTRY;
 import static org.wso2.ballerinalang.util.LambdaExceptionUtils.rethrow;
@@ -820,14 +822,20 @@ public class CompiledPackageSymbolEnter {
         invokableSymbol.taintTable = new HashMap<>();
         for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
             int paramIndex = taintTableDataInStream.readShort();
-            Boolean returnTaintedStatus = taintTableDataInStream.readBoolean();
-            List<Boolean> parameterTaintedStatusList = new ArrayList<>();
+            TaintRecord.TaintedStatus returnTaintedStatus =
+                    convertByteToTaintedState(taintTableDataInStream.readByte());
+            List<TaintRecord.TaintedStatus> parameterTaintedStatusList = new ArrayList<>();
             for (int columnIndex = 1; columnIndex < columnCount; columnIndex++) {
-                parameterTaintedStatusList.add(taintTableDataInStream.readBoolean());
+                parameterTaintedStatusList.add(convertByteToTaintedState(taintTableDataInStream.readByte()));
             }
             TaintRecord taintRecord = new TaintRecord(returnTaintedStatus, parameterTaintedStatusList);
             invokableSymbol.taintTable.put(paramIndex, taintRecord);
         }
+    }
+
+    private TaintRecord.TaintedStatus convertByteToTaintedState(byte readByte) {
+        return EnumSet.allOf(TaintRecord.TaintedStatus.class).stream()
+                .filter(taintedStatus -> readByte == taintedStatus.getByteValue()).findFirst().get();
     }
 
     private void setDocumentation(BSymbol symbol, Map<AttributeInfo.Kind, byte[]> attrDataMap) throws IOException {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -95,10 +95,8 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Stack;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.compiler.semantics.model.Scope.NOT_FOUND_ENTRY;
 import static org.wso2.ballerinalang.util.LambdaExceptionUtils.rethrow;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -821,17 +821,17 @@ public class CompiledPackageSymbolEnter {
         for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
             int paramIndex = taintTableDataInStream.readShort();
             TaintRecord.TaintedStatus returnTaintedStatus =
-                    convertByteToTaintedState(taintTableDataInStream.readByte());
+                    convertByteToTaintedStatus(taintTableDataInStream.readByte());
             List<TaintRecord.TaintedStatus> parameterTaintedStatusList = new ArrayList<>();
             for (int columnIndex = 1; columnIndex < columnCount; columnIndex++) {
-                parameterTaintedStatusList.add(convertByteToTaintedState(taintTableDataInStream.readByte()));
+                parameterTaintedStatusList.add(convertByteToTaintedStatus(taintTableDataInStream.readByte()));
             }
             TaintRecord taintRecord = new TaintRecord(returnTaintedStatus, parameterTaintedStatusList);
             invokableSymbol.taintTable.put(paramIndex, taintRecord);
         }
     }
 
-    private TaintRecord.TaintedStatus convertByteToTaintedState(byte readByte) {
+    private TaintRecord.TaintedStatus convertByteToTaintedStatus(byte readByte) {
         return EnumSet.allOf(TaintRecord.TaintedStatus.class).stream()
                 .filter(taintedStatus -> readByte == taintedStatus.getByteValue()).findFirst().get();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1704,9 +1704,10 @@ public class CodeGenerator extends BLangNodeVisitor {
         // It is not useful to preserve the propagated taint errors, since user will not be able to correct the compiled
         // code and will not need to know internals of the already compiled code.
         if (taintRecord.taintError == null || taintRecord.taintError.isEmpty()) {
-            List<Boolean> storedTaintTableValue = new ArrayList<>();
-            storedTaintTableValue.add(taintRecord.returnTaintedStatus);
-            storedTaintTableValue.addAll(taintRecord.parameterTaintedStatusList);
+            List<Byte> storedTaintTableValue = new ArrayList<>();
+            storedTaintTableValue.add(taintRecord.returnTaintedStatus.getByteValue());
+            storedTaintTableValue.addAll(taintRecord.parameterTaintedStatusList.stream().map(taintedStatus ->
+                    taintedStatus.getByteValue()).collect(Collectors.toList()));
             taintTableAttributeInfo.taintTable.put(index, storedTaintTableValue);
             return true;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3040,7 +3040,7 @@ public class Desugar extends BLangNodeVisitor {
 
         // Set the taint information to the constructed init function
         initFunction.symbol.taintTable = new HashMap<>();
-        TaintRecord taintRecord = new TaintRecord(Boolean.FALSE, new ArrayList<>());
+        TaintRecord taintRecord = new TaintRecord(TaintRecord.TaintedStatus.UNTAINTED, new ArrayList<>());
         initFunction.symbol.taintTable.put(TaintAnalyzer.ALL_UNTAINTED_TABLE_ENTRY_INDEX, taintRecord);
 
         // Update Object type with attached function details

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -166,7 +166,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.xml.XMLConstants;
 
 /**
@@ -1863,9 +1862,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
     /**
      * Analyze an invocation with the intention of determine if the arguments passed to the invocation results in a
-     * taint-error. Delegates the analysis of each individual argument to {@link #analyzeInvocationArgument(int,
-     * BLangInvocation, BLangExpression, List<TaintedStatus>) analyzeInvocationArgument}. After analysis of all
-     * arguments, update the combined tainted status of the return value.
+     * taint-error. Delegates the analysis of each individual argument to analyzeInvocationArgument. After analysis of
+     * all arguments, update the combined tainted status of the return value.
      *
      * @param invocationExpr invocation expression
      */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -157,7 +157,6 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
-import static org.wso2.ballerinalang.compiler.semantics.model.symbols.TaintRecord.TaintedStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -167,6 +166,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.xml.XMLConstants;
+
+import static org.wso2.ballerinalang.compiler.semantics.model.symbols.TaintRecord.TaintedStatus;
 
 /**
  * Generate taint-table for each invokable node.
@@ -452,8 +453,7 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         compoundAssignment.expr.accept(this);
         TaintedStatus exprTaintedStatus = this.taintedStatus;
 
-        TaintedStatus combinedTaintedStatus =
-                getCombinedTaintedStatus(varRefTaintedStatus, exprTaintedStatus);
+        TaintedStatus combinedTaintedStatus = getCombinedTaintedStatus(varRefTaintedStatus, exprTaintedStatus);
         visitAssignment(compoundAssignment.varRef, combinedTaintedStatus, compoundAssignment.pos);
     }
 
@@ -467,8 +467,7 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         scopeNode.scopeBody.accept(this);
     }
 
-    private void visitAssignment(BLangExpression varRefExpr, TaintedStatus varTaintedStatus,
-                                 DiagnosticPos pos) {
+    private void visitAssignment(BLangExpression varRefExpr, TaintedStatus varTaintedStatus, DiagnosticPos pos) {
         if (varTaintedStatus != TaintedStatus.IGNORED) {
             // Generate error if a global variable has been assigned with a tainted value.
             if (varTaintedStatus == TaintedStatus.TAINTED && varRefExpr instanceof BLangVariableReference) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -157,6 +157,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
+import static org.wso2.ballerinalang.compiler.semantics.model.symbols.TaintRecord.TaintedStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -206,9 +207,6 @@ public class TaintAnalyzer extends BLangNodeVisitor {
     private BLangIdentifier currWorkerIdentifier;
     private BLangIdentifier currForkIdentifier;
 
-    private enum TaintedStatus {
-        TAINTED, UNTAINTED, IGNORED
-    }
     private TaintedStatus taintedStatus;
     private TaintedStatus returnTaintedStatus;
 
@@ -455,7 +453,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         compoundAssignment.expr.accept(this);
         TaintedStatus exprTaintedStatus = this.taintedStatus;
 
-        TaintedStatus combinedTaintedStatus = getCombinedTaintedStatus(varRefTaintedStatus, exprTaintedStatus);
+        TaintedStatus combinedTaintedStatus =
+                getCombinedTaintedStatus(varRefTaintedStatus, exprTaintedStatus);
         visitAssignment(compoundAssignment.varRef, combinedTaintedStatus, compoundAssignment.pos);
     }
 
@@ -469,7 +468,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         scopeNode.scopeBody.accept(this);
     }
 
-    private void visitAssignment(BLangExpression varRefExpr, TaintedStatus varTaintedStatus, DiagnosticPos pos) {
+    private void visitAssignment(BLangExpression varRefExpr, TaintedStatus varTaintedStatus,
+                                 DiagnosticPos pos) {
         if (varTaintedStatus != TaintedStatus.IGNORED) {
             // Generate error if a global variable has been assigned with a tainted value.
             if (varTaintedStatus == TaintedStatus.TAINTED && varRefExpr instanceof BLangVariableReference) {
@@ -1510,7 +1510,7 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 || (invNode.getKind() == NodeKind.FUNCTION && ((BLangFunction) invNode).attachedOuterFunction)) {
             if (Symbols.isNative(invNode.symbol)
                     || (invNode.getKind() == NodeKind.FUNCTION && ((BLangFunction) invNode).interfaceFunction)) {
-                attachTaintTableBasedOnAnnotations(invNode);
+                attachNativeFunctionTaintTable(invNode);
                 return false;
             }
             Map<Integer, TaintRecord> taintTable = new HashMap<>();
@@ -1532,10 +1532,11 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 // If taint error occurred when no parameter is tainted, there is no point of checking tainted status of
                 // returns when each parameter is tainted. An compiler error will get generated for the usage anyway,
                 // hence adding dummy table to the function to make sure remaining analysis stays intact.
-                List<Boolean> paramTaintedStatus = Collections.nCopies(totalParamCount, Boolean.FALSE);
-                taintTable.put(ALL_UNTAINTED_TABLE_ENTRY_INDEX, new TaintRecord(Boolean.FALSE, paramTaintedStatus));
+                List<TaintedStatus> paramTaintedStatus = Collections.nCopies(totalParamCount, TaintedStatus.UNTAINTED);
+                taintTable.put(ALL_UNTAINTED_TABLE_ENTRY_INDEX, new TaintRecord(TaintedStatus.UNTAINTED,
+                        paramTaintedStatus));
                 for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
-                    taintTable.put(paramIndex, new TaintRecord(Boolean.FALSE, paramTaintedStatus));
+                    taintTable.put(paramIndex, new TaintRecord(TaintedStatus.UNTAINTED, paramTaintedStatus));
                 }
                 taintErrorSet.clear();
             } else {
@@ -1601,20 +1602,23 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 taintTable.put(paramIndex, new TaintRecord(new ArrayList<>(taintErrorSet)));
             }
         } else if (this.blockedNode == null) {
+            // This is when taint analysis was successful for the function body without any blocking invocations.
             if (invokableNode.returnTypeNode.type != symTable.nilType) {
-                updatedReturnTaintedStatusBasedOnAnnotations(invokableNode.returnTypeAnnAttachments);
+                // If return values are annotated with "tainted" or "untainted" annotations, update the observed tainted
+                // status with the annotated statue.
+                TaintedStatus taintedStatusBasedOnAnnotations =
+                        getTaintedStatusBasedOnAnnotations(invokableNode.returnTypeAnnAttachments);
+                if (taintedStatusBasedOnAnnotations != TaintedStatus.IGNORED) {
+                    this.returnTaintedStatus = taintedStatusBasedOnAnnotations;
+                }
             } else {
+                // If function has no return, "untainted" is written as the tainted state of the return, to denote that
+                // the parameter being analyzed can be a tainted value without causing a taint-error.
                 this.returnTaintedStatus = TaintedStatus.UNTAINTED;
             }
 
-            Boolean storedReturnTaintedStatus = this.returnTaintedStatus == TaintedStatus.TAINTED;
-
             updateParameterTaintedStatuses();
-            List<Boolean> paramTaintedStatusList = parameterTaintedStatus.stream()
-                    .map(taintedStatus -> taintedStatus == TaintedStatus.TAINTED ? Boolean.TRUE : Boolean.FALSE)
-                    .collect(Collectors.toList());
-
-            taintTable.put(paramIndex, new TaintRecord(storedReturnTaintedStatus, paramTaintedStatusList));
+            taintTable.put(paramIndex, new TaintRecord(this.returnTaintedStatus, parameterTaintedStatus));
         }
     }
 
@@ -1670,45 +1674,53 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         }
     }
 
-    private void attachTaintTableBasedOnAnnotations(BLangInvokableNode invokableNode) {
+    private void attachNativeFunctionTaintTable(BLangInvokableNode invokableNode) {
         if (invokableNode.symbol.taintTable == null) {
             // Extract tainted status of the function by looking at annotations added to returns.
-            Boolean retParamsTaintedStatus = hasAnnotation(invokableNode.returnTypeAnnAttachments, ANNOTATION_TAINTED);
+            boolean hasTaintedAnnotation = hasAnnotation(invokableNode.returnTypeAnnAttachments, ANNOTATION_TAINTED);
+            TaintedStatus retParamsTaintedStatus =
+                    hasTaintedAnnotation ? TaintedStatus.TAINTED : TaintedStatus.UNTAINTED;
 
             int requiredParamCount = invokableNode.requiredParams.size();
             int defaultableParamCount = invokableNode.defaultableParams.size();
             int totalParamCount =
                     requiredParamCount + defaultableParamCount + (invokableNode.restParam == null ? 0 : 1);
 
-            List<Boolean> paramTaintedStatusList = Collections.nCopies(totalParamCount, Boolean.FALSE);
+            // Since this native function is being analyzed, the parameter tainted state depends on annotations.
+            // If no parameter annotations are present, leave the tainted state of the argument unchanged.
+            List<TaintedStatus> paramTaintedStatusList = new ArrayList<>();
+            for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
+                BLangVariable param = getParam(invokableNode, paramIndex, requiredParamCount, defaultableParamCount);
+                TaintedStatus taintedStateBasedOnAnnotations = getTaintedStatusBasedOnAnnotations(param.annAttachments);
+                paramTaintedStatusList.add(taintedStateBasedOnAnnotations);
+            }
+
             // Append taint table with tainted status when no parameter is tainted.
             Map<Integer, TaintRecord> taintTable = new HashMap<>();
             taintTable.put(ALL_UNTAINTED_TABLE_ENTRY_INDEX, new TaintRecord(retParamsTaintedStatus,
                     paramTaintedStatusList));
 
-            if (totalParamCount > 0) {
-                // Append taint table with tainted status when each parameter is tainted.
-                for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
-                    BLangVariable param = getParam(invokableNode, paramIndex, requiredParamCount,
-                            defaultableParamCount);
-                    // If parameter is sensitive, test for this parameter being tainted is invalid.
-                    if (hasAnnotation(param, ANNOTATION_SENSITIVE)) {
-                        continue;
-                    }
-                    taintTable.put(paramIndex, new TaintRecord(retParamsTaintedStatus, paramTaintedStatusList));
+            // Append taint table with tainted status when each parameter is tainted.
+            for (int paramIndex = 0; paramIndex < totalParamCount; paramIndex++) {
+                BLangVariable param = getParam(invokableNode, paramIndex, requiredParamCount, defaultableParamCount);
+                // If parameter is sensitive, test for this parameter being tainted is invalid.
+                if (hasAnnotation(param, ANNOTATION_SENSITIVE)) {
+                    continue;
                 }
+                taintTable.put(paramIndex, new TaintRecord(retParamsTaintedStatus, paramTaintedStatusList));
             }
             invokableNode.symbol.taintTable = taintTable;
         }
     }
 
-    private void updatedReturnTaintedStatusBasedOnAnnotations(List<BLangAnnotationAttachment> retParamsAnnotations) {
-        if (hasAnnotation(retParamsAnnotations, ANNOTATION_UNTAINTED)) {
-            this.returnTaintedStatus = TaintedStatus.UNTAINTED;
+    private TaintedStatus getTaintedStatusBasedOnAnnotations(List<BLangAnnotationAttachment> annotations) {
+        if (hasAnnotation(annotations, ANNOTATION_UNTAINTED)) {
+            return TaintedStatus.UNTAINTED;
         }
-        if (hasAnnotation(retParamsAnnotations, ANNOTATION_TAINTED)) {
-            this.returnTaintedStatus = TaintedStatus.TAINTED;
+        if (hasAnnotation(annotations, ANNOTATION_TAINTED)) {
+            return TaintedStatus.TAINTED;
         }
+        return TaintedStatus.IGNORED;
     }
 
     private boolean processBlockedNode(BLangInvokableNode invokableNode) {
@@ -1782,22 +1794,24 @@ public class TaintAnalyzer extends BLangNodeVisitor {
     }
 
     private void combinedParameterTaintedStatus(List<TaintedStatus> combinedArgTaintedStatus,
-                                                List<Boolean> argTaintedStatus) {
+                                                List<TaintedStatus> argTaintedStatus) {
         if (combinedArgTaintedStatus.isEmpty()) {
-            List<TaintedStatus> argTaintedStatusTempList = argTaintedStatus.stream().map(taintedStatus ->
-                    taintedStatus ? TaintedStatus.TAINTED : TaintedStatus.UNTAINTED).collect(Collectors.toList());
-            combinedArgTaintedStatus.addAll(argTaintedStatusTempList);
+            combinedArgTaintedStatus.addAll(argTaintedStatus);
         } else {
             // Merge lists together while making sure "Tainted" status of "argTaintedStatus" list is not overwritten
             // with "Untainted", whereas it is allowed to overwritten "Untainted" status with with "Tainted".
             for (int paramIndex = 0; paramIndex < argTaintedStatus.size(); paramIndex++) {
-                if (argTaintedStatus.get(paramIndex) == Boolean.TRUE) {
+                if (argTaintedStatus.get(paramIndex) == TaintedStatus.TAINTED) {
                     combinedArgTaintedStatus.set(paramIndex, TaintedStatus.TAINTED);
                 }
             }
         }
     }
 
+    /**
+     * Update the maps that hold the parameter tainted status, with the tainted statuses of the parameter for the
+     * current invocation.
+     */
     private void updateParameterTaintedStatuses() {
         updateParameterTaintedStatuses(requiredParams, 0);
         updateParameterTaintedStatuses(defaultableParams, requiredParams.size());
@@ -1807,20 +1821,35 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         }
     }
 
+    /**
+     * Update the map that hold the parameter tainted status, with the tainted statuses of the parameter for the
+     * current invocation. Parameter tainted state is maintained in a single list (to persist into the compiled code).
+     *
+     * @param paramList list of parameters to be used to identify the tainted state of the parameter after invocation
+     * @param startIndex the start position of the tainted status list corresponding to current paramList
+     */
     private void updateParameterTaintedStatuses(List<BLangVariable> paramList, int startIndex) {
         if (parameterTaintedStatus.size() <= startIndex) {
+            // If list do not have the tainted state of current parameter list already, add new entries to the list.
             paramList.forEach(param -> {
-                if (hasAnnotation(param.annAttachments, ANNOTATION_TAINTED)) {
-                    parameterTaintedStatus.add(TaintedStatus.TAINTED);
+                TaintedStatus taintedStateBasedOnAnnotations = getTaintedStatusBasedOnAnnotations(param.annAttachments);
+                if (taintedStateBasedOnAnnotations == TaintedStatus.IGNORED) {
+                    // If annotations are not use, use the analyzed status.
+                    parameterTaintedStatus.add(param.symbol.tainted ? TaintedStatus.TAINTED : TaintedStatus.UNTAINTED);
                 } else {
-                    parameterTaintedStatus.add(param.symbol.tainted ?
-                            TaintedStatus.TAINTED : TaintedStatus.UNTAINTED);
+                    // If parameter has "tainted" or "untainted" annotation, argument should be updated according to the
+                    // annotated status regardless of the analyzed status. This is useful if someone need to explicitly
+                    // mark any argument that is set as a parameter "tainted" or "untainted".
+                    parameterTaintedStatus.add(taintedStateBasedOnAnnotations);
                 }
             });
         } else {
+            // If list already contains tainted state of current parameter list, update the existing list. This can
+            // happen, when there are multiple returns within the same function.
             for (int paramIndex = 0; paramIndex < paramList.size(); paramIndex++) {
                 BLangVariable param = paramList.get(paramIndex);
-                if (param.symbol.tainted) {
+                TaintedStatus taintedStateBasedOnAnnotations = getTaintedStatusBasedOnAnnotations(param.annAttachments);
+                if (taintedStateBasedOnAnnotations == TaintedStatus.TAINTED || param.symbol.tainted) {
                     parameterTaintedStatus.set(startIndex + paramIndex, TaintedStatus.TAINTED);
                 }
                 // Ignore if param is untainted. Where there are multiple return statements in a function, it is
@@ -1832,6 +1861,14 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
     // Private methods relevant to invocation analysis.
 
+    /**
+     * Analyze an invocation with the intention of determine if the arguments passed to the invocation results in a
+     * taint-error. Delegates the analysis of each individual argument to {@link #analyzeInvocationArgument(int,
+     * BLangInvocation, BLangExpression, List<TaintedStatus>) analyzeInvocationArgument}. After analysis of all
+     * arguments, update the combined tainted status of the return value.
+     *
+     * @param invocationExpr invocation expression
+     */
     private void analyzeInvocation(BLangInvocation invocationExpr) {
         BInvokableSymbol invokableSymbol = (BInvokableSymbol) invocationExpr.symbol;
         Map<Integer, TaintRecord> taintTable = invokableSymbol.taintTable;
@@ -1846,12 +1883,9 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 // Example: Tainted value returned by function is passed to another functions's sensitive parameter.
                 addTaintError(allParamsUntaintedRecord.taintError);
             } else {
-                returnTaintedStatus = allParamsUntaintedRecord.returnTaintedStatus ?
-                        TaintedStatus.TAINTED : TaintedStatus.UNTAINTED;
+                returnTaintedStatus = allParamsUntaintedRecord.returnTaintedStatus;
                 if (allParamsUntaintedRecord.parameterTaintedStatusList != null) {
-                    argTaintedStatusList = allParamsUntaintedRecord.parameterTaintedStatusList.stream()
-                            .map(taintedStatus -> taintedStatus ? TaintedStatus.TAINTED : TaintedStatus.UNTAINTED)
-                            .collect(Collectors.toList());
+                    argTaintedStatusList = new ArrayList<>(allParamsUntaintedRecord.parameterTaintedStatusList);
                 }
             }
         }
@@ -1868,8 +1902,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
             for (int argIndex = 0; argIndex < requiredArgsCount; argIndex++) {
                 BLangExpression argExpr = invocationExpr.requiredArgs.get(argIndex);
-                TaintedStatus argumentAnalysisResult = analyzeInvocationArgument(argIndex, invokableSymbol,
-                        invocationExpr, argExpr, argTaintedStatusList);
+                TaintedStatus argumentAnalysisResult = analyzeInvocationArgument(argIndex, invocationExpr, argExpr,
+                        argTaintedStatusList);
                 if (argumentAnalysisResult == TaintedStatus.IGNORED) {
                     return;
                 } else if (argumentAnalysisResult == TaintedStatus.TAINTED) {
@@ -1893,8 +1927,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                             break;
                         }
                     }
-                    TaintedStatus argumentAnalysisResult = analyzeInvocationArgument(paramIndex, invokableSymbol,
-                            invocationExpr, argExpr, argTaintedStatusList);
+                    TaintedStatus argumentAnalysisResult = analyzeInvocationArgument(paramIndex, invocationExpr,
+                            argExpr, argTaintedStatusList);
                     if (argumentAnalysisResult == TaintedStatus.IGNORED) {
                         return;
                     } else if (argumentAnalysisResult == TaintedStatus.TAINTED) {
@@ -1909,8 +1943,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 BLangExpression argExpr = invocationExpr.restArgs.get(argIndex);
                 // Pick the index of the rest parameter in the invokable definition.
                 int paramIndex = requiredParamCount + defaultableParamCount;
-                TaintedStatus argumentAnalysisResult = analyzeInvocationArgument(paramIndex, invokableSymbol,
-                        invocationExpr, argExpr, argTaintedStatusList);
+                TaintedStatus argumentAnalysisResult = analyzeInvocationArgument(paramIndex, invocationExpr, argExpr,
+                        argTaintedStatusList);
                 if (argumentAnalysisResult == TaintedStatus.IGNORED) {
                     return;
                 } else if (argumentAnalysisResult == TaintedStatus.TAINTED) {
@@ -2003,13 +2037,23 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         }
     }
 
-    private TaintedStatus analyzeInvocationArgument(int paramIndex, BInvokableSymbol invokableSymbol,
-                                                    BLangInvocation invocationExpr, BLangExpression argExpr,
-                                                    List<TaintedStatus> argTaintedStatusList) {
+    /**
+     * Analyze one invocation argument, determine if the argument expression is tainted, if so consult the taint table
+     * of the invokable to check if a taint-error is present.
+     *
+     * @param paramIndex index of the parameter for the current argument
+     * @param invocationExpr invocation expression relevant to the invocation
+     * @param argExpr argument expression being analyzed
+     * @param argTaintedStatusList the combined argument tainted status list
+     * @return tainted status of the argument expression
+     */
+    private TaintedStatus analyzeInvocationArgument(int paramIndex, BLangInvocation invocationExpr,
+                                                    BLangExpression argExpr, List<TaintedStatus> argTaintedStatusList) {
         argExpr.accept(this);
         // If current argument is tainted, look-up the taint-table for the record of return-tainted-status when the
         // given argument is in tainted state.
         if (this.taintedStatus == TaintedStatus.TAINTED) {
+            BInvokableSymbol invokableSymbol = (BInvokableSymbol) invocationExpr.symbol;
             TaintRecord taintRecord = invokableSymbol.taintTable.get(paramIndex);
             int requiredParamCount = invokableSymbol.params.size();
             int defaultableParamCount = invokableSymbol.defaultableParams.size();
@@ -2035,9 +2079,10 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 });
             } else {
                 combinedParameterTaintedStatus(argTaintedStatusList, taintRecord.parameterTaintedStatusList);
-                return taintRecord.returnTaintedStatus ? TaintedStatus.TAINTED : TaintedStatus.UNTAINTED;
+                return taintRecord.returnTaintedStatus;
             }
         } else if (this.taintedStatus == TaintedStatus.IGNORED) {
+            // If argument is a recursive call or a function loop ignore the invocation and proceed.
             return TaintedStatus.IGNORED;
         }
         return TaintedStatus.UNTAINTED;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/TaintRecord.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/TaintRecord.java
@@ -29,15 +29,35 @@ import java.util.List;
  * @since 0.965.0
  */
 public class TaintRecord {
-    public Boolean returnTaintedStatus;
-    public List<Boolean> parameterTaintedStatusList;
+    /**
+     * Represents taint status or a return or a parameter. When used in maintaining parameter tainted status, "ignored"
+     * state is used to denote that the tainted status of the argument should be left unchanged, where as tainted and
+     * untainted statues are used to change the argument tainted status accordingly.
+     */
+    public enum TaintedStatus {
+        IGNORED((byte)0), TAINTED((byte)1), UNTAINTED((byte)2);
+
+        // Value used to represent the taint status in the compiled code.
+        private final byte byteValue;
+
+        TaintedStatus(byte byteValue) {
+            this.byteValue = byteValue;
+        }
+
+        public byte getByteValue() {
+            return byteValue;
+        }
+    }
+
+    public TaintedStatus returnTaintedStatus;
+    public List<TaintedStatus> parameterTaintedStatusList;
     public List<TaintError> taintError;
 
     public TaintRecord(List<TaintError> taintError) {
         this.taintError = taintError;
     }
 
-    public TaintRecord(Boolean returnTaintedStatus, List<Boolean> parameterTaintedStatusList) {
+    public TaintRecord(TaintedStatus returnTaintedStatus, List<TaintedStatus> parameterTaintedStatusList) {
         this.returnTaintedStatus = returnTaintedStatus;
         this.parameterTaintedStatusList = parameterTaintedStatusList;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/TaintRecord.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/TaintRecord.java
@@ -35,7 +35,7 @@ public class TaintRecord {
      * untainted statues are used to change the argument tainted status accordingly.
      */
     public enum TaintedStatus {
-        IGNORED((byte)0), TAINTED((byte)1), UNTAINTED((byte)2);
+        IGNORED((byte) 0), TAINTED((byte) 1), UNTAINTED((byte) 2);
 
         // Value used to represent the taint status in the compiled code.
         private final byte byteValue;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/PackageInfoWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/PackageInfoWriter.java
@@ -549,9 +549,9 @@ public class PackageInfoWriter {
                 attrDataOutStream.writeShort(taintTableAttributeInfo.columnCount);
                 for (Integer paramIndex : taintTableAttributeInfo.taintTable.keySet()) {
                     attrDataOutStream.writeShort(paramIndex);
-                    List<Boolean> taintRecord = taintTableAttributeInfo.taintTable.get(paramIndex);
-                    for (Boolean taintStatus : taintRecord) {
-                        attrDataOutStream.writeBoolean(taintStatus);
+                    List<Byte> taintRecord = taintTableAttributeInfo.taintTable.get(paramIndex);
+                    for (Byte taintStatus : taintRecord) {
+                        attrDataOutStream.writeByte(taintStatus);
                     }
                 }
                 break;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/attributes/TaintTableAttributeInfo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/attributes/TaintTableAttributeInfo.java
@@ -32,7 +32,7 @@ public class TaintTableAttributeInfo implements AttributeInfo {
 
     public int columnCount;
     public int rowCount;
-    public Map<Integer, List<Boolean>> taintTable = new LinkedHashMap<>();
+    public Map<Integer, List<Byte>> taintTable = new LinkedHashMap<>();
 
     public TaintTableAttributeInfo(int attributeNameIndex) {
         this.attributeNameIndex = attributeNameIndex;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -509,4 +509,19 @@ public class TaintedStatusPropagationTest {
         BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'secureIn'", 40, 20);
         BAssertUtil.validateError(result, 4, "tainted value passed to sensitive parameter 'secureIn'", 44, 20);
     }
+
+    @Test
+    public void testParameterStatusWithNativeInvocations() {
+        CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
+                "param-status-with-native-invocations.bal");
+        Assert.assertEquals(result.getDiagnostics().length, 0);
+    }
+
+    @Test
+    public void testParameterStatusWithNativeInvocationsNegative() {
+        CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
+                "param-status-with-native-invocations-negative.bal");
+        Assert.assertEquals(result.getDiagnostics().length, 1);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'sqlQuery'", 32, 38);
+    }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -38,10 +38,11 @@ public class IOTest {
     @Test
     public void testCharacterIONegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/character-io-negative.bal");
-        Assert.assertEquals(result.getDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'path'", 9, 54);
-        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'numberOfChars'", 16, 31);
-        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'sensitiveValue'", 19,
+        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'path'", 12, 54);
+        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'numberOfChars'", 16, 31);
+        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'sensitiveValue'", 19,
                 26);
     }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/param-status-with-native-invocations-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/param-status-with-native-invocations-negative.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mysql;
+import ballerina/io;
+
+endpoint mysql:Client mysqlDB {
+    host: "localhost",
+    port: 3306,
+    name: "ballerinademo",
+    username: "demouser",
+    password: "password@123",
+    dbOptions: { useSSL: false}
+};
+
+public function main(string... args) {
+    string s1 = args[0];
+    io:println(s1);
+    table t1 = check mysqlDB->select("SELECT id, age, name from employee where name = " + s1, ());
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/param-status-with-native-invocations.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/param-status-with-native-invocations.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mysql;
+import ballerina/io;
+
+endpoint mysql:Client mysqlDB {
+    host: "localhost",
+    port: 3306,
+    name: "ballerinademo",
+    username: "demouser",
+    password: "password@123",
+    dbOptions: { useSSL: false}
+};
+
+public function main(string... args) {
+    string s1 = "static-value";
+    io:println(s1);
+    table t1 = check mysqlDB->select("SELECT id, age, name from employee where name = " + s1, ());
+}


### PR DESCRIPTION
## Purpose
When a function invocation is analyzed for tainted-status tracking, the taint-analyzer will update the argument's tainted-status according to the taint-table. This is done to make sure tainted status is correctly propagated when a parameter is used as a "out parameter" or "in-out parameter". 

Due to an implementation issue, the same logic cannot be used for `native` functions. Since, taint-analyzer has no way of knowing the outcome of a `native` function, it depends on annotations for analyzing `native` functions. 

```ballerina
# Prints an any value to the STDOUT in a new line.
# + a - The value to be printed.
public extern function println(any... a);
```

In the above situation, what would happen to the the input parameter `a` cannot be identified. Since there are no annotations attached to the parameter, taint-analyzer incorrectly assume that the outcome becomes untainted. 

# Solution 

As a fix, it is required to maintain that the tainted-status of the argument to function `println` should be unchanged as a result of this invocation. 

Currently, tainted status of parameters are maintained as a boolean. Hence it is not possible to represent three outcomes:
- Argument should be tainted after the invocation
- Argument should be untainted after the invocation
- Argument tainted status should be unchanged after the invocation

Due to this, this PR changes the way taint-status is persisted in the compiled code. Instead of `boolean` a `byte` is used for the purpose. 

Resolves: #11386