### PR TITLE
Fix is json returns false after converting record to json

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -4924,6 +4924,8 @@ public class BVM {
             case TypeTags.ARRAY_TAG:
                 // Element type of the array should be 'is type' JSON
                 return checkIsType(((BArrayType) sourceType).getElementType(), targetType, unresolvedTypes);
+            case TypeTags.MAP_TAG:
+                return checkCastByType(((BMapType) sourceType).getConstrainedType(), targetType, unresolvedTypes);
             default:
                 return false;
         }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
@@ -743,4 +743,11 @@ public class NativeConversionTest {
         Assert.assertTrue(returns[0] instanceof BMap);
         Assert.assertEquals(returns[0].stringValue(), "{f:3.0}");
     }
+
+    @Test(description = "Test result is json after converting record to json")
+    public void testRecordToJsonWithIsJson() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testRecordToJsonWithIsJson");
+        Assert.assertTrue(returns[0] instanceof BBoolean);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
@@ -1002,3 +1002,9 @@ function testJsonIntToFloat() returns A|error {
     json j = {f : 3.0};
     return check A.create(j);
 }
+
+function testRecordToJsonWithIsJson() returns boolean {
+    Person2 person = {name:"Waruna", age:10};
+    var personData = json.create(person);
+    return personData is json;
+}


### PR DESCRIPTION
## Purpose
> When we convert a record to Json, it will stamp to map<json>. When we check the is json method, it will returns false as we do not check map<json> is  json which should return true. This PR will fix that.