### PR TITLE
Improving String representation for stamped values

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
@@ -293,7 +293,8 @@ public class BMap<K, V extends BValue> implements BRefType, BCollection, Seriali
                 case TypeTags.JSON_TAG:
                     return getJSONString();
                 default:
-                    String keySeparator = type.getTag() == TypeTags.MAP_TAG ? "\"" : "";
+                    String keySeparator = type.getTag() == TypeTags.MAP_TAG || type.getTag() == TypeTags.ANYDATA_TAG
+                            ? "\"" : "";
                     for (Iterator<Map.Entry<K, V>> i = map.entrySet().iterator(); i.hasNext();) {
                         String key;
                         Map.Entry<K, V> e = i.next();
@@ -329,7 +330,8 @@ public class BMap<K, V extends BValue> implements BRefType, BCollection, Seriali
                 case TypeTags.JSON_TAG:
                     return getJSONString();
                 default:
-                    String keySeparator = type.getTag() == TypeTags.MAP_TAG ? "\"" : "";
+                    String keySeparator = type.getTag() == TypeTags.MAP_TAG || type.getTag() == TypeTags.ANYDATA_TAG
+                            ? "\"" : "";
                     map.forEach((mapKey, value) -> {
                         String key = keySeparator + mapKey + keySeparator;
                         sj.add(key + ":" + getStringValue(value));


### PR DESCRIPTION
## Purpose

This will fix following issues when getting string representation for stamped values.

1. Fix casting issue when serializing non ref array 

Class cast exception can be observed When getting json string from json type map when it contains any non ref array ( ex.array).
This will also fix not serializing record types and json arrays in json generator.

2. Fix Bmap toString method for record types 

After stamping map to anydata type, it will have the type as Anydata. When getting the string value of that bmap, key will be printed without double quotes hence existing test cases will be failed.
This will be fixed with handling for record types as well.

