### PR TITLE
Fix documentation, constant negative, invocation context tests

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.balo.BaloCreator;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -81,7 +82,9 @@ public class DocumentationTest {
         Assert.assertEquals(personNameSymbol.markdownDocumentation.parameters.size(), 0);
         Assert.assertNull(personNameSymbol.markdownDocumentation.returnValueDescription);
 
-        BSymbol getNameFuncSymbol = personSymbol.scope.lookup(new Name("Person.getName")).symbol;
+        BObjectTypeSymbol personObjSymbol = (BObjectTypeSymbol) personSymbol;
+
+        BSymbol getNameFuncSymbol = personObjSymbol.methodScope.lookup(new Name("Person.getName")).symbol;
         Assert.assertNotNull(getNameFuncSymbol.markdownDocumentation);
         Assert.assertEquals(getNameFuncSymbol.markdownDocumentation.description.replaceAll
                 (CARRIAGE_RETURN_CHAR, EMPTY_STRING), "get the users name.");
@@ -89,7 +92,7 @@ public class DocumentationTest {
         Assert.assertEquals(getNameFuncSymbol.markdownDocumentation.parameters.get(0).description
                 .replaceAll(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "integer value");
 
-        BSymbol isMaleFuncSymbol = personSymbol.scope.lookup(new Name("Person.isMale")).symbol;
+        BSymbol isMaleFuncSymbol = personObjSymbol.methodScope.lookup(new Name("Person.isMale")).symbol;
         Assert.assertNotNull(isMaleFuncSymbol.markdownDocumentation);
         Assert.assertEquals(isMaleFuncSymbol.markdownDocumentation.description.replaceAll(CARRIAGE_RETURN_CHAR,
                 EMPTY_STRING), "Indicate whether this is a male or female.");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/InvocationContextTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/InvocationContextTest.java
@@ -41,55 +41,55 @@ public class InvocationContextTest {
     }
 
     @Test(description = "Test case for accessing invocationId from invocation context")
-    public void testInvocationId() throws Exception {
+    public void testInvocationId() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testInvocationId");
         Assert.assertTrue(returns[0] instanceof BString);
     }
 
     @Test(description = "Test case for processing userId in authentication context")
-    public void testUserId() throws Exception {
+    public void testUserId() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testUserId");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
     @Test(description = "Test case for processing username in authentication context")
-    public void testUsername() throws Exception {
+    public void testUsername() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testUsername");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
     @Test(description = "Test case for processing user claims in authentication context")
-    public void testUserClaims() throws Exception {
+    public void testUserClaims() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testUserClaims");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
     @Test(description = "Test case for processing allowedScopes in authentication context")
-    public void testAllowedScopes() throws Exception {
+    public void testAllowedScopes() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testAllowedScopes");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
     @Test(description = "Test case for processing authType in authentication context")
-    public void testAuthType() throws Exception {
+    public void testAuthType() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testAuthType");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
     @Test(description = "Test case for processing authToken in authentication context")
-    public void testAuthToken() throws Exception {
+    public void testAuthToken() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testAuthToken");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
     @Test(description = "Test case for custom attributes in Invocation Context")
-    public void testCustomAttributes() throws Exception {
+    public void testCustomAttributes() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testAttributes");
         Assert.assertTrue(returns[0] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());

--- a/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_negative/.ballerina/.gitignore
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_negative/.ballerina/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/ballerina-unit-test/src/test/resources/test-src/documentation/markdown_annotation.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/documentation/markdown_annotation.bal
@@ -2,10 +2,10 @@
 # + a - annotation `field a` documentation
 # + b - annotation `field b` documentation
 # + c - annotation `field c` documentation
-type Tst object {
-    public string a = "";
-    public string b = "";
-    public string c = "";
+type Tst record {
+    string a = "";
+    string b = "";
+    string c = "";
 };
 
 # Documentation for Test annotation

--- a/tests/ballerina-unit-test/src/test/resources/test-src/runtime/invocation-context.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/runtime/invocation-context.bal
@@ -22,9 +22,7 @@ function testUserClaims () returns (boolean) {
     if (runtime:getInvocationContext().userPrincipal.claims.hasKey("email")) {
         string emailInContext = "";
         var result = runtime:getInvocationContext().userPrincipal.claims["email"];
-        if (result is any) {
-            emailInContext = <string> result;
-        }
+        emailInContext = <string> result;
 
         return "tom@ballerina.com" == emailInContext;
     }


### PR DESCRIPTION
Fix documentation, constant negative, invocation context tests.

Added the .ballerina dir to avoid a test failure with ConstantNegativeTest case