### PR TITLE
Fix compilation issues in table literal syntax tests

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
@@ -87,10 +87,8 @@ public class BTable implements BRefType<Object>, BCollection {
         //Create table with given constraints.
         BType constrainedType = ((BTableType) type).getConstrainedType();
         this.tableProvider = TableProvider.getInstance();
-        if (constrainedType != null) {
-            this.tableName = tableProvider.createTable(constrainedType, keyColumns, indexColumns);
-            this.constraintType = (BStructureType) constrainedType;
-        }
+        this.tableName = tableProvider.createTable(constrainedType, keyColumns, indexColumns);
+        this.constraintType = (BStructureType) constrainedType;
         this.primaryKeys = keyColumns;
         this.indices = indexColumns;
         //Insert initial data
@@ -154,7 +152,7 @@ public class BTable implements BRefType<Object>, BCollection {
         if (isIteratorGenerationConditionMet()) {
             generateIterator();
         }
-        if (!nextPrefetched && iterator != null) {
+        if (!nextPrefetched) {
             hasNextVal = iterator.next();
             nextPrefetched = true;
         }
@@ -171,7 +169,7 @@ public class BTable implements BRefType<Object>, BCollection {
         if (isIteratorGenerationConditionMet()) {
             generateIterator();
         }
-        if (!nextPrefetched && iterator != null) {
+        if (!nextPrefetched) {
             iterator.next();
         } else {
             nextPrefetched = false;
@@ -197,10 +195,7 @@ public class BTable implements BRefType<Object>, BCollection {
         // Make next row the current row
         moveToNext();
         // Create BStruct from current row
-        if (iterator != null) {
-            return (BMap<String, BValue>) iterator.generateNext();
-        }
-        return new BMap<>(BTypes.typeAny);
+        return (BMap<String, BValue>) iterator.generateNext();
     }
 
     /**
@@ -225,10 +220,6 @@ public class BTable implements BRefType<Object>, BCollection {
     }
 
     public void addData(BMap<String, BValue> data, Context context) {
-        if (this.constraintType == null) {
-            throw new BallerinaException("incompatible types: record of type:" + data.getType().getName()
-                    + " cannot be added to a table with no type");
-        }
         if (data.getType() != this.constraintType) {
             throw new BallerinaException("incompatible types: record of type:" + data.getType().getName()
                     + " cannot be added to a table with type:" + this.constraintType.getName());
@@ -256,10 +247,6 @@ public class BTable implements BRefType<Object>, BCollection {
 
         try {
             BType functionInputType = lambdaFunction.value().getParamTypes()[0];
-            if (this.constraintType == null) {
-                throw new BallerinaException("incompatible types: function with record type:"
-                        + functionInputType.getName() + " cannot be used to remove records from a table with no type");
-            }
             if (functionInputType != this.constraintType) {
                 throw new BallerinaException("incompatible types: function with record type:"
                         + functionInputType.getName() + " cannot be used to remove records from a table with type:"
@@ -334,7 +321,7 @@ public class BTable implements BRefType<Object>, BCollection {
     }
 
     protected boolean isIteratorGenerationConditionMet() {
-        return this.iterator == null && this.constraintType != null;
+        return this.iterator == null;
     }
 
     protected void resetIterationHelperAttributes() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3523,11 +3523,8 @@ public class Desugar extends BLangNodeVisitor {
                     BLangTableLiteral table = new BLangTableLiteral();
                     table.type = type;
                     return rewriteExpr(table);
-                } else if (((BTableType) type).getConstraint().tag == TypeTags.NONE) {
-                    BLangTableLiteral table = new BLangTableLiteral();
-                    table.type = new BTableType(TypeTags.TABLE, symTable.noType, symTable.tableType.tsymbol);
-                    return rewriteExpr(table);
                 }
+
                 break;
             case TypeTags.ARRAY:
                 BLangArrayLiteral array = new BLangArrayLiteral();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -715,9 +715,6 @@ public class Types {
             case TypeTags.TABLE:
                 BTableType tableType = (BTableType) collectionType;
                 if (variableSize == 1) {
-                    if (tableType.constraint.tag == TypeTags.NONE) {
-                        return Lists.of(symTable.anyType);
-                    }
                     return Lists.of(tableType.constraint);
                 } else if (variableSize == 2) {
                     return Lists.of(symTable.intType, tableType.constraint);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralSyntaxTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralSyntaxTest.java
@@ -111,22 +111,6 @@ public class TableLiteralSyntaxTest {
     }
 
     @Test
-    public void testUnconstraintTable() {
-        BValue[] returns = BRunUtil.invoke(result, "testUnconstraintTable");
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);
-        Assert.assertEquals(returns[1].stringValue(), "[]");
-        Assert.assertTrue("<results></results>".equals(returns[2].stringValue()) || "<results/>"
-                .equals(returns[2].stringValue()));
-        Assert.assertEquals(((BInteger) returns[3]).intValue(), 0);
-        Assert.assertEquals(((BInteger) returns[4]).intValue(), 0);
-        Assert.assertEquals(returns[5].stringValue(), "{}");
-        Assert.assertTrue(returns[6].stringValue()
-                .contains("incompatible types: record of type:Person cannot be added to a table with no type"));
-        Assert.assertTrue(returns[7].stringValue().contains("incompatible types: function with record type:Person"
-                + " cannot be used to remove records from a table with no type"));
-    }
-
-    @Test
     public void testTableLiteralDataAndAddWithKey() {
         BValue[] returns = BRunUtil.invoke(result, "testTableLiteralDataAndAddWithKey");
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 5);

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_literal_syntax.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_literal_syntax.bal
@@ -30,10 +30,10 @@ type Person2 record {
     boolean married;
 };
 
-table<Person> tGlobal;
+table<Person> tGlobal = table{};
 
 function testTableDefaultValueForLocalVariable() returns (int) {
-    table<Person> t1;
+    table<Person> t1 = table {};
     Person p1 = { id: 1, age: 30, salary: 300.50, name: "jane", married: true };
     _ = t1.add(p1);
     int count = t1.count();
@@ -192,36 +192,6 @@ function testTableAddWhileIterating() returns (int, int) {
     }
     int count = t1.count();
     return (loopVariable, count);
-}
-
-function testUnconstraintTable() returns (int, json, xml, int, int, any, error?, int|error) {
-    table t1;
-    //iterable operation
-    int count1 = t1.count();
-    //json conversion
-    json j = check <json>t1;
-    //xml conversion
-    xml x = check <xml>t1;
-    //Iterate with while loop
-    int iter1 = 0;
-    while (t1.hasNext()) {
-        var data = t1.getNext();
-        iter1 = iter1 + 1;
-    }
-    //Iterate with foreach
-    int iter2 = 0;
-    foreach datarow in t1 {
-        iter2 = iter2 + 1;
-    }
-    //Get next row
-    any row = t1.getNext();
-    //Add data
-    Person p1 = { id: 1, age: 30, salary: 300.50, name: "jane", married: true };
-    error? e1 = t1.add(p1);
-    //Remove data
-    int|error e2 = t1.remove(isBelow35);
-
-    return (count1, j, x, iter1, iter2, row, e1, e2);
 }
 
 function isBelow35(Person p) returns (boolean) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_literal_syntax_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_literal_syntax_negative.bal
@@ -99,8 +99,16 @@ function testTableRemoveInvalidFunctionPointer() returns (int, json) {
     _ = dt.add(p2);
     _ = dt.add(p3);
 
-    int count = check dt.remove(isBelow35Invalid);
-    json j = check <json>dt;
+    var res = dt.remove(isBelow35Invalid);
+    int count = -1;
+    if (res is int) {
+        count = res;
+    }
+    var res2 = <json>dt;
+    json j = {};
+    if (res2 is json) {
+        j =  res;
+    }
 
     return (count, j);
 }


### PR DESCRIPTION
## Purpose
$Subject
and reverts the relevant changes done in https://github.com/ballerina-platform/ballerina-lang/pull/10352
as 
1. Now it is not possible to declare a variable and not initialize it 
and 
2. Initializing a table variable without a constraint is not possible


Still the compilation of table_literal_syntax_negative.bal fails with the following NPE.

```bash
java.lang.NullPointerException
	at org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog.reportDiagnostic(BLangDiagnosticLog.java:106)
	at org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog.error(BLangDiagnosticLog.java:76)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.lambda$checkMissingRequiredFields$8(TypeChecker.java:497)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkMissingRequiredFields(TypeChecker.java:488)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.visit(TypeChecker.java:440)
	at org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.accept(BLangRecordLiteral.java:69)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExpr(TypeChecker.java:231)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExpr(TypeChecker.java:203)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExprs(TypeChecker.java:217)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.visit(TypeChecker.java:318)
	at org.wso2.ballerinalang.compiler.tree.expressions.BLangTableLiteral.accept(BLangTableLiteral.java:79)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExpr(TypeChecker.java:231)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExpr(TypeChecker.java:203)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:478)
	at org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable.accept(BLangSimpleVariable.java:56)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1715)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1682)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeDef(SemanticAnalyzer.java:1674)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:852)
	at org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef.accept(BLangSimpleVariableDef.java:42)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1715)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1682)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeStmt(SemanticAnalyzer.java:1678)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.lambda$visit$36(SemanticAnalyzer.java:840)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:840)
	at org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt.accept(BLangBlockStmt.java:54)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1715)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1682)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeStmt(SemanticAnalyzer.java:1678)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:326)
	at org.wso2.ballerinalang.compiler.tree.BLangFunction.accept(BLangFunction.java:66)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1715)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:1682)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeDef(SemanticAnalyzer.java:1674)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.lambda$visit$4(SemanticAnalyzer.java:265)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:265)
	at org.wso2.ballerinalang.compiler.tree.BLangPackage.accept(BLangPackage.java:159)
	at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyze(SemanticAnalyzer.java:243)
	at org.wso2.ballerinalang.compiler.CompilerDriver.typeCheck(CompilerDriver.java:183)
	at org.wso2.ballerinalang.compiler.CompilerDriver.compile(CompilerDriver.java:140)
	at org.wso2.ballerinalang.compiler.CompilerDriver.compilePackageSymbol(CompilerDriver.java:132)
	at org.wso2.ballerinalang.compiler.CompilerDriver.compilePackage(CompilerDriver.java:101)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at org.wso2.ballerinalang.compiler.Compiler.compilePackages(Compiler.java:161)
	at org.wso2.ballerinalang.compiler.Compiler.compilePackage(Compiler.java:179)
	at org.wso2.ballerinalang.compiler.Compiler.compile(Compiler.java:88)
	at org.ballerinalang.launcher.util.BCompileUtil.compile(BCompileUtil.java:287)
	at org.ballerinalang.launcher.util.BCompileUtil.compile(BCompileUtil.java:217)
	at org.ballerinalang.launcher.util.BCompileUtil.compile(BCompileUtil.java:199)
	at org.ballerinalang.launcher.util.BCompileUtil.compile(BCompileUtil.java:116)
	at org.ballerinalang.test.types.table.TableLiteralSyntaxTest.setup(TableLiteralSyntaxTest.java:42)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:59)
	at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:451)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:222)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:142)
	at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:163)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:105)
	at org.testng.TestRunner.privateRun(TestRunner.java:648)
	at org.testng.TestRunner.run(TestRunner.java:505)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:455)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:450)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:415)
	at org.testng.SuiteRunner.run(SuiteRunner.java:364)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:84)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1187)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1116)
	at org.testng.TestNG.runSuites(TestNG.java:1028)
	at org.testng.TestNG.run(TestNG.java:996)
	at org.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:72)
	at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:123)
```
When debugging I noticed that, `diagnostic.pos` in below code snippet becomes null.
```java
    private void reportDiagnostic(BDiagnostic diagnostic) {
        if (diagnostic.kind == Diagnostic.Kind.ERROR) {
            errorCount++;
        }
        storeDiagnosticInPackage(diagnostic.pos.src.pkgID, diagnostic);

        // Notify the listener
        this.listener.received(diagnostic);
    }
```
This happens during the compilation of table initialization in the following.
```ballerina
function testTableLiteralDataAndAdd2() returns (int) {
    Person p4 = { id: 4, age: 30, salary: 300.50, name: "john", married: true };
    Person p5 = { id: 5, age: 30, salary: 300.50, name: "mary", married: true };

    table<Person> t1 = table {
        { key id, key salary, name, age, married2 },
        [{ 1, 300.5, "jane",  30, true },
        { 2, 302.5, "anne",  23, false },
        { 3, 320.5, "john",  33, true }
        ]
    };

    _ = t1.add(p4);
    _ = t1.add(p5);

    int count = t1.count();
    return count;
}
```
This needs to be fixed.