### PR TITLE
Allow float types to do modular division with the divisor as zero

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -1921,12 +1921,6 @@ public class CPU {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                if (sf.doubleRegs[j] == 0) {
-                    ctx.setError(BLangVMErrors.createError(ctx, " / by zero"));
-                    handleError(ctx);
-                    break;
-                }
-
                 sf.doubleRegs[k] = sf.doubleRegs[i] % sf.doubleRegs[j];
                 break;
             case InstructionCodes.DMOD:

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/BuiltinOperationsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/BuiltinOperationsTest.java
@@ -81,6 +81,36 @@ public class BuiltinOperationsTest {
         Assert.assertEquals(((BBoolean) returns[2]).booleanValue(), false);
     }
 
+    @Test(description = "Test result that is returned from a mod with divisor as zero")
+    public void testModWithDivisorAsZero() {
+        BValue[] returns = BRunUtil.invoke(result, "testModWithDivisorAsZero", new BValue[0]);
+
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(((BBoolean) returns[0]).booleanValue(), true);
+        Assert.assertEquals(((BBoolean) returns[1]).booleanValue(), false);
+        Assert.assertEquals(((BBoolean) returns[2]).booleanValue(), false);
+    }
+
+    @Test(description = "Test result that is returned from a mod with both dividend and divisor as zero")
+    public void testModZeroByZero() {
+        BValue[] returns = BRunUtil.invoke(result, "testModZeroByZero", new BValue[0]);
+
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(((BBoolean) returns[0]).booleanValue(), true);
+        Assert.assertEquals(((BBoolean) returns[1]).booleanValue(), false);
+        Assert.assertEquals(((BBoolean) returns[2]).booleanValue(), false);
+    }
+
+    @Test(description = "Test result that is returned from a mod with divisor as a finite number")
+    public void testModWithDivisorAsFinite() {
+        BValue[] returns = BRunUtil.invoke(result, "testModWithDivisorAsFinite", new BValue[0]);
+
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(((BBoolean) returns[0]).booleanValue(), false);
+        Assert.assertEquals(((BBoolean) returns[1]).booleanValue(), false);
+        Assert.assertEquals(((BBoolean) returns[2]).booleanValue(), true);
+    }
+
     @Test(description = "Test negative tests")
     public void testNegativeTests() {
         Assert.assertEquals(resNegative.getErrorCount(), 5);

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/builtinoperations/builtinoperations.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/builtinoperations/builtinoperations.bal
@@ -38,3 +38,18 @@ function testWithCalc() returns (boolean, boolean, boolean) {
     boolean bool = f.isInfinite();
     return (bool, f.isFinite(), f.isNaN());
 }
+
+function testModWithDivisorAsZero() returns (boolean, boolean, boolean) {
+    float a = 10.0 % 0.0;
+    return (a.isNaN(), a.isInfinite(), a.isFinite());
+}
+
+function testModWithDivisorAsFinite() returns (boolean, boolean, boolean) {
+    float a = 10.0 % 3.0;
+    return (a.isNaN(), a.isInfinite(), a.isFinite());
+}
+
+function testModZeroByZero() returns (boolean, boolean, boolean) {
+    float a = 0.0 % 0.0;
+    return (a.isNaN(), a.isInfinite(), a.isFinite());
+}


### PR DESCRIPTION
## Purpose
> $subject

## Automation tests
 - Unit tests 
 
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
