### PR TITLE
[WebSub] Change Server to Listener and migrate tests

### DIFF
--- a/stdlib/websub/src/main/ballerina/websub/annotation.bal
+++ b/stdlib/websub/src/main/ballerina/websub/annotation.bal
@@ -36,7 +36,7 @@ import ballerina/http;
 # + followRedirects - The HTTP redirect related configuration specifying if subscription requests should be sent
 #                     to redirected hubs/topics
 public type SubscriberServiceConfiguration record {
-    Server[] endpoints = [];
+    Listener[] endpoints = [];
     string path = "";
     boolean subscribeOnStartUp = false;
     string resourceUrl = "";

--- a/stdlib/websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
+++ b/stdlib/websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
@@ -23,8 +23,7 @@ import ballerina/log;
 # Object representing the WebSubSubscriber Service Endpoint.
 #
 # + config - The configuration for the endpoint
-# + serviceEndpoint - The underlying HTTP service endpoint
-public type Server object {
+public type Listener object {
 
     *AbstractListener;
 
@@ -71,7 +70,7 @@ public type Server object {
 
 };
 
-function Server.init(SubscriberServiceEndpointConfiguration c) {
+function Listener.init(SubscriberServiceEndpointConfiguration c) {
     self.config = c;
     http:ServiceEndpointConfiguration serviceConfig = {
         host: c.host,
@@ -86,22 +85,18 @@ function Server.init(SubscriberServiceEndpointConfiguration c) {
     self.initWebSubSubscriberServiceEndpoint();
 }
 
-function Server.__start() returns error? {
+function Listener.__start() returns error? {
     // TODO: handle data and return error on error
     self.startWebSubSubscriberServiceEndpoint();
     self.sendSubscriptionRequests();
     return;
 }
 
-//function Listener.getCallerActions() returns http:Connection {
-//    return self.serviceEndpoint.getCallerActions();
-//}
-
-function Server.__stop() returns error? {
+function Listener.__stop() returns error? {
     return self.serviceEndpoint.__stop();
 }
 
-function Server.sendSubscriptionRequests() {
+function Listener.sendSubscriptionRequests() {
     map[] subscriptionDetailsArray = self.retrieveSubscriptionParameters();
 
     foreach subscriptionDetails in subscriptionDetailsArray {

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/BallerinaWebSubConnectionListener.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/BallerinaWebSubConnectionListener.java
@@ -79,7 +79,7 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.VERIFICATIO
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.VERIFICATION_REQUEST_TOPIC;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_CALLER;
-import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_SERVER;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_LISTENER;
 import static org.ballerinalang.net.websub.WebSubUtils.getHttpRequest;
 import static org.ballerinalang.net.websub.WebSubUtils.getJsonBody;
 
@@ -226,7 +226,7 @@ public class BallerinaWebSubConnectionListener extends BallerinaHTTPConnectorLis
     private BMap<String, BValue> getWebSubCaller(HttpResource httpResource, HttpCarbonMessage httpCarbonMessage) {
         BMap<String, BValue> subscriberServiceServer =
                 createBStruct(httpResource.getBalResource().getResourceInfo().getPackageInfo().getProgramFile(),
-                              WEBSUB_PACKAGE, WEBSUB_SERVICE_SERVER);
+                              WEBSUB_PACKAGE, WEBSUB_SERVICE_LISTENER);
 
         BMap<String, BValue> httpServiceServer = BLangConnectorSPIUtil.createBStruct(
                 httpResource.getBalResource().getResourceInfo().getPackageInfo().getProgramFile(),

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
@@ -27,13 +27,12 @@ public class WebSubSubscriberConstants {
 
     public static final String GENERIC_SUBSCRIBER_SERVICE_TYPE = "Service";
     public static final String WEBSUB_SERVICE_REGISTRY = "WEBSUB_SERVICE_REGISTRY";
-    public static final String WEBSUB_SUBSCRIBER_SERVICE_ENDPOINT_NAME =
-                                                        "ballerina/websub:Listener";
+
     public static final String SERVICE_ENDPOINT = "Listener";
     public static final String SERVICE_ENDPOINT_CONFIG_NAME = "config";
     public static final String ANN_NAME_WEBSUB_SUBSCRIBER_SERVICE_CONFIG = "SubscriberServiceConfig";
     public static final String WEBSUB_PACKAGE = "ballerina/websub";
-    public static final String WEBSUB_SERVICE_SERVER = "Server";
+    public static final String WEBSUB_SERVICE_LISTENER = "Listener";
     public static final String WEBSUB_SERVICE_CALLER = "Caller";
     public static final String WEBSUB_HTTP_ENDPOINT = "serviceEndpoint";
     public static final String WEBSUB_SERVICE_NAME = "webSubServiceName";

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/InitWebSubSubscriberServiceEndpoint.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/InitWebSubSubscriberServiceEndpoint.java
@@ -53,6 +53,7 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.TOPIC_ID_HE
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.TOPIC_ID_PAYLOAD_KEY;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_HTTP_ENDPOINT;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_LISTENER;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_REGISTRY;
 
 /**
@@ -64,7 +65,8 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERV
 @BallerinaFunction(
         orgName = "ballerina", packageName = "websub",
         functionName = "initWebSubSubscriberServiceEndpoint",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = "Server", structPackage = WEBSUB_PACKAGE)
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = WEBSUB_SERVICE_LISTENER,
+                structPackage = WEBSUB_PACKAGE)
 )
 public class InitWebSubSubscriberServiceEndpoint extends BlockingNativeCallableUnit {
 

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RegisterWebSubSubscriberServiceEndpoint.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RegisterWebSubSubscriberServiceEndpoint.java
@@ -34,6 +34,7 @@ import org.ballerinalang.net.websub.WebSubServicesRegistry;
 
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.LISTENER_SERVICE_ENDPOINT;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_LISTENER;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_REGISTRY;
 
 /**
@@ -45,7 +46,8 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERV
 @BallerinaFunction(
         orgName = "ballerina", packageName = "websub",
         functionName = "registerWebSubSubscriberServiceEndpoint",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = "Server", structPackage = WEBSUB_PACKAGE),
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = WEBSUB_SERVICE_LISTENER,
+                structPackage = WEBSUB_PACKAGE),
         args = {@Argument(name = "serviceType", type = TypeKind.TYPEDESC)},
         isPublic = true
 )

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RetrieveSubscriptionParameters.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/RetrieveSubscriptionParameters.java
@@ -58,6 +58,7 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ENDPOINT_CO
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.SERVICE_ENDPOINT_CONFIG_NAME;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_HTTP_ENDPOINT;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_LISTENER;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_NAME;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_REGISTRY;
 
@@ -70,7 +71,8 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERV
 @BallerinaFunction(
         orgName = "ballerina", packageName = "websub",
         functionName = "retrieveSubscriptionParameters",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = "Server", structPackage = WEBSUB_PACKAGE),
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = WEBSUB_SERVICE_LISTENER,
+                structPackage = WEBSUB_PACKAGE),
         returnType = {@ReturnType(type = TypeKind.ARRAY)}
 )
 public class RetrieveSubscriptionParameters extends BlockingNativeCallableUnit {

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/SetTopic.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/SetTopic.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import static org.ballerinalang.net.http.HttpConstants.DEFAULT_HOST;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_HTTP_ENDPOINT;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_LISTENER;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_REGISTRY;
 
 /**
@@ -48,7 +49,8 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERV
         functionName = "setTopic",
         args = {@Argument(name = "webSubServiceName", type = TypeKind.STRING),
                 @Argument(name = "topic", type = TypeKind.STRING)},
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = "Server", structPackage = WEBSUB_PACKAGE),
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = WEBSUB_SERVICE_LISTENER,
+                structPackage = WEBSUB_PACKAGE),
         isPublic = true
 )
 public class SetTopic extends AbstractHttpNativeFunction {

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/StartWebSubSubscriberServiceEndpoint.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/StartWebSubSubscriberServiceEndpoint.java
@@ -34,6 +34,8 @@ import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_HTTP_ENDPOINT;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_PACKAGE;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_SERVICE_LISTENER;
 
 /**
  * Set WebSub connection listener on startup.
@@ -44,8 +46,8 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.WEBSUB_HTTP
 @BallerinaFunction(
         orgName = "ballerina", packageName = "websub",
         functionName = "startWebSubSubscriberServiceEndpoint",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = "Server",
-                structPackage = WebSubSubscriberConstants.WEBSUB_PACKAGE),
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = WEBSUB_SERVICE_LISTENER,
+                structPackage = WEBSUB_PACKAGE),
         isPublic = true
 )
 public class StartWebSubSubscriberServiceEndpoint extends AbstractHttpNativeFunction {

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
@@ -34,7 +34,7 @@ websub:Client websubHubClientEP = new websub:Client({
     url: webSubHub.hubUrl
 });
 
-listener http:Server publisherServiceEP = new http:Server(8080);
+listener http:Listener publisherServiceEP = new http:Listener(8080);
 
 service publisher on publisherServiceEP {
     @http:ResourceConfig {

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
@@ -19,30 +19,28 @@ import ballerina/io;
 import ballerina/log;
 import ballerina/websub;
 
-@final string WEBSUB_TOPIC_ONE = "http://one.websub.topic.com";
-@final string WEBSUB_TOPIC_TWO = "http://two.websub.topic.com";
-@final string WEBSUB_TOPIC_THREE = "http://three.websub.topic.com";
-@final string WEBSUB_TOPIC_FOUR = "http://four.websub.topic.com";
-@final string WEBSUB_TOPIC_FIVE = "http://one.redir.topic.com";
-@final string WEBSUB_TOPIC_SIX = "http://two.redir.topic.com";
+const string WEBSUB_TOPIC_ONE = "http://one.websub.topic.com";
+const string WEBSUB_TOPIC_TWO = "http://two.websub.topic.com";
+const string WEBSUB_TOPIC_THREE = "http://three.websub.topic.com";
+const string WEBSUB_TOPIC_FOUR = "http://four.websub.topic.com";
+const string WEBSUB_TOPIC_FIVE = "http://one.redir.topic.com";
+const string WEBSUB_TOPIC_SIX = "http://two.redir.topic.com";
 
 boolean remoteTopicRegistered = false;
 
 websub:WebSubHub webSubHub = startHubAndRegisterTopic();
 
-endpoint websub:Client websubHubClientEP {
+websub:Client websubHubClientEP = new websub:Client({
     url: webSubHub.hubUrl
-};
+});
 
-endpoint http:Listener publisherServiceEP {
-    port:8080
-};
+listener http:Server publisherServiceEP = new http:Server(8080);
 
-service<http:Service> publisher bind publisherServiceEP {
+service publisher on publisherServiceEP {
     @http:ResourceConfig {
         methods: ["GET", "HEAD"]
     }
-    discover(endpoint caller, http:Request req) {
+    resource function discover(http:Caller caller, http:Request req) {
         http:Response response = new;
         // Add a link header indicating the hub and topic
         websub:addWebSubLinkHeader(response, [webSubHub.hubUrl], WEBSUB_TOPIC_ONE);
@@ -56,7 +54,7 @@ service<http:Service> publisher bind publisherServiceEP {
     @http:ResourceConfig {
         methods: ["POST"]
     }
-    notify(endpoint caller, http:Request req) {
+    resource function notify(http:Caller caller, http:Request req) {
         remoteRegisterTopic();
         string mode = "";
         string contentType = "";
@@ -88,7 +86,7 @@ service<http:Service> publisher bind publisherServiceEP {
         }
     }
 
-    topicInfo(endpoint caller, http:Request req) {
+    resource function topicInfo(http:Caller caller, http:Request req) {
         if (req.hasHeader("x-topic")) {
             string topicName = req.getHeader("x-topic");
             websub:SubscriberDetails[] details = webSubHub.getSubscribers(topicName);
@@ -123,11 +121,11 @@ service<http:Service> publisher bind publisherServiceEP {
     }
 }
 
-service<http:Service> publisherTwo bind publisherServiceEP {
+service publisherTwo on publisherServiceEP {
     @http:ResourceConfig {
         methods: ["GET", "HEAD"]
     }
-    discover(endpoint caller, http:Request req) {
+    resource function discover(http:Caller caller, http:Request req) {
         http:Response response = new;
         // Add a link header indicating the hub and topic
         websub:addWebSubLinkHeader(response, [webSubHub.hubUrl], WEBSUB_TOPIC_FOUR);
@@ -141,7 +139,7 @@ service<http:Service> publisherTwo bind publisherServiceEP {
     @http:ResourceConfig {
         methods: ["POST"]
     }
-    notify(endpoint caller, http:Request req) {
+    resource function notify(http:Caller caller, http:Request req) {
         http:Response response = new;
         response.statusCode = 202;
         var err = caller->respond(response);

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/02_redirection_publishers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/02_redirection_publishers.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/log;
 import ballerina/websub;
 
-listener http:Server publisherServiceEPTwo = new http:Server(8081);
+listener http:Listener publisherServiceEPTwo = new http:Listener(8081);
 
 service original on publisherServiceEPTwo {
     resource function one(http:Caller caller, http:Request req) {

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/02_redirection_publishers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/02_redirection_publishers.bal
@@ -18,24 +18,22 @@ import ballerina/http;
 import ballerina/log;
 import ballerina/websub;
 
-endpoint http:Listener publisherServiceEPTwo {
-    port:8081
-};
+listener http:Server publisherServiceEPTwo = new http:Server(8081);
 
-service<http:Service> original bind publisherServiceEPTwo {
-    one(endpoint caller, http:Request req) {
+service original on publisherServiceEPTwo {
+    resource function one(http:Caller caller, http:Request req) {
         http:Response res = new;
         _ = caller->redirect(res, http:REDIRECT_MOVED_PERMANENTLY_301, ["http://localhost:8081/redirected/one"]);
     }
 
-    two(endpoint caller, http:Request req) {
+    resource function two(http:Caller caller, http:Request req) {
         http:Response res = new;
         _ = caller->redirect(res, http:REDIRECT_FOUND_302, ["http://localhost:8081/redirected/two"]);
     }
 }
 
-service<http:Service> redirected bind publisherServiceEPTwo {
-    one(endpoint caller, http:Request req) {
+service redirected on publisherServiceEPTwo {
+    resource function one(http:Caller caller, http:Request req) {
         http:Response res = new;
         websub:addWebSubLinkHeader(res, ["http://localhost:8081/hub/one"], WEBSUB_TOPIC_FIVE);
         var err = caller->respond(res);
@@ -44,7 +42,7 @@ service<http:Service> redirected bind publisherServiceEPTwo {
         }
     }
 
-    two(endpoint caller, http:Request req) {
+    resource function two(http:Caller caller, http:Request req) {
         http:Response res = new;
         websub:addWebSubLinkHeader(res, ["http://localhost:8081/hub/two"], WEBSUB_TOPIC_SIX);
         var err = caller->respond(res);
@@ -54,13 +52,13 @@ service<http:Service> redirected bind publisherServiceEPTwo {
     }
 }
 
-service<http:Service> hub bind publisherServiceEPTwo {
-    one(endpoint caller, http:Request req) {
+service hub on publisherServiceEPTwo {
+    resource function one(http:Caller caller, http:Request req) {
         http:Response res = new;
         _ = caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, ["https://localhost:9191/websub/hub"]);
     }
 
-    two(endpoint caller, http:Request req) {
+    resource function two(http:Caller caller, http:Request req) {
         http:Response res = new;
         _ = caller->redirect(res, http:REDIRECT_PERMANENT_REDIRECT_308, ["https://localhost:9191/websub/hub"]);
     }

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_custom_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_custom_subscribers.bal
@@ -103,7 +103,7 @@ public type WebhookServerForPayload object {
 
     *AbstractListener;
 
-    private websub:Server websubServer;
+    private websub:Listener websubListener;
 
     public function __init(WebhookListenerConfiguration config) {
         websub:ExtensionConfig extensionConfig = {
@@ -125,19 +125,19 @@ public type WebhookServerForPayload object {
             port: config.port,
             extensionConfig: extensionConfig
         };
-        self.websubServer = new(sseConfig);
+        self.websubListener = new(sseConfig);
     }
 
     public function __attach(service serviceType, map<any> data) returns error? {
-        return self.websubServer.__attach(serviceType, data);
+        return self.websubListener.__attach(serviceType, data);
     }
 
     public function __start() returns error? {
-        return self.websubServer.__start();
+        return self.websubListener.__start();
     }
 
     public function __stop() returns error? {
-        return self.websubServer.__stop();
+        return self.websubListener.__stop();
     }
 };
 
@@ -146,7 +146,7 @@ public type WebhookServerForHeader object {
 
     *AbstractListener;
 
-    private websub:Server websubServer;
+    private websub:Listener websubListener;
 
     public function __init(WebhookListenerConfiguration config) {
         websub:ExtensionConfig extensionConfig = {
@@ -163,19 +163,19 @@ public type WebhookServerForHeader object {
             port: config.port,
             extensionConfig: extensionConfig
         };
-        self.websubServer = new(sseConfig);
+        self.websubListener = new(sseConfig);
     }
 
     public function __attach(service serviceType, map<any> data) returns error? {
-        return self.websubServer.__attach(serviceType, data);
+        return self.websubListener.__attach(serviceType, data);
     }
 
     public function __start() returns error? {
-        return self.websubServer.__start();
+        return self.websubListener.__start();
     }
 
     public function __stop() returns error? {
-        return self.websubServer.__stop();
+        return self.websubListener.__stop();
     }
 };
 
@@ -184,7 +184,7 @@ public type WebhookServerForHeaderAndPayload object {
 
     *AbstractListener;
 
-    private websub:Server websubServer;
+    private websub:Listener websubListener;
 
     public function __init(WebhookListenerConfiguration config) {
         websub:ExtensionConfig extensionConfig = {
@@ -222,18 +222,18 @@ public type WebhookServerForHeaderAndPayload object {
             port: config.port,
             extensionConfig: extensionConfig
         };
-        self.websubServer = new(sseConfig);
+        self.websubListener = new(sseConfig);
     }
 
     public function __attach(service serviceType, map<any> data) returns error? {
-        return self.websubServer.__attach(serviceType, data);
+        return self.websubListener.__attach(serviceType, data);
     }
 
     public function __start() returns error? {
-        return self.websubServer.__start();
+        return self.websubListener.__start();
     }
 
     public function __stop() returns error? {
-        return self.websubServer.__stop();
+        return self.websubListener.__stop();
     }
 };

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_different_content_type_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_different_content_type_subscribers.bal
@@ -19,9 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-endpoint websub:Listener websubEP {
-    port:8282
-};
+listener websub:Server websubEP = new websub:Server({ port: 8282 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",
@@ -31,8 +29,8 @@ endpoint websub:Listener websubEP {
     leaseSeconds: 3000,
     secret: "Kslk30SNF2AChs2"
 }
-service<websub:Service> websubSubscriber bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriber on websubEP {
+    resource function onNotification (websub:Notification notification) {
         if (notification.getContentType() == mime:TEXT_PLAIN) {
             var payload = notification.getTextPayload();
             if (payload is string) {
@@ -65,8 +63,8 @@ service<websub:Service> websubSubscriber bind websubEP {
     topic: "http://one.websub.topic.com",
     leaseSeconds: 1000
 }
-service<websub:Service> websubSubscriberTwo bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriberTwo on websubEP {
+    resource function onNotification (websub:Notification notification) {
         if (notification.getContentType() == mime:TEXT_PLAIN) {
             var payload = notification.getTextPayload();
             if (payload is string) {

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_different_content_type_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_different_content_type_subscribers.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Server websubEP = new websub:Server({ port: 8282 });
+listener websub:Listener websubEP = new websub:Listener({ port: 8282 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_multiple_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_multiple_subscribers.bal
@@ -19,9 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-endpoint websub:Listener websubEP {
-    port:8383
-};
+listener websub:Server websubEP = new websub:Server({ port: 8383 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",
@@ -32,8 +30,8 @@ endpoint websub:Listener websubEP {
     leaseSeconds: 3600,
     secret: "Kslk30SNF2AChs2"
 }
-service<websub:Service> websubSubscriber bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriber on websubEP {
+    resource function onNotification (websub:Notification notification) {
         var payload = notification.getJsonPayload();
         if (payload is json) {
             io:println("WebSub Notification Received by One: " + payload.toString());
@@ -50,8 +48,8 @@ service<websub:Service> websubSubscriber bind websubEP {
     leaseSeconds: 1200,
     secret: "SwklSSf42DLA"
 }
-service<websub:Service> websubSubscriberTwo bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriberTwo on websubEP {
+    resource function onNotification (websub:Notification notification) {
         var payload = notification.getJsonPayload();
         if (payload is json) {
             io:println("WebSub Notification Received by Two: " + payload.toString());

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_multiple_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_multiple_subscribers.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Server websubEP = new websub:Server({ port: 8383 });
+listener websub:Listener websubEP = new websub:Listener({ port: 8383 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_redirected_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_redirected_subscribers.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Server websubEP = new websub:Server({ port: 8484 });
+listener websub:Listener websubEP = new websub:Listener({ port: 8484 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_redirected_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_redirected_subscribers.bal
@@ -19,9 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-endpoint websub:Listener websubEP {
-    port:8484
-};
+listener websub:Server websubEP = new websub:Server({ port: 8484 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",
@@ -33,8 +31,8 @@ endpoint websub:Listener websubEP {
         enabled: true
     }
 }
-service<websub:Service> websubSubscriber bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriber on websubEP {
+    resource function onNotification (websub:Notification notification) {
         var payload = notification.getJsonPayload();
         if (payload is json) {
             io:println("WebSub Notification Received: " + payload.toString());
@@ -54,8 +52,8 @@ service<websub:Service> websubSubscriber bind websubEP {
         enabled: true
     }
 }
-service<websub:Service> websubSubscriberTwo bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriberTwo on websubEP {
+    resource function onNotification (websub:Notification notification) {
         var payload = notification.getJsonPayload();
         if (payload is json) {
             io:println("WebSub Notification Received: " + payload.toString());

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_subscriber.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_subscriber.bal
@@ -20,9 +20,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-endpoint websub:Listener websubEP {
-    port:8181
-};
+listener websub:Server websubEP = new websub:Server({ port: 8181 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",
@@ -30,8 +28,8 @@ endpoint websub:Listener websubEP {
     topic: "http://one.websub.topic.com",
     hub: config:getAsString("test.hub.url")
 }
-service<websub:Service> websubSubscriber bind websubEP {
-    onNotification (websub:Notification notification) {
+service websubSubscriber on websubEP {
+    resource function onNotification (websub:Notification notification) {
         var payload = notification.getJsonPayload();
         if (payload is json) {
             io:println("WebSub Notification Received: " + payload.toString());
@@ -49,8 +47,8 @@ service<websub:Service> websubSubscriber bind websubEP {
     leaseSeconds: 3650,
     secret: "Kslk30SNF2AChs2"
 }
-service<websub:Service> websubSubscriberTwo bind websubEP {
-    onIntentVerification (endpoint caller, websub:IntentVerificationRequest request) {
+service websubSubscriberTwo on websubEP {
+    resource function onIntentVerification (websub:Caller caller, websub:IntentVerificationRequest request) {
         http:Response response = request.buildSubscriptionVerificationResponse("http://one.websub.topic.com");
         if (response.statusCode == 202) {
             io:println("Intent verified explicitly for subscription change request");
@@ -60,7 +58,7 @@ service<websub:Service> websubSubscriberTwo bind websubEP {
         _ = caller->respond(untaint response);
     }
 
-    onNotification (websub:Notification notification) {
+    resource function onNotification (websub:Notification notification) {
         var payload = notification.getPayloadAsString();
         if (payload is string) {
             io:println("WebSub Notification Received by Two: " + payload);

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_subscriber.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_subscriber.bal
@@ -20,7 +20,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Server websubEP = new websub:Server({ port: 8181 });
+listener websub:Listener websubEP = new websub:Listener({ port: 8181 });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_unsubscription_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_unsubscription_client.bal
@@ -18,10 +18,10 @@ import ballerina/io;
 import ballerina/runtime;
 import ballerina/websub;
 
-// This is the remote WebSub Hub Endpoint to which subscription and unsubscription requests are sent.
-endpoint websub:Client websubHubClientEP {
+// This is the client used to send subscription and unsubscription requests.
+websub:Client websubHubClientEP = new websub:Client({
     url: "https://localhost:9191/websub/hub"
-};
+});
 
 public function main(string... args) {
 


### PR DESCRIPTION
## Purpose
This PR changes the `websub:Server` to `websub:Listener` and migrates tests according to the latest changes.