### PR TITLE
Improve is-like check for records

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -4776,8 +4776,9 @@ public class BVM {
         for (Map.Entry targetTypeEntry : targetTypeField.entrySet()) {
             String fieldName = targetTypeEntry.getKey().toString();
 
+            int flags = targetType.getFields().get(fieldName).flags;
             if (!(((BMap) sourceValue).getMap().containsKey(fieldName)) &&
-                    !(Flags.isFlagOn(targetType.getFields().get(fieldName).flags, Flags.OPTIONAL))) {
+                    (!Flags.isFlagOn(flags, Flags.OPTIONAL) && Flags.isFlagOn(flags, Flags.REQUIRED))) {
                 return false;
             }
         }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/Flags.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/Flags.java
@@ -27,6 +27,7 @@ public class Flags {
     public static final int PUBLIC = 1;
     public static final int NATIVE = 2;
     public static final int ATTACHED = 8;
+    public static final int REQUIRED = 256;
     public static final int OPTIONAL = 8192;
     public static final int SERVICE = 524288;
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
@@ -446,8 +446,8 @@ public class ConstrainedMapTest {
                 "testJsonToStructConversionStructWithConstrainedMapNegative");
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BError) returns[0]).getReason();
-        Assert.assertEquals(errorMsg, "incompatible stamp operation: 'json' value cannot be stamped as " +
-                "'PersonComplexTwo'");
+        Assert.assertEquals(errorMsg,
+                            "incompatible stamp operation: 'json' value cannot be stamped as 'PersonComplexTwo'");
     }
 
     @Test(description = "Test constrained map with union retrieving string value.")

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/map/constrained-map.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/map/constrained-map.bal
@@ -419,15 +419,15 @@ function testMapOfElementTypeRefArray () returns ((string, int)) {
 }
 
 type PersonComplex record {
-    string name;
-    int age;
-    PersonComplex? parent;
-    json info;
-    map<string> address;
-    int[] marks;
-    anydata a;
-    float score;
-    boolean alive;
+    string name = "";
+    int age = 0;
+    PersonComplex? parent = ();
+    json info = ();
+    map<string> address = {};
+    int[] marks = [];
+    anydata a = ();
+    float score = 0.0;
+    boolean alive = false;
     !...
 };
 
@@ -463,15 +463,15 @@ function testJsonToStructConversionStructWithConstrainedMap () returns (string, 
 }
 
 type PersonComplexTwo record {
-    string name;
-    int age;
-    PersonComplexTwo? parent;
-    json info;
-    map<int> address;
-    int[] marks;
-    anydata a;
-    float score;
-    boolean alive;
+    string name = "";
+    int age = 0;
+    PersonComplexTwo? parent = ();
+    json info = ();
+    map<int> address = {};
+    int[] marks = [];
+    anydata a = ();
+    float score = 0.0;
+    boolean alive = false;
     !...
 };
 


### PR DESCRIPTION
## Purpose
> $subject. With this change, an empty record literal will be matched to a record type whose fields are either all optional or a combination of optional fields and required fields with explicit default values.

## Sample
>For example, the following previously returned an error. But now, this will return a converted record.
```ballerina
import ballerina/io;

public function main() {
    json j = {};
    Person|error p = Person.create(j);
    io:println(p);
}

type Person record {
    string name = "";
    int age = 0;
    !...
};
```