### PR TITLE
Fix recursive issue of isAnydata method while checking record types with same refrence

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -132,6 +132,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -3384,37 +3385,46 @@ public class CPU {
     }
 
     private static boolean isAnydata(BType type) {
+        return isAnydata(type, new HashSet<>());
+    }
+
+    private static boolean isAnydata(BType type, Set<BType> unresolvedTypes) {
         if (type.getTag() <= TypeTags.ANYDATA_TAG) {
             return true;
         }
 
         switch (type.getTag()) {
             case TypeTags.MAP_TAG:
-                return isAnydata(((BMapType) type).getConstrainedType());
+                return isAnydata(((BMapType) type).getConstrainedType(), unresolvedTypes);
             case TypeTags.RECORD_TYPE_TAG:
+                if (unresolvedTypes.contains(type)) {
+                    return true;
+                }
+                unresolvedTypes.add(type);
                 BRecordType recordType = (BRecordType) type;
                 List<BType> fieldTypes = recordType.getFields().values().stream()
-                        .map(BField::getFieldType)
-                        .collect(Collectors.toList());
-                return isAnydata(fieldTypes) && (recordType.sealed || isAnydata(recordType.restFieldType));
+                                                   .map(BField::getFieldType)
+                                                   .collect(Collectors.toList());
+                return isAnydata(fieldTypes, unresolvedTypes) && (recordType.sealed ||
+                        isAnydata(recordType.restFieldType, unresolvedTypes));
             case TypeTags.UNION_TAG:
-                return isAnydata(((BUnionType) type).getMemberTypes());
+                return isAnydata(((BUnionType) type).getMemberTypes(), unresolvedTypes);
             case TypeTags.TUPLE_TAG:
-                return isAnydata(((BTupleType) type).getTupleTypes());
+                return isAnydata(((BTupleType) type).getTupleTypes(), unresolvedTypes);
             case TypeTags.ARRAY_TAG:
-                return isAnydata(((BArrayType) type).getElementType());
+                return isAnydata(((BArrayType) type).getElementType(), unresolvedTypes);
             case TypeTags.FINITE_TYPE_TAG:
                 Set<BType> valSpaceTypes = ((BFiniteType) type).valueSpace.stream()
-                                                                        .map(BValue::getType)
-                                                                        .collect(Collectors.toSet());
-                return isAnydata(valSpaceTypes);
+                                                                          .map(BValue::getType)
+                                                                          .collect(Collectors.toSet());
+                return isAnydata(valSpaceTypes, unresolvedTypes);
             default:
                 return false;
         }
     }
 
-    private static boolean isAnydata(Collection<BType> types) {
-        return types.stream().allMatch(CPU::isAnydata);
+    private static boolean isAnydata(Collection<BType> types, Set<BType> unresolvedTypes) {
+        return types.stream().allMatch(bType -> isAnydata(bType, unresolvedTypes));
     }
 
     private static BType getElementType(BType type) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXML;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -81,6 +82,17 @@ public class AnydataTest {
         BMap closedFoo = (BMap) returns[1];
         assertEquals(closedFoo.getType().getName(), "ClosedFoo");
         assertEquals(((BInteger) closedFoo.get("ca")).intValue(), 35);
+    }
+
+    @Test(description = "Test cyclic record types assignment")
+    public void testCyclicRecordAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testCyclicRecordAssignment");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertTrue(returns[0] instanceof BMap<?, ?>);
+        BMap bMap = (BMap) returns[0];
+        Assert.assertEquals(bMap.get("name").stringValue(), "Child");
+        Assert.assertEquals(((BInteger) bMap.get("age")).intValue(), 25);
+        Assert.assertEquals(((BMap) bMap.get("parent")).get("name").stringValue(), "Parent");
     }
 
     @Test(description = "Test XML assignment")

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -29,6 +29,20 @@ type Employee record {
     float salary;
     !...
 };
+    
+type Person record {
+    string name = "";
+    int age = 0;
+    Person? parent = ();
+    json info = ();
+    map<anydata>? address = ();
+    int[]? marks = ();
+    anydata a = ();
+    float score = 0.0;
+    boolean alive = false;
+    Person[]? children = ();
+    !...
+};
 
 function testLiteralValueAssignment() returns (anydata, anydata, anydata, anydata) {
     anydata adi = 10;
@@ -62,6 +76,23 @@ function testRecordAssignment() returns (anydata, anydata) {
     anydata adcr = cf;
 
     return (adr, adcr);
+}
+
+function testCyclicRecordAssignment() returns (anydata) {
+    Person p = {name:"Child",
+                age:25,
+                parent:{name:"Parent", age:50},
+                address:{"city":"Colombo", "country":"SriLanka"},
+                info:{status:"single"},
+                marks:[67, 38, 91]
+    };
+    anydata adp = p;
+    any p2 =  <Person> adp;
+    if(p2 is anydata){
+        return p2;
+    } else {
+        return ();
+    }
 }
 
 function testXMLAssignment() returns (anydata, anydata) {


### PR DESCRIPTION
## Purpose
> Stack over flow issue can be observed in isAnydata method  while manipulating record types which has same reference. This PR will fix that.
ex. 

```ballerina

type Person record {
    string name = "";
    int age = 0;
    Person? parent = ();
    json info = ();
    map<anydata>? address = ();
    int[]? marks = ();
    anydata a = ();
    float score = 0.0;
    boolean alive = false;
    Person[]? children = ();
    !...
};

function testCyclicRecordAssignment() returns (anydata) {
    Person p = {name:"Child",
                age:25,
                parent:{name:"Parent", age:50},
                address:{"city":"Colombo", "country":"SriLanka"},
                info:{status:"single"},
                marks:[67, 38, 91]
    };
    anydata adp = p;
    any p2 =  <Person>adp;
    if(p2 is anydata){
        return p2;
    } else {
        return ();
    }
}

```
testCyclicRecordAssignment function will produce stack overflow issue at compiler time and runtime due to isAnydata method not supporting cyclic record types.