### PR TITLE
Fix not showing supported ballerina versions

### DIFF
--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_pull/packaging_pull.bal
@@ -131,11 +131,11 @@ function pullPackage(http:Client httpEndpoint, string url, string pkgPath, strin
     } else if (statusCode != "200") {
         var resp = httpResponse.getJsonPayload();
         if (resp is json) {
-            if (!(statusCode == "404" && isBuild)) {
-                return createError(resp.message.toString());
-            } else {
+            if (statusCode == "404" && isBuild && resp.message.toString().contains("could not find module")) {
                 // To ignore printing the error
                 return createError("");
+            } else {
+                return createError(resp.message.toString());
             }
         } else {
             return createError("error occurred when pulling the module");


### PR DESCRIPTION
## Purpose
> 404 status code is returned from central where there are is no such package is found or when a package is found but incompatible with the ballerina version. Issue existed that CLI stopped showing the incompatible version error. With this fix incompatible version error will be shown on CLI.
