### PR TITLE
Skip dataflow analysis for channels

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -169,6 +169,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.util.Flags;
@@ -986,7 +987,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     private void addUninitializedVar(BLangVariable variable) {
-        if (!this.uninitializedVars.containsKey(variable.symbol)) {
+        if (variable.symbol.type.tag != TypeTags.CHANNEL && !this.uninitializedVars.containsKey(variable.symbol)) {
             this.uninitializedVars.put(variable.symbol, InitStatus.UN_INIT);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -464,7 +464,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 dlog.error(varNode.pos, DiagnosticCode.SEALED_ARRAY_TYPE_NOT_INITIALIZED);
                 return;
             }
-            if (varNode.symbol.owner.tag == SymTag.PACKAGE) {
+            if (varNode.symbol.type.tag != TypeTags.CHANNEL && varNode.symbol.owner.tag == SymTag.PACKAGE) {
                 dlog.error(varNode.pos, DiagnosticCode.UNINITIALIZED_VARIABLE, varNode.name);
             }
             return;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/channels/channel-worker-interactions.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/channels/channel-worker-interactions.bal
@@ -4,7 +4,7 @@ channel<json> chn;
 function workerWithChannels() returns json {
     worker w1 {
         json key = {"id":50, name:"john"};
-        json result;
+        json result = {};
         result <- chn, key;
         return result;
     }
@@ -25,7 +25,7 @@ function sendBeforeReceive() returns json {
 
     worker w1 {
         json key = {"id":50, name:"john"};
-        json result;
+        json result = {};
         result <- chn, key;
         return result;
     }
@@ -38,7 +38,7 @@ function nullKeyChannels() returns json {
     }
 
     worker w1 {
-        json result;
+        json result = {};
         result <- chn;
         return result;
     }
@@ -57,7 +57,7 @@ function multipleInteractions() returns json {
     }
 
     worker w1 {
-        json result;
+        json result = {};
         json key = {"id":50, name:"john"};
         json key2 = {"id":60, name:"john"};
         result <- chn, key2;
@@ -81,7 +81,7 @@ function multipleChannels() returns json {
     }
 
     worker w1 {
-        json result;
+        json result = {};
         json key = {"id":50, name:"john"};
         result <- chn,key;
         result <- chn2, key;
@@ -103,7 +103,7 @@ function xmlChannels() returns xml {
         }
 
         worker w1 {
-            xml result;
+            xml result = xml `key`;
             xml key = xml `<key><id>50</id><name>john</name></key>`;
             xml key2 = xml `<key><id>60</id><name>john</name></key>`;
             result <- xmlChn, key2;
@@ -129,11 +129,11 @@ function primitiveTypeChannels() returns boolean {
     "message" -> strChan, key;
     b -> byteChan, key;
 
-    int intResult;
-    float floatResult;
-    byte byteResult;
-    string strResult;
-    boolean boolResult;
+    int intResult = 0;
+    float floatResult = 0;
+    byte byteResult = 0;
+    string strResult = "";
+    boolean boolResult = false;
     intResult <- intChan, key;
 
     if (intResult == 10) {


### PR DESCRIPTION
There is no initialization defined for channels. Hence removing that check and fixed test cases.