### PR TITLE
Update locked dependencies of vscode-plugin and extended-language-client

### DIFF
--- a/composer/extended-language-client/package-lock.json
+++ b/composer/extended-language-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "extended-language-client",
-  "version": "0.982.0",
+  "version": "0.983.1-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,9 +17,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.35.tgz",
-      "integrity": "sha512-kD1uIxy8hqpV34slD0giWLJEdSv4XGWID4OfmqPp0Z/+75z/+0stFmgkvbSRexgZWmN52YyF8mmBx87ZEAih6g==",
+      "version": "8.10.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+      "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
       "dev": true
     },
     "@types/pluralize": {
@@ -35,14 +35,14 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
+        "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "amdefine": {
@@ -84,6 +84,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "append-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "requires": {
+        "buffer-equal": "1.0.0"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -227,7 +235,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
       }
@@ -260,15 +267,19 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -366,41 +377,7 @@
         "inherits": "2.0.3",
         "process-nextick-args": "2.0.0",
         "readable-stream": "2.3.6"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        }
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -426,10 +403,9 @@
       }
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -455,7 +431,7 @@
       "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "growl": "1.10.5",
+        "growl": "1.10.3",
         "js-yaml": "3.12.0",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.7",
@@ -489,7 +465,7 @@
     },
     "deep-assign": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
       "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
       "requires": {
         "is-obj": "1.0.1"
@@ -510,16 +486,23 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -527,13 +510,13 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.0.6",
+        "readable-stream": "2.3.6",
         "stream-shift": "1.0.0"
       }
     },
@@ -541,7 +524,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
       "requires": {
         "jsbn": "0.1.1",
         "safer-buffer": "2.1.2"
@@ -571,12 +553,30 @@
         "esutils": "2.0.2",
         "optionator": "0.8.2",
         "source-map": "0.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "estraverse": {
@@ -592,12 +592,11 @@
       "dev": true
     },
     "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+      "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
       "requires": {
         "duplexer": "0.1.1",
-        "flatmap-stream": "0.1.1",
         "from": "0.1.7",
         "map-stream": "0.0.7",
         "pause-stream": "0.0.11",
@@ -616,7 +615,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "2.2.4"
@@ -656,9 +655,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -691,7 +690,7 @@
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "3.1.0",
+        "randomatic": "3.1.1",
         "repeat-element": "1.1.3",
         "repeat-string": "1.6.1"
       }
@@ -701,10 +700,14 @@
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
     },
-    "flatmap-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw=="
+    "flush-write-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -725,29 +728,28 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.20"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        }
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs-mkdirp-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+      "requires": {
+        "graceful-fs": "4.1.15",
+        "through2": "2.0.5"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -759,11 +761,16 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
+        "graceful-fs": "4.1.15",
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2"
       }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -780,10 +787,11 @@
       }
     },
     "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
+        "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "minimatch": "3.0.4",
@@ -847,6 +855,18 @@
         "unique-stream": "2.2.1"
       },
       "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -863,9 +883,14 @@
             "string_decoder": "0.10.31"
           }
         },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
         "through2": {
           "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
             "readable-stream": "1.0.34",
@@ -875,15 +900,14 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
     },
     "gulp-chmod": {
       "version": "2.0.0",
@@ -892,7 +916,7 @@
       "requires": {
         "deep-assign": "1.0.0",
         "stat-mode": "0.2.2",
-        "through2": "2.0.1"
+        "through2": "2.0.5"
       }
     },
     "gulp-filter": {
@@ -930,9 +954,14 @@
             "string_decoder": "0.10.31"
           }
         },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
         "through2": {
           "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
             "readable-stream": "1.0.34",
@@ -946,10 +975,10 @@
       "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
       "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
       "requires": {
-        "event-stream": "3.3.6",
-        "node.extend": "1.1.6",
+        "event-stream": "3.3.5",
+        "node.extend": "1.1.8",
         "request": "2.88.0",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "vinyl": "2.2.0"
       },
       "dependencies": {
@@ -962,42 +991,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
           "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
-          }
         },
         "vinyl": {
           "version": "2.2.0",
@@ -1020,9 +1013,9 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
         "convert-source-map": "1.6.0",
-        "graceful-fs": "4.1.11",
+        "graceful-fs": "4.1.15",
         "strip-bom": "2.0.0",
-        "through2": "2.0.1",
+        "through2": "2.0.5",
         "vinyl": "1.2.0"
       },
       "dependencies": {
@@ -1053,7 +1046,7 @@
       "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
       "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
       "requires": {
-        "event-stream": "3.3.6",
+        "event-stream": "3.3.5",
         "mkdirp": "0.5.1",
         "queue": "3.1.0",
         "vinyl-fs": "2.4.4"
@@ -1064,10 +1057,10 @@
       "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
       "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
       "requires": {
-        "event-stream": "3.3.6",
+        "event-stream": "3.3.5",
         "streamifier": "0.1.1",
         "tar": "2.2.1",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "vinyl": "1.2.0"
       },
       "dependencies": {
@@ -1076,46 +1069,10 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
         "replace-ext": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
-          }
         },
         "vinyl": {
           "version": "1.2.0",
@@ -1130,17 +1087,17 @@
       }
     },
     "gulp-vinyl-zip": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
-      "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.1.tgz",
+      "integrity": "sha512-OPnsZkMwiU8UbH5BMlYRb/SccOAZUnwUW7mQvqYadap8MMdgN7ae0ua1rMEE2s9EyqqijN1Sdvoz29/MbPaq9Q==",
       "requires": {
-        "event-stream": "3.3.6",
+        "event-stream": "3.3.5",
         "queue": "4.5.0",
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "vinyl": "2.2.0",
-        "vinyl-fs": "2.4.4",
+        "vinyl-fs": "3.0.3",
         "yauzl": "2.10.0",
-        "yazl": "2.4.3"
+        "yazl": "2.5.0"
       },
       "dependencies": {
         "clone": {
@@ -1153,10 +1110,35 @@
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
           "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
         },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        "glob-stream": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+          "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+          "requires": {
+            "extend": "3.0.2",
+            "glob": "7.1.3",
+            "glob-parent": "3.1.0",
+            "is-negated-glob": "1.0.0",
+            "ordered-read-streams": "1.0.1",
+            "pumpify": "1.5.1",
+            "readable-stream": "2.3.6",
+            "remove-trailing-separator": "1.1.0",
+            "to-absolute-glob": "2.0.2",
+            "unique-stream": "2.2.1"
+          }
+        },
+        "is-valid-glob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+          "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
+        },
+        "ordered-read-streams": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+          "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+          "requires": {
+            "readable-stream": "2.3.6"
+          }
         },
         "queue": {
           "version": "4.5.0",
@@ -1166,35 +1148,13 @@
             "inherits": "2.0.3"
           }
         },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+        "to-absolute-glob": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+          "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "is-absolute": "1.0.0",
+            "is-negated-glob": "1.0.0"
           }
         },
         "vinyl": {
@@ -1208,6 +1168,30 @@
             "cloneable-readable": "1.1.2",
             "remove-trailing-separator": "1.1.0",
             "replace-ext": "1.0.0"
+          }
+        },
+        "vinyl-fs": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+          "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+          "requires": {
+            "fs-mkdirp-stream": "1.0.0",
+            "glob-stream": "6.1.0",
+            "graceful-fs": "4.1.15",
+            "is-valid-glob": "1.0.0",
+            "lazystream": "1.0.0",
+            "lead": "1.0.0",
+            "object.assign": "4.1.0",
+            "pumpify": "1.5.1",
+            "readable-stream": "2.3.6",
+            "remove-bom-buffer": "3.0.0",
+            "remove-bom-stream": "1.2.0",
+            "resolve-options": "1.1.0",
+            "through2": "2.0.5",
+            "to-through": "2.0.0",
+            "value-or-function": "3.0.0",
+            "vinyl": "2.2.0",
+            "vinyl-sourcemap": "1.1.0"
           }
         }
       }
@@ -1232,12 +1216,6 @@
           "requires": {
             "lodash": "4.17.11"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },
@@ -1247,12 +1225,20 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "5.5.2",
+        "ajv": "6.5.5",
         "har-schema": "2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1265,10 +1251,14 @@
       }
     },
     "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "he": {
       "version": "1.1.1",
@@ -1282,7 +1272,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "sshpk": "1.15.2"
       }
     },
     "inflight": {
@@ -1303,6 +1293,15 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "requires": {
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -1340,6 +1339,11 @@
         "is-extglob": "2.1.1"
       }
     },
+    "is-negated-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -1373,6 +1377,14 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "1.0.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1383,6 +1395,14 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -1392,6 +1412,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1437,6 +1462,42 @@
         "supports-color": "3.2.3",
         "which": "1.3.1",
         "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "js-tokens": {
@@ -1453,21 +1514,12 @@
       "requires": {
         "argparse": "1.0.10",
         "esprima": "4.0.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1475,9 +1527,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1518,7 +1570,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "2.3.6"
       }
     },
     "lcov-parse": {
@@ -1526,6 +1578,14 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
+    },
+    "lead": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "requires": {
+        "flush-write-stream": "1.0.3"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -1575,7 +1635,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "2.3.6"
       }
     },
     "micromatch": {
@@ -1630,16 +1690,16 @@
       }
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "1.37.0"
       }
     },
     "minimatch": {
@@ -1651,10 +1711,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.10",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-      "dev": true
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1662,13 +1721,6 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
       }
     },
     "mocha": {
@@ -1690,10 +1742,22 @@
         "supports-color": "5.4.0"
       },
       "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+          "dev": true
+        },
         "commander": {
           "version": "2.15.1",
           "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         },
         "glob": {
@@ -1709,6 +1773,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "growl": {
+          "version": "1.10.5",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
@@ -1744,10 +1814,11 @@
       }
     },
     "node.extend": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-      "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+      "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
       "requires": {
+        "has": "1.0.3",
         "is": "3.2.1"
       }
     },
@@ -1768,6 +1839,14 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
+    "now-and-later": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+      "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1777,6 +1856,22 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -1801,7 +1896,7 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
+        "minimist": "0.0.8",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
@@ -1833,7 +1928,7 @@
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "requires": {
         "is-stream": "1.1.0",
-        "readable-stream": "2.0.6"
+        "readable-stream": "2.3.6"
       }
     },
     "parse-glob": {
@@ -1869,7 +1964,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
@@ -1926,19 +2021,38 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "requires": {
+        "duplexify": "3.6.1",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
+      }
+    },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -1946,9 +2060,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
     },
     "queue": {
       "version": "3.1.0",
@@ -1959,9 +2073,9 @@
       }
     },
     "randomatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "requires": {
         "is-number": "4.0.0",
         "kind-of": "6.0.2",
@@ -1981,15 +2095,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.0.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "0.10.31",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -1999,6 +2114,25 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
         "is-equal-shallow": "0.1.3"
+      }
+    },
+    "remove-bom-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+      "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+      "requires": {
+        "is-buffer": "1.1.6",
+        "is-utf8": "0.2.1"
+      }
+    },
+    "remove-bom-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+      "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+      "requires": {
+        "remove-bom-buffer": "3.0.0",
+        "safe-buffer": "5.1.2",
+        "through2": "2.0.5"
       }
     },
     "remove-trailing-separator": {
@@ -2032,13 +2166,13 @@
         "combined-stream": "1.0.7",
         "extend": "3.0.2",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.0",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
+        "mime-types": "2.1.21",
         "oauth-sign": "0.9.0",
         "performance-now": "2.1.0",
         "qs": "6.5.2",
@@ -2059,27 +2193,20 @@
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
+    "resolve-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+      "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "requires": {
+        "value-or-function": "3.0.0"
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "safe-buffer": {
@@ -2093,19 +2220,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.5.9",
@@ -2114,13 +2236,6 @@
       "requires": {
         "buffer-from": "1.1.1",
         "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
     "split": {
@@ -2138,9 +2253,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "requires": {
         "asn1": "0.2.4",
         "assert-plus": "1.0.0",
@@ -2177,7 +2292,7 @@
       "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
       "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "2.3.6"
       }
     },
     "streamifier": {
@@ -2186,9 +2301,12 @@
       "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -2217,17 +2335,16 @@
       }
     },
     "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "dev": true,
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "2.0.0"
       }
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
         "block-stream": "0.0.9",
@@ -2241,11 +2358,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-      "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
-        "readable-stream": "2.0.6",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },
@@ -2254,7 +2371,7 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "2.0.1",
+        "through2": "2.0.5",
         "xtend": "4.0.1"
       }
     },
@@ -2276,6 +2393,14 @@
         }
       }
     },
+    "to-through": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+      "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+      "requires": {
+        "through2": "2.0.5"
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -2283,6 +2408,13 @@
       "requires": {
         "psl": "1.1.29",
         "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "ts-node": {
@@ -2293,7 +2425,7 @@
       "requires": {
         "arrify": "1.0.1",
         "buffer-from": "1.1.1",
-        "diff": "3.5.0",
+        "diff": "3.3.1",
         "make-error": "1.3.5",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
@@ -2324,30 +2456,22 @@
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
         "chalk": "2.4.1",
-        "commander": "2.17.1",
-        "diff": "3.5.0",
+        "commander": "2.19.0",
+        "diff": "3.3.1",
         "glob": "7.1.3",
         "js-yaml": "3.12.0",
         "minimatch": "3.0.4",
         "resolve": "1.8.1",
-        "semver": "5.5.1",
+        "semver": "5.6.0",
         "tslib": "1.9.3",
         "tsutils": "2.29.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
         },
         "resolve": {
           "version": "1.8.1",
@@ -2380,8 +2504,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -2399,9 +2522,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
-      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
     },
     "uglify-js": {
@@ -2415,14 +2538,19 @@
         "source-map": "0.6.1"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
           "dev": true,
           "optional": true
         }
       }
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "unique-stream": {
       "version": "2.2.1",
@@ -2433,12 +2561,20 @@
         "through2-filter": "2.0.0"
       }
     },
-    "url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "querystringify": "2.0.0",
+        "punycode": "2.1.1"
+      }
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "requires": {
+        "querystringify": "2.1.0",
         "requires-port": "1.0.0"
       }
     },
@@ -2456,6 +2592,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+    },
+    "value-or-function": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
     },
     "verror": {
       "version": "1.10.0",
@@ -2481,9 +2622,9 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
-        "duplexify": "3.6.0",
+        "duplexify": "3.6.1",
         "glob-stream": "5.3.5",
-        "graceful-fs": "4.1.11",
+        "graceful-fs": "4.1.15",
         "gulp-sourcemaps": "1.6.0",
         "is-valid-glob": "0.3.0",
         "lazystream": "1.0.0",
@@ -2491,10 +2632,10 @@
         "merge-stream": "1.0.1",
         "mkdirp": "0.5.1",
         "object-assign": "4.1.1",
-        "readable-stream": "2.0.6",
+        "readable-stream": "2.3.6",
         "strip-bom": "2.0.0",
         "strip-bom-stream": "1.0.0",
-        "through2": "2.0.1",
+        "through2": "2.0.5",
         "through2-filter": "2.0.0",
         "vali-date": "1.0.0",
         "vinyl": "1.2.0"
@@ -2527,44 +2668,45 @@
       "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
       "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
       "requires": {
-        "through2": "2.0.3",
+        "through2": "2.0.5",
         "vinyl": "0.4.6"
+      }
+    },
+    "vinyl-sourcemap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+      "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "requires": {
+        "append-buffer": "1.0.2",
+        "convert-source-map": "1.6.0",
+        "graceful-fs": "4.1.15",
+        "normalize-path": "2.1.1",
+        "now-and-later": "2.0.0",
+        "remove-bom-buffer": "3.0.0",
+        "vinyl": "2.2.0"
       },
       "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
         },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
+        "clone-stats": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+        "vinyl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -2581,53 +2723,15 @@
         "gulp-remote-src-vscode": "0.5.0",
         "gulp-symdest": "1.1.0",
         "gulp-untar": "0.0.7",
-        "gulp-vinyl-zip": "2.1.0",
+        "gulp-vinyl-zip": "2.1.1",
         "mocha": "4.1.0",
         "request": "2.88.0",
-        "semver": "5.5.1",
+        "semver": "5.6.0",
         "source-map-support": "0.5.9",
-        "url-parse": "1.4.3",
+        "url-parse": "1.4.4",
         "vinyl-source-stream": "1.1.2"
       },
       "dependencies": {
-        "browser-stdout": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-        },
-        "diff": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
-        },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
         "mocha": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
@@ -2659,14 +2763,6 @@
               }
             }
           }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
         }
       }
     },
@@ -2676,11 +2772,11 @@
       "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
     },
     "vscode-languageclient": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.0.tgz",
-      "integrity": "sha512-Z95Kps8UqD4o17HE3uCkZuvenOsxHVH46dKmaGVpGixEFZigPaVuVxLM/JWeIY9aRenoC0ZD9CK1O7L4jpffKg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.1.tgz",
+      "integrity": "sha512-jMxshi+BPRQFNG8GB00dJv7ldqMda0be26laYYll/udtJuHbog6RqK10GSxHWDN0PgY0b0m5fePyTk3bq8a0TA==",
       "requires": {
-        "semver": "5.5.1",
+        "semver": "5.6.0",
         "vscode-languageserver-protocol": "3.13.0"
       }
     },
@@ -2733,9 +2829,9 @@
       }
     },
     "yazl": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
-      "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.0.tgz",
+      "integrity": "sha512-rgptqKwX/f1/7bIRF1FHb4HGsP5k11QyxBpDl1etUDfNpTa7CNjDOYNPFnIaEzZ9dRq0c47IEJS+sy+T39JCLw==",
       "requires": {
         "buffer-crc32": "0.2.13"
       }

--- a/tool-plugins/vscode/package-lock.json
+++ b/tool-plugins/vscode/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "ballerina",
-    "version": "0.982.1-SNAPSHOT",
+    "version": "0.983.1-SNAPSHOT",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@types/chai": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
-            "integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+            "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
             "dev": true
         },
         "@types/events": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
             "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
             "dev": true
         },
@@ -24,13 +24,13 @@
             "requires": {
                 "@types/events": "1.2.0",
                 "@types/minimatch": "3.0.3",
-                "@types/node": "8.10.36"
+                "@types/node": "8.10.38"
             }
         },
         "@types/lodash": {
-            "version": "4.14.117",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-            "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==",
+            "version": "4.14.118",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
+            "integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==",
             "dev": true
         },
         "@types/minimatch": {
@@ -46,9 +46,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.10.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
-            "integrity": "sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw==",
+            "version": "8.10.38",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+            "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
             "dev": true
         },
         "@types/ws": {
@@ -58,7 +58,7 @@
             "dev": true,
             "requires": {
                 "@types/events": "1.2.0",
-                "@types/node": "8.10.36"
+                "@types/node": "8.10.38"
             }
         },
         "abbrev": {
@@ -68,14 +68,14 @@
             "dev": true
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+            "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
+                "fast-deep-equal": "2.0.1",
                 "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
             }
         },
         "amdefine": {
@@ -116,6 +116,14 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+        },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "requires": {
+                "buffer-equal": "1.0.0"
+            }
         },
         "argparse": {
             "version": "1.0.10",
@@ -204,4961 +212,17 @@
                 "lodash": "4.17.11"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "@babel/highlight": "7.0.0"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "esutils": "2.0.2",
-                        "js-tokens": "4.0.0"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "js-tokens": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "@types/jest": {
-                    "version": "22.2.3",
-                    "bundled": true
-                },
-                "@types/lodash": {
-                    "version": "4.14.117",
-                    "bundled": true
-                },
-                "@types/node": {
-                    "version": "8.10.36",
-                    "bundled": true
-                },
-                "abab": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "acorn": {
-                    "version": "5.7.3",
-                    "bundled": true
-                },
-                "acorn-globals": {
-                    "version": "4.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "acorn": "6.0.2",
-                        "acorn-walk": "6.1.0"
-                    },
-                    "dependencies": {
-                        "acorn": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "acorn-walk": {
-                    "version": "6.1.0",
-                    "bundled": true
-                },
-                "ajv": {
-                    "version": "5.5.2",
-                    "bundled": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
-                    }
-                },
-                "ansi-escapes": {
-                    "version": "3.1.0",
-                    "bundled": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "bundled": true
-                },
-                "anymatch": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
-                    },
-                    "dependencies": {
-                        "arr-diff": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "array-unique": {
-                            "version": "0.3.2",
-                            "bundled": true
-                        },
-                        "braces": {
-                            "version": "2.3.2",
-                            "bundled": true,
-                            "requires": {
-                                "arr-flatten": "1.1.0",
-                                "array-unique": "0.3.2",
-                                "extend-shallow": "2.0.1",
-                                "fill-range": "4.0.0",
-                                "isobject": "3.0.1",
-                                "repeat-element": "1.1.3",
-                                "snapdragon": "0.8.2",
-                                "snapdragon-node": "2.1.1",
-                                "split-string": "3.1.0",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "expand-brackets": {
-                            "version": "2.1.4",
-                            "bundled": true,
-                            "requires": {
-                                "debug": "2.6.9",
-                                "define-property": "0.2.5",
-                                "extend-shallow": "2.0.1",
-                                "posix-character-classes": "0.1.1",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "define-property": {
-                                    "version": "0.2.5",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-descriptor": "0.1.6"
-                                    }
-                                },
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                },
-                                "is-accessor-descriptor": {
-                                    "version": "0.1.6",
-                                    "bundled": true,
-                                    "requires": {
-                                        "kind-of": "3.2.2"
-                                    },
-                                    "dependencies": {
-                                        "kind-of": {
-                                            "version": "3.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "is-buffer": "1.1.6"
-                                            }
-                                        }
-                                    }
-                                },
-                                "is-data-descriptor": {
-                                    "version": "0.1.4",
-                                    "bundled": true,
-                                    "requires": {
-                                        "kind-of": "3.2.2"
-                                    },
-                                    "dependencies": {
-                                        "kind-of": {
-                                            "version": "3.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "is-buffer": "1.1.6"
-                                            }
-                                        }
-                                    }
-                                },
-                                "is-descriptor": {
-                                    "version": "0.1.6",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-accessor-descriptor": "0.1.6",
-                                        "is-data-descriptor": "0.1.4",
-                                        "kind-of": "5.1.0"
-                                    }
-                                },
-                                "kind-of": {
-                                    "version": "5.1.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "extglob": {
-                            "version": "2.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "array-unique": "0.3.2",
-                                "define-property": "1.0.0",
-                                "expand-brackets": "2.1.4",
-                                "extend-shallow": "2.0.1",
-                                "fragment-cache": "0.2.1",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "define-property": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-descriptor": "1.0.2"
-                                    }
-                                },
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "fill-range": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "extend-shallow": "2.0.1",
-                                "is-number": "3.0.0",
-                                "repeat-string": "1.6.1",
-                                "to-regex-range": "2.1.1"
-                            },
-                            "dependencies": {
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-accessor-descriptor": "1.0.0",
-                                "is-data-descriptor": "1.0.0",
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-number": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        },
-                        "micromatch": {
-                            "version": "3.1.10",
-                            "bundled": true,
-                            "requires": {
-                                "arr-diff": "4.0.0",
-                                "array-unique": "0.3.2",
-                                "braces": "2.3.2",
-                                "define-property": "2.0.2",
-                                "extend-shallow": "3.0.2",
-                                "extglob": "2.0.4",
-                                "fragment-cache": "0.2.1",
-                                "kind-of": "6.0.2",
-                                "nanomatch": "1.2.13",
-                                "object.pick": "1.3.0",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            }
-                        }
-                    }
-                },
-                "append-transform": {
-                    "version": "0.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "default-require-extensions": "1.0.0"
-                    }
-                },
-                "argparse": {
-                    "version": "1.0.10",
-                    "bundled": true,
-                    "requires": {
-                        "sprintf-js": "1.0.3"
-                    }
-                },
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "arr-flatten": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "arr-union": {
-                    "version": "3.1.0",
-                    "bundled": true
-                },
-                "array-equal": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "array-filter": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "array-map": {
-                    "version": "0.0.0",
-                    "bundled": true
-                },
-                "array-reduce": {
-                    "version": "0.0.0",
-                    "bundled": true
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "bundled": true
-                },
-                "arrify": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "asn1": {
-                    "version": "0.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "safer-buffer": "2.1.2"
-                    }
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "assign-symbols": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "astral-regex": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "async": {
-                    "version": "2.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "lodash": "4.17.11"
-                    }
-                },
-                "async-each": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "async-limiter": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true
-                },
-                "atob": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "bundled": true
-                },
-                "aws4": {
-                    "version": "1.8.0",
-                    "bundled": true
-                },
-                "babel-code-frame": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "esutils": "2.0.2",
-                        "js-tokens": "3.0.2"
-                    }
-                },
-                "babel-core": {
-                    "version": "6.26.3",
-                    "bundled": true,
-                    "requires": {
-                        "babel-code-frame": "6.26.0",
-                        "babel-generator": "6.26.1",
-                        "babel-helpers": "6.24.1",
-                        "babel-messages": "6.23.0",
-                        "babel-register": "6.26.0",
-                        "babel-runtime": "6.26.0",
-                        "babel-template": "6.26.0",
-                        "babel-traverse": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "convert-source-map": "1.6.0",
-                        "debug": "2.6.9",
-                        "json5": "0.5.1",
-                        "lodash": "4.17.11",
-                        "minimatch": "3.0.4",
-                        "path-is-absolute": "1.0.1",
-                        "private": "0.1.8",
-                        "slash": "1.0.0",
-                        "source-map": "0.5.7"
-                    }
-                },
-                "babel-generator": {
-                    "version": "6.26.1",
-                    "bundled": true,
-                    "requires": {
-                        "babel-messages": "6.23.0",
-                        "babel-runtime": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "detect-indent": "4.0.0",
-                        "jsesc": "1.3.0",
-                        "lodash": "4.17.11",
-                        "source-map": "0.5.7",
-                        "trim-right": "1.0.1"
-                    }
-                },
-                "babel-helpers": {
-                    "version": "6.24.1",
-                    "bundled": true,
-                    "requires": {
-                        "babel-runtime": "6.26.0",
-                        "babel-template": "6.26.0"
-                    }
-                },
-                "babel-jest": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "babel-plugin-istanbul": "4.1.6",
-                        "babel-preset-jest": "22.4.4"
-                    }
-                },
-                "babel-messages": {
-                    "version": "6.23.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-runtime": "6.26.0"
-                    }
-                },
-                "babel-plugin-istanbul": {
-                    "version": "4.1.6",
-                    "bundled": true,
-                    "requires": {
-                        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                        "find-up": "2.1.0",
-                        "istanbul-lib-instrument": "1.10.2",
-                        "test-exclude": "4.2.3"
-                    }
-                },
-                "babel-plugin-jest-hoist": {
-                    "version": "22.4.4",
-                    "bundled": true
-                },
-                "babel-plugin-syntax-object-rest-spread": {
-                    "version": "6.13.0",
-                    "bundled": true
-                },
-                "babel-plugin-transform-es2015-modules-commonjs": {
-                    "version": "6.26.2",
-                    "bundled": true,
-                    "requires": {
-                        "babel-plugin-transform-strict-mode": "6.24.1",
-                        "babel-runtime": "6.26.0",
-                        "babel-template": "6.26.0",
-                        "babel-types": "6.26.0"
-                    }
-                },
-                "babel-plugin-transform-strict-mode": {
-                    "version": "6.24.1",
-                    "bundled": true,
-                    "requires": {
-                        "babel-runtime": "6.26.0",
-                        "babel-types": "6.26.0"
-                    }
-                },
-                "babel-preset-jest": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "babel-plugin-jest-hoist": "22.4.4",
-                        "babel-plugin-syntax-object-rest-spread": "6.13.0"
-                    }
-                },
-                "babel-register": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-core": "6.26.3",
-                        "babel-runtime": "6.26.0",
-                        "core-js": "2.5.7",
-                        "home-or-tmp": "2.0.0",
-                        "lodash": "4.17.11",
-                        "mkdirp": "0.5.1",
-                        "source-map-support": "0.4.18"
-                    },
-                    "dependencies": {
-                        "source-map-support": {
-                            "version": "0.4.18",
-                            "bundled": true,
-                            "requires": {
-                                "source-map": "0.5.7"
-                            }
-                        }
-                    }
-                },
-                "babel-runtime": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "core-js": "2.5.7",
-                        "regenerator-runtime": "0.11.1"
-                    }
-                },
-                "babel-template": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-runtime": "6.26.0",
-                        "babel-traverse": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "lodash": "4.17.11"
-                    }
-                },
-                "babel-traverse": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-code-frame": "6.26.0",
-                        "babel-messages": "6.23.0",
-                        "babel-runtime": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "debug": "2.6.9",
-                        "globals": "9.18.0",
-                        "invariant": "2.2.4",
-                        "lodash": "4.17.11"
-                    }
-                },
-                "babel-types": {
-                    "version": "6.26.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-runtime": "6.26.0",
-                        "esutils": "2.0.2",
-                        "lodash": "4.17.11",
-                        "to-fast-properties": "1.0.3"
-                    }
-                },
-                "babylon": {
-                    "version": "6.18.0",
-                    "bundled": true
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "base": {
-                    "version": "0.11.2",
-                    "bundled": true,
-                    "requires": {
-                        "cache-base": "1.0.1",
-                        "class-utils": "0.3.6",
-                        "component-emitter": "1.2.1",
-                        "define-property": "1.0.0",
-                        "isobject": "3.0.1",
-                        "mixin-deep": "1.3.1",
-                        "pascalcase": "0.1.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "is-descriptor": "1.0.2"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-accessor-descriptor": "1.0.0",
-                                "is-data-descriptor": "1.0.0",
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "tweetnacl": "0.14.5"
-                    }
-                },
-                "binary-extensions": {
-                    "version": "1.12.0",
-                    "bundled": true
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "bundled": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "bundled": true,
-                    "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.3"
-                    }
-                },
-                "browser-process-hrtime": {
-                    "version": "0.1.3",
-                    "bundled": true
-                },
-                "browser-resolve": {
-                    "version": "1.11.3",
-                    "bundled": true,
-                    "requires": {
-                        "resolve": "1.1.7"
-                    }
-                },
-                "bser": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "node-int64": "0.4.0"
-                    }
-                },
-                "buffer-from": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "cache-base": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "collection-visit": "1.0.0",
-                        "component-emitter": "1.2.1",
-                        "get-value": "2.0.6",
-                        "has-value": "1.0.0",
-                        "isobject": "3.0.1",
-                        "set-value": "2.0.0",
-                        "to-object-path": "0.3.0",
-                        "union-value": "1.0.0",
-                        "unset-value": "1.0.0"
-                    },
-                    "dependencies": {
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "callsites": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "camelcase": {
-                    "version": "4.1.0",
-                    "bundled": true
-                },
-                "capture-exit": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "rsvp": "3.6.2"
-                    }
-                },
-                "caseless": {
-                    "version": "0.11.0",
-                    "bundled": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "chokidar": {
-                    "version": "1.7.0",
-                    "bundled": true,
-                    "requires": {
-                        "anymatch": "1.3.2",
-                        "async-each": "1.0.1",
-                        "glob-parent": "2.0.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "2.0.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.2.1"
-                    },
-                    "dependencies": {
-                        "anymatch": {
-                            "version": "1.3.2",
-                            "bundled": true,
-                            "requires": {
-                                "micromatch": "2.3.11",
-                                "normalize-path": "2.1.1"
-                            }
-                        }
-                    }
-                },
-                "ci-info": {
-                    "version": "1.6.0",
-                    "bundled": true
-                },
-                "class-utils": {
-                    "version": "0.3.6",
-                    "bundled": true,
-                    "requires": {
-                        "arr-union": "3.1.0",
-                        "define-property": "0.2.5",
-                        "isobject": "3.0.1",
-                        "static-extend": "0.1.2"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "requires": {
-                                "is-descriptor": "0.1.6"
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "cliui": {
-                    "version": "4.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-regex": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "co": {
-                    "version": "4.6.0",
-                    "bundled": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "collection-visit": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "map-visit": "1.0.0",
-                        "object-visit": "1.0.1"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "bundled": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "bundled": true
-                },
-                "combined-stream": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "requires": {
-                        "delayed-stream": "1.0.0"
-                    }
-                },
-                "commander": {
-                    "version": "2.19.0",
-                    "bundled": true
-                },
-                "component-emitter": {
-                    "version": "1.2.1",
-                    "bundled": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "convert-source-map": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.1.2"
-                    }
-                },
-                "copy-descriptor": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "core-js": {
-                    "version": "2.5.7",
-                    "bundled": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "coveralls": {
-                    "version": "2.13.3",
-                    "bundled": true,
-                    "requires": {
-                        "js-yaml": "3.6.1",
-                        "lcov-parse": "0.0.10",
-                        "log-driver": "1.2.5",
-                        "minimist": "1.2.0",
-                        "request": "2.79.0"
-                    }
-                },
-                "cpx": {
-                    "version": "1.5.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-runtime": "6.26.0",
-                        "chokidar": "1.7.0",
-                        "duplexer": "0.1.1",
-                        "glob": "7.1.3",
-                        "glob2base": "0.0.12",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "resolve": "1.1.7",
-                        "safe-buffer": "5.1.2",
-                        "shell-quote": "1.6.1",
-                        "subarg": "1.0.0"
-                    }
-                },
-                "cross-spawn": {
-                    "version": "5.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
-                    }
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
-                    "bundled": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "cssom": {
-                    "version": "0.3.4",
-                    "bundled": true
-                },
-                "cssstyle": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "cssom": "0.3.4"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "data-urls": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "abab": "2.0.0",
-                        "whatwg-mimetype": "2.2.0",
-                        "whatwg-url": "7.0.0"
-                    },
-                    "dependencies": {
-                        "whatwg-url": {
-                            "version": "7.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "lodash.sortby": "4.7.0",
-                                "tr46": "1.0.1",
-                                "webidl-conversions": "4.0.2"
-                            }
-                        }
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "bundled": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "decamelize": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "decode-uri-component": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "deep-is": {
-                    "version": "0.1.3",
-                    "bundled": true
-                },
-                "default-require-extensions": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "strip-bom": "2.0.0"
-                    }
-                },
-                "define-properties": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "object-keys": "1.0.12"
-                    }
-                },
-                "define-property": {
-                    "version": "2.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "is-descriptor": "1.0.2",
-                        "isobject": "3.0.1"
-                    },
-                    "dependencies": {
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-accessor-descriptor": "1.0.0",
-                                "is-data-descriptor": "1.0.0",
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "detect-indent": {
-                    "version": "4.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "repeating": "2.0.1"
-                    }
-                },
-                "detect-newline": {
-                    "version": "2.1.0",
-                    "bundled": true
-                },
-                "diff": {
-                    "version": "3.5.0",
-                    "bundled": true
-                },
-                "domexception": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "webidl-conversions": "4.0.2"
-                    }
-                },
-                "duplexer": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "ecc-jsbn": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "jsbn": "0.1.1",
-                        "safer-buffer": "2.1.2"
-                    }
-                },
-                "error-ex": {
-                    "version": "1.3.2",
-                    "bundled": true,
-                    "requires": {
-                        "is-arrayish": "0.2.1"
-                    }
-                },
-                "es-abstract": {
-                    "version": "1.12.0",
-                    "bundled": true,
-                    "requires": {
-                        "es-to-primitive": "1.2.0",
-                        "function-bind": "1.1.1",
-                        "has": "1.0.3",
-                        "is-callable": "1.1.4",
-                        "is-regex": "1.0.4"
-                    }
-                },
-                "es-to-primitive": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-callable": "1.1.4",
-                        "is-date-object": "1.0.1",
-                        "is-symbol": "1.0.2"
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "bundled": true
-                },
-                "escodegen": {
-                    "version": "1.11.0",
-                    "bundled": true,
-                    "requires": {
-                        "esprima": "3.1.3",
-                        "estraverse": "4.2.0",
-                        "esutils": "2.0.2",
-                        "optionator": "0.8.2",
-                        "source-map": "0.6.1"
-                    },
-                    "dependencies": {
-                        "esprima": {
-                            "version": "3.1.3",
-                            "bundled": true
-                        },
-                        "source-map": {
-                            "version": "0.6.1",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "esprima": {
-                    "version": "2.7.3",
-                    "bundled": true
-                },
-                "estraverse": {
-                    "version": "4.2.0",
-                    "bundled": true
-                },
-                "esutils": {
-                    "version": "2.0.2",
-                    "bundled": true
-                },
-                "exec-sh": {
-                    "version": "0.2.2",
-                    "bundled": true,
-                    "requires": {
-                        "merge": "1.2.0"
-                    }
-                },
-                "execa": {
-                    "version": "0.7.0",
-                    "bundled": true,
-                    "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                    }
-                },
-                "exit": {
-                    "version": "0.1.2",
-                    "bundled": true
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "is-posix-bracket": "0.1.1"
-                    }
-                },
-                "expand-range": {
-                    "version": "1.8.2",
-                    "bundled": true,
-                    "requires": {
-                        "fill-range": "2.2.4"
-                    }
-                },
-                "expect": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-styles": "3.2.1",
-                        "jest-diff": "22.4.3",
-                        "jest-get-type": "22.4.3",
-                        "jest-matcher-utils": "22.4.3",
-                        "jest-message-util": "22.4.3",
-                        "jest-regex-util": "22.4.3"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        }
-                    }
-                },
-                "extend": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "extend-shallow": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
-                    },
-                    "dependencies": {
-                        "is-extendable": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-plain-object": "2.0.4"
-                            }
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "bundled": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "extsprintf": {
-                    "version": "1.3.0",
-                    "bundled": true
-                },
-                "fast-deep-equal": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "fast-json-stable-stringify": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "fast-levenshtein": {
-                    "version": "2.0.6",
-                    "bundled": true
-                },
-                "fb-watchman": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "bser": "2.0.0"
-                    }
-                },
-                "filename-regex": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "fileset": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "glob": "7.1.3",
-                        "minimatch": "3.0.4"
-                    }
-                },
-                "fill-range": {
-                    "version": "2.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "3.1.0",
-                        "repeat-element": "1.1.3",
-                        "repeat-string": "1.6.1"
-                    }
-                },
-                "find-index": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "find-up": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "locate-path": "2.0.0"
-                    }
-                },
-                "for-in": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "for-own": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "for-in": "1.0.2"
-                    }
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.7",
-                        "mime-types": "2.1.21"
-                    }
-                },
-                "fragment-cache": {
-                    "version": "0.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "map-cache": "0.2.2"
-                    }
-                },
-                "fs-extra": {
-                    "version": "6.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.2"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "function-bind": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "generate-function": {
-                    "version": "2.3.1",
-                    "bundled": true,
-                    "requires": {
-                        "is-property": "1.0.2"
-                    }
-                },
-                "generate-object-property": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-property": "1.0.2"
-                    }
-                },
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "get-stream": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "get-value": {
-                    "version": "2.0.6",
-                    "bundled": true
-                },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "glob-base": {
-                    "version": "0.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "glob-parent": "2.0.0",
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "glob2base": {
-                    "version": "0.0.12",
-                    "bundled": true,
-                    "requires": {
-                        "find-index": "0.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "9.18.0",
-                    "bundled": true
-                },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "bundled": true
-                },
-                "growly": {
-                    "version": "1.3.0",
-                    "bundled": true
-                },
-                "handlebars": {
-                    "version": "4.0.12",
-                    "bundled": true,
-                    "requires": {
-                        "async": "2.6.1",
-                        "optimist": "0.6.1",
-                        "source-map": "0.6.1",
-                        "uglify-js": "3.4.9"
-                    },
-                    "dependencies": {
-                        "source-map": {
-                            "version": "0.6.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "har-schema": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "har-validator": {
-                    "version": "2.0.6",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.19.0",
-                        "is-my-json-valid": "2.19.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "has": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "function-bind": "1.1.1"
-                    }
-                },
-                "has-ansi": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "has-symbols": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "has-value": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "1.0.0",
-                        "isobject": "3.0.1"
-                    },
-                    "dependencies": {
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "has-values": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-number": "3.0.0",
-                        "kind-of": "4.0.0"
-                    },
-                    "dependencies": {
-                        "is-number": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "kind-of": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "is-buffer": "1.1.6"
-                            }
-                        }
-                    }
-                },
-                "hawk": {
-                    "version": "3.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "hoek": {
-                    "version": "2.16.3",
-                    "bundled": true
-                },
-                "home-or-tmp": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                    }
-                },
-                "homedir-polyfill": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "parse-passwd": "1.0.0"
-                    }
-                },
-                "hosted-git-info": {
-                    "version": "2.7.1",
-                    "bundled": true
-                },
-                "html-encoding-sniffer": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "whatwg-encoding": "1.0.5"
-                    }
-                },
-                "http-signature": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.15.1"
-                    }
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "requires": {
-                        "safer-buffer": "2.1.2"
-                    }
-                },
-                "import-local": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "pkg-dir": "2.0.0",
-                        "resolve-cwd": "2.0.0"
-                    }
-                },
-                "imurmurhash": {
-                    "version": "0.1.4",
-                    "bundled": true
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true
-                },
-                "invariant": {
-                    "version": "2.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "loose-envify": "1.4.0"
-                    }
-                },
-                "invert-kv": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "is-arrayish": {
-                    "version": "0.2.1",
-                    "bundled": true
-                },
-                "is-binary-path": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "binary-extensions": "1.12.0"
-                    }
-                },
-                "is-buffer": {
-                    "version": "1.1.6",
-                    "bundled": true
-                },
-                "is-builtin-module": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "builtin-modules": "1.1.1"
-                    }
-                },
-                "is-callable": {
-                    "version": "1.1.4",
-                    "bundled": true
-                },
-                "is-ci": {
-                    "version": "1.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "ci-info": "1.6.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "is-date-object": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "bundled": true,
-                    "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "is-dotfile": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "is-equal-shallow": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "is-primitive": "2.0.0"
-                    }
-                },
-                "is-extendable": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-finite": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "number-is-nan": "1.0.1"
-                    }
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "is-generator-fn": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "is-my-ip-valid": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-my-json-valid": {
-                    "version": "2.19.0",
-                    "bundled": true,
-                    "requires": {
-                        "generate-function": "2.3.1",
-                        "generate-object-property": "1.2.0",
-                        "is-my-ip-valid": "1.0.0",
-                        "jsonpointer": "4.0.1",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "is-plain-object": {
-                    "version": "2.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "isobject": "3.0.1"
-                    },
-                    "dependencies": {
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "is-posix-bracket": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "is-primitive": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "is-property": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "is-regex": {
-                    "version": "1.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "has": "1.0.3"
-                    }
-                },
-                "is-stream": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "is-symbol": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "has-symbols": "1.0.0"
-                    }
-                },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "is-utf8": {
-                    "version": "0.2.1",
-                    "bundled": true
-                },
-                "is-windows": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "isexe": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true
-                },
-                "istanbul-api": {
-                    "version": "1.3.7",
-                    "bundled": true,
-                    "requires": {
-                        "async": "2.6.1",
-                        "fileset": "2.0.3",
-                        "istanbul-lib-coverage": "1.2.1",
-                        "istanbul-lib-hook": "1.2.2",
-                        "istanbul-lib-instrument": "1.10.2",
-                        "istanbul-lib-report": "1.1.5",
-                        "istanbul-lib-source-maps": "1.2.6",
-                        "istanbul-reports": "1.5.1",
-                        "js-yaml": "3.12.0",
-                        "mkdirp": "0.5.1",
-                        "once": "1.4.0"
-                    },
-                    "dependencies": {
-                        "esprima": {
-                            "version": "4.0.1",
-                            "bundled": true
-                        },
-                        "js-yaml": {
-                            "version": "3.12.0",
-                            "bundled": true,
-                            "requires": {
-                                "argparse": "1.0.10",
-                                "esprima": "4.0.1"
-                            }
-                        }
-                    }
-                },
-                "istanbul-lib-coverage": {
-                    "version": "1.2.1",
-                    "bundled": true
-                },
-                "istanbul-lib-hook": {
-                    "version": "1.2.2",
-                    "bundled": true,
-                    "requires": {
-                        "append-transform": "0.4.0"
-                    }
-                },
-                "istanbul-lib-instrument": {
-                    "version": "1.10.2",
-                    "bundled": true,
-                    "requires": {
-                        "babel-generator": "6.26.1",
-                        "babel-template": "6.26.0",
-                        "babel-traverse": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "istanbul-lib-coverage": "1.2.1",
-                        "semver": "5.6.0"
-                    }
-                },
-                "istanbul-lib-report": {
-                    "version": "1.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "istanbul-lib-coverage": "1.2.1",
-                        "mkdirp": "0.5.1",
-                        "path-parse": "1.0.6",
-                        "supports-color": "3.2.3"
-                    },
-                    "dependencies": {
-                        "has-flag": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "supports-color": {
-                            "version": "3.2.3",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "1.0.0"
-                            }
-                        }
-                    }
-                },
-                "istanbul-lib-source-maps": {
-                    "version": "1.2.6",
-                    "bundled": true,
-                    "requires": {
-                        "debug": "3.2.6",
-                        "istanbul-lib-coverage": "1.2.1",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "source-map": "0.5.7"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.2.6",
-                            "bundled": true,
-                            "requires": {
-                                "ms": "2.1.1"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.1.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "istanbul-reports": {
-                    "version": "1.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "handlebars": "4.0.12"
-                    }
-                },
-                "jest": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "import-local": "1.0.0",
-                        "jest-cli": "22.4.4"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "jest-cli": {
-                            "version": "22.4.4",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-escapes": "3.1.0",
-                                "chalk": "2.4.1",
-                                "exit": "0.1.2",
-                                "glob": "7.1.3",
-                                "graceful-fs": "4.1.11",
-                                "import-local": "1.0.0",
-                                "is-ci": "1.2.1",
-                                "istanbul-api": "1.3.7",
-                                "istanbul-lib-coverage": "1.2.1",
-                                "istanbul-lib-instrument": "1.10.2",
-                                "istanbul-lib-source-maps": "1.2.6",
-                                "jest-changed-files": "22.4.3",
-                                "jest-config": "22.4.4",
-                                "jest-environment-jsdom": "22.4.3",
-                                "jest-get-type": "22.4.3",
-                                "jest-haste-map": "22.4.3",
-                                "jest-message-util": "22.4.3",
-                                "jest-regex-util": "22.4.3",
-                                "jest-resolve-dependencies": "22.4.3",
-                                "jest-runner": "22.4.4",
-                                "jest-runtime": "22.4.4",
-                                "jest-snapshot": "22.4.3",
-                                "jest-util": "22.4.3",
-                                "jest-validate": "22.4.4",
-                                "jest-worker": "22.4.3",
-                                "micromatch": "2.3.11",
-                                "node-notifier": "5.2.1",
-                                "realpath-native": "1.0.2",
-                                "rimraf": "2.6.2",
-                                "slash": "1.0.0",
-                                "string-length": "2.0.0",
-                                "strip-ansi": "4.0.0",
-                                "which": "1.3.1",
-                                "yargs": "10.1.2"
-                            }
-                        },
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-regex": "3.0.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-changed-files": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "throat": "4.1.0"
-                    }
-                },
-                "jest-config": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "glob": "7.1.3",
-                        "jest-environment-jsdom": "22.4.3",
-                        "jest-environment-node": "22.4.3",
-                        "jest-get-type": "22.4.3",
-                        "jest-jasmine2": "22.4.4",
-                        "jest-regex-util": "22.4.3",
-                        "jest-resolve": "22.4.3",
-                        "jest-util": "22.4.3",
-                        "jest-validate": "22.4.4",
-                        "pretty-format": "22.4.3"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-diff": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "diff": "3.5.0",
-                        "jest-get-type": "22.4.3",
-                        "pretty-format": "22.4.3"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-docblock": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "detect-newline": "2.1.0"
-                    }
-                },
-                "jest-environment-jsdom": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "jest-mock": "22.4.3",
-                        "jest-util": "22.4.3",
-                        "jsdom": "11.12.0"
-                    }
-                },
-                "jest-environment-node": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "jest-mock": "22.4.3",
-                        "jest-util": "22.4.3"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "22.4.3",
-                    "bundled": true
-                },
-                "jest-haste-map": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "fb-watchman": "2.0.0",
-                        "graceful-fs": "4.1.11",
-                        "jest-docblock": "22.4.3",
-                        "jest-serializer": "22.4.3",
-                        "jest-worker": "22.4.3",
-                        "micromatch": "2.3.11",
-                        "sane": "2.5.2"
-                    }
-                },
-                "jest-jasmine2": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "co": "4.6.0",
-                        "expect": "22.4.3",
-                        "graceful-fs": "4.1.11",
-                        "is-generator-fn": "1.0.0",
-                        "jest-diff": "22.4.3",
-                        "jest-matcher-utils": "22.4.3",
-                        "jest-message-util": "22.4.3",
-                        "jest-snapshot": "22.4.3",
-                        "jest-util": "22.4.3",
-                        "source-map-support": "0.5.9"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-leak-detector": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "pretty-format": "22.4.3"
-                    }
-                },
-                "jest-matcher-utils": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "jest-get-type": "22.4.3",
-                        "pretty-format": "22.4.3"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-message-util": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "@babel/code-frame": "7.0.0",
-                        "chalk": "2.4.1",
-                        "micromatch": "2.3.11",
-                        "slash": "1.0.0",
-                        "stack-utils": "1.0.1"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-mock": {
-                    "version": "22.4.3",
-                    "bundled": true
-                },
-                "jest-regex-util": {
-                    "version": "22.4.3",
-                    "bundled": true
-                },
-                "jest-resolve": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "browser-resolve": "1.11.3",
-                        "chalk": "2.4.1"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-resolve-dependencies": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "jest-regex-util": "22.4.3"
-                    }
-                },
-                "jest-runner": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "exit": "0.1.2",
-                        "jest-config": "22.4.4",
-                        "jest-docblock": "22.4.3",
-                        "jest-haste-map": "22.4.3",
-                        "jest-jasmine2": "22.4.4",
-                        "jest-leak-detector": "22.4.3",
-                        "jest-message-util": "22.4.3",
-                        "jest-runtime": "22.4.4",
-                        "jest-util": "22.4.3",
-                        "jest-worker": "22.4.3",
-                        "throat": "4.1.0"
-                    }
-                },
-                "jest-runtime": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "babel-core": "6.26.3",
-                        "babel-jest": "22.4.4",
-                        "babel-plugin-istanbul": "4.1.6",
-                        "chalk": "2.4.1",
-                        "convert-source-map": "1.6.0",
-                        "exit": "0.1.2",
-                        "graceful-fs": "4.1.11",
-                        "jest-config": "22.4.4",
-                        "jest-haste-map": "22.4.3",
-                        "jest-regex-util": "22.4.3",
-                        "jest-resolve": "22.4.3",
-                        "jest-util": "22.4.3",
-                        "jest-validate": "22.4.4",
-                        "json-stable-stringify": "1.0.1",
-                        "micromatch": "2.3.11",
-                        "realpath-native": "1.0.2",
-                        "slash": "1.0.0",
-                        "strip-bom": "3.0.0",
-                        "write-file-atomic": "2.3.0",
-                        "yargs": "10.1.2"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "strip-bom": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-serializer": {
-                    "version": "22.4.3",
-                    "bundled": true
-                },
-                "jest-snapshot": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "jest-diff": "22.4.3",
-                        "jest-matcher-utils": "22.4.3",
-                        "mkdirp": "0.5.1",
-                        "natural-compare": "1.4.0",
-                        "pretty-format": "22.4.3"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-util": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "callsites": "2.0.0",
-                        "chalk": "2.4.1",
-                        "graceful-fs": "4.1.11",
-                        "is-ci": "1.2.1",
-                        "jest-message-util": "22.4.3",
-                        "mkdirp": "0.5.1",
-                        "source-map": "0.6.1"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "source-map": {
-                            "version": "0.6.1",
-                            "bundled": true
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-validate": {
-                    "version": "22.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "chalk": "2.4.1",
-                        "jest-config": "22.4.4",
-                        "jest-get-type": "22.4.3",
-                        "leven": "2.1.0",
-                        "pretty-format": "22.4.3"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "jest-worker": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "merge-stream": "1.0.1"
-                    }
-                },
-                "js-tokens": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "js-yaml": {
-                    "version": "3.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "2.7.3"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "jsdom": {
-                    "version": "11.12.0",
-                    "bundled": true,
-                    "requires": {
-                        "abab": "2.0.0",
-                        "acorn": "5.7.3",
-                        "acorn-globals": "4.3.0",
-                        "array-equal": "1.0.0",
-                        "cssom": "0.3.4",
-                        "cssstyle": "1.1.1",
-                        "data-urls": "1.0.1",
-                        "domexception": "1.0.1",
-                        "escodegen": "1.11.0",
-                        "html-encoding-sniffer": "1.0.2",
-                        "left-pad": "1.3.0",
-                        "nwsapi": "2.0.9",
-                        "parse5": "4.0.0",
-                        "pn": "1.1.0",
-                        "request": "2.88.0",
-                        "request-promise-native": "1.0.5",
-                        "sax": "1.2.4",
-                        "symbol-tree": "3.2.2",
-                        "tough-cookie": "2.3.4",
-                        "w3c-hr-time": "1.0.1",
-                        "webidl-conversions": "4.0.2",
-                        "whatwg-encoding": "1.0.5",
-                        "whatwg-mimetype": "2.2.0",
-                        "whatwg-url": "6.5.0",
-                        "ws": "5.2.2",
-                        "xml-name-validator": "3.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "aws-sign2": {
-                            "version": "0.7.0",
-                            "bundled": true
-                        },
-                        "caseless": {
-                            "version": "0.12.0",
-                            "bundled": true
-                        },
-                        "form-data": {
-                            "version": "2.3.3",
-                            "bundled": true,
-                            "requires": {
-                                "asynckit": "0.4.0",
-                                "combined-stream": "1.0.7",
-                                "mime-types": "2.1.21"
-                            }
-                        },
-                        "har-validator": {
-                            "version": "5.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "ajv": "5.5.2",
-                                "har-schema": "2.0.0"
-                            }
-                        },
-                        "http-signature": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "assert-plus": "1.0.0",
-                                "jsprim": "1.4.1",
-                                "sshpk": "1.15.1"
-                            }
-                        },
-                        "oauth-sign": {
-                            "version": "0.9.0",
-                            "bundled": true
-                        },
-                        "qs": {
-                            "version": "6.5.2",
-                            "bundled": true
-                        },
-                        "request": {
-                            "version": "2.88.0",
-                            "bundled": true,
-                            "requires": {
-                                "aws-sign2": "0.7.0",
-                                "aws4": "1.8.0",
-                                "caseless": "0.12.0",
-                                "combined-stream": "1.0.7",
-                                "extend": "3.0.2",
-                                "forever-agent": "0.6.1",
-                                "form-data": "2.3.3",
-                                "har-validator": "5.1.0",
-                                "http-signature": "1.2.0",
-                                "is-typedarray": "1.0.0",
-                                "isstream": "0.1.2",
-                                "json-stringify-safe": "5.0.1",
-                                "mime-types": "2.1.21",
-                                "oauth-sign": "0.9.0",
-                                "performance-now": "2.1.0",
-                                "qs": "6.5.2",
-                                "safe-buffer": "5.1.2",
-                                "tough-cookie": "2.4.3",
-                                "tunnel-agent": "0.6.0",
-                                "uuid": "3.3.2"
-                            },
-                            "dependencies": {
-                                "tough-cookie": {
-                                    "version": "2.4.3",
-                                    "bundled": true,
-                                    "requires": {
-                                        "psl": "1.1.29",
-                                        "punycode": "1.4.1"
-                                    }
-                                }
-                            }
-                        },
-                        "tunnel-agent": {
-                            "version": "0.6.0",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "5.1.2"
-                            }
-                        }
-                    }
-                },
-                "jsesc": {
-                    "version": "1.3.0",
-                    "bundled": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true
-                },
-                "json-schema-traverse": {
-                    "version": "0.3.1",
-                    "bundled": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true
-                },
-                "json5": {
-                    "version": "0.5.1",
-                    "bundled": true
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11"
-                    }
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true
-                },
-                "jsonpointer": {
-                    "version": "4.0.1",
-                    "bundled": true
-                },
-                "jsprim": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.3.0",
-                        "json-schema": "0.2.3",
-                        "verror": "1.10.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "bundled": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                },
-                "lcid": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "invert-kv": "1.0.0"
-                    }
-                },
-                "lcov-parse": {
-                    "version": "0.0.10",
-                    "bundled": true
-                },
-                "left-pad": {
-                    "version": "1.3.0",
-                    "bundled": true
-                },
-                "leven": {
-                    "version": "2.1.0",
-                    "bundled": true
-                },
-                "levn": {
-                    "version": "0.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
-                    }
-                },
                 "lodash": {
                     "version": "4.17.11",
-                    "bundled": true
-                },
-                "lodash.sortby": {
-                    "version": "4.7.0",
-                    "bundled": true
-                },
-                "log-driver": {
-                    "version": "1.2.5",
-                    "bundled": true
-                },
-                "loose-envify": {
-                    "version": "1.4.0",
                     "bundled": true,
-                    "requires": {
-                        "js-tokens": "3.0.2"
-                    }
-                },
-                "lru-cache": {
-                    "version": "4.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    }
-                },
-                "make-error": {
-                    "version": "1.3.5",
-                    "bundled": true
-                },
-                "makeerror": {
-                    "version": "1.0.11",
-                    "bundled": true,
-                    "requires": {
-                        "tmpl": "1.0.4"
-                    }
-                },
-                "map-cache": {
-                    "version": "0.2.2",
-                    "bundled": true
-                },
-                "map-visit": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "object-visit": "1.0.1"
-                    }
-                },
-                "math-random": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "mem": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "mimic-fn": "1.2.0"
-                    }
-                },
-                "merge": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "merge-stream": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "readable-stream": "2.3.6"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "bundled": true,
-                    "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
-                    }
-                },
-                "mime-db": {
-                    "version": "1.37.0",
-                    "bundled": true
-                },
-                "mime-types": {
-                    "version": "2.1.21",
-                    "bundled": true,
-                    "requires": {
-                        "mime-db": "1.37.0"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "brace-expansion": "1.1.11"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "mixin-deep": {
-                    "version": "1.3.1",
-                    "bundled": true,
-                    "requires": {
-                        "for-in": "1.0.2",
-                        "is-extendable": "1.0.1"
-                    },
-                    "dependencies": {
-                        "is-extendable": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-plain-object": "2.0.4"
-                            }
-                        }
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "0.0.8",
-                            "bundled": true
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "nanomatch": {
-                    "version": "1.2.13",
-                    "bundled": true,
-                    "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "fragment-cache": "0.2.1",
-                        "is-windows": "1.0.2",
-                        "kind-of": "6.0.2",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                    },
-                    "dependencies": {
-                        "arr-diff": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "array-unique": {
-                            "version": "0.3.2",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "natural-compare": {
-                    "version": "1.4.0",
-                    "bundled": true
-                },
-                "node-int64": {
-                    "version": "0.4.0",
-                    "bundled": true
-                },
-                "node-notifier": {
-                    "version": "5.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "growly": "1.3.0",
-                        "semver": "5.6.0",
-                        "shellwords": "0.1.1",
-                        "which": "1.3.1"
-                    }
-                },
-                "normalize-package-data": {
-                    "version": "2.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "hosted-git-info": "2.7.1",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.6.0",
-                        "validate-npm-package-license": "3.0.4"
-                    }
-                },
-                "normalize-path": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "remove-trailing-separator": "1.1.0"
-                    }
-                },
-                "npm-run-path": {
-                    "version": "2.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "path-key": "2.0.1"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "nwsapi": {
-                    "version": "2.0.9",
-                    "bundled": true
-                },
-                "oauth-sign": {
-                    "version": "0.8.2",
-                    "bundled": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true
-                },
-                "object-copy": {
-                    "version": "0.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "copy-descriptor": "0.1.1",
-                        "define-property": "0.2.5",
-                        "kind-of": "3.2.2"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "requires": {
-                                "is-descriptor": "0.1.6"
-                            }
-                        }
-                    }
-                },
-                "object-keys": {
-                    "version": "1.0.12",
-                    "bundled": true
-                },
-                "object-visit": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "isobject": "3.0.1"
-                    },
-                    "dependencies": {
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "object.getownpropertydescriptors": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "define-properties": "1.1.3",
-                        "es-abstract": "1.12.0"
-                    }
-                },
-                "object.omit": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "for-own": "0.1.5",
-                        "is-extendable": "0.1.1"
-                    }
-                },
-                "object.pick": {
-                    "version": "1.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "isobject": "3.0.1"
-                    },
-                    "dependencies": {
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "optimist": {
-                    "version": "0.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "0.0.10",
-                        "wordwrap": "0.0.3"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "0.0.10",
-                            "bundled": true
-                        }
-                    }
-                },
-                "optionator": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "requires": {
-                        "deep-is": "0.1.3",
-                        "fast-levenshtein": "2.0.6",
-                        "levn": "0.3.0",
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2",
-                        "wordwrap": "1.0.0"
-                    },
-                    "dependencies": {
-                        "wordwrap": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "os-locale": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
-                    }
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "p-finally": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "p-limit": {
-                    "version": "1.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "p-try": "1.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "p-limit": "1.3.0"
-                    }
-                },
-                "p-try": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "parse-glob": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "glob-base": "0.3.0",
-                        "is-dotfile": "1.0.3",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "parse-json": {
-                    "version": "2.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "error-ex": "1.3.2"
-                    }
-                },
-                "parse-passwd": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "parse5": {
-                    "version": "4.0.0",
-                    "bundled": true
-                },
-                "pascalcase": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "path-parse": {
-                    "version": "1.0.6",
-                    "bundled": true
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "performance-now": {
-                    "version": "2.1.0",
-                    "bundled": true
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "bundled": true
-                },
-                "pinkie": {
-                    "version": "2.0.4",
-                    "bundled": true
-                },
-                "pinkie-promise": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "pinkie": "2.0.4"
-                    }
-                },
-                "pkg-dir": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "find-up": "2.1.0"
-                    }
-                },
-                "pn": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "posix-character-classes": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "prelude-ls": {
-                    "version": "1.1.2",
-                    "bundled": true
-                },
-                "preserve": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "prettier": {
-                    "version": "1.14.3",
-                    "bundled": true
-                },
-                "pretty-format": {
-                    "version": "22.4.3",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0",
-                        "ansi-styles": "3.2.1"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        }
-                    }
-                },
-                "private": {
-                    "version": "0.1.8",
-                    "bundled": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "pseudomap": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "psl": {
-                    "version": "1.1.29",
-                    "bundled": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "bundled": true
-                },
-                "qs": {
-                    "version": "6.3.2",
-                    "bundled": true
-                },
-                "randomatic": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-number": "4.0.0",
-                        "kind-of": "6.0.2",
-                        "math-random": "1.0.1"
-                    },
-                    "dependencies": {
-                        "is-number": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
-                    },
-                    "dependencies": {
-                        "find-up": {
-                            "version": "1.1.2",
-                            "bundled": true,
-                            "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
-                            }
-                        },
-                        "path-exists": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "pinkie-promise": "2.0.1"
-                            }
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "readdirp": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "micromatch": "3.1.10",
-                        "readable-stream": "2.3.6"
-                    },
-                    "dependencies": {
-                        "arr-diff": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "array-unique": {
-                            "version": "0.3.2",
-                            "bundled": true
-                        },
-                        "braces": {
-                            "version": "2.3.2",
-                            "bundled": true,
-                            "requires": {
-                                "arr-flatten": "1.1.0",
-                                "array-unique": "0.3.2",
-                                "extend-shallow": "2.0.1",
-                                "fill-range": "4.0.0",
-                                "isobject": "3.0.1",
-                                "repeat-element": "1.1.3",
-                                "snapdragon": "0.8.2",
-                                "snapdragon-node": "2.1.1",
-                                "split-string": "3.1.0",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "expand-brackets": {
-                            "version": "2.1.4",
-                            "bundled": true,
-                            "requires": {
-                                "debug": "2.6.9",
-                                "define-property": "0.2.5",
-                                "extend-shallow": "2.0.1",
-                                "posix-character-classes": "0.1.1",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "define-property": {
-                                    "version": "0.2.5",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-descriptor": "0.1.6"
-                                    }
-                                },
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                },
-                                "is-accessor-descriptor": {
-                                    "version": "0.1.6",
-                                    "bundled": true,
-                                    "requires": {
-                                        "kind-of": "3.2.2"
-                                    },
-                                    "dependencies": {
-                                        "kind-of": {
-                                            "version": "3.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "is-buffer": "1.1.6"
-                                            }
-                                        }
-                                    }
-                                },
-                                "is-data-descriptor": {
-                                    "version": "0.1.4",
-                                    "bundled": true,
-                                    "requires": {
-                                        "kind-of": "3.2.2"
-                                    },
-                                    "dependencies": {
-                                        "kind-of": {
-                                            "version": "3.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "is-buffer": "1.1.6"
-                                            }
-                                        }
-                                    }
-                                },
-                                "is-descriptor": {
-                                    "version": "0.1.6",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-accessor-descriptor": "0.1.6",
-                                        "is-data-descriptor": "0.1.4",
-                                        "kind-of": "5.1.0"
-                                    }
-                                },
-                                "kind-of": {
-                                    "version": "5.1.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "extglob": {
-                            "version": "2.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "array-unique": "0.3.2",
-                                "define-property": "1.0.0",
-                                "expand-brackets": "2.1.4",
-                                "extend-shallow": "2.0.1",
-                                "fragment-cache": "0.2.1",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "define-property": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-descriptor": "1.0.2"
-                                    }
-                                },
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "fill-range": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "extend-shallow": "2.0.1",
-                                "is-number": "3.0.0",
-                                "repeat-string": "1.6.1",
-                                "to-regex-range": "2.1.1"
-                            },
-                            "dependencies": {
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-accessor-descriptor": "1.0.0",
-                                "is-data-descriptor": "1.0.0",
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-number": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        },
-                        "micromatch": {
-                            "version": "3.1.10",
-                            "bundled": true,
-                            "requires": {
-                                "arr-diff": "4.0.0",
-                                "array-unique": "0.3.2",
-                                "braces": "2.3.2",
-                                "define-property": "2.0.2",
-                                "extend-shallow": "3.0.2",
-                                "extglob": "2.0.4",
-                                "fragment-cache": "0.2.1",
-                                "kind-of": "6.0.2",
-                                "nanomatch": "1.2.13",
-                                "object.pick": "1.3.0",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            }
-                        }
-                    }
-                },
-                "realpath-native": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "util.promisify": "1.0.0"
-                    }
-                },
-                "regenerator-runtime": {
-                    "version": "0.11.1",
-                    "bundled": true
-                },
-                "regex-cache": {
-                    "version": "0.4.4",
-                    "bundled": true,
-                    "requires": {
-                        "is-equal-shallow": "0.1.3"
-                    }
-                },
-                "regex-not": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "extend-shallow": "3.0.2",
-                        "safe-regex": "1.1.0"
-                    }
-                },
-                "remove-trailing-separator": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "repeat-element": {
-                    "version": "1.1.3",
-                    "bundled": true
-                },
-                "repeat-string": {
-                    "version": "1.6.1",
-                    "bundled": true
-                },
-                "repeating": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "is-finite": "1.0.2"
-                    }
-                },
-                "request": {
-                    "version": "2.79.0",
-                    "bundled": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.7",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.21",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.3.2"
-                    }
-                },
-                "request-promise-core": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "lodash": "4.17.11"
-                    }
-                },
-                "request-promise-native": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "requires": {
-                        "request-promise-core": "1.1.1",
-                        "stealthy-require": "1.1.1",
-                        "tough-cookie": "2.3.4"
-                    }
-                },
-                "require-directory": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "resolve": {
-                    "version": "1.1.7",
-                    "bundled": true
-                },
-                "resolve-cwd": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "resolve-from": "3.0.0"
-                    }
-                },
-                "resolve-from": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "resolve-url": {
-                    "version": "0.2.1",
-                    "bundled": true
-                },
-                "ret": {
-                    "version": "0.1.15",
-                    "bundled": true
-                },
-                "rimraf": {
-                    "version": "2.6.2",
-                    "bundled": true,
-                    "requires": {
-                        "glob": "7.1.3"
-                    }
-                },
-                "rsvp": {
-                    "version": "3.6.2",
-                    "bundled": true
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true
-                },
-                "safe-regex": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "ret": "0.1.15"
-                    }
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "sane": {
-                    "version": "2.5.2",
-                    "bundled": true,
-                    "requires": {
-                        "anymatch": "2.0.0",
-                        "capture-exit": "1.2.0",
-                        "exec-sh": "0.2.2",
-                        "fb-watchman": "2.0.0",
-                        "micromatch": "3.1.10",
-                        "minimist": "1.2.0",
-                        "walker": "1.0.7",
-                        "watch": "0.18.0"
-                    },
-                    "dependencies": {
-                        "arr-diff": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "array-unique": {
-                            "version": "0.3.2",
-                            "bundled": true
-                        },
-                        "braces": {
-                            "version": "2.3.2",
-                            "bundled": true,
-                            "requires": {
-                                "arr-flatten": "1.1.0",
-                                "array-unique": "0.3.2",
-                                "extend-shallow": "2.0.1",
-                                "fill-range": "4.0.0",
-                                "isobject": "3.0.1",
-                                "repeat-element": "1.1.3",
-                                "snapdragon": "0.8.2",
-                                "snapdragon-node": "2.1.1",
-                                "split-string": "3.1.0",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "expand-brackets": {
-                            "version": "2.1.4",
-                            "bundled": true,
-                            "requires": {
-                                "debug": "2.6.9",
-                                "define-property": "0.2.5",
-                                "extend-shallow": "2.0.1",
-                                "posix-character-classes": "0.1.1",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "define-property": {
-                                    "version": "0.2.5",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-descriptor": "0.1.6"
-                                    }
-                                },
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                },
-                                "is-accessor-descriptor": {
-                                    "version": "0.1.6",
-                                    "bundled": true,
-                                    "requires": {
-                                        "kind-of": "3.2.2"
-                                    },
-                                    "dependencies": {
-                                        "kind-of": {
-                                            "version": "3.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "is-buffer": "1.1.6"
-                                            }
-                                        }
-                                    }
-                                },
-                                "is-data-descriptor": {
-                                    "version": "0.1.4",
-                                    "bundled": true,
-                                    "requires": {
-                                        "kind-of": "3.2.2"
-                                    },
-                                    "dependencies": {
-                                        "kind-of": {
-                                            "version": "3.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "is-buffer": "1.1.6"
-                                            }
-                                        }
-                                    }
-                                },
-                                "is-descriptor": {
-                                    "version": "0.1.6",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-accessor-descriptor": "0.1.6",
-                                        "is-data-descriptor": "0.1.4",
-                                        "kind-of": "5.1.0"
-                                    }
-                                },
-                                "kind-of": {
-                                    "version": "5.1.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "extglob": {
-                            "version": "2.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "array-unique": "0.3.2",
-                                "define-property": "1.0.0",
-                                "expand-brackets": "2.1.4",
-                                "extend-shallow": "2.0.1",
-                                "fragment-cache": "0.2.1",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            },
-                            "dependencies": {
-                                "define-property": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-descriptor": "1.0.2"
-                                    }
-                                },
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "fill-range": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "extend-shallow": "2.0.1",
-                                "is-number": "3.0.0",
-                                "repeat-string": "1.6.1",
-                                "to-regex-range": "2.1.1"
-                            },
-                            "dependencies": {
-                                "extend-shallow": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-extendable": "0.1.1"
-                                    }
-                                }
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-accessor-descriptor": "1.0.0",
-                                "is-data-descriptor": "1.0.0",
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-number": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-buffer": "1.1.6"
-                                    }
-                                }
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        },
-                        "micromatch": {
-                            "version": "3.1.10",
-                            "bundled": true,
-                            "requires": {
-                                "arr-diff": "4.0.0",
-                                "array-unique": "0.3.2",
-                                "braces": "2.3.2",
-                                "define-property": "2.0.2",
-                                "extend-shallow": "3.0.2",
-                                "extglob": "2.0.4",
-                                "fragment-cache": "0.2.1",
-                                "kind-of": "6.0.2",
-                                "nanomatch": "1.2.13",
-                                "object.pick": "1.3.0",
-                                "regex-not": "1.0.2",
-                                "snapdragon": "0.8.2",
-                                "to-regex": "3.0.2"
-                            }
-                        }
-                    }
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true
-                },
-                "semver": {
-                    "version": "5.6.0",
-                    "bundled": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "set-value": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "split-string": "3.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "shebang-regex": "1.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "shell-quote": {
-                    "version": "1.6.1",
-                    "bundled": true,
-                    "requires": {
-                        "array-filter": "0.0.1",
-                        "array-map": "0.0.0",
-                        "array-reduce": "0.0.0",
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "shellwords": {
-                    "version": "0.1.1",
-                    "bundled": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "slash": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "snapdragon": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "requires": {
-                        "base": "0.11.2",
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "map-cache": "0.2.2",
-                        "source-map": "0.5.7",
-                        "source-map-resolve": "0.5.2",
-                        "use": "3.1.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "requires": {
-                                "is-descriptor": "0.1.6"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        }
-                    }
-                },
-                "snapdragon-node": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "define-property": "1.0.0",
-                        "isobject": "3.0.1",
-                        "snapdragon-util": "3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "is-descriptor": "1.0.2"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "is-accessor-descriptor": "1.0.0",
-                                "is-data-descriptor": "1.0.0",
-                                "kind-of": "6.0.2"
-                            }
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "snapdragon-util": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "sntp": {
-                    "version": "1.0.9",
-                    "bundled": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "bundled": true
-                },
-                "source-map-resolve": {
-                    "version": "0.5.2",
-                    "bundled": true,
-                    "requires": {
-                        "atob": "2.1.2",
-                        "decode-uri-component": "0.2.0",
-                        "resolve-url": "0.2.1",
-                        "source-map-url": "0.4.0",
-                        "urix": "0.1.0"
-                    }
-                },
-                "source-map-support": {
-                    "version": "0.5.9",
-                    "bundled": true,
-                    "requires": {
-                        "buffer-from": "1.1.1",
-                        "source-map": "0.6.1"
-                    },
-                    "dependencies": {
-                        "source-map": {
-                            "version": "0.6.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "source-map-url": {
-                    "version": "0.4.0",
-                    "bundled": true
-                },
-                "spdx-correct": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "spdx-expression-parse": "3.0.0",
-                        "spdx-license-ids": "3.0.1"
-                    }
-                },
-                "spdx-exceptions": {
-                    "version": "2.2.0",
-                    "bundled": true
-                },
-                "spdx-expression-parse": {
-                    "version": "3.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "spdx-exceptions": "2.2.0",
-                        "spdx-license-ids": "3.0.1"
-                    }
-                },
-                "spdx-license-ids": {
-                    "version": "3.0.1",
-                    "bundled": true
-                },
-                "split-string": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "extend-shallow": "3.0.2"
-                    }
-                },
-                "sprintf-js": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "sshpk": {
-                    "version": "1.15.1",
-                    "bundled": true,
-                    "requires": {
-                        "asn1": "0.2.4",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.2",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.2",
-                        "getpass": "0.1.7",
-                        "jsbn": "0.1.1",
-                        "safer-buffer": "2.1.2",
-                        "tweetnacl": "0.14.5"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "stack-utils": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "static-extend": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "define-property": "0.2.5",
-                        "object-copy": "0.1.0"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "requires": {
-                                "is-descriptor": "0.1.6"
-                            }
-                        }
-                    }
-                },
-                "stealthy-require": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "string-length": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "astral-regex": "1.0.0",
-                        "strip-ansi": "4.0.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-regex": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-regex": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.1.2"
-                    }
-                },
-                "stringstream": {
-                    "version": "0.0.6",
-                    "bundled": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "is-utf8": "0.2.1"
-                    }
-                },
-                "strip-eof": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "subarg": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "1.2.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "symbol-tree": {
-                    "version": "3.2.2",
-                    "bundled": true
-                },
-                "test-exclude": {
-                    "version": "4.2.3",
-                    "bundled": true,
-                    "requires": {
-                        "arrify": "1.0.1",
-                        "micromatch": "2.3.11",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "require-main-filename": "1.0.1"
-                    }
-                },
-                "throat": {
-                    "version": "4.1.0",
-                    "bundled": true
-                },
-                "tmpl": {
-                    "version": "1.0.4",
-                    "bundled": true
-                },
-                "to-fast-properties": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "to-object-path": {
-                    "version": "0.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "to-regex": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "regex-not": "1.0.2",
-                        "safe-regex": "1.1.0"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1"
-                    },
-                    "dependencies": {
-                        "is-number": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "kind-of": "3.2.2"
-                            }
-                        }
-                    }
-                },
-                "tough-cookie": {
-                    "version": "2.3.4",
-                    "bundled": true,
-                    "requires": {
-                        "punycode": "1.4.1"
-                    }
-                },
-                "tr46": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "punycode": "2.1.1"
-                    },
-                    "dependencies": {
-                        "punycode": {
-                            "version": "2.1.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "trim-right": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "ts-jest": {
-                    "version": "22.4.6",
-                    "bundled": true,
-                    "requires": {
-                        "babel-core": "6.26.3",
-                        "babel-plugin-istanbul": "4.1.6",
-                        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                        "babel-preset-jest": "22.4.4",
-                        "cpx": "1.5.0",
-                        "fs-extra": "6.0.0",
-                        "jest-config": "22.4.4",
-                        "lodash": "4.17.11",
-                        "pkg-dir": "2.0.0",
-                        "source-map-support": "0.5.9",
-                        "yargs": "11.1.0"
-                    },
-                    "dependencies": {
-                        "yargs": {
-                            "version": "11.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "cliui": "4.1.0",
-                                "decamelize": "1.2.0",
-                                "find-up": "2.1.0",
-                                "get-caller-file": "1.0.3",
-                                "os-locale": "2.1.0",
-                                "require-directory": "2.1.1",
-                                "require-main-filename": "1.0.1",
-                                "set-blocking": "2.0.0",
-                                "string-width": "2.1.1",
-                                "which-module": "2.0.0",
-                                "y18n": "3.2.1",
-                                "yargs-parser": "9.0.2"
-                            }
-                        },
-                        "yargs-parser": {
-                            "version": "9.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "camelcase": "4.1.0"
-                            }
-                        }
-                    }
-                },
-                "ts-node": {
-                    "version": "3.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "arrify": "1.0.1",
-                        "chalk": "2.4.1",
-                        "diff": "3.5.0",
-                        "make-error": "1.3.5",
-                        "minimist": "1.2.0",
-                        "mkdirp": "0.5.1",
-                        "source-map-support": "0.4.18",
-                        "tsconfig": "6.0.0",
-                        "v8flags": "3.1.1",
-                        "yn": "2.0.0"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "source-map-support": {
-                            "version": "0.4.18",
-                            "bundled": true,
-                            "requires": {
-                                "source-map": "0.5.7"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "tsconfig": {
-                    "version": "6.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "strip-bom": "3.0.0",
-                        "strip-json-comments": "2.0.1"
-                    },
-                    "dependencies": {
-                        "strip-bom": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "tslib": {
-                    "version": "1.9.3",
-                    "bundled": true
-                },
-                "tslint": {
-                    "version": "5.11.0",
-                    "bundled": true,
-                    "requires": {
-                        "babel-code-frame": "6.26.0",
-                        "builtin-modules": "1.1.1",
-                        "chalk": "2.4.1",
-                        "commander": "2.19.0",
-                        "diff": "3.5.0",
-                        "glob": "7.1.3",
-                        "js-yaml": "3.12.0",
-                        "minimatch": "3.0.4",
-                        "resolve": "1.8.1",
-                        "semver": "5.6.0",
-                        "tslib": "1.9.3",
-                        "tsutils": "2.29.0"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "color-convert": "1.9.3"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.5.0"
-                            }
-                        },
-                        "esprima": {
-                            "version": "4.0.1",
-                            "bundled": true
-                        },
-                        "js-yaml": {
-                            "version": "3.12.0",
-                            "bundled": true,
-                            "requires": {
-                                "argparse": "1.0.10",
-                                "esprima": "4.0.1"
-                            }
-                        },
-                        "resolve": {
-                            "version": "1.8.1",
-                            "bundled": true,
-                            "requires": {
-                                "path-parse": "1.0.6"
-                            }
-                        },
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "bundled": true,
-                            "requires": {
-                                "has-flag": "3.0.0"
-                            }
-                        }
-                    }
-                },
-                "tslint-config-prettier": {
-                    "version": "1.15.0",
-                    "bundled": true
-                },
-                "tsutils": {
-                    "version": "2.29.0",
-                    "bundled": true,
-                    "requires": {
-                        "tslib": "1.9.3"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.4.3",
-                    "bundled": true
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true
-                },
-                "type-check": {
-                    "version": "0.3.2",
-                    "bundled": true,
-                    "requires": {
-                        "prelude-ls": "1.1.2"
-                    }
-                },
-                "typescript": {
-                    "version": "2.9.2",
-                    "bundled": true
-                },
-                "uglify-js": {
-                    "version": "3.4.9",
-                    "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "commander": "2.17.1",
-                        "source-map": "0.6.1"
-                    },
-                    "dependencies": {
-                        "commander": {
-                            "version": "2.17.1",
-                            "bundled": true,
-                            "optional": true
-                        },
-                        "source-map": {
-                            "version": "0.6.1",
-                            "bundled": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "union-value": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "arr-union": "3.1.0",
-                        "get-value": "2.0.6",
-                        "is-extendable": "0.1.1",
-                        "set-value": "0.4.3"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "is-extendable": "0.1.1"
-                            }
-                        },
-                        "set-value": {
-                            "version": "0.4.3",
-                            "bundled": true,
-                            "requires": {
-                                "extend-shallow": "2.0.1",
-                                "is-extendable": "0.1.1",
-                                "is-plain-object": "2.0.4",
-                                "to-object-path": "0.3.0"
-                            }
-                        }
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "bundled": true
-                },
-                "unset-value": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "has-value": "0.3.1",
-                        "isobject": "3.0.1"
-                    },
-                    "dependencies": {
-                        "has-value": {
-                            "version": "0.3.1",
-                            "bundled": true,
-                            "requires": {
-                                "get-value": "2.0.6",
-                                "has-values": "0.1.4",
-                                "isobject": "2.1.0"
-                            },
-                            "dependencies": {
-                                "isobject": {
-                                    "version": "2.1.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "isarray": "1.0.0"
-                                    }
-                                }
-                            }
-                        },
-                        "has-values": {
-                            "version": "0.1.4",
-                            "bundled": true
-                        },
-                        "isobject": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "urix": {
-                    "version": "0.1.0",
-                    "bundled": true
-                },
-                "use": {
-                    "version": "3.1.1",
-                    "bundled": true
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "util.promisify": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "define-properties": "1.1.3",
-                        "object.getownpropertydescriptors": "2.0.3"
-                    }
-                },
-                "uuid": {
-                    "version": "3.3.2",
-                    "bundled": true
-                },
-                "v8flags": {
-                    "version": "3.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "homedir-polyfill": "1.0.1"
-                    }
-                },
-                "validate-npm-package-license": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "spdx-correct": "3.0.2",
-                        "spdx-expression-parse": "3.0.0"
-                    }
-                },
-                "verror": {
-                    "version": "1.10.0",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "w3c-hr-time": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "browser-process-hrtime": "0.1.3"
-                    }
-                },
-                "walker": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "requires": {
-                        "makeerror": "1.0.11"
-                    }
-                },
-                "watch": {
-                    "version": "0.18.0",
-                    "bundled": true,
-                    "requires": {
-                        "exec-sh": "0.2.2",
-                        "minimist": "1.2.0"
-                    }
-                },
-                "webidl-conversions": {
-                    "version": "4.0.2",
-                    "bundled": true
-                },
-                "whatwg-encoding": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "requires": {
-                        "iconv-lite": "0.4.24"
-                    }
-                },
-                "whatwg-mimetype": {
-                    "version": "2.2.0",
-                    "bundled": true
-                },
-                "whatwg-url": {
-                    "version": "6.5.0",
-                    "bundled": true,
-                    "requires": {
-                        "lodash.sortby": "4.7.0",
-                        "tr46": "1.0.1",
-                        "webidl-conversions": "4.0.2"
-                    }
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "bundled": true,
-                    "requires": {
-                        "isexe": "2.0.0"
-                    }
-                },
-                "which-module": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "wordwrap": {
-                    "version": "0.0.3",
-                    "bundled": true
-                },
-                "wrap-ansi": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
-                    },
-                    "dependencies": {
-                        "is-fullwidth-code-point": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "number-is-nan": "1.0.1"
-                            }
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
-                            }
-                        }
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "write-file-atomic": {
-                    "version": "2.3.0",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "signal-exit": "3.0.2"
-                    }
-                },
-                "ws": {
-                    "version": "5.2.2",
-                    "bundled": true,
-                    "requires": {
-                        "async-limiter": "1.0.0"
-                    }
-                },
-                "xml-name-validator": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "xtend": {
-                    "version": "4.0.1",
-                    "bundled": true
-                },
-                "y18n": {
-                    "version": "3.2.1",
-                    "bundled": true
-                },
-                "yallist": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "yargs": {
-                    "version": "10.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "8.1.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "8.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "camelcase": "4.1.0"
-                    }
-                },
-                "yn": {
-                    "version": "2.0.0",
-                    "bundled": true
+                    "dev": true
                 }
             }
         },
         "async": {
-            "version": "1.5.2",
-            "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-            "dev": true
+            "version": "1.2.1",
+            "resolved": "http://registry.npmjs.org/async/-/async-1.2.1.tgz",
+            "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
         },
         "async-limiter": {
             "version": "1.0.0",
@@ -5268,6 +332,11 @@
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+        },
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -5355,8 +424,8 @@
             "requires": {
                 "css-select": "1.2.0",
                 "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
+                "entities": "1.1.2",
+                "htmlparser2": "3.10.0",
                 "lodash": "4.17.11",
                 "parse5": "3.0.3"
             }
@@ -5385,11 +454,6 @@
                 "process-nextick-args": "2.0.0",
                 "readable-stream": "2.3.6"
             }
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "color-convert": {
             "version": "1.9.3",
@@ -5470,20 +534,20 @@
         },
         "css-select": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
                 "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "css-what": "2.1.2",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "1.0.2"
             }
         },
         "css-what": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-            "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+            "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
             "dev": true
         },
         "csv": {
@@ -5529,9 +593,9 @@
             }
         },
         "decache": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/decache/-/decache-4.4.0.tgz",
-            "integrity": "sha1-b232uF1+fEQQqTL/wmSJt46azRM=",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/decache/-/decache-4.5.0.tgz",
+            "integrity": "sha512-XLFg1feTf4cZ5MBxJWEkvQTo7m5PiYF7oNkCGT/ibytYOUGucLBr+WZB+cbyK+6Z4wpazFbrmoUAU0+/6DC/2w==",
             "dev": true,
             "requires": {
                 "callsite": "1.0.0"
@@ -5539,7 +603,7 @@
         },
         "deep-assign": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "requires": {
                 "is-obj": "1.0.1"
@@ -5559,6 +623,14 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "1.0.12"
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -5583,21 +655,21 @@
             "dev": true,
             "requires": {
                 "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "entities": "1.1.2"
             },
             "dependencies": {
                 "domelementtype": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                     "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
                     "dev": true
                 }
             }
         },
         "domelementtype": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+            "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==",
             "dev": true
         },
         "domhandler": {
@@ -5606,7 +678,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1.2.1"
             }
         },
         "domutils": {
@@ -5616,12 +688,12 @@
             "dev": true,
             "requires": {
                 "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "domelementtype": "1.2.1"
             }
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
         "duplexify": {
@@ -5653,9 +725,9 @@
             }
         },
         "entities": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
             "dev": true
         },
         "escape-string-regexp": {
@@ -5678,7 +750,7 @@
             "dependencies": {
                 "source-map": {
                     "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                     "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                     "dev": true,
                     "optional": true,
@@ -5707,12 +779,11 @@
             "dev": true
         },
         "event-stream": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+            "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
             "requires": {
                 "duplexer": "0.1.1",
-                "flatmap-stream": "0.1.1",
                 "from": "0.1.7",
                 "map-stream": "0.0.7",
                 "pause-stream": "0.0.11",
@@ -5731,7 +802,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
                 "fill-range": "2.2.4"
@@ -5771,9 +842,9 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -5806,7 +877,7 @@
             "requires": {
                 "is-number": "2.1.0",
                 "isobject": "2.1.0",
-                "randomatic": "3.1.0",
+                "randomatic": "3.1.1",
                 "repeat-element": "1.1.3",
                 "repeat-string": "1.6.1"
             }
@@ -5816,10 +887,14 @@
             "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
             "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
         },
-        "flatmap-stream": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-            "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw=="
+        "flush-write-stream": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+            }
         },
         "for-in": {
             "version": "1.0.2",
@@ -5846,13 +921,22 @@
             "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.7",
-                "mime-types": "2.1.20"
+                "mime-types": "2.1.21"
             }
         },
         "from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+        },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "requires": {
+                "graceful-fs": "4.1.15",
+                "through2": "2.0.5"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -5864,11 +948,16 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "4.1.11",
+                "graceful-fs": "4.1.15",
                 "inherits": "2.0.3",
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "get-func-name": {
             "version": "2.0.0",
@@ -5972,7 +1061,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
                         "core-util-is": "1.0.2",
@@ -5988,7 +1077,7 @@
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
                         "readable-stream": "1.0.34",
@@ -5998,9 +1087,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
         },
         "growl": {
             "version": "1.10.3",
@@ -6014,7 +1103,7 @@
             "requires": {
                 "deep-assign": "1.0.0",
                 "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "through2": "2.0.5"
             }
         },
         "gulp-filter": {
@@ -6043,7 +1132,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
                         "core-util-is": "1.0.2",
@@ -6059,7 +1148,7 @@
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
                         "readable-stream": "1.0.34",
@@ -6073,10 +1162,10 @@
             "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "requires": {
-                "event-stream": "3.3.6",
-                "node.extend": "1.1.6",
+                "event-stream": "3.3.5",
+                "node.extend": "1.1.8",
                 "request": "2.88.0",
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "vinyl": "2.2.0"
             },
             "dependencies": {
@@ -6111,9 +1200,9 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "requires": {
                 "convert-source-map": "1.6.0",
-                "graceful-fs": "4.1.11",
+                "graceful-fs": "4.1.15",
                 "strip-bom": "2.0.0",
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "vinyl": "1.2.0"
             },
             "dependencies": {
@@ -6144,7 +1233,7 @@
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "requires": {
-                "event-stream": "3.3.6",
+                "event-stream": "3.3.5",
                 "mkdirp": "0.5.1",
                 "queue": "3.1.0",
                 "vinyl-fs": "2.4.4"
@@ -6155,10 +1244,10 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "requires": {
-                "event-stream": "3.3.6",
+                "event-stream": "3.3.5",
                 "streamifier": "0.1.1",
                 "tar": "2.2.1",
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "vinyl": "1.2.0"
             },
             "dependencies": {
@@ -6185,17 +1274,17 @@
             }
         },
         "gulp-vinyl-zip": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
-            "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.1.tgz",
+            "integrity": "sha512-OPnsZkMwiU8UbH5BMlYRb/SccOAZUnwUW7mQvqYadap8MMdgN7ae0ua1rMEE2s9EyqqijN1Sdvoz29/MbPaq9Q==",
             "requires": {
-                "event-stream": "3.3.6",
+                "event-stream": "3.3.5",
                 "queue": "4.5.0",
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "vinyl": "2.2.0",
-                "vinyl-fs": "2.4.4",
+                "vinyl-fs": "3.0.3",
                 "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "yazl": "2.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -6208,12 +1297,51 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
+                "glob-stream": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+                    "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+                    "requires": {
+                        "extend": "3.0.2",
+                        "glob": "7.1.3",
+                        "glob-parent": "3.1.0",
+                        "is-negated-glob": "1.0.0",
+                        "ordered-read-streams": "1.0.1",
+                        "pumpify": "1.5.1",
+                        "readable-stream": "2.3.6",
+                        "remove-trailing-separator": "1.1.0",
+                        "to-absolute-glob": "2.0.2",
+                        "unique-stream": "2.2.1"
+                    }
+                },
+                "is-valid-glob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+                    "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
+                },
+                "ordered-read-streams": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+                    "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+                    "requires": {
+                        "readable-stream": "2.3.6"
+                    }
+                },
                 "queue": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.0.tgz",
                     "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
                     "requires": {
                         "inherits": "2.0.3"
+                    }
+                },
+                "to-absolute-glob": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+                    "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+                    "requires": {
+                        "is-absolute": "1.0.0",
+                        "is-negated-glob": "1.0.0"
                     }
                 },
                 "vinyl": {
@@ -6227,6 +1355,30 @@
                         "cloneable-readable": "1.1.2",
                         "remove-trailing-separator": "1.1.0",
                         "replace-ext": "1.0.0"
+                    }
+                },
+                "vinyl-fs": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+                    "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+                    "requires": {
+                        "fs-mkdirp-stream": "1.0.0",
+                        "glob-stream": "6.1.0",
+                        "graceful-fs": "4.1.15",
+                        "is-valid-glob": "1.0.0",
+                        "lazystream": "1.0.0",
+                        "lead": "1.0.0",
+                        "object.assign": "4.1.0",
+                        "pumpify": "1.5.1",
+                        "readable-stream": "2.3.6",
+                        "remove-bom-buffer": "3.0.0",
+                        "remove-bom-stream": "1.2.0",
+                        "resolve-options": "1.1.0",
+                        "through2": "2.0.5",
+                        "to-through": "2.0.0",
+                        "value-or-function": "3.0.0",
+                        "vinyl": "2.2.0",
+                        "vinyl-sourcemap": "1.1.0"
                     }
                 }
             }
@@ -6260,12 +1412,20 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "5.5.2",
+                "ajv": "6.5.5",
                 "har-schema": "2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -6282,23 +1442,47 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+        },
         "he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "htmlparser2": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+            "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
             "dev": true,
             "requires": {
                 "domelementtype": "1.3.0",
                 "domhandler": "2.4.2",
                 "domutils": "1.5.1",
-                "entities": "1.1.1",
+                "entities": "1.1.2",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "readable-stream": "3.0.6"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.3.0",
+                    "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                    "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+                    "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                }
             }
         },
         "http-signature": {
@@ -6308,7 +1492,7 @@
             "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
-                "sshpk": "1.15.1"
+                "sshpk": "1.15.2"
             }
         },
         "inflight": {
@@ -6329,6 +1513,15 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
             "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+        },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "requires": {
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.2"
+            }
         },
         "is-buffer": {
             "version": "1.1.6",
@@ -6366,6 +1559,11 @@
                 "is-extglob": "2.1.1"
             }
         },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
+        },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -6386,7 +1584,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-posix-bracket": {
@@ -6399,6 +1597,14 @@
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "requires": {
+                "is-unc-path": "1.0.0"
+            }
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -6408,6 +1614,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "requires": {
+                "unc-path-regex": "0.1.2"
+            }
         },
         "is-utf8": {
             "version": "0.2.1",
@@ -6454,7 +1668,7 @@
             "dev": true,
             "requires": {
                 "abbrev": "1.0.9",
-                "async": "1.5.2",
+                "async": "1.2.1",
                 "escodegen": "1.8.1",
                 "esprima": "2.7.3",
                 "glob": "5.0.15",
@@ -6534,9 +1748,9 @@
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify": {
             "version": "1.0.1",
@@ -6569,7 +1783,7 @@
         },
         "kind-of": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
             "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
         },
         "lazystream": {
@@ -6578,6 +1792,14 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
                 "readable-stream": "2.3.6"
+            }
+        },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "requires": {
+                "flush-write-stream": "1.0.3"
             }
         },
         "levn": {
@@ -6627,7 +1849,7 @@
             "dev": true,
             "requires": {
                 "argparse": "1.0.10",
-                "entities": "1.1.1",
+                "entities": "1.1.2",
                 "linkify-it": "2.0.3",
                 "mdurl": "1.0.1",
                 "uc.micro": "1.0.5"
@@ -6710,16 +1932,16 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
         },
         "mime-types": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "requires": {
-                "mime-db": "1.36.0"
+                "mime-db": "1.37.0"
             }
         },
         "minimatch": {
@@ -6732,7 +1954,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
@@ -6832,11 +2054,6 @@
                 "lodash": "3.9.3"
             },
             "dependencies": {
-                "async": {
-                    "version": "1.2.1",
-                    "resolved": "http://registry.npmjs.org/async/-/async-1.2.1.tgz",
-                    "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
-                },
                 "lodash": {
                     "version": "3.9.3",
                     "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
@@ -6867,10 +2084,11 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node.extend": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "requires": {
+                "has": "1.0.3",
                 "is": "3.2.1"
             }
         },
@@ -6891,10 +2109,18 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "now-and-later": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
         "nth-check": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
             "dev": true,
             "requires": {
                 "boolbase": "1.0.0"
@@ -6909,6 +2135,22 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-keys": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "requires": {
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.12"
+            }
         },
         "object.omit": {
             "version": "2.0.1",
@@ -6975,13 +2217,13 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -7023,7 +2265,7 @@
         },
         "parse-semver": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
@@ -7036,7 +2278,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.10.36"
+                "@types/node": "8.10.38"
             }
         },
         "path-dirname": {
@@ -7046,7 +2288,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
@@ -7068,7 +2310,7 @@
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
                 "through": "2.3.8"
@@ -7125,10 +2367,29 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
             "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "requires": {
+                "duplexify": "3.6.1",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+            }
+        },
         "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "q": {
             "version": "1.5.1",
@@ -7155,9 +2416,9 @@
             }
         },
         "randomatic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
             "requires": {
                 "is-number": "4.0.0",
                 "kind-of": "6.0.2",
@@ -7187,7 +2448,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
                 "core-util-is": "1.0.2",
@@ -7249,7 +2510,7 @@
                 },
                 "through2": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
@@ -7257,6 +2518,25 @@
                         "xtend": "4.0.1"
                     }
                 }
+            }
+        },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "requires": {
+                "is-buffer": "1.1.6",
+                "is-utf8": "0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "requires": {
+                "remove-bom-buffer": "3.0.0",
+                "safe-buffer": "5.1.2",
+                "through2": "2.0.5"
             }
         },
         "remove-trailing-separator": {
@@ -7291,12 +2571,12 @@
                 "extend": "3.0.2",
                 "forever-agent": "0.6.1",
                 "form-data": "2.3.3",
-                "har-validator": "5.1.0",
+                "har-validator": "5.1.3",
                 "http-signature": "1.2.0",
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
                 "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.20",
+                "mime-types": "2.1.21",
                 "oauth-sign": "0.9.0",
                 "performance-now": "2.1.0",
                 "qs": "6.5.2",
@@ -7316,6 +2596,14 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
             "dev": true
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "requires": {
+                "value-or-function": "3.0.0"
+            }
         },
         "rimraf": {
             "version": "2.6.2",
@@ -7382,9 +2670,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-            "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
             "requires": {
                 "asn1": "0.2.4",
                 "assert-plus": "1.0.0",
@@ -7444,7 +2732,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -7486,7 +2774,7 @@
         },
         "tar": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
                 "block-stream": "0.0.9",
@@ -7496,13 +2784,13 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "requires": {
                 "readable-stream": "2.3.6",
                 "xtend": "4.0.1"
@@ -7513,7 +2801,7 @@
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "xtend": "4.0.1"
             }
         },
@@ -7544,6 +2832,14 @@
                 }
             }
         },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "requires": {
+                "through2": "2.0.5"
+            }
+        },
         "toml": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
@@ -7556,6 +2852,13 @@
             "requires": {
                 "psl": "1.1.29",
                 "punycode": "1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
             }
         },
         "ts-node": {
@@ -7636,7 +2939,7 @@
         },
         "tunnel": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "resolved": "http://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
             "dev": true
         },
@@ -7718,6 +3021,11 @@
                 }
             }
         },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+        },
         "underscore": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -7733,6 +3041,14 @@
                 "through2-filter": "2.0.0"
             }
         },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "2.1.1"
+            }
+        },
         "url-join": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
@@ -7740,9 +3056,9 @@
             "dev": true
         },
         "url-parse": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+            "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "requires": {
                 "querystringify": "2.1.0",
                 "requires-port": "1.0.0"
@@ -7762,6 +3078,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
             "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+        },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
         },
         "verror": {
             "version": "1.10.0",
@@ -7789,7 +3110,7 @@
             "requires": {
                 "duplexify": "3.6.1",
                 "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "graceful-fs": "4.1.15",
                 "gulp-sourcemaps": "1.6.0",
                 "is-valid-glob": "0.3.0",
                 "lazystream": "1.0.0",
@@ -7800,7 +3121,7 @@
                 "readable-stream": "2.3.6",
                 "strip-bom": "2.0.0",
                 "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "through2-filter": "2.0.0",
                 "vali-date": "1.0.0",
                 "vinyl": "1.2.0"
@@ -7833,14 +3154,53 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "requires": {
-                "through2": "2.0.3",
+                "through2": "2.0.5",
                 "vinyl": "0.4.6"
             }
         },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "requires": {
+                "append-buffer": "1.0.2",
+                "convert-source-map": "1.6.0",
+                "graceful-fs": "4.1.15",
+                "normalize-path": "2.1.1",
+                "now-and-later": "2.0.0",
+                "remove-bom-buffer": "3.0.0",
+                "vinyl": "2.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "requires": {
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
+                    }
+                }
+            }
+        },
         "vsce": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.52.0.tgz",
-            "integrity": "sha512-k+KYoTx1sacpYf2BHTA7GN82MNSlf2N4EuppFWwtTN/Sh6fWzIJafxxCNBCDK0H+5NDWfRGZheBY8C3/HOE2ZA==",
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.53.0.tgz",
+            "integrity": "sha512-okap3jGyz6JeUNJon09MJbjsyAq3zeEJj3YpbYGjslDNn+0g5HikK1VGykNcpVTy5imYdwBAuIDubsm3xPFTEA==",
             "dev": true,
             "requires": {
                 "cheerio": "1.0.0-rc.2",
@@ -7859,7 +3219,7 @@
                 "url-join": "1.1.0",
                 "vso-node-api": "6.1.2-preview",
                 "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "yazl": "2.5.0"
             }
         },
         "vscode": {
@@ -7874,12 +3234,12 @@
                 "gulp-remote-src-vscode": "0.5.0",
                 "gulp-symdest": "1.1.0",
                 "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
+                "gulp-vinyl-zip": "2.1.1",
                 "mocha": "4.1.0",
                 "request": "2.88.0",
                 "semver": "5.6.0",
                 "source-map-support": "0.5.9",
-                "url-parse": "1.4.3",
+                "url-parse": "1.4.4",
                 "vinyl-source-stream": "1.1.2"
             },
             "dependencies": {
@@ -8001,7 +3361,7 @@
         },
         "ws": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
             "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
             "requires": {
                 "async-limiter": "1.0.0",
@@ -8023,9 +3383,9 @@
             }
         },
         "yazl": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
-            "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.0.tgz",
+            "integrity": "sha512-rgptqKwX/f1/7bIRF1FHb4HGsP5k11QyxBpDl1etUDfNpTa7CNjDOYNPFnIaEzZ9dRq0c47IEJS+sy+T39JCLw==",
             "requires": {
                 "buffer-crc32": "0.2.13"
             }


### PR DESCRIPTION
## Purpose

We are still locked in a compromised module version of event-stream lib. As this version is removed from npm our build is failing. This will remove it and depend on a non-compromised available version.
