### PR TITLE
Fix issue in error type inferring

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -345,6 +345,8 @@ public enum DiagnosticCode {
     // Dataflow analysis related error codes
     PARTIALLY_INITIALIZED_VARIABLE("partially.initialized.variable"),
 
+    CANNOT_INFER_ERROR_TYPE("cannot.infer.error.type"),
+
     // Seal inbuilt function related codes
     INCOMPATIBLE_STAMP_TYPE("incompatible.stamp.type"),
     NOT_SUPPORTED_SOURCE_TYPE_FOR_STAMP("not.supported.source.for.stamp")

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -142,6 +142,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MAX_VALUE;
@@ -1508,33 +1509,19 @@ public class TypeChecker extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangErrorConstructorExpr errorConstructorExpr) {
-        final boolean isExpectedErrorType = expType.tag == TypeTags.ERROR;
-        final BErrorType expectedResultType = isExpectedErrorType ? (BErrorType) expType : symTable.errorType;
-
-        // No matter what message expression has to be exist and it's type should be string type.
-        Optional.ofNullable(errorConstructorExpr.reasonExpr).map(expr -> checkExpr(expr, env, symTable.stringType))
-                .orElseThrow(AssertionError::new);
-
-        Optional.ofNullable(errorConstructorExpr.detailsExpr).ifPresent(expr -> {
-            if (isExpectedErrorType) {
-                checkExpr(expr, env, expectedResultType.detailType);
-            } else {
-                // Give correct error message.
-                BType givenType = checkExpr(expr, env, symTable.noType);
-                if (givenType.tag != TypeTags.MAP && givenType.tag != TypeTags.RECORD) {
-                    dlog.error(expr.pos, DiagnosticCode.REQUIRE_ERROR_MAPPING_VALUE);
-                } else {
-                    // TODO : improve this for union types.
-                    dlog.error(errorConstructorExpr.pos, DiagnosticCode.INCOMPATIBLE_TYPES, symTable.errorType,
-                            expType);
-                }
-            }
-        });
-
-        if (!isExpectedErrorType) {
+        if (expType.tag != TypeTags.ERROR) {
+            dlog.error(errorConstructorExpr.pos, DiagnosticCode.CANNOT_INFER_ERROR_TYPE, expType);
             resultType = symTable.semanticError;
             return;
         }
+
+        // No matter what, message expression has to exist and it's type should be string type.
+        Optional.ofNullable(errorConstructorExpr.reasonExpr)
+                .map(expr -> checkExpr(expr, env, symTable.stringType))
+                .orElseThrow(AssertionError::new);
+
+        Optional.ofNullable(errorConstructorExpr.detailsExpr)
+                .ifPresent(expr -> checkExpr(expr, env, ((BErrorType) expType).detailType));
         resultType = expType;
     }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -852,6 +852,9 @@ warning.undefined.documentation.public.function=\
 warning.usage.of.deprecated.function=\
   usage of deprecated function ''{0}''
 
+error.cannot.infer.error.type=\
+  cannot infer type of the error from ''{0}''
+
 error.only.simple.literals.can.be.assigned.to.const=\
   only simple literals can be assigned to a constant
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/errors/TestErrorNegative.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/errors/TestErrorNegative.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.types.errors;
+
+import org.ballerinalang.launcher.util.BAssertUtil;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Negative test cases for error.
+ */
+public class TestErrorNegative {
+
+    @Test
+    public void testNegative() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/types/errors/error-negative.bal");
+        Assert.assertEquals(compileResult.getErrorCount(), 2);
+        BAssertUtil.validateError(compileResult, 0, "cannot infer type of the error from 'error|string'", 2, 22);
+        BAssertUtil.validateError(compileResult, 1, "cannot infer type of the error from 'string|error'", 3, 12);
+    }
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/errors/error-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/errors/error-negative.bal
@@ -1,0 +1,4 @@
+function test () returns string|error {
+    error|string e = error("error1");
+    return error("error2");
+}


### PR DESCRIPTION
## Purpose
This PR fixes an issue of error type inferring.

Eg -

```ballerina
function test() returns string|error {
    return error("error"); // Exact type of error cannot be inferred here.
}
```