### PR TITLE
Add temp fix to make mysql stored procs returning one resultset work

### DIFF
--- a/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
+++ b/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
@@ -252,7 +252,8 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         // of stored procedures returning only one result set in MySQL. Refer ballerina-platform/ballerina-lang#8643
         if (databaseProductName.contains(MYSQL) && (structTypes != null && structTypes.size() > 1)) {
             throw new BallerinaException(
-                    "Retrieving result sets from stored procedures returning more than one result set, is not supported ");
+                    "Retrieving result sets from stored procedures returning more than one result set, is not "
+                            + "supported");
         } else if (structTypes == null || resultSets.size() != structTypes.size()) {
             throw new BallerinaException(
                     "Mismatching record type count: " + (structTypes == null ? 0 : structTypes.size()) + " and "

--- a/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
+++ b/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
@@ -250,7 +250,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         BValueArray bTables = new BValueArray(new BArrayType(BTypes.typeTable));
         // TODO: "mysql" equality condition is part of the temporary fix to support returning the result set in the case
         // of stored procedures returning only one result set in MySQL. Refer ballerina-platform/ballerina-lang#8643
-        if (databaseProductName.contains(MYSQL) && structTypes.size() > 1) {
+        if (databaseProductName.contains(MYSQL) && (structTypes != null && structTypes.size() > 1)) {
             throw new BallerinaException(
                     "Retrieving result sets from stored procedures returning more than one result set, is not supported ");
         } else if (structTypes == null || resultSets.size() != structTypes.size()) {


### PR DESCRIPTION
## Purpose
$Subject.

This doesn't completely fix https://github.com/ballerina-platform/ballerina-lang/issues/8643 but makes returning result sets from the stored procedures that have only one returned result set work.