### PR TITLE
 Fix record variable in structured match test cases

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3433,7 +3433,7 @@ public class Desugar extends BLangNodeVisitor {
                 String fieldName = recordVariable.variableList.get(i).key.value;
                 BType fieldType = getStructuredBindingPatternType(
                         recordVariable.variableList.get(i).valueBindingPattern);
-                BVarSymbol fieldSymbol = new BVarSymbol(0, names.fromString(fieldName), env.enclPkg.symbol.pkgID,
+                BVarSymbol fieldSymbol = new BVarSymbol(Flags.REQUIRED, names.fromString(fieldName), env.enclPkg.symbol.pkgID,
                         fieldType, recordSymbol);
 
                 fields.add(new BField(names.fromString(fieldName), fieldSymbol));

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredRecordPatternsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredRecordPatternsTest.java
@@ -75,7 +75,7 @@ public class MatchStructuredRecordPatternsTest {
         Assert.assertEquals(bString.stringValue(), "Matched Values : 12, {s:\"S\", i:23, f:5.6}");
     }
 
-    @Test(description = "Test basics of structured pattern match statement 4", groups = "broken")
+    @Test(description = "Test basics of structured pattern match statement 4")
     public void testMatchStatementBasics4() {
         BValue[] returns = BRunUtil.invoke(result, "testStructuredMatchPatternsBasic4", new BValue[]{});
         Assert.assertEquals(returns.length, 1);
@@ -86,7 +86,7 @@ public class MatchStructuredRecordPatternsTest {
         Assert.assertEquals(bString.stringValue(), "Matched Values : {b:12, f:{s:\"S\", i:23, f:5.6}}");
     }
 
-    @Test(description = "Test basics of structured pattern match statement 5", groups = "broken")
+    @Test(description = "Test basics of structured pattern match statement 5")
     public void testMatchStatementBasics5() {
         BValue[] returns = BRunUtil.invoke(result, "testStructuredMatchPatternsBasics5", new BValue[]{});
         Assert.assertEquals(returns.length, 1);
@@ -117,7 +117,7 @@ public class MatchStructuredRecordPatternsTest {
         Assert.assertEquals(results.getString(++i), msg + "single var : bar2");
     }
 
-    @Test(description = "Test structured pattern runtime matching", groups = "broken")
+    @Test(description = "Test structured pattern runtime matching")
     public void testRuntimeCheck() {
         BValue[] returns = BRunUtil.invoke(result, "testRuntimeCheck", new BValue[]{});
         Assert.assertEquals(returns.length, 1);


### PR DESCRIPTION
## Purpose
When creating an anonymous record type to match a record variable in match, we now set all the fields as required