### PR TITLE
Fix JAVA_HOME resolving in lang-server launch scripts

### DIFF
--- a/distribution/zip/ballerina-tools/resources/language-server-launcher.sh
+++ b/distribution/zip/ballerina-tools/resources/language-server-launcher.sh
@@ -121,6 +121,11 @@ if $mingw ; then
   # TODO classpath?
 fi
 
+# If the jre is found inside BALLERINA_HOME, override JAVA_HOME
+if [ -x "$BALLERINA_HOME/bre/lib/jre1.8.0_172" ] ; then
+  JAVA_HOME="$BALLERINA_HOME/bre/lib/jre1.8.0_172"
+fi
+
 if [ -z "$JAVACMD" ] ; then
   if [ -n "$JAVA_HOME"  ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
@@ -132,11 +137,6 @@ if [ -z "$JAVACMD" ] ; then
   else
     JAVACMD=java
   fi
-fi
-
-# If the jre is found in BALLERINA_HOME, override java executable
-if [ -x "$BALLERINA_HOME/bre/lib/jre1.8.0_172/bin/java" ] ; then
-  JAVACMD="$BALLERINA_HOME/bre/lib/jre1.8.0_172/bin/java"
 fi
 
 if [ ! -x "$JAVACMD" ] ; then


### PR DESCRIPTION
Instead of overriding JAVACMD variable, we need to override JAVA_HOME, when jre is found inside BALLERINA_HOME. Otherwise, validation logic inside the script to validate jre version can fail in some envs where they have JAVA_HOME pointed to a non-compatible version of jre.