### PR TITLE
 Fix finite types from balo issue for floating point literals

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -563,7 +563,7 @@ public class CompiledPackageSymbolEnter {
             case TypeDescriptor.SIG_FLOAT:
                 valueCPIndex = dataInStream.readInt();
                 FloatCPEntry floatCPEntry = (FloatCPEntry) this.env.constantPool[valueCPIndex];
-                litExpr.value = floatCPEntry.getValue();
+                litExpr.value = Double.toString(floatCPEntry.getValue());
                 litExpr.typeTag = TypeTags.FLOAT;
                 break;
             case TypeDescriptor.SIG_DECIMAL:

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/ConstantTests.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/ConstantTests.java
@@ -253,4 +253,13 @@ public class ConstantTests {
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "Ballerina rocks");
     }
+
+    @Test
+    public void testFloatAsFiniteType() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testFloatAsFiniteType");
+        Assert.assertNotNull(returns[0]);
+        Assert.assertNotNull(returns[1]);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 2.0);
+        Assert.assertEquals(((BFloat) returns[1]).floatValue(), 4.0);
+    }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantTest.java
@@ -231,6 +231,15 @@ public class ConstantTest {
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), 2.0);
     }
 
+    @Test
+    public void testFloatAsFiniteType() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testFloatAsFiniteType");
+        Assert.assertNotNull(returns[0]);
+        Assert.assertNotNull(returns[1]);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 2.0);
+        Assert.assertEquals(((BFloat) returns[1]).floatValue(), 4.0);
+    }
+
     // Note - Decimal without type cannot be specified.
     @Test
     public void testDecimalWithType() {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_balo/constant/constant.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_balo/constant/constant.bal
@@ -234,3 +234,12 @@ function testStringTypeWithoutType() returns StringTypeWithoutType {
     StringTypeWithoutType t = "Ballerina rocks";
     return t;
 }
+
+// -----------------------------------------------------------
+
+function testFloatAsFiniteType() returns (foo:FiniteFloatType, foo:FiniteFloatType) {
+    foo:FiniteFloatType f1 = 2.0;
+    foo:FiniteFloatType f2 = 4.0;
+
+    return (f1, f2);
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/foo/constant.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/foo/constant.bal
@@ -33,3 +33,6 @@ public const decimal decimalWithType = 4.0;
 
 public const string stringWithType = "Ballerina is awesome";
 public const stringWithoutType = "Ballerina rocks";
+
+
+public type FiniteFloatType floatWithType|floatWithoutType;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/constant/constant.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/constant/constant.bal
@@ -191,6 +191,17 @@ function testFloatWithoutType() returns float {
 
 // -----------------------------------------------------------
 
+type FiniteFloatType floatWithType|floatWithoutType;
+
+function testFloatAsFiniteType() returns (FiniteFloatType, FiniteFloatType) {
+    FiniteFloatType f1 = 2.0;
+    FiniteFloatType f2 = 4.0;
+
+    return (f1, f2);
+}
+
+// -----------------------------------------------------------
+
 const decimal decimalWithType = 50.0;
 
 function testDecimalWithType() returns decimal {


### PR DESCRIPTION
## Purpose
This PR fixes #12164. This PR also adds test cases to test float constants as finite type from both same package and a `balo`. With this PR, balo constants related test cases also got fixed.
