### PR TITLE
Fix error in compile full-project for single bal files

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompiler.java
@@ -28,7 +28,6 @@ import org.ballerinalang.repository.PackageRepository;
 import org.ballerinalang.toml.model.Manifest;
 import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.ballerinalang.util.diagnostic.DiagnosticListener;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -186,14 +185,14 @@ public class LSCompiler {
     /**
      * Get the BLangPackage for a given program.
      *
-     * @param context                   Language Server Context
-     * @param docManager                Document manager
-     * @param preserveWS                Enable preserve whitespace
-     * @param errStrategy               custom error strategy class
-     * @param compileFullProject        updateAndCompileFile full project from the source root
-     * @return {@link Either}           Either single BLang Package or a list of packages when compile full project
+     * @param context            Language Server Context
+     * @param docManager         Document manager
+     * @param preserveWS         Enable preserve whitespace
+     * @param errStrategy        custom error strategy class
+     * @param compileFullProject updateAndCompileFile full project from the source root
+     * @return {@link List}      A list of packages when compile full project
      */
-    public Either<List<BLangPackage>, BLangPackage> getBLangPackage(LSContext context,
+    public List<BLangPackage> getBLangPackage(LSContext context,
                                               WorkspaceDocumentManager docManager, boolean preserveWS,
                                               Class errStrategy,
                                               boolean compileFullProject) {
@@ -209,7 +208,7 @@ public class LSCompiler {
 
         PackageRepository pkgRepo = new WorkspacePackageRepository(sourceRoot, docManager);
         List<BLangPackage> packages = new ArrayList<>();
-        if (compileFullProject && !sourceRoot.isEmpty()) {
+        if (sourceDoc.hasProjectRepo() && compileFullProject && !sourceRoot.isEmpty()) {
             File projectDir = new File(sourceRoot);
             Arrays.stream(projectDir.listFiles()).forEach(
                     file -> {
@@ -227,7 +226,6 @@ public class LSCompiler {
                         }
                     }
             );
-            return Either.forLeft(packages);
         } else {
             PackageID pkgID;
             String pkgName = LSCompilerUtil.getPackageNameForGivenFile(sourceRoot, sourceDoc.getPath().toString());
@@ -246,9 +244,9 @@ public class LSCompiler {
             Compiler compiler = LSCompilerUtil.getCompiler(context, relativeFilePath, compilerContext, errStrategy);
             BLangPackage bLangPackage = compiler.compile(pkgName);
             LSPackageCache.getInstance(compilerContext).invalidate(bLangPackage.packageID);
-
-            return Either.forRight(bLangPackage);
+            packages.add(bLangPackage);
         }
+        return packages;
     }
 
     private boolean isBallerinaPackage(File dir) {

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/TextDocumentFormatUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/TextDocumentFormatUtil.java
@@ -89,7 +89,7 @@ public class TextDocumentFormatUtil {
         String[] uriParts = uri.split(Pattern.quote("/"));
         String fileName = uriParts[uriParts.length - 1];
         final BLangPackage bLangPackage = lsCompiler.getBLangPackage(context, documentManager,
-                true, LSCustomErrorStrategy.class, false).getRight();
+                true, LSCustomErrorStrategy.class, false).get(0);
         context.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY, bLangPackage.symbol.getName().getValue());
         final List<Diagnostic> diagnostics = new ArrayList<>();
         JsonArray errors = new JsonArray();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -157,7 +157,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
             try {
                 BLangPackage bLangPackage = lsCompiler.getBLangPackage(context, documentManager, false,
                                                                        CompletionCustomErrorStrategy.class,
-                                                                       false).getRight();
+                                                                       false).get(0);
                 context.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                         bLangPackage.symbol.getName().getValue());
                 context.put(DocumentServiceKeys.CURRENT_BLANG_PACKAGE_CONTEXT_KEY, bLangPackage);
@@ -194,7 +194,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
             hoverContext.put(DocumentServiceKeys.POSITION_KEY, position);
             try {
                 BLangPackage currentBLangPackage = lsCompiler.getBLangPackage(hoverContext, documentManager, false,
-                        LSCustomErrorStrategy.class, false).getRight();
+                        LSCustomErrorStrategy.class, false).get(0);
                 hoverContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                  currentBLangPackage.symbol.getName().getValue());
                 hover = HoverUtil.getHoverContent(hoverContext, currentBLangPackage);
@@ -229,7 +229,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 signatureContext.put(DocumentServiceKeys.FILE_URI_KEY, uri);
                 SignatureHelp signatureHelp;
                 BLangPackage bLangPackage = lsCompiler.getBLangPackage(signatureContext, documentManager, false,
-                        LSCustomErrorStrategy.class, false).getRight();
+                        LSCustomErrorStrategy.class, false).get(0);
                 signatureContext.put(DocumentServiceKeys.CURRENT_BLANG_PACKAGE_CONTEXT_KEY, bLangPackage);
                 signatureContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                      bLangPackage.symbol.getName().getValue());
@@ -261,9 +261,8 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 LSServiceOperationContext definitionContext = new LSServiceOperationContext();
                 definitionContext.put(DocumentServiceKeys.FILE_URI_KEY, fileUri);
                 definitionContext.put(DocumentServiceKeys.POSITION_KEY, position);
-                BLangPackage currentBLangPackage =
-                        lsCompiler.getBLangPackage(definitionContext, documentManager, false,
-                                LSCustomErrorStrategy.class, false).getRight();
+                BLangPackage currentBLangPackage = lsCompiler.getBLangPackage(definitionContext, documentManager, false,
+                                LSCustomErrorStrategy.class, false).get(0);
                 definitionContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                       currentBLangPackage.symbol.getName().getValue());
                 PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(definitionContext);
@@ -295,22 +294,14 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 LSServiceOperationContext referenceContext = new LSServiceOperationContext();
                 referenceContext.put(DocumentServiceKeys.FILE_URI_KEY, fileUri);
                 referenceContext.put(DocumentServiceKeys.POSITION_KEY, params);
-                boolean isBallerinaProject = document.hasProjectRepo();
-                Either<List<BLangPackage>, BLangPackage> eitherBLangPackage =
-                        lsCompiler.getBLangPackage(referenceContext, documentManager, false,
-                                                   LSCustomErrorStrategy.class,
-                                                   isBallerinaProject);
-                BLangPackage currentBLangPackage;
-                List<BLangPackage> bLangPackages;
-                if (isBallerinaProject) {
-                    bLangPackages = eitherBLangPackage.getLeft();
-                    // Get the current package from multiple.
-                    currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, fileUri);
-                } else {
-                    currentBLangPackage = eitherBLangPackage.getRight();
-                    bLangPackages = Collections.singletonList(currentBLangPackage);
+                List<BLangPackage> bLangPackages = lsCompiler.getBLangPackage(referenceContext, documentManager, false,
+                                                                                   LSCustomErrorStrategy.class, true);
+                // Get the current package from multiple.
+                BLangPackage currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, fileUri);
+                if (currentBLangPackage == null) {
+                    // fail quietly
+                    return contents;
                 }
-
                 referenceContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                      currentBLangPackage.symbol.getName().getValue());
 
@@ -365,7 +356,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 symbolsContext.put(DocumentServiceKeys.FILE_URI_KEY, fileUri);
                 symbolsContext.put(DocumentServiceKeys.SYMBOL_LIST_KEY, symbols);
                 BLangPackage bLangPackage = lsCompiler.getBLangPackage(symbolsContext, documentManager, false,
-                        LSCustomErrorStrategy.class, false).getRight();
+                        LSCustomErrorStrategy.class, false).get(0);
                 symbolsContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,
                                    bLangPackage.symbol.getName().getValue());
                 Optional<BLangCompilationUnit> documentCUnit = bLangPackage.getCompilationUnits().stream()
@@ -509,30 +500,25 @@ class BallerinaTextDocumentService implements TextDocumentService {
     public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
         return CompletableFuture.supplyAsync(() -> {
             TextDocumentIdentifier identifier = params.getTextDocument();
-            LSDocument document = new LSDocument(identifier.getUri());
+            String fileUri = identifier.getUri();
+            LSDocument document = new LSDocument(fileUri);
             Path renameFilePath = document.getPath();
             Path compilationPath = getUntitledFilePath(renameFilePath.toString()).orElse(renameFilePath);
             Optional<Lock> lock = documentManager.lockFile(compilationPath);
             WorkspaceEdit workspaceEdit = new WorkspaceEdit();
             try {
                 LSServiceOperationContext renameContext = new LSServiceOperationContext();
-                renameContext.put(DocumentServiceKeys.FILE_URI_KEY, identifier.getUri());
+                renameContext.put(DocumentServiceKeys.FILE_URI_KEY, fileUri);
                 renameContext.put(DocumentServiceKeys.POSITION_KEY,
                                   new TextDocumentPositionParams(identifier, params.getPosition()));
                 List<Location> contents = new ArrayList<>();
-                boolean isBallerinaProject = document.hasProjectRepo();
-                Either<List<BLangPackage>, BLangPackage> eitherBLangPackage =
-                        lsCompiler.getBLangPackage(renameContext, documentManager, false, LSCustomErrorStrategy.class,
-                                                   isBallerinaProject);
-                BLangPackage currentBLangPackage;
-                List<BLangPackage> bLangPackages;
-                if (isBallerinaProject) {
-                    bLangPackages = eitherBLangPackage.getLeft();
-                    // Get the current package from multiple.
-                    currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, identifier.getUri());
-                } else {
-                    currentBLangPackage = eitherBLangPackage.getRight();
-                    bLangPackages = Collections.singletonList(currentBLangPackage);
+                List<BLangPackage> bLangPackages = lsCompiler.getBLangPackage(renameContext, documentManager, false,
+                                                                              LSCustomErrorStrategy.class, true);
+                // Get the current package from multiple.
+                BLangPackage currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, fileUri);
+                if (currentBLangPackage == null) {
+                    // fail quietly
+                    return workspaceEdit;
                 }
 
                 renameContext.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -74,8 +74,7 @@ public class BallerinaWorkspaceService implements WorkspaceService {
             symbolsContext.put(DocumentServiceKeys.SYMBOL_LIST_KEY, symbols);
             symbolsContext.put(DocumentServiceKeys.FILE_URI_KEY, path.toUri().toString());
             List<BLangPackage> bLangPackage = lsCompiler.getBLangPackage(symbolsContext, workspaceDocumentManager,
-                                                                         false,
-                                                                         LSCustomErrorStrategy.class, true).getLeft();
+                                                                         false, LSCustomErrorStrategy.class, true);
             if (bLangPackage != null) {
                 bLangPackage.forEach(aPackage -> aPackage.compUnits.forEach(compUnit -> {
                     String unitName = compUnit.getName();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandUtil.java
@@ -302,7 +302,8 @@ public class CommandUtil {
         TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
         context.put(DocumentServiceKeys.POSITION_KEY, new TextDocumentPositionParams(identifier, position));
         List<BLangPackage> bLangPackages = lsCompiler.getBLangPackage(context, documentManager, false,
-                                                                      LSCustomErrorStrategy.class, true).getLeft();
+                                                                      LSCustomErrorStrategy.class, true);
+
         // Get the current package.
         BLangPackage currentBLangPackage = CommonUtil.getCurrentPackageByFileName(bLangPackages, uri);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/AddAllDocumentationExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/AddAllDocumentationExecutor.java
@@ -69,8 +69,7 @@ public class AddAllDocumentationExecutor implements LSCommandExecutor {
         LSCompiler lsCompiler = context.get(ExecuteCommandKeys.LS_COMPILER_KEY);
         BLangPackage bLangPackage = lsCompiler.getBLangPackage(context,
                                                                context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY),
-                                                               false, LSCustomErrorStrategy.class, false)
-                .getRight();
+                                                               false, LSCustomErrorStrategy.class, false).get(0);
 
         context.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY, bLangPackage.symbol.getName().getValue());
         String relativeSourcePath = context.get(DocumentServiceKeys.RELATIVE_FILE_PATH_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/AddDocumentationExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/AddDocumentationExecutor.java
@@ -67,9 +67,8 @@ public class AddDocumentationExecutor implements LSCommandExecutor {
         }
         LSCompiler lsCompiler = context.get(ExecuteCommandKeys.LS_COMPILER_KEY);
         WorkspaceDocumentManager documentManager = context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY);
-        BLangPackage bLangPackage = lsCompiler
-                .getBLangPackage(context, documentManager, false, LSCustomErrorStrategy.class, false)
-                .getRight();
+        BLangPackage bLangPackage = lsCompiler.getBLangPackage(context, documentManager, false,
+                                                               LSCustomErrorStrategy.class, false).get(0);
 
         String relativeSourcePath = context.get(DocumentServiceKeys.RELATIVE_FILE_PATH_KEY);
         context.put(DocumentServiceKeys.CURRENT_BLANG_PACKAGE_CONTEXT_KEY, bLangPackage);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateObjectInitializerExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateObjectInitializerExecutor.java
@@ -73,8 +73,8 @@ public class CreateObjectInitializerExecutor implements LSCommandExecutor {
         }
         LSCompiler lsCompiler = context.get(ExecuteCommandKeys.LS_COMPILER_KEY);
         WorkspaceDocumentManager documentManager = context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY);
-        BLangPackage bLangPackage = lsCompiler.getBLangPackage(context, documentManager,
-                false, LSCustomErrorStrategy.class, false).getRight();
+        BLangPackage bLangPackage = lsCompiler.getBLangPackage(context, documentManager, false,
+                                                               LSCustomErrorStrategy.class, false).get(0);
         context.put(DocumentServiceKeys.CURRENT_BLANG_PACKAGE_CONTEXT_KEY, bLangPackage);
         context.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY, bLangPackage.symbol.getName().getValue());
         String relativeSourcePath = context.get(DocumentServiceKeys.RELATIVE_FILE_PATH_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateTestExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateTestExecutor.java
@@ -161,7 +161,7 @@ public class CreateTestExecutor implements LSCommandExecutor {
         // Compile the source file
         WorkspaceDocumentManager docManager = context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY);
         LSCompiler lsCompiler = context.get(ExecuteCommandKeys.LS_COMPILER_KEY);
-        BLangPackage builtSourceFile = lsCompiler.getBLangPackage(context, docManager, false, null, false).getRight();
+        BLangPackage builtSourceFile = lsCompiler.getBLangPackage(context, docManager, false, null, false).get(0);
 
         // Generate test file and notify Client
         BallerinaLanguageServer ballerinaLanguageServer = context.get(ExecuteCommandKeys.LANGUAGE_SERVER_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/ImportModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/ImportModuleExecutor.java
@@ -86,9 +86,8 @@ public class ImportModuleExecutor implements LSCommandExecutor {
             int lastNewLineCharIndex = Math.max(fileContent.lastIndexOf('\n'), fileContent.lastIndexOf('\r'));
             int lastCharCol = fileContent.substring(lastNewLineCharIndex + 1).length();
             LSCompiler lsCompiler = context.get(ExecuteCommandKeys.LS_COMPILER_KEY);
-            BLangPackage bLangPackage = lsCompiler
-                    .getBLangPackage(context, documentManager, false, LSCustomErrorStrategy.class, false)
-                    .getRight();
+            BLangPackage bLangPackage = lsCompiler.getBLangPackage(context, documentManager, false,
+                                                                   LSCustomErrorStrategy.class, false).get(0);
             context.put(DocumentServiceKeys.CURRENT_PACKAGE_NAME_KEY, bLangPackage.symbol.getName().getValue());
             String relativeSourcePath = context.get(DocumentServiceKeys.RELATIVE_FILE_PATH_KEY);
             BLangPackage srcOwnerPkg = CommonUtil.getSourceOwnerBLangPackage(relativeSourcePath, bLangPackage);

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/variableAssignmentRequiredCodeAction.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/variableAssignmentRequiredCodeAction.json
@@ -10,7 +10,7 @@
     }
   },
   "expected": {
-    "title": "Create Variable",
+    "title": "Create Local Variable",
     "command": "CREATE_VAR",
     "arguments": [
       {


### PR DESCRIPTION
## Purpose
Fix error in compile full-project for single bal files

When the `compileFullProject` flag is set for single bal files; it still search for modules in other projects as mentioned in #12311.

## Approach
Even `compileFullProject` is set need to check `hasProjectRepo` as well. This results returning a single `BLangPackage`, thus needed to revamp getBLangPackage() method as well.

Thus this PR resolves #12311