### PR TITLE
Fix api-designer test script to state that no tests are specified

### DIFF
--- a/composer/packages/api-designer/package.json
+++ b/composer/packages/api-designer/package.json
@@ -10,10 +10,9 @@
     "clean": "composer pkg:clean",
     "lint": "composer pkg:lint",
     "build": "npm run copy-less && composer pkg:build",
-    "test": "composer pkg:test",
+    "test": "echo \"No tests specified\"",
     "coverage": "composer pkg:test:coverage",
     "watch": "composer pkg:watch",
-    "watch:test": "composer pkg:test:watch",
     "storybook": "composer pkg:storybook"
   },
   "author": "ballerina.io",


### PR DESCRIPTION
## Purpose
Avoid the common test script for packages failing due to api-designer containing no tests