### PR TITLE
Add more flexibility to http client creation

### DIFF
--- a/stdlib/http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/client_endpoint.bal
@@ -30,8 +30,9 @@ public type Client client object {
     public ClientEndpointConfig config = {};
     public Client httpClient;
 
-    public function __init(ClientEndpointConfig c) {
-        self.config = c;
+    public function __init(string url, ClientEndpointConfig? config = ()) {
+        self.config = config ?: {};
+        self.config.url = url;
         var result = initialize(self.config);
         if (result is error) {
             panic result;

--- a/stdlib/http/src/main/ballerina/http/resiliency/failover_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/resiliency/failover_client_endpoint.bal
@@ -506,7 +506,7 @@ function createFailoverHttpClientArray(FailoverClientEndpointConfiguration failo
 
     foreach target in failoverClientConfig.targets {
         ClientEndpointConfig epConfig = createClientEPConfigFromFailoverEPConfig(failoverClientConfig, target);
-        httpClients[i] = new(epConfig);
+        httpClients[i] = new(target.url, config = epConfig);
         i += 1;
     }
     return httpClients;

--- a/stdlib/http/src/main/ballerina/http/resiliency/load_balance_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/resiliency/load_balance_client_endpoint.bal
@@ -400,7 +400,7 @@ function createLoadBalanceHttpClientArray(LoadBalanceClientEndpointConfiguration
 
     foreach target in loadBalanceClientConfig.targets {
         ClientEndpointConfig epConfig = createClientEPConfigFromLoalBalanceEPConfig(loadBalanceClientConfig, target);
-        httpClients[i] = new(epConfig);
+        httpClients[i] = new(target.url , config = epConfig);
         i += 1;
     }
     return httpClients;


### PR DESCRIPTION
With this http:Client can be created just passing the url in the constructor as http:Client httpClient = new("http://localhost:8080/hello");