### PR TITLE
Fix expressions unit tests

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
@@ -113,10 +113,14 @@ public class DivisionOperationTest {
         Assert.assertEquals(actualResult, expectedResult, DELTA, "Result of the division operation is incorrect");
     }
 
-    @Test(description = "Test float by zero", expectedExceptions = BLangRuntimeException.class)
+    @Test(description = "Test float by zero")
     public void testFloatDivideByZeroExpr() {
         BValue[] args = { new BFloat(300.0f), new BFloat(0) };
-        BRunUtil.invoke(result, "floatDivide", args);
+        BValue[] returns = BRunUtil.invoke(result, "floatDivide", args);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BFloat.class, "Return type of the division is invalid");
+        Assert.assertTrue(Double.isInfinite(((BFloat) returns[0]).floatValue()),
+                "Result of the division operation is incorrect");
     }
 
     @Test(description = "Test devide statement with errors")

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -46,6 +46,7 @@ import static org.ballerinalang.launcher.util.BAssertUtil.validateError;
  *
  * @since 0.985.0
  */
+@Test(groups = "broken")
 public class EqualAndNotEqualOperationsTest {
 
     CompileResult result;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/RefEqualAndNotEqualOperationsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/RefEqualAndNotEqualOperationsTest.java
@@ -38,6 +38,7 @@ import static org.ballerinalang.launcher.util.BAssertUtil.validateError;
  *
  * @since 0.985.0
  */
+@Test(groups = "broken")
 public class RefEqualAndNotEqualOperationsTest {
 
     CompileResult result;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinfunctions/FreezeAndIsFrozenTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinfunctions/FreezeAndIsFrozenTest.java
@@ -42,6 +42,7 @@ import static org.ballerinalang.launcher.util.BAssertUtil.validateError;
  *
  * @since 0.985.0
  */
+@Test(groups = "broken")
 public class FreezeAndIsFrozenTest {
 
     private static final String FREEZE_ERROR_OCCURRED_ERR_MSG =

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/LengthOperationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/LengthOperationTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
  *
  * @version 0.983
  */
+@Test(groups = "broken")
 public class LengthOperationTest {
 
     private CompileResult result;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
@@ -40,7 +40,7 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
 /**
  * Test Cases for type conversion.
  */
-@Test
+@Test(groups = "broken")
 public class NativeConversionTest {
 
     private CompileResult compileResult;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/fieldaccess/SafeNavigationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/fieldaccess/SafeNavigationTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
  * 
  * @since 0.970.0
  */
+@Test(groups = "broken")
 public class SafeNavigationTest {
 
     CompileResult result;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  *
  * @since 0.90
  */
+@Test(groups = "broken")
 public class FunctionPointersTest {
 
     private CompileResult fpProgram, privateFPProgram, globalProgram, structProgram;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/match/MatchExpressionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/match/MatchExpressionTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
  *
  * @since 0.970.0
  */
+@Test(groups = "broken")
 public class MatchExpressionTest {
 
     private CompileResult compileResult;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.Test;
 /**
  * Test Cases for type casting.
  */
+@Test(groups = "broken")
 public class TypeCastExprTest {
     private static final double DELTA = 0.01;
     private CompileResult result;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/async/basic-async-operations.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/async/basic-async-operations.bal
@@ -1,7 +1,7 @@
 import ballerina/runtime;
 import ballerina/io;
 
-int globalResult;
+int globalResult = 0;
 
 function testAsyncNonNativeBasic1() returns int {
   future<int> f1 = start add(5, 2);

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr-precedence.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr-precedence.bal
@@ -24,9 +24,12 @@ function multiBinaryANDExpr(boolean one, boolean two, boolean three) returns (in
     }
 }
 
-function getBoolean() returns (boolean ) {
+function getBoolean() returns (boolean) {
     json j = {};
-    string val = "ss";
-    val = check <string>j.isPresent;
-    return (val == "test");
+    var val = <string>j.isPresent;
+    if (val is string) {
+        return (val == "test");
+    } else {
+        panic val;
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr.bal
@@ -1,5 +1,5 @@
 function makeChild(boolean stone, boolean value) returns (boolean) {
-    boolean result;
+    boolean result = false;
     // stone and valuable
     if (stone && value) {
         result = true;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation-negative.bal
@@ -36,25 +36,25 @@ function checkLessThanEqualForUnsupportedType () returns (boolean) {
 }
 
 function checkGreaterThan () returns (boolean) {
-    int a;
-    string b;
+    int a = 0;
+    string b = "";
     return a > b;
 }
 
 function checkGreaterThanEual () returns (boolean) {
-    int a;
-    string b;
+    int a = 0;
+    string b = "";
     return a >= b;
 }
 
 function checkLessThan () returns (boolean) {
-    int a;
-    string b;
+    int a = 0;
+    string b = "";
     return a < b;
 }
 
 function checkLessThanEqual () returns (boolean) {
-    int a;
-    string b;
+    int a = 0;
+    string b = "";
     return a <= b;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation.bal
@@ -1,5 +1,5 @@
 function testIntRanges(int a) returns (int) {
-    int retunType;
+    int retunType = 0;
     if (a <= 0) {
         retunType = 1;
     } else if ((a > 0) && (a < 100)) {
@@ -11,7 +11,7 @@ function testIntRanges(int a) returns (int) {
 }
 
 function testFloatRanges(float a) returns (int) {
-    int retunType;
+    int retunType = 0;
     if (a <= 0.0) {
         retunType = 1;
     } else if ((a > 0.0) && (a < 100.0)) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/builtinoperations/length-operation.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/builtinoperations/length-operation.bal
@@ -56,7 +56,7 @@ function arrayLengthAccessTestArrayInitializerCase (int x, int y) returns (int) 
     return tempArr[0];
 }
 
-function arrayLengthAccessTestMapInitializerCase (int x, int y) returns (int) {
+function arrayLengthAccessTestMapInitializerCase (int x, int y) returns (int|error) {
     int[] arr = [];
     arr[0] = x;
     arr[1] = y;
@@ -162,7 +162,7 @@ function lengthOfMap () returns (int) {
 }
 
 function lengthOfEmptyMap () returns (int) {
-    map namesMap;
+    map namesMap = {};
     int length = namesMap.length();
     return length;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -60,16 +60,14 @@ public type Person record {
 function testElvisRecordTypePositive() returns (string, int) {
     Person|() xP = { name: "Jim", age: 100 };
     Person dP = { name: "default", age: 0 };
-    Person b = {};
-    b = xP ?: dP;
+    Person b = xP ?: dP;
     return (b.name, b.age);
 }
 
 function testElvisRecordTypeNegative() returns (string, int) {
     Person|() xP = ();
     Person dP = { name: "default", age: 0 };
-    Person b = {};
-    b = xP ?: dP;
+    Person b = xP ?: dP;
     return (b.name, b.age);
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-success.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-success.bal
@@ -3,7 +3,7 @@
 
 string ^"global var" = "this is a IL with global var";
 
-json ^"global json";
+json ^"global json" = {};
 
 function getGlobalVarWithIL() returns (string) {
     return ^"global var";

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/invocations/function-invocation-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/invocations/function-invocation-expr.bal
@@ -37,7 +37,7 @@ function testReturnNativeFuncInvocationWithinNativeFuncInvocation(float x) retur
 
 function sum (int a) returns @untainted int {
     int x;
-    int val;
+    int val = 0;
     if (a > 0) {
         x = sum(a - 1);
         val =  a + x;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -167,7 +167,7 @@ type Bar object {
 };
 
 function testArrowExprInRecord() returns int {
-    Foo f;
+    Foo f = {};
     return f.lambda(5);
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
@@ -91,7 +91,7 @@ function testFunctionPointerAsFuncParam() returns (int, string) {
     return (sumFunction(5, 8), s);
 }
 
-function testAnyToFuncPointerConversion_1() returns (int) {
+function testAnyToFuncPointerConversion_1() returns (int|error) {
     any anyFunc = function (int a, int b) returns (int) {
                 int value =  a + b;
                 return value;
@@ -131,7 +131,7 @@ function testFuncPointerConversion() returns (int) {
     return personFunc(p);
 }
 
-function testAnyToFuncPointerConversion_2() returns (int) {
+function testAnyToFuncPointerConversion_2() returns (int|error) {
     any anyFunc = function (Student s) returns (int) {
                         return s.getAge();
                     };

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
@@ -1,4 +1,4 @@
-int add;
+int add = 0;
 
 function testInt1 () returns (int, int, int, int, int, float) {
     add = 0;
@@ -27,7 +27,7 @@ function filterIntNegative (int i) returns boolean {
     return i >= 0;
 }
 
-float fadd;
+float fadd = 0;
 function testFloat1() returns (float, int, float, float, float, float){
     fadd = 0.0;
     float[] fa = [1.1, 2.2, -3.3, 4.4, 5.5];
@@ -55,7 +55,7 @@ function filterFloatNegative (float i) returns boolean {
     return i >= 0;
 }
 
-string output;
+string output = "";
 
 function testBasicArray1 (string[] values) returns string {
     output = "";
@@ -125,7 +125,7 @@ function concatString ((string, string) v) returns (string) {
 
 json j1 = {name:"bob", age:10, pass:true, subjects:[{subject:"maths", marks:75}, {subject:"English", marks:85}]};
 
-function jsonTest () returns (string, string[], int, int, string[]) {
+function jsonTest () returns (string, string[], int, int, string[])|error {
     output = "";
     j1.foreach(function (json j) {
                    output = output + j.toString();

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/iterable-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/iterable-negative.bal
@@ -1,5 +1,5 @@
-int count;
-string word;
+int count = 0;
+string word = "";
 
 function test1(){
     int x = 0;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/template-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/template-expr.bal
@@ -43,7 +43,7 @@ function testArrayVariableAccessInJSONInit () returns (json) {
     return msg;
 }
 
-function testMapVariableAccessInJSONInit () returns (json) {
+function testMapVariableAccessInJSONInit () returns (json|error) {
     json msg;
     map myMap;
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -32,7 +32,7 @@ function foo (int a, string b, boolean c) returns (string) {
 
 type Person record {
     string name;
-    string location;
+    string location?;
 };
 
 function test6 (string s) returns (string) {
@@ -40,7 +40,7 @@ function test6 (string s) returns (string) {
     return p.name;
 }
 
-function test7 (string s) returns (int) {
+function test7 (string s) returns (int|error) {
     map m = {"data" : s == "one" ? 1 : 2};
     var y = check <int>m.data;
     return y;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -18,21 +18,21 @@ function inttofloat(int value) returns (float) {
     return result;
 }
 
-function stringtoint(string value) returns (int) {
+function stringtoint(string value) returns (int|error) {
     int result;
     //string to int should be a unsafe conversion
     result = check <int>value;
     return result;
 }
 
-function testJsonIntToString() returns (string) {
+function testJsonIntToString() returns (string|error) {
     json j = 5;
     int value;
     value = check <int>j;
     return <string> value;
 }
 
-function stringtofloat(string value) returns (float) {
+function stringtofloat(string value) returns (float|error) {
     float result;
     //string to float should be a conversion
     result = check <float>value;
@@ -83,7 +83,7 @@ function anyjsontostring() returns (string) {
     return result;
 }
 
-function testJsonToStringCast() returns (string) {
+function testJsonToStringCast() returns (string|error) {
     json j = "hello";
     string value;
     value = check <string>j;
@@ -98,21 +98,21 @@ function testJSONObjectToStringCast() returns (string | error) {
     return value;
 }
 
-function testJsonToInt() returns (int){
+function testJsonToInt() returns (int|error){
     json j = 5;
     int value;
     value = check <int>j;
     return value;
 }
 
-function testJsonToFloat() returns (float){
+function testJsonToFloat() returns (float|error){
     json j = 7.65;
     float value;
     value = check <float>j;
     return value;
 }
 
-function testJsonToBoolean() returns (boolean){
+function testJsonToBoolean() returns (boolean|error){
     json j = true;
     boolean value;
     value = check <boolean>j;
@@ -159,7 +159,7 @@ function testStructToStruct() returns (Student) {
 //    return <Student> p;
 //}
 
-function testStructAsAnyToStruct() returns (Person) {
+function testStructAsAnyToStruct() returns (Person|error) {
     Person p1 = { name:"Supun",
                     age:25,
                     parent:{name:"Parent", age:50},
@@ -172,7 +172,7 @@ function testStructAsAnyToStruct() returns (Person) {
     return p2;
 }
 
-function testAnyToStruct() returns (Person) {
+function testAnyToStruct() returns (Person|error) {
     json address = {"city":"Kandy", "country":"SriLanka"};
     map parent = {name:"Parent", age:50};
     map info = {status:"single"};
@@ -189,8 +189,8 @@ function testAnyToStruct() returns (Person) {
     return p2;
 }
 
-function testAnyNullToStruct() returns (Person) {
-    any a;
+function testAnyNullToStruct() returns (Person|error) {
+    any a = ();
     var p = check <Person> a;
     return p;
 }
@@ -211,35 +211,35 @@ function testMapToAnyExplicit() returns (any) {
     return <any> m;
 }
 
-function testBooleanInJsonToInt() returns (int) {
+function testBooleanInJsonToInt() returns (int|error) {
     json j = true;
     int value;
     value = check <int>j;
     return value;
 }
 
-function testIncompatibleJsonToInt() returns (int) {
+function testIncompatibleJsonToInt() returns (int|error) {
     json j = "hello";
     int value;
     value = check <int>j;
     return value;
 }
 
-function testIntInJsonToFloat() returns (float) {
+function testIntInJsonToFloat() returns (float|error) {
     json j = 7;
     float value;
     value = check <float>j;
     return value;
 }
 
-function testIncompatibleJsonToFloat() returns (float) {
+function testIncompatibleJsonToFloat() returns (float|error) {
     json j = "hello";
     float value;
     value = check <float>j;
     return value;
 }
 
-function testIncompatibleJsonToBoolean() returns (boolean) {
+function testIncompatibleJsonToBoolean() returns (boolean|error) {
     json j = "hello";
     boolean value;
     value = check <boolean>j;
@@ -251,15 +251,15 @@ type Address record {
     string country;
 };
 
-function testNullJsonToString() returns (string) {
-    json j;
+function testNullJsonToString() returns (string|error) {
+    json j = {};
     string value;
     value = check <string>j;
     return value;
 }
 
-function testNullJsonToInt() returns (int) {
-    json j;
+function testNullJsonToInt() returns (int|error) {
+    json j = {};
     int value;
     value = check <int>j;
     return value;
@@ -268,49 +268,49 @@ function testNullJsonToInt() returns (int) {
 
 
 
-function testNullJsonToFloat() returns (float) {
-    json j;
+function testNullJsonToFloat() returns (float|error) {
+    json j = {};
     float value;
     value = check <float>j;
     return value;
 }
 
-function testNullJsonToBoolean() returns (boolean) {
-    json j;
+function testNullJsonToBoolean() returns (boolean|error) {
+    json j = {};
     boolean value;
     value = check <boolean>j;
     return value;
 }
 
-function testAnyIntToJson() returns (json) {
+function testAnyIntToJson() returns (json|error) {
     any a = 8;
     json value;
     value = check <json> a;
     return value;
 }
 
-function testAnyStringToJson() returns (json) {
+function testAnyStringToJson() returns (json|error) {
     any a = "Supun";
     json value;
     value = check <json> a;
     return value;
 }
 
-function testAnyBooleanToJson() returns (json) {
+function testAnyBooleanToJson() returns (json|error) {
     any a = true;
     json value;
     value = check <json> a;
     return value;
 }
 
-function testAnyFloatToJson() returns (json) {
+function testAnyFloatToJson() returns (json|error) {
     any a = 8.73;
     json value;
     value = check <json> a;
     return value;
 }
 
-function testAnyMapToJson() returns (json) {
+function testAnyMapToJson() returns (json|error) {
     map m = {name:"supun"};
     any a = m;
     json value;
@@ -318,7 +318,7 @@ function testAnyMapToJson() returns (json) {
     return value;
 }
 
-function testAnyStructToJson() returns (json) {
+function testAnyStructToJson() returns (json|error) {
     Address adrs = {city:"CA"};
     any a = adrs;
     json value;
@@ -326,14 +326,14 @@ function testAnyStructToJson() returns (json) {
     return value;
 }
 
-function testAnyNullToJson() returns (json) {
+function testAnyNullToJson() returns (json|error) {
     any a = null;
     json value;
     value = check <json> a;
     return value;
 }
 
-function testAnyJsonToJson() returns (json) {
+function testAnyJsonToJson() returns (json|error) {
     json j = {home:"SriLanka"};
     any a = j;
     json value;
@@ -341,22 +341,22 @@ function testAnyJsonToJson() returns (json) {
     return value;
 }
 
-function testAnyArrayToJson() returns (json) {
+function testAnyArrayToJson() returns (json|error) {
     any[] a = [8,4,6];
     json value;
     value = check <json> a;
     return value;
 }
 
-function testAnyNullToMap() returns (map) {
-    any a;
+function testAnyNullToMap() returns (map|error) {
+    any a = ();
     map value;
     value = check <map> a;
     return value;
 }
 
-function testAnyNullToXml() returns (xml) {
-    any a;
+function testAnyNullToXml() returns (xml|error) {
+    any a = ();
     xml value;
     value = check <xml> a;
     return value;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typecast/value-type-casting.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typecast/value-type-casting.bal
@@ -46,13 +46,13 @@ function floatToAny (float value) returns (any) {
     return result;
 }
 
-function stringToInt(string value) returns (int) {
+function stringToInt(string value) returns (int|error) {
     int result;
     result = check <int>value;
     return result;
 }
 
-function stringToFloat(string value) returns (float) {
+function stringToFloat(string value) returns (float|error) {
     float result;
     result = check <float>value;
     return result;
@@ -94,7 +94,7 @@ function booleanToAny(boolean value) returns (any) {
     return result;
 }
 
-function anyToInt () returns (int) {
+function anyToInt () returns (int|error) {
     int i = 5;
     any a = i;
     int value;
@@ -102,7 +102,7 @@ function anyToInt () returns (int) {
     return value;
 }
 
-function anyToFloat () returns (float) {
+function anyToFloat () returns (float|error) {
     float f = 5.0;
     any a = f;
     float value;
@@ -118,8 +118,8 @@ function anyToString () returns (string) {
     return value;
 }
 
-function anyToBoolean () returns (boolean) {
-    boolean b;
+function anyToBoolean () returns (boolean|error) {
+    boolean b = false;
     any a = b;
     boolean value;
     value = check <boolean>a;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/lengthof-operation-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/lengthof-operation-negative.bal
@@ -1,6 +1,6 @@
 function arrayLengthAccessNullArrayCase(int x, int y) returns (int) {
     int z = x + y;
-    int[] arr;
+    int[] arr = [];
     int length;
     length = (arr.length());
     return length;
@@ -8,14 +8,14 @@ function arrayLengthAccessNullArrayCase(int x, int y) returns (int) {
 
 
 function arrayLengthAccessTestJSONArrayNegativeNullCase(int x, int y) returns (int) {
-    json arr;
+    json arr = ();
     int length;
     length = (arr.length());
     return length;
 }
 
 function arrayLengthAccessNullMapCase(int x, int y) returns (int) {
-    map m;
+    map m = {};
     int length;
     length = (m.length());
     return length;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/lengthof-operation.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/lengthof-operation.bal
@@ -40,7 +40,7 @@ function arrayLengthAccessTestArrayInitializerCase (int x, int y) returns (int) 
     return tempArr[0];
 }
 
-function arrayLengthAccessTestMapInitializerCase (int x, int y) returns (int) {
+function arrayLengthAccessTestMapInitializerCase (int x, int y) returns (int|error) {
     int[] arr = [];
     arr[0] = x;
     arr[1] = y;
@@ -138,7 +138,7 @@ function lengthOfMap (int x, int y) returns (int) {
 }
 
 function lengthOfMapEmpty (int x, int y) returns (int) {
-    map namesMap;
+    map namesMap = {};
     int length = namesMap.length();
     return length;
 }
@@ -166,7 +166,7 @@ function lengthOfBlob() returns (int, int) {
 }
 
 function lengthOfNullString() returns (int) {
-    string foo;
+    string foo = "";
     return foo.length();
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation-negative.bal
@@ -1,6 +1,6 @@
 function testJsonPositive() returns (json) {
     json j1;
-    json j2;
+    json j2 = ();
     j1 = {"name":"Jack"};
     j1 = +j2;
 
@@ -9,7 +9,7 @@ function testJsonPositive() returns (json) {
 
 function testJsonNegative() returns (json) {
     json j1;
-    json j2;
+    json j2 = ();
     j1 = {"name":"Jack"};
     j1 = -j2;
 
@@ -18,7 +18,7 @@ function testJsonNegative() returns (json) {
 
 function testJsonNot() returns (json) {
     json j1;
-    json j2;
+    json j2 = ();
     j1 = {"name":"Jack"};
     j1 = !j2;
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/varref/record-variable-reference-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/varref/record-variable-reference-negative.bal
@@ -29,7 +29,7 @@ type Person record {
     string name;
     boolean married;
     Age age;
-    (string, int) extra;
+    (string, int) extra?;
     !...
 };
 
@@ -37,7 +37,7 @@ type Person2 record {
     string name;
     boolean married;
     ClosedAge age;
-    (string, int) extra;
+    (string, int) extra?;
     !...
 };
 
@@ -90,8 +90,8 @@ type Bar record {
 
 function testInvalidTypes() {
 
-    Bar fooVar1;
-    string fooVar2;
+    Bar fooVar1 = {var1: 0, var2: ("", 0, false)};
+    string fooVar2 = "";
 
     Foo f = {var1: "var1String", var2: {var1: 12, var2: ("barString", 14, true)}};
     {var1: fooVar1, var2: fooVar2};

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/varref/record-variable-reference.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/varref/record-variable-reference.bal
@@ -23,7 +23,7 @@ type Person record {
     string name;
     boolean married;
     Age age;
-    (string, int) extra;
+    (string, int) extra?;
     !...
 };
 
@@ -80,7 +80,7 @@ function testRestParam() returns map {
     OpenRecord openRecord = {var1: "var1", var2: false, var3: 12, var4: "text"};
     string var1;
     boolean var2;
-    map rest;
+    map rest = {};
     {var1, var2, ...rest} = openRecord;
     return rest;
 }
@@ -136,7 +136,7 @@ function testRecordInsideTupleInsideRecord() returns (string[], string, map) {
 
     string[] namesOfChildren;
     Child[] children;
-    map child;
+    map child = {};
 
     Parent parent = {namesOfChildren: ["A", "B"], children: [ch1, ch2], child: ch3};
     {namesOfChildren, children, ...child} = parent;
@@ -166,7 +166,7 @@ function testRecordInsideTupleInsideRecord2() returns (string, int, int, string)
 function testFieldAndIndexBasedVarRefs() returns (anydata, anydata) {
     (int, Age) yearAndAge3 = (2002, {age: 22, format: "Z"});
     Child ch3 = {name: "D", yearAndAge: yearAndAge3};
-    map<anydata> m;
+    map<anydata> m = {};
     {name: m.var1, yearAndAge: (m["var2"], _)} = ch3;
     return (m.var1, m.var2);
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
@@ -230,7 +230,7 @@ function testVarRefWithUnionType5() returns ((string|int, int|boolean), float|(i
 
 function testFieldAndIndexBasedVarRefs() returns (anydata, anydata) {
     (int, (string, boolean)) t1 = (2002, ("S1", true));
-    map<anydata> m;
+    map<anydata> m = {};
     (m.var1, (m.var2, _)) = t1;
     return (m.var1, m.var2);
 }

--- a/tests/ballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/ballerina-unit-test/src/test/resources/testng.xml
@@ -46,7 +46,7 @@ under the License.
             <package name="org.ballerinalang.test.vm.*"/>
             <!--package name="org.ballerinalang.test.annotations.*"/>-->
             <!--package name="org.ballerinalang.test.expressions.*"/>-->
-            <package name="org.ballerinalang.test.expressions.stamp.*"/>
+            <package name="org.ballerinalang.test.expressions.*"/>
             <package name="org.ballerinalang.test.documentation.*"/>
             <!--package name="org.ballerinalang.test.statements.*">
                 <exclude name="org.ballerinalang.test.statements.transform.*"/>


### PR DESCRIPTION
## Purpose
This PR fixes and re-enables expression related unit tests. There are 9 classes that need further analysis with the new language changes. Those were marked as `broken` temporarily. 