### PR TITLE
Transaction blockId improvement

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -3072,13 +3072,13 @@ public class BVM {
         sf.refRegs[i] = new BMap<>(structInfo.getType());
     }
 
-    private static void beginTransaction(Strand strand, int transactionType, int transactionBlockId,
+    private static void beginTransaction(Strand strand, int transactionType, int transactionBlockIdIndex,
                                          int retryCountRegIndex, int committedFuncIndex, int abortedFuncIndex) {
         if (transactionType == Transactions.TransactionType.PARTICIPANT.value) {
-            beginTransactionLocalParticipant(strand, transactionBlockId, committedFuncIndex, abortedFuncIndex);
+            beginTransactionLocalParticipant(strand, transactionBlockIdIndex, committedFuncIndex, abortedFuncIndex);
             return;
         } else if (transactionType == Transactions.TransactionType.REMOTE_PARTICIPANT.value) {
-            beginRemoteParticipant(strand, transactionBlockId, committedFuncIndex, abortedFuncIndex);
+            beginRemoteParticipant(strand, transactionBlockIdIndex, committedFuncIndex, abortedFuncIndex);
             return;
         }
 
@@ -3102,13 +3102,14 @@ public class BVM {
             handleError(strand);
             return;
         }
+        String transactionBlockId = getTrxBlockIdFromCP(strand, transactionBlockIdIndex);
 
         TransactionLocalContext transactionLocalContext = createAndNotifyGlobalTx(strand, transactionBlockId);
         strand.setLocalTransactionContext(transactionLocalContext);
         transactionLocalContext.beginTransactionBlock(transactionBlockId, retryCount);
     }
 
-    private static void beginRemoteParticipant(Strand strand, int transactionBlockId, int committedFuncIndex,
+    private static void beginRemoteParticipant(Strand strand, int transactionBlockIdIndex, int committedFuncIndex,
                                                int abortedFuncIndex) {
         TransactionLocalContext localTransactionContext = strand.getLocalTransactionContext();
         if (localTransactionContext == null) {
@@ -3130,7 +3131,7 @@ public class BVM {
             FunctionRefCPEntry funcRefCPEntry = (FunctionRefCPEntry) strand.currentFrame.constPool[abortedFuncIndex];
             fpAborted = new BFunctionPointer(funcRefCPEntry.getFunctionInfo());
         }
-
+        String transactionBlockId = getTrxBlockIdFromCP(strand, transactionBlockIdIndex);
         localTransactionContext.setResourceParticipant(true);
         String globalTransactionId = localTransactionContext.getGlobalTransactionId();
         localTransactionContext.beginTransactionBlock(transactionBlockId, -1);
@@ -3146,7 +3147,7 @@ public class BVM {
         strand.setError(error);
     }
 
-    private static void beginTransactionLocalParticipant(Strand strand, int transactionBlockId,
+    private static void beginTransactionLocalParticipant(Strand strand, int transactionBlockIdCpIndex,
                                                          int committedFuncIndex, int abortedFuncIndex) {
         TransactionLocalContext transactionLocalContext = strand.getLocalTransactionContext();
         if (transactionLocalContext == null) {
@@ -3154,6 +3155,8 @@ public class BVM {
             // We have no business here. This is a no-op.
             return;
         }
+
+        String transactionBlockId = getTrxBlockIdFromCP(strand, transactionBlockIdCpIndex);
 
         // Register committed function handler if exists.
         TransactionResourceManager transactionResourceManager = TransactionResourceManager.getInstance();
@@ -3179,7 +3182,12 @@ public class BVM {
         strand.currentFrame.trxParticipant = StackFrame.TransactionParticipantType.LOCAL_PARTICIPANT;
     }
 
-    private static TransactionLocalContext createAndNotifyGlobalTx(Strand ctx, int transactionBlockId) {
+    private static String getTrxBlockIdFromCP(Strand strand, int index) {
+        StringCPEntry stringCPEntry = (StringCPEntry) strand.currentFrame.constPool[index];
+        return stringCPEntry.getValue();
+    }
+
+    private static TransactionLocalContext createAndNotifyGlobalTx(Strand ctx, String transactionBlockId) {
         BValue[] txResult = TransactionUtils.notifyTransactionBegin(ctx, null, null,
                 transactionBlockId, TransactionConstants.DEFAULT_COORDINATION_TYPE);
 
@@ -3196,10 +3204,13 @@ public class BVM {
         return TransactionLocalContext.create(globalTransactionId, null, null);
     }
 
-    private static void retryTransaction(Strand strand, int transactionBlockId, int trAbortEndIp, int trEndStatusReg) {
+    private static void retryTransaction(Strand strand, int transactionBlockIdCpIndex,
+                                         int trAbortEndIp, int trEndStatusReg) {
         strand.currentFrame.intRegs[trEndStatusReg] = 0; // set trend status to normal.
         TransactionLocalContext transactionLocalContext = strand.getLocalTransactionContext();
         transactionLocalContext.getAndClearFailure();
+
+        String transactionBlockId = getTrxBlockIdFromCP(strand, transactionBlockIdCpIndex);
         if (transactionLocalContext.isRetryPossible(strand, transactionBlockId)) {
             if (transactionLocalContext.isRetryAttempt(transactionBlockId)) {
                 TransactionLocalContext newLocalTransaction = createAndNotifyGlobalTx(strand, transactionBlockId);
@@ -3219,9 +3230,11 @@ public class BVM {
         strand.currentFrame.ip = trAbortEndIp;
     }
 
-    private static void endTransaction(Strand strand, int txBlockId, int endType, int statusRegIndex,
+    private static void endTransaction(Strand strand, int transactionBlockIdCpIndex, int endType, int statusRegIndex,
                                        int errorRegIndex) {
         TransactionLocalContext localTxInfo = strand.getLocalTransactionContext();
+        String txBlockId = getTrxBlockIdFromCP(strand, transactionBlockIdCpIndex);
+
         try {
             //In success case no need to do anything as with the transaction end phase it will be committed.
             switch (Transactions.TransactionStatus.getConst(endType)) {
@@ -3247,7 +3260,7 @@ public class BVM {
         }
     }
 
-    private static void transactionAbortedEnd(Strand strand, int txBlockId, TransactionLocalContext localTxInfo,
+    private static void transactionAbortedEnd(Strand strand, String txBlockId, TransactionLocalContext localTxInfo,
                                               int statusRegIndex, int errorRegIndex) {
         // Notify only if, aborted by 'abort' statement.
         if (strand.currentFrame.intRegs[statusRegIndex] == 0) {
@@ -3271,7 +3284,7 @@ public class BVM {
         strand.currentFrame.intRegs[statusRegIndex] = 0;
     }
 
-    private static void transactionEndEnd(Strand strand, int transactionBlockId,
+    private static void transactionEndEnd(Strand strand, String transactionBlockId,
                                           TransactionLocalContext transactionLocalContext) {
         boolean isOuterTx = transactionLocalContext.onTransactionEnd(transactionBlockId);
         if (isOuterTx) {
@@ -3279,7 +3292,7 @@ public class BVM {
         }
     }
 
-    private static void transactionBlockEnd(Strand strand, int transactionBlockId, int statusRegIndex,
+    private static void transactionBlockEnd(Strand strand, String transactionBlockId, int statusRegIndex,
                                             TransactionLocalContext transactionLocalContext, int errorRegIndex) {
         // Tx reached end of block, it may or may not successfully finished.
         TransactionLocalContext.TransactionFailure failure = transactionLocalContext.getFailure();
@@ -3324,12 +3337,12 @@ public class BVM {
     }
 
     private static TransactionUtils.CoordinatorCommit notifyGlobalPrepareAndCommit(
-            Strand ctx, int transactionBlockId, TransactionLocalContext transactionLocalContext) {
+            Strand ctx, String transactionBlockId, TransactionLocalContext transactionLocalContext) {
         return TransactionUtils.notifyTransactionEnd(ctx,
                 transactionLocalContext.getGlobalTransactionId(), transactionBlockId);
     }
 
-    private static void notifyTransactionAbort(Strand strand, int transactionBlockId,
+    private static void notifyTransactionAbort(Strand strand, String transactionBlockId,
                                                TransactionLocalContext transactionLocalContext) {
         TransactionUtils.notifyTransactionAbort(strand, transactionLocalContext.getGlobalTransactionId(),
                 transactionBlockId);
@@ -3337,7 +3350,7 @@ public class BVM {
                 .notifyAbort(transactionLocalContext.getGlobalTransactionId(), transactionBlockId, false);
     }
 
-    private static void transactionFailedEnd(Strand strand, int transactionBlockId,
+    private static void transactionFailedEnd(Strand strand, String transactionBlockId,
                                              TransactionLocalContext transactionLocalContext,
                                              int runOnRetryBlockRegIndex) {
         // Invoking tr_end with transaction status of FAILED means tx has failed for some reason.

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/transactions/TransactionUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/transactions/TransactionUtils.java
@@ -21,7 +21,6 @@ import org.ballerinalang.bre.bvm.BVMExecutor;
 import org.ballerinalang.bre.bvm.Strand;
 import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BError;
-import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.util.codegen.FunctionInfo;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/transactions/TransactionUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/transactions/TransactionUtils.java
@@ -36,10 +36,10 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 public class TransactionUtils {
 
     public static BValue[] notifyTransactionBegin(Strand ctx, String globalTransactionId, String url,
-                                                  int transactionBlockId, String protocol) {
+                                                  String transactionBlockId, String protocol) {
         BValue[] args = {
                 (globalTransactionId == null ? null : new BString(globalTransactionId)),
-                new BInteger(transactionBlockId), new BString(url),
+                new BString(transactionBlockId), new BString(url),
                 new BString(protocol)
         };
         BValue[] returns = invokeCoordinatorFunction(ctx, TransactionConstants.COORDINATOR_BEGIN_TRANSACTION, args);
@@ -48,8 +48,8 @@ public class TransactionUtils {
     }
 
     public static CoordinatorCommit notifyTransactionEnd(Strand ctx, String globalTransactionId,
-            int transactionBlockId) {
-        BValue[] args = {new BString(globalTransactionId), new BInteger(transactionBlockId)};
+            String transactionBlockId) {
+        BValue[] args = {new BString(globalTransactionId), new BString(transactionBlockId)};
         BValue[] returns = invokeCoordinatorFunction(ctx, TransactionConstants.COORDINATOR_END_TRANSACTION, args);
         checkTransactionCoordinatorError(returns[0], "error in transaction end: ");
 
@@ -66,9 +66,8 @@ public class TransactionUtils {
         }
     }
 
-    public static void notifyTransactionAbort(Strand ctx, String globalTransactionId,
-            int transactionBlockId) {
-        BValue[] args = {new BString(globalTransactionId), new BInteger(transactionBlockId)};
+    public static void notifyTransactionAbort(Strand ctx, String globalTransactionId, String transactionBlockId) {
+        BValue[] args = {new BString(globalTransactionId), new BString(transactionBlockId)};
         invokeCoordinatorFunction(ctx, TransactionConstants.COORDINATOR_ABORT_TRANSACTION, args);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1791,11 +1791,8 @@ public class CodeGenerator extends BLangNodeVisitor {
             }
         }
         // Participate in transaction.
-        String transactionIndexStr = String.valueOf(transactionIndex);
-        StringCPEntry stringCPEntry = new StringCPEntry(
-                addUTF8CPEntry(currentPkgInfo, transactionIndexStr), transactionIndexStr);
-        int strCPIndex = currentPkgInfo.addCPEntry(stringCPEntry);
-        Operand transactionIndexOperand = getOperand(strCPIndex);
+        int txIdCPIndex = getTransactionIdCpIndex(transactionIndex);
+        Operand transactionIndexOperand = getOperand(txIdCPIndex);
         int participantType = getParticipantTypeTag(function);
         Operand transactionType = getOperand(participantType);
         RegIndex retryCountRegIndex = getRegIndex(TypeTags.INT);
@@ -2876,11 +2873,8 @@ public class CodeGenerator extends BLangNodeVisitor {
     public void visit(BLangTransaction transactionNode) {
         ++transactionIndex;
 
-        String transactionIndexStr = String.valueOf(transactionIndex);
-        StringCPEntry stringCPEntry = new StringCPEntry(
-                addUTF8CPEntry(currentPkgInfo, transactionIndexStr), transactionIndexStr);
-        int strCPIndex = currentPkgInfo.addCPEntry(stringCPEntry);
-        Operand transactionIndexOperand = getOperand(strCPIndex);
+        int txIdCpIndex = getTransactionIdCpIndex(transactionIndex);
+        Operand transactionIndexOperand = getOperand(txIdCpIndex);
 
         Operand retryCountRegIndex = new RegIndex(-1, TypeTags.INT);
         if (transactionNode.retryCount != null) {
@@ -2983,6 +2977,20 @@ public class CodeGenerator extends BLangNodeVisitor {
         emit(InstructionCodes.BR_FALSE, trEndStatusReg, oneAfterRethrowInstructionAddress);
         emit(InstructionCodes.PANIC, errorRegIndex);
         oneAfterRethrowInstructionAddress.value = nextIP();
+    }
+
+    private int getTransactionIdCpIndex(int transactionIndex) {
+        StringBuilder txNameBuilder = new StringBuilder();
+        String transactionIndexStr = txNameBuilder
+                .append(currentPkgID.orgName)
+                .append("$")
+                .append(currentPkgID.name)
+                .append("$")
+                .append(transactionIndex)
+                .toString();
+        StringCPEntry stringCPEntry = new StringCPEntry(
+                addUTF8CPEntry(currentPkgInfo, transactionIndexStr), transactionIndexStr);
+        return currentPkgInfo.addCPEntry(stringCPEntry);
     }
 
     public void visit(BLangAbort abortNode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1791,7 +1791,11 @@ public class CodeGenerator extends BLangNodeVisitor {
             }
         }
         // Participate in transaction.
-        Operand transactionIndexOperand = getOperand(transactionIndex);
+        String transactionIndexStr = String.valueOf(transactionIndex);
+        StringCPEntry stringCPEntry = new StringCPEntry(
+                addUTF8CPEntry(currentPkgInfo, transactionIndexStr), transactionIndexStr);
+        int strCPIndex = currentPkgInfo.addCPEntry(stringCPEntry);
+        Operand transactionIndexOperand = getOperand(strCPIndex);
         int participantType = getParticipantTypeTag(function);
         Operand transactionType = getOperand(participantType);
         RegIndex retryCountRegIndex = getRegIndex(TypeTags.INT);
@@ -2871,7 +2875,13 @@ public class CodeGenerator extends BLangNodeVisitor {
 
     public void visit(BLangTransaction transactionNode) {
         ++transactionIndex;
-        Operand transactionIndexOperand = getOperand(transactionIndex);
+
+        String transactionIndexStr = String.valueOf(transactionIndex);
+        StringCPEntry stringCPEntry = new StringCPEntry(
+                addUTF8CPEntry(currentPkgInfo, transactionIndexStr), transactionIndexStr);
+        int strCPIndex = currentPkgInfo.addCPEntry(stringCPEntry);
+        Operand transactionIndexOperand = getOperand(strCPIndex);
+
         Operand retryCountRegIndex = new RegIndex(-1, TypeTags.INT);
         if (transactionNode.retryCount != null) {
             this.genNode(transactionNode.retryCount, this.env);

--- a/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/SQLDatasourceUtils.java
+++ b/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/SQLDatasourceUtils.java
@@ -1129,7 +1129,7 @@ public class SQLDatasourceUtils {
 
     private static void notifyTxMarkForAbort(Context context, TransactionLocalContext transactionLocalContext) {
         String globalTransactionId = transactionLocalContext.getGlobalTransactionId();
-        int transactionBlockId = transactionLocalContext.getCurrentTransactionBlockId();
+        String transactionBlockId = transactionLocalContext.getCurrentTransactionBlockId();
 
         transactionLocalContext.markFailure();
         if (transactionLocalContext.isRetryPossible(context.getStrand(), transactionBlockId)) {
@@ -1591,7 +1591,7 @@ public class SQLDatasourceUtils {
         boolean isXAConnection = datasource.isXAConnection();
         TransactionLocalContext transactionLocalContext = context.getLocalTransactionInfo();
         String globalTxId = transactionLocalContext.getGlobalTransactionId();
-        int currentTxBlockId = transactionLocalContext.getCurrentTransactionBlockId();
+        String currentTxBlockId = transactionLocalContext.getCurrentTransactionBlockId();
         BallerinaTransactionContext txContext = transactionLocalContext.getTransactionContext(connectorId);
         if (txContext == null) {
             if (isXAConnection) {

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/SessionConnector.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/SessionConnector.java
@@ -110,7 +110,7 @@ public class SessionConnector implements BallerinaTransactionContext {
             if (Objects.isNull(txContext)) {
                 transactionLocalContext.registerTransactionContext(getConnectorId(), this);
                 String globalTxId = transactionLocalContext.getGlobalTransactionId();
-                int currentTxBlockId = transactionLocalContext.getCurrentTransactionBlockId();
+                String currentTxBlockId = transactionLocalContext.getCurrentTransactionBlockId();
                 TransactionResourceManager.getInstance().register(globalTxId, currentTxBlockId, this);
             }
         }

--- a/stdlib/transactions/src/main/ballerina/transactions/2pc_participant.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/2pc_participant.bal
@@ -169,7 +169,7 @@ type LocalParticipant object {
         return ((), self);
     }
 
-    function prepareMe(string transactionId, int transactionBlockId) returns PrepareResult|error {
+    function prepareMe(string transactionId, string transactionBlockId) returns PrepareResult|error {
         string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
         if (!participatedTransactions.hasKey(participatedTxnId)) {
             error err = error(TRANSACTION_UNKNOWN);
@@ -218,7 +218,7 @@ type LocalParticipant object {
         return (); // No matching protocol
     }
 
-    function notifyMe(string action, int participatedTxnBlockId) returns NotifyResult|error {
+    function notifyMe(string action, string participatedTxnBlockId) returns NotifyResult|error {
         string participatedTxnId = getParticipatedTransactionId(self.participatedTxn.transactionId, participatedTxnBlockId);
         if (action == COMMAND_COMMIT) {
             if (self.participatedTxn.state == TXN_STATE_PREPARED) {

--- a/stdlib/transactions/src/main/ballerina/transactions/2pc_transaction.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/2pc_transaction.bal
@@ -21,7 +21,7 @@ import ballerina/time;
 type TwoPhaseCommitTransaction object {
 
     string transactionId;
-    int transactionBlockId;
+    string transactionBlockId;
     string coordinationType;
     boolean isInitiated = false; // Indicates whether this is a transaction that was initiated or is participated in
     map<Participant> participants = {};
@@ -30,7 +30,7 @@ type TwoPhaseCommitTransaction object {
     TransactionState state = TXN_STATE_ACTIVE;
     private boolean possibleMixedOutcome = false;
 
-    function __init(string transactionId, int transactionBlockId, string coordinationType = "2pc") {
+    function __init(string transactionId, string transactionBlockId, string coordinationType = "2pc") {
         self.transactionId = transactionId;
         self.transactionBlockId = transactionBlockId;
         self.coordinationType = coordinationType;
@@ -38,7 +38,7 @@ type TwoPhaseCommitTransaction object {
 
     // This function will be called by the initiator
     function twoPhaseCommit() returns string|error {
-        log:printInfo(io:sprintf("Running 2-phase commit for transaction: %s:%d", self.transactionId,
+        log:printInfo(io:sprintf("Running 2-phase commit for transaction: %s:%s", self.transactionId,
                 self.transactionBlockId));
         string|error ret = "";
 
@@ -224,7 +224,7 @@ type TwoPhaseCommitTransaction object {
 
     // This function will be called by the initiator
     function abortInitiatorTransaction() returns string|error {
-        log:printInfo(io:sprintf("Aborting initiated transaction: %s:%d", self.transactionId, self.transactionBlockId));
+        log:printInfo(io:sprintf("Aborting initiated transaction: %s:%s", self.transactionId, self.transactionBlockId));
         string|error ret = "";
         // return response to the initiator. ( Aborted | Mixed )
         var result = self.notifyParticipants(COMMAND_ABORT, ());

--- a/stdlib/transactions/src/main/ballerina/transactions/commons.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/commons.bal
@@ -171,7 +171,7 @@ function getCoordinatorProtocolAt(string protocolName, int transactionBlockId) r
         transactionBlockId;
 }
 
-function getParticipantProtocolAt(string protocolName, int transactionBlockId) returns string {
+function getParticipantProtocolAt(string protocolName, string transactionBlockId) returns string {
     //TODO: protocolName is unused for the moment
     return "http://" + coordinatorHost + ":" + coordinatorPort + participant2pcCoordinatorBasePath + "/" +
         transactionBlockId;
@@ -184,7 +184,7 @@ function getParticipantProtocolAt(string protocolName, int transactionBlockId) r
 #                      is being created for.
 # + transactionBlockId - The ID of the transaction block.
 # + return - TransactionContext if the coordination type is valid or an error in case of an invalid coordination type.
-function createTransactionContext(string coordinationType, int transactionBlockId) returns TransactionContext|error {
+function createTransactionContext(string coordinationType, string transactionBlockId) returns TransactionContext|error {
     if (!isValidCoordinationType(coordinationType)) {
         string msg = "Invalid-Coordination-Type:" + coordinationType;
         log:printError(msg);
@@ -215,7 +215,7 @@ function createTransactionContext(string coordinationType, int transactionBlockI
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + registerAtURL - The URL of the initiator
 # + return - TransactionContext if the registration is successul or an error in case of a failure.
-function registerLocalParticipantWithInitiator(string transactionId, int transactionBlockId, string registerAtURL)
+function registerLocalParticipantWithInitiator(string transactionId, string transactionBlockId, string registerAtURL)
     returns TransactionContext|error {
 
     string participantId = getParticipantId(transactionBlockId);
@@ -316,7 +316,7 @@ function getParticipant2pcClient(string participantURL) returns Participant2pcCl
 # + registerAtURL - The URL of the coordinator.
 # + participantProtocols - The coordination protocals supported by the participant.
 # + return - TransactionContext if the registration is successful or an error in case of a failure.
-public function registerParticipantWithRemoteInitiator(string transactionId, int transactionBlockId,
+public function registerParticipantWithRemoteInitiator(string transactionId, string transactionBlockId,
                                                        string registerAtURL, RemoteProtocol[] participantProtocols)
     returns TransactionContext|error {
 
@@ -359,12 +359,12 @@ public function registerParticipantWithRemoteInitiator(string transactionId, int
     }
 }
 
-function getParticipatedTransactionId(string transactionId, int transactionBlockId) returns string {
+function getParticipatedTransactionId(string transactionId, string transactionBlockId) returns string {
     string id = transactionId + ":" + transactionBlockId;
     return id;
 }
 
-function getParticipantId(int transactionBlockId) returns string {
+function getParticipantId(string transactionBlockId) returns string {
     string participantId = localParticipantId + ":" + transactionBlockId;
     return participantId;
 }

--- a/stdlib/transactions/src/main/ballerina/transactions/connector_initiator.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/connector_initiator.bal
@@ -39,7 +39,7 @@ type InitiatorClientEP client object {
         self.httpClient = httpEP;
     }
 
-    remote function register(string transactionId, int transactionBlockId, RemoteProtocol[] participantProtocols)
+    remote function register(string transactionId, string transactionBlockId, RemoteProtocol[] participantProtocols)
                  returns RegistrationResponse|error {
         http:Client httpClient = self.httpClient;
         string participantId = getParticipantId(transactionBlockId);

--- a/stdlib/transactions/src/main/ballerina/transactions/data.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/data.bal
@@ -17,7 +17,7 @@
 public type TransactionContext record {
     string contextVersion = "1.0";
     string transactionId = "";
-    int transactionBlockId = 0;
+    string transactionBlockId = "";
     string coordinationType = "";
     string registerAtURL = "";
 };

--- a/stdlib/transactions/src/main/ballerina/transactions/service_participant_2pc.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/service_participant_2pc.bal
@@ -37,7 +37,7 @@ service Participant2pcService on coordinatorListener {
         body:"prepareReq",
         consumes:["application/json"]
     }
-    resource function prepare(http:Caller conn, http:Request req, int transactionBlockId, PrepareRequest prepareReq) {
+    resource function prepare(http:Caller conn, http:Request req, string transactionBlockId, PrepareRequest prepareReq) {
         http:Response res = new;
         string transactionId = prepareReq.transactionId;
         string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
@@ -96,7 +96,7 @@ service Participant2pcService on coordinatorListener {
         body:"notifyReq",
         consumes:["application/json"]
     }
-    resource function notify(http:Caller conn, http:Request req, int transactionBlockId, NotifyRequest notifyReq) {
+    resource function notify(http:Caller conn, http:Request req, string transactionBlockId, NotifyRequest notifyReq) {
         http:Response res = new;
         string transactionId = notifyReq.transactionId;
         string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);

--- a/stdlib/transactions/src/main/ballerina/transactions/transaction_block.bal
+++ b/stdlib/transactions/src/main/ballerina/transactions/transaction_block.bal
@@ -29,7 +29,7 @@
 # + registerAtUrl - The URL of the initiator
 # + coordinationType - Coordination type of this transaction
 # + return - Newly created/existing TransactionContext for this transaction.
-function beginTransaction(string? transactionId, int transactionBlockId, string registerAtUrl,
+function beginTransaction(string? transactionId, string transactionBlockId, string registerAtUrl,
                           string coordinationType) returns TransactionContext|error {
     if (transactionId is string) {
         if (initiatedTransactions.hasKey(transactionId)) { // if participant & initiator are in the same process
@@ -53,7 +53,7 @@ function beginTransaction(string? transactionId, int transactionBlockId, string 
 # + transactionId - Globally unique transaction ID.
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + return - nil or error when transaction abortion is successful or not respectively.
-function abortTransaction(string transactionId, int transactionBlockId) returns error? {
+function abortTransaction(string transactionId, string transactionBlockId) returns error? {
     string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
     var txn = participatedTransactions[participatedTxnId];
     if (txn is TwoPhaseCommitTransaction) {
@@ -82,7 +82,7 @@ function abortTransaction(string transactionId, int transactionBlockId) returns 
 # + transactionId - Globally unique transaction ID.
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + return - A string or an error representing the transaction end succcess status or failure respectively.
-function endTransaction(string transactionId, int transactionBlockId) returns string|error {
+function endTransaction(string transactionId, string transactionBlockId) returns string|error {
     string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
     if (!initiatedTransactions.hasKey(transactionId) && !participatedTransactions.hasKey(participatedTxnId)) {
         error err = error("Transaction: " + participatedTxnId + " not found");
@@ -119,7 +119,7 @@ function endTransaction(string transactionId, int transactionBlockId) returns st
 # + transactionId - Globally unique transaction ID.
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + return - true or false representing whether this instance is an intiator or not.
-function isInitiator(string transactionId, int transactionBlockId) returns boolean {
+function isInitiator(string transactionId, string transactionBlockId) returns boolean {
     if (initiatedTransactions.hasKey(transactionId)) {
         string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
         if (!participatedTransactions.hasKey(participatedTxnId)) {
@@ -134,21 +134,21 @@ function isInitiator(string transactionId, int transactionBlockId) returns boole
 # + transactionId - Globally unique transaction ID.
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + return - true or false representing whether the resource manager preparation is successful or not.
-extern function prepareResourceManagers(string transactionId, int transactionBlockId) returns boolean;
+extern function prepareResourceManagers(string transactionId, string transactionBlockId) returns boolean;
 
 # Commit local resource managers.
 #
 # + transactionId - Globally unique transaction ID.
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + return - true or false representing whether the commit is successful or not.
-extern function commitResourceManagers(string transactionId, int transactionBlockId) returns boolean;
+extern function commitResourceManagers(string transactionId, string transactionBlockId) returns boolean;
 
 # Abort local resource managers.
 #
 # + transactionId - Globally unique transaction ID.
 # + transactionBlockId - ID of the transaction block. Each transaction block in a process has a unique ID.
 # + return - true or false representing whether the resource manager abortion is successful or not.
-extern function abortResourceManagers(string transactionId, int transactionBlockId) returns boolean;
+extern function abortResourceManagers(string transactionId, string transactionBlockId) returns boolean;
 
 # Get the current transaction id. This function is useful for user code to save state against a transaction ID,
 # so that when the `oncommit` or `onabort` functions registered for a transaction can retrieve that state using the

--- a/stdlib/transactions/src/main/java/io/ballerina/transactions/AbortResourceManagers.java
+++ b/stdlib/transactions/src/main/java/io/ballerina/transactions/AbortResourceManagers.java
@@ -36,14 +36,14 @@ import org.ballerinalang.util.transactions.TransactionResourceManager;
         orgName = "ballerina", packageName = "transactions",
         functionName = "abortResourceManagers",
         args = {@Argument(name = "transactionId", type = TypeKind.STRING),
-                @Argument(name = "transactionBlockId", type = TypeKind.INT)},
+                @Argument(name = "transactionBlockId", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.BOOLEAN)}
 )
 public class AbortResourceManagers extends BlockingNativeCallableUnit {
 
     public void execute(Context ctx) {
         String transactionId = ctx.getStringArgument(0);
-        int transactionBlockId = (int) ctx.getIntArgument(0);
+        String transactionBlockId = ctx.getStringArgument(1);
         boolean abortSuccessful =
                 TransactionResourceManager.getInstance().notifyAbort(transactionId, transactionBlockId, false);
         ctx.setReturnValues(new BBoolean(abortSuccessful));

--- a/stdlib/transactions/src/main/java/io/ballerina/transactions/CommitResourceManagers.java
+++ b/stdlib/transactions/src/main/java/io/ballerina/transactions/CommitResourceManagers.java
@@ -36,14 +36,14 @@ import org.ballerinalang.util.transactions.TransactionResourceManager;
         orgName = "ballerina", packageName = "transactions",
         functionName = "commitResourceManagers",
         args = {@Argument(name = "transactionId", type = TypeKind.STRING),
-                @Argument(name = "transactionBlockId", type = TypeKind.INT)},
+                @Argument(name = "transactionBlockId", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.BOOLEAN)}
 )
 public class CommitResourceManagers extends BlockingNativeCallableUnit {
 
     public void execute(Context ctx) {
         String transactionId = ctx.getStringArgument(0);
-        int transactionBlockId = (int) ctx.getIntArgument(0);
+        String transactionBlockId = ctx.getStringArgument(1);
         boolean commitSuccessful =
                 TransactionResourceManager.getInstance().notifyCommit(transactionId, transactionBlockId);
         ctx.setReturnValues(new BBoolean(commitSuccessful));

--- a/stdlib/transactions/src/main/java/io/ballerina/transactions/PrepareResourceManagers.java
+++ b/stdlib/transactions/src/main/java/io/ballerina/transactions/PrepareResourceManagers.java
@@ -36,14 +36,14 @@ import org.ballerinalang.util.transactions.TransactionResourceManager;
         orgName = "ballerina", packageName = "transactions",
         functionName = "prepareResourceManagers",
         args = {@Argument(name = "transactionId", type = TypeKind.STRING),
-                @Argument(name = "transactionBlockId", type = TypeKind.INT)},
+                @Argument(name = "transactionBlockId", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.BOOLEAN)}
 )
 public class PrepareResourceManagers extends BlockingNativeCallableUnit {
 
     public void execute(Context ctx) {
         String transactionId = ctx.getStringArgument(0);
-        int transactionBlockId = (int) ctx.getIntArgument(0);
+        String transactionBlockId = ctx.getStringArgument(1);
         boolean prepareSuccessful =
                 TransactionResourceManager.getInstance().prepare(transactionId, transactionBlockId);
         ctx.setReturnValues(new BBoolean(prepareSuccessful));


### PR DESCRIPTION
## Purpose
Turn transaction block id from integer to a string comprising of package path of the Ballerina program and the unique compile time constant.

`transaction block id = {orgName}${packageName}${seqNo}`

Example: org$transaction$55

Before this PR we had transaction block id to be a compile time unique sequence number. And we had the chance of  transaction block id collusion when different packages with transaction statements where compiled in different occasions, and run in one Ballerina runtime.
