### PR TITLE
Add is system span flag for user spans

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/observability/ObserverContext.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/observability/ObserverContext.java
@@ -53,6 +53,8 @@ public class ObserverContext {
 
     private ObserverContext parent;
 
+    private boolean isSystemSpan;
+
     public ObserverContext() {
         this.properties = new HashMap<>();
         this.tags = new HashMap<>();
@@ -138,4 +140,11 @@ public class ObserverContext {
         this.parent = parent;
     }
 
+    public boolean isSystemSpan() {
+        return isSystemSpan;
+    }
+
+    public void setSystemSpan(boolean userSpan) {
+        isSystemSpan = userSpan;
+    }
 }

--- a/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/stdlib/observability/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -94,6 +94,7 @@ public class OpenTracerBallerinaWrapper {
         tags.forEach((observerContext::addTag));
 
         if (parentSpanId == SYSTEM_TRACE_INDICATOR) {
+            observerContext.setSystemSpan(true);
             ObserveUtils.getObserverContextOfCurrentFrame(context).ifPresent(observerContext::setParent);
             ObserveUtils.setObserverContextToCurrentFrame(context.getStrand(), observerContext);
             return startSpan(observerContext, true, spanName);
@@ -131,7 +132,9 @@ public class OpenTracerBallerinaWrapper {
         }
         ObserverContext observerContext = observerContextList.get(spanId);
         if (observerContext != null) {
-            ObserveUtils.setObserverContextToCurrentFrame(context.getStrand(), observerContext.getParent());
+            if (observerContext.isSystemSpan()) {
+                ObserveUtils.setObserverContextToCurrentFrame(context.getStrand(), observerContext.getParent());
+            }
             TracingUtils.stopObservation(observerContext);
             observerContext.setFinished();
             observerContextList.remove(spanId);


### PR DESCRIPTION
## Purpose
When attaching a user span to an OOTB span, we add the new observer context to the current frame. When finishing this span, we get the parent of this observer context and set it to the current frame. This should only be done if the user span is attached to an OOTB span. Hence I have added a flag to keep track of such user spans