### PR TITLE
Remove @readonly annotation from standard lib source

### DIFF
--- a/stdlib/http/src/main/ballerina/http/http_filter.bal
+++ b/stdlib/http/src/main/ballerina/http/http_filter.bal
@@ -43,10 +43,10 @@ public type Filter abstract object {
 # + attributes - Attributes to share between filters
 public type FilterContext object {
 
-    @readonly public service serviceType;
-    @readonly public string serviceName = "";
-    @readonly public string resourceName = "";
-    @readonly public map<any> attributes = {};
+    public service serviceType;
+    public string serviceName = "";
+    public string resourceName = "";
+    public map<any> attributes = {};
 
     public function __init(service serviceType, string serviceName, string resourceName) {
         self.serviceType = serviceType;

--- a/stdlib/http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/service_endpoint.bal
@@ -99,8 +99,8 @@ function Listener.init(ServiceEndpointConfiguration c) {
 # + host - The remote host name/IP
 # + port - The remote port
 public type Remote record {
-    @readonly string host = "";
-    @readonly int port = 0;
+    string host = "";
+    int port = 0;
     !...
 };
 
@@ -109,8 +109,8 @@ public type Remote record {
 # + host - The local host name/IP
 # + port - The local port
 public type Local record {
-    @readonly string host = "";
-    @readonly int port = 0;
+    string host = "";
+    int port = 0;
     !...
 };
 

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_caller.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_caller.bal
@@ -23,11 +23,11 @@
 # + attributes - A map to store connection related attributes
 public type WebSocketCaller client object {
 
-    @readonly public string id = "";
-    @readonly public string negotiatedSubProtocol = "";
-    @readonly public boolean isSecure = false;
-    @readonly public boolean isOpen = false;
-    @readonly public map<any> attributes = {};
+    public string id = "";
+    public string negotiatedSubProtocol = "";
+    public boolean isSecure = false;
+    public boolean isOpen = false;
+    public map<any> attributes = {};
 
     private WebSocketConnector conn = new;
 

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
@@ -24,12 +24,12 @@
 # + attributes - A map to store connection related attributes
 public type WebSocketClient client object {
 
-    @readonly public string id = "";
-    @readonly public string negotiatedSubProtocol = "";
-    @readonly public boolean isSecure = false;
-    @readonly public boolean isOpen = false;
-    @readonly public Response response = new;
-    @readonly public map<any> attributes = {};
+    public string id = "";
+    public string negotiatedSubProtocol = "";
+    public boolean isSecure = false;
+    public boolean isOpen = false;
+    public Response response = new;
+    public map<any> attributes = {};
 
     private WebSocketConnector conn = new;
     private string url = "";

--- a/stdlib/observability/src/main/ballerina/observe/natives.bal
+++ b/stdlib/observability/src/main/ballerina/observe/natives.bal
@@ -68,9 +68,9 @@ public extern function lookupMetric(string name, map<string>? tags = ()) returns
 # + metricTags - Tags associated with the counter metric.
 public type Counter object {
 
-    @readonly public string name;
-    @readonly public string description;
-    @readonly public map<string> metricTags;
+    public string name;
+    public string description;
+    public map<string> metricTags;
 
     # This instantiates the Counter object. Name field is mandatory, and description and tags fields
     # are optional and have its own default values when no params are passed.
@@ -132,10 +132,10 @@ public type Counter object {
 #                      of the gauge during its usage.
 public type Gauge object {
 
-    @readonly public string name;
-    @readonly public string description;
-    @readonly public map<string> metricTags;
-    @readonly public StatisticConfig[] statisticConfigs;
+    public string name;
+    public string description;
+    public map<string> metricTags;
+    public StatisticConfig[] statisticConfigs;
 
     # This instantiates the Gauge object. Name field is mandatory, and description, tags, and statitics config fields
     # are optional and have its own default values when no params are passed.
@@ -220,12 +220,12 @@ public type Gauge object {
 # + value - Current value the metric.
 # + summary - If the metric is configured with statistics config, then the calculated statistics of the metric.
 public type Metric record {
-    @readonly string name;
-    @readonly string desc;
-    @readonly map<string> tags;
-    @readonly string metricType;
-    @readonly int|float value;
-    @readonly Snapshot[]? summary;
+    string name;
+    string desc;
+    map<string> tags;
+    string metricType;
+    int|float value;
+    Snapshot[]? summary;
 };
 
 # This represents the statistic configuration that can be used to instatiate gauge metric.
@@ -244,8 +244,8 @@ public type StatisticConfig record {
 # + percentile - The percentile of the reported value.
 # + value - The value of the percentile.
 public type PercentileValue record {
-    @readonly float percentile;
-    @readonly float value;
+    float percentile;
+    float value;
 };
 
 # This represents the snapshot of the statistics calculation of the gauge.
@@ -257,10 +257,10 @@ public type PercentileValue record {
 # + stdDev - The standard deviation value within the time window.
 # + percentileValues - The percentiles values calculated wihtin the time window.
 public type Snapshot record {
-    @readonly int timeWindow;
-    @readonly float mean;
-    @readonly float max;
-    @readonly float min;
-    @readonly float stdDev;
-    @readonly PercentileValue[] percentileValues;
+    int timeWindow;
+    float mean;
+    float max;
+    float min;
+    float stdDev;
+    PercentileValue[] percentileValues;
 };

--- a/stdlib/transactions/src/main/ballerina/transactions/2pc_participant.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/2pc_participant.bal
@@ -20,14 +20,14 @@ import ballerina/log;
 #
 # + name - protocol name
 type Protocol record {
-    @readonly string name = "";
+    string name = "";
 };
 
 # This represents the protocol associated with the coordination type.
 #
 # + name - protocol name
 type LocalProtocol record {
-    @readonly string name = "";
+    string name = "";
 };
 
 # This represents the protocol associated with the coordination type.
@@ -36,8 +36,8 @@ type LocalProtocol record {
 # + url - protocol URL. This URL will have a value only if the participant is remote. If the participant is local,
 #         the `protocolFn` will be called
 public type RemoteProtocol record {
-    @readonly string name = "";
-    @readonly string url = "";
+    string name = "";
+    string url = "";
 };
 
 type Participant abstract object {

--- a/stdlib/transactions/src/main/ballerina/transactions/data.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/data.bal
@@ -15,11 +15,11 @@
 // under the License.
 
 public type TransactionContext record {
-    @readonly string contextVersion = "1.0";
-    @readonly string transactionId = "";
-    @readonly int transactionBlockId = 0;
-    @readonly string coordinationType = "";
-    @readonly string registerAtURL = "";
+    string contextVersion = "1.0";
+    string transactionId = "";
+    int transactionBlockId = 0;
+    string coordinationType = "";
+    string registerAtURL = "";
 };
 
 type RegistrationRequest record {

--- a/stdlib/websub/src/main/ballerina/websub/hub_configuration.bal
+++ b/stdlib/websub/src/main/ballerina/websub/hub_configuration.bal
@@ -31,14 +31,14 @@ const string DEFAULT_DB_NAME = "HUB_DB";
 const string DEFAULT_DB_USERNAME = "sa";
 const string DEFAULT_DB_PASSWORD = "";
 
-@readonly string hubHost = DEFAULT_HOST;
-@readonly int hubPort = 0;
-@readonly int hubLeaseSeconds = DEFAULT_LEASE_SECONDS_VALUE;
-@readonly string hubSignatureMethod = DEFAULT_SIGNATURE_METHOD;
-@readonly boolean hubRemotePublishingEnabled = false;
-@readonly RemotePublishMode hubRemotePublishMode = PUBLISH_MODE_DIRECT;
-@readonly boolean hubTopicRegistrationRequired = false;
-@readonly string hubPublicUrl = "";
+string hubHost = DEFAULT_HOST;
+int hubPort = 0;
+int hubLeaseSeconds = DEFAULT_LEASE_SECONDS_VALUE;
+string hubSignatureMethod = DEFAULT_SIGNATURE_METHOD;
+boolean hubRemotePublishingEnabled = false;
+RemotePublishMode hubRemotePublishMode = PUBLISH_MODE_DIRECT;
+boolean hubTopicRegistrationRequired = false;
+string hubPublicUrl = "";
 
 final boolean hubPersistenceEnabled = config:getAsBoolean("b7a.websub.hub.enablepersistence");
 final string hubDatabaseDirectory = config:getAsString("b7a.websub.hub.db.directory", default = DEFAULT_DB_DIRECTORY);
@@ -47,9 +47,9 @@ final string hubDatabaseUsername = config:getAsString("b7a.websub.hub.db.usernam
 final string hubDatabasePassword = config:getAsString("b7a.websub.hub.db.password", default = DEFAULT_DB_PASSWORD);
 //TODO:add pool options
 
-@readonly boolean hubSslEnabled = false;
-@readonly http:ServiceSecureSocket? hubServiceSecureSocket = ();
-@readonly http:SecureSocket? hubClientSecureSocket = ();
+boolean hubSslEnabled = false;
+http:ServiceSecureSocket? hubServiceSecureSocket = ();
+http:SecureSocket? hubClientSecureSocket = ();
 
 # Function to bind and start the Ballerina WebSub Hub service.
 #


### PR DESCRIPTION
## Purpose
This is a temporary measure to fix the compilation failures. Need to go through each of these and replace with the proper alternative

