### PR TITLE
Bind 2 listeners to the service in EchoServiceSampleTestCase

### DIFF
--- a/tests/ballerina-integration-test/src/test/resources/http/httpservices/15_https_echo_service.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http/httpservices/15_https_echo_service.bal
@@ -34,7 +34,7 @@ service echo2 on echoEP2 {
 @http:ServiceConfig  {
     basePath:"/echoOne"
 }
-service echoOne1 on echoEP2 {
+service echoOne1 on echoEP2, echoHttpEP {
     @http:ResourceConfig {
         methods:["POST"],
         path:"/abc"


### PR DESCRIPTION
## Purpose
Earlier this test was written to bind 2 listeners to the service. Re-updating the test as we can attach multiple listeners to a service now.
