### PR TITLE
Add several debug logs to help investigate plugin activation issues

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -65,25 +65,28 @@ export class BallerinaExtension {
 
             // Check if ballerina home is set.
             if (this.hasBallerinaHomeSetting()) {
+                log("Ballerina home is configured in settings.");
                 this.ballerinaHome = this.getBallerinaHome();
                 // Lets check if ballerina home is valid.
                 if (!this.isValidBallerinaHome(this.ballerinaHome)) {
+                    log("Configured Ballerina home is not valid.");
                     // Ballerina home in setting is invalid show message and quit.
                     // Prompt to correct the home. // TODO add auto ditection.
                     this.showMessageInvalidBallerinaHome();
                     return Promise.resolve();
                 }
             } else {
+                log("Auto detecting Ballerina home.");
                 // If ballerina home is not set try to auto ditect ballerina home.
                 // TODO If possible try to update the setting page.
                 this.ballerinaHome = this.autoDitectBallerinaHome();
                 if (!this.ballerinaHome) {
                     this.showMessageInstallBallerina();
-                    log("Unable to auto ditect ballerina home.");
+                    log("Unable to auto detect Ballerina home.");
                     return Promise.resolve();
                 }
             }
-
+            log("Using " + this.ballerinaHome + " as the Ballerina home.");
             // Validate the ballerina version.
             const pluginVersion = this.extention.packageJSON.version.split('-')[0];
             return this.getBallerinaVersion(this.ballerinaHome).then(ballerinaVersion => {
@@ -101,6 +104,7 @@ export class BallerinaExtension {
                 // Following was put in to handle server startup failiers.
                 const disposeDidChange = this.langClient.onDidChangeState(stateChangeEvent => {
                     if (stateChangeEvent.newState === LS_STATE.Stopped) {
+                        log("Coudn't establish language server connection.");
                         this.showPluginActivationError();
                     }
                 });
@@ -113,7 +117,8 @@ export class BallerinaExtension {
                 });
             });
 
-        } catch {
+        } catch (ex) {
+            log("Error while activating plugin: " + (ex.message ? ex.message : ex));
             // If any failure occurs while intializing show an error messege
             this.showPluginActivationError();
             return Promise.resolve();

--- a/tool-plugins/vscode/src/server/server.ts
+++ b/tool-plugins/vscode/src/server/server.ts
@@ -22,7 +22,7 @@ import { log } from '../utils/logger';
 import { ServerOptions } from 'vscode-languageclient';
 
 export function getServerOptions(ballerinaHome: string) : ServerOptions {
-    log(`Using Ballerina installtion at ${ballerinaHome}`);
+    log(`Using Ballerina installation at ${ballerinaHome} for Language server.`);
 
     let cmd;
     const cwd = path.join(ballerinaHome, 'lib', 'tools', 'lang-server', 'launcher');
@@ -35,7 +35,7 @@ export function getServerOptions(ballerinaHome: string) : ServerOptions {
     }
 
     if (process.env.LSDEBUG === "true") {
-        log('Language Server is staring in debug mode');
+        log('Language Server is staring in debug mode.');
         args.push('--debug');
     }
     if (process.env.LS_CUSTOM_CLASSPATH) {


### PR DESCRIPTION
These logs will be flushed to Ballerina output channel in vscode output window
if user sets ballerina.debugLog to true in vscode settings.

<img width="1312" alt="screen shot 2018-11-30 at 11 00 29 am" src="https://user-images.githubusercontent.com/1505855/49270380-2ef35600-f48f-11e8-9d61-371750f0ceab.png">
