### PR TITLE
[WebSub] Update Listener and Client __init functions

### DIFF
--- a/stdlib/websub/src/main/ballerina/websub/hub_client.bal
+++ b/stdlib/websub/src/main/ballerina/websub/hub_client.bal
@@ -27,20 +27,23 @@ import ballerina/mime;
 public type Client client object {
 
     public string hubUrl;
-    HubClientEndpointConfig config = {};
+    HubClientEndpointConfig? config = ();
 
     private http:Client httpClientEndpoint;
     private http:FollowRedirects? followRedirects = ();
 
-    public function __init(HubClientEndpointConfig config) {
-        self.hubUrl = config.url;
-        http:ClientEndpointConfig httpConfig = {
-            url: config.url,
-            auth: config.auth,
-            secureSocket: config.clientSecureSocket,
-            followRedirects: config.followRedirects
-        };
-        self.httpClientEndpoint = new (self.hubUrl, config = httpConfig);
+    public function __init(string url, HubClientEndpointConfig? config = ()) {
+        self.hubUrl = url;
+        http:ClientEndpointConfig? httpClientConfig = ();
+        if (config is HubClientEndpointConfig) {
+            http:ClientEndpointConfig httpConfig = {
+                auth: config.auth,
+                secureSocket: config.clientSecureSocket,
+                followRedirects: config.followRedirects
+            };
+            httpClientConfig = httpConfig;
+        }
+        self.httpClientEndpoint = new (self.hubUrl, config = httpClientConfig);
         self.config = config;
     }
 
@@ -221,12 +224,10 @@ remote function Client.notifyUpdate(string topic, map<string>? headers = ()) ret
 
 # Record representing the configuration parameters for the WebSub Hub Client Endpoint.
 #
-# + url - The URL of the target Hub
 # + clientSecureSocket - SSL/TLS related options for the underlying HTTP Client
 # + auth - Authentication mechanism for the underlying HTTP Client
 # + followRedirects - HTTP redirect related configuration
 public type HubClientEndpointConfig record {
-    string url = "";
     http:SecureSocket? clientSecureSocket = ();
     http:AuthConfig? auth = ();
     http:FollowRedirects? followRedirects = ();

--- a/stdlib/websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
+++ b/stdlib/websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
@@ -258,11 +258,10 @@ function retrieveHubAndTopicUrl(string resourceUrl, http:AuthConfig? auth, http:
 # + subscriptionDetails - Map containing subscription details
 function invokeClientConnectorForSubscription(string hub, http:AuthConfig? auth, http:SecureSocket? localSecureSocket,
                                               http:FollowRedirects? followRedirects, map subscriptionDetails) {
-    Client websubHubClientEP = new Client({
-        url:hub,
+    Client websubHubClientEP = new Client(hub, config = {
         clientSecureSocket: localSecureSocket,
-        auth:auth,
-        followRedirects:followRedirects
+        auth: auth,
+        followRedirects: followRedirects
     });
 
     string topic = <string>subscriptionDetails.topic;

--- a/stdlib/websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
+++ b/stdlib/websub/src/main/ballerina/websub/subscriber_service_endpoint.bal
@@ -27,12 +27,12 @@ public type Listener object {
 
     *AbstractListener;
 
-    public SubscriberServiceEndpointConfiguration config = {};
+    public SubscriberServiceEndpointConfiguration? config = ();
 
     private http:Listener? serviceEndpoint = ();
 
-    public function __init(SubscriberServiceEndpointConfiguration config) {
-        self.init(config);
+    public function __init(int port, SubscriberServiceEndpointConfiguration? config = ()) {
+        self.init(port, sseEpConfig =  config);
     }
 
     public function __attach(service s, map<any> data) returns error? {
@@ -43,8 +43,8 @@ public type Listener object {
 
     # Gets called when the endpoint is being initialized during module initialization.
     #
-    # + c - The Subscriber Service Endpoint Configuration of the endpoint
-    function init(SubscriberServiceEndpointConfiguration c);
+    # + sseEpConfig - The Subscriber Service Endpoint Configuration of the endpoint
+    function init(int port, SubscriberServiceEndpointConfiguration? sseEpConfig = ());
 
     extern function initWebSubSubscriberServiceEndpoint();
 
@@ -70,16 +70,17 @@ public type Listener object {
 
 };
 
-function Listener.init(SubscriberServiceEndpointConfiguration c) {
-    self.config = c;
-    http:ServiceEndpointConfiguration serviceConfig = {
-        host: c.host,
-        port: c.port,
-        secureSocket:
-        c.httpServiceSecureSocket
-    };
-    http:Listener httpEndpoint = new(c.port, config = serviceConfig);
-    //httpEndpoint.init(serviceConfig);
+function Listener.init(int port, SubscriberServiceEndpointConfiguration? sseEpConfig = ()) {
+    self.config = sseEpConfig;
+    http:ServiceEndpointConfiguration? serviceConfig = ();
+    if (sseEpConfig is SubscriberServiceEndpointConfiguration) {
+        http:ServiceEndpointConfiguration httpServiceConfig = {
+            host: sseEpConfig.host,
+            secureSocket: sseEpConfig.httpServiceSecureSocket
+        };
+        serviceConfig = httpServiceConfig;
+    }
+    http:Listener httpEndpoint = new(port, config = serviceConfig);
     self.serviceEndpoint = httpEndpoint;
 
     self.initWebSubSubscriberServiceEndpoint();
@@ -164,12 +165,10 @@ function Listener.sendSubscriptionRequests() {
 # Object representing the configuration for the WebSub Subscriber Service Endpoint.
 #
 # + host - The host name/IP of the endpoint
-# + port - The port to which the endpoint should bind to
 # + httpServiceSecureSocket - The SSL configurations for the service endpoint
 # + extensionConfig - The extension configuration to introduce custom subscriber services (webhooks)
 public type SubscriberServiceEndpointConfiguration record {
     string host = "";
-    int port = 0;
     http:ServiceSecureSocket? httpServiceSecureSocket = ();
     ExtensionConfig? extensionConfig = ();
     !...

--- a/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/InitWebSubSubscriberServiceEndpoint.java
+++ b/stdlib/websub/src/main/java/org/ballerinalang/net/websub/nativeimpl/InitWebSubSubscriberServiceEndpoint.java
@@ -81,10 +81,10 @@ public class InitWebSubSubscriberServiceEndpoint extends BlockingNativeCallableU
 
         WebSubServicesRegistry webSubServicesRegistry;
 
-        BMap<String, BValue> extensionConfig = (BMap<String, BValue>) config.get(SERVICE_CONFIG_EXTENSION_CONFIG);
-        if (extensionConfig == null) {
+        if (config == null || config.get(SERVICE_CONFIG_EXTENSION_CONFIG) == null) {
              webSubServicesRegistry = new WebSubServicesRegistry(new WebSocketServicesRegistry());
         } else {
+            BMap<String, BValue> extensionConfig = (BMap<String, BValue>) config.get(SERVICE_CONFIG_EXTENSION_CONFIG);
             String topicIdentifier = extensionConfig.get(EXTENSION_CONFIG_TOPIC_IDENTIFIER).stringValue();
             BString topicHeader = null;
             BMap<String, BValue> headerResourceMap = null;

--- a/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/services/01_websub_publisher.bal
@@ -30,9 +30,7 @@ boolean remoteTopicRegistered = false;
 
 websub:WebSubHub webSubHub = startHubAndRegisterTopic();
 
-websub:Client websubHubClientEP = new websub:Client({
-    url: webSubHub.hubUrl
-});
+websub:Client websubHubClientEP = new websub:Client(webSubHub.hubUrl);
 
 listener http:Listener publisherServiceEP = new http:Listener(8080);
 

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_custom_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_custom_subscribers.bal
@@ -22,7 +22,6 @@ const string MOCK_HEADER = "MockHeader";
 
 public type WebhookListenerConfiguration record {
     string host = "";
-    int port = 0;
 };
 
 public type MockActionEvent record {
@@ -36,7 +35,7 @@ public type MockDomainEvent record {
 @websub:SubscriberServiceConfig {
     path:"/key"
 }
-service keyWebhook on new WebhookServerForPayload({port: 8585}) {
+service keyWebhook on new WebhookServerForPayload(8585) {
     resource function onCreated(websub:Notification notification, MockActionEvent event) {
         io:println("Created Notification Received, action: ", event.action);
     }
@@ -53,7 +52,7 @@ service keyWebhook on new WebhookServerForPayload({port: 8585}) {
 @websub:SubscriberServiceConfig {
     path:"/header"
 }
-service headerWebhook on new WebhookServerForHeader({port: 8686}) {
+service headerWebhook on new WebhookServerForHeader(8686) {
     resource function onIssue(websub:Notification notification, MockActionEvent event) {
         io:println("Issue Notification Received, header value: ", notification.getHeader(MOCK_HEADER),
             " action: ", event.action);
@@ -72,7 +71,7 @@ service headerWebhook on new WebhookServerForHeader({port: 8686}) {
 @websub:SubscriberServiceConfig {
     path:"/headerAndPayload"
 }
-service headerAndPayloadWebhook on new WebhookServerForHeaderAndPayload({port: 8787}) {
+service headerAndPayloadWebhook on new WebhookServerForHeaderAndPayload(8787) {
     resource function onIssueCreated(websub:Notification notification, MockActionEvent event) {
         io:println("Issue Created Notification Received, header value: ", notification.getHeader(MOCK_HEADER),
             " action: ", event.action);
@@ -105,7 +104,7 @@ public type WebhookServerForPayload object {
 
     private websub:Listener websubListener;
 
-    public function __init(WebhookListenerConfiguration config) {
+    public function __init(int port, WebhookListenerConfiguration? config = ()) {
         websub:ExtensionConfig extensionConfig = {
             topicIdentifier: websub:TOPIC_ID_PAYLOAD_KEY,
             payloadKeyResourceMap: {
@@ -120,12 +119,12 @@ public type WebhookServerForPayload object {
                 }
             }
         };
+        string host = config is () ? "" : config.host;
         websub:SubscriberServiceEndpointConfiguration sseConfig = {
-            host: config.host,
-            port: config.port,
+            host: host,
             extensionConfig: extensionConfig
         };
-        self.websubListener = new(sseConfig);
+        self.websubListener = new(port, config = sseConfig);
     }
 
     public function __attach(service serviceType, map<any> data) returns error? {
@@ -148,7 +147,7 @@ public type WebhookServerForHeader object {
 
     private websub:Listener websubListener;
 
-    public function __init(WebhookListenerConfiguration config) {
+    public function __init(int port, WebhookListenerConfiguration? config = ()) {
         websub:ExtensionConfig extensionConfig = {
             topicIdentifier: websub:TOPIC_ID_HEADER,
             topicHeader: MOCK_HEADER,
@@ -158,12 +157,12 @@ public type WebhookServerForHeader object {
                 "status" : ("onStatus", MockActionEvent)
             }
         };
+        string host = config is () ? "" : config.host;
         websub:SubscriberServiceEndpointConfiguration sseConfig = {
-            host: config.host,
-            port: config.port,
+            host: host,
             extensionConfig: extensionConfig
         };
-        self.websubListener = new(sseConfig);
+        self.websubListener = new(port, config = sseConfig);
     }
 
     public function __attach(service serviceType, map<any> data) returns error? {
@@ -186,7 +185,7 @@ public type WebhookServerForHeaderAndPayload object {
 
     private websub:Listener websubListener;
 
-    public function __init(WebhookListenerConfiguration config) {
+    public function __init(int port, WebhookListenerConfiguration? config = ()) {
         websub:ExtensionConfig extensionConfig = {
             topicIdentifier: websub:TOPIC_ID_HEADER_AND_PAYLOAD,
             topicHeader: MOCK_HEADER,
@@ -217,12 +216,12 @@ public type WebhookServerForHeaderAndPayload object {
                 }
             }
         };
+        string host = config is () ? "" : config.host;
         websub:SubscriberServiceEndpointConfiguration sseConfig = {
-            host: config.host,
-            port: config.port,
+            host: host,
             extensionConfig: extensionConfig
         };
-        self.websubListener = new(sseConfig);
+        self.websubListener = new(port, config = sseConfig);
     }
 
     public function __attach(service serviceType, map<any> data) returns error? {

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_different_content_type_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_different_content_type_subscribers.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Listener websubEP = new websub:Listener({ port: 8282 });
+listener websub:Listener websubEP = new websub:Listener(8282);
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_multiple_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_multiple_subscribers.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Listener websubEP = new websub:Listener({ port: 8383 });
+listener websub:Listener websubEP = new websub:Listener(8383);
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_redirected_subscribers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_redirected_subscribers.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Listener websubEP = new websub:Listener({ port: 8484 });
+listener websub:Listener websubEP = new websub:Listener(8484);
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_subscriber.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_subscriber.bal
@@ -20,7 +20,7 @@ import ballerina/mime;
 import ballerina/http;
 import ballerina/websub;
 
-listener websub:Listener websubEP = new websub:Listener({ port: 8181 });
+listener websub:Listener websubEP = new websub:Listener(8181, config = { host: "0.0.0.0" });
 
 @websub:SubscriberServiceConfig {
     path:"/websub",

--- a/tests/ballerina-integration-test/src/test/resources/websub/test_unsubscription_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websub/test_unsubscription_client.bal
@@ -19,9 +19,7 @@ import ballerina/runtime;
 import ballerina/websub;
 
 // This is the client used to send subscription and unsubscription requests.
-websub:Client websubHubClientEP = new websub:Client({
-    url: "https://localhost:9191/websub/hub"
-});
+websub:Client websubHubClientEP = new websub:Client("https://localhost:9191/websub/hub");
 
 public function main(string... args) {
 


### PR DESCRIPTION
## Purpose
This PR updates 
- the `websub:Listener` `__init` function to accept the port as a required parameter and config as an optional parameter
- the `websub:Client` `__init` function to accept the URL as a required parameter and config as an optional parameter

In both cases the ability to specify these values via the config itself has been removed.