### PR TITLE
Fix websocket listener compiler plugin issue

### DIFF
--- a/stdlib/http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/service_endpoint.bal
@@ -418,4 +418,32 @@ function getInferredJwtAuthProviderConfig(AuthProvider authProvider) returns aut
 /// WebSocket Service Endpoint ///
 //////////////////////////////////
 # Represents a WebSocket service endpoint.
-public type WebSocketListener Listener;
+// public type WebSocketListener Listener;
+public type WebSocketListener object {
+
+    *AbstractListener;
+
+    private Listener httpEndpoint;
+
+    public function __start() returns error? {
+        return self.httpEndpoint.start();
+    }
+
+    public function __stop() returns error? {
+        return self.httpEndpoint.stop();
+    }
+
+    public function __attach(service s, map<any> annotationData) returns error? {
+        return self.httpEndpoint.register(s, annotationData);
+    }
+
+
+    # Gets invoked during module initialization to initialize the endpoint.
+    #
+    # + port - The port of the endpoint
+    # + config - The `ServiceEndpointConfiguration` of the endpoint
+    public function __init(int port, ServiceEndpointConfiguration? config = ()) {
+        self.httpEndpoint = new(port, config = config);
+    }
+
+};


### PR DESCRIPTION
## Purpose
This fix should be reverted once the following labelling issue is fixed.
public type WebSocketListener Listener; // this makes the type of WebSocketListener to Listener