### PR TITLE
Fix failing debugger functionalities

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -2954,14 +2954,23 @@ public class BVM {
                 /*
                  In case of a for loop, need to clear the last hit line, so that, same line can get hit again.
                  */
-                debugContext.clearLastDebugLine();
+                debugContext.clearContext();
                 break;
             case STEP_IN:
+                debugHit(ctx, currentExecLine, debugger);
+                return true;
             case STEP_OVER:
+                if (debugContext.getFramePointer() < ctx.fp) {
+                    return false;
+                }
                 debugHit(ctx, currentExecLine, debugger);
                 return true;
             case STEP_OUT:
-                break;
+                if (debugContext.getFramePointer() > ctx.fp) {
+                    debugHit(ctx, currentExecLine, debugger);
+                    return true;
+                }
+                return false;
             default:
                 debugger.notifyExit();
                 debugger.stopDebugging();
@@ -2995,7 +3004,7 @@ public class BVM {
      * @param debugger        Debugger object.
      */
     private static void debugHit(Strand ctx, LineNumberInfo currentExecLine, Debugger debugger) {
-        ctx.getDebugContext().setLastLine(currentExecLine);
+        ctx.getDebugContext().updateContext(currentExecLine, ctx.fp);
         debugger.pauseWorker(ctx);
         debugger.notifyDebugHit(ctx, currentExecLine, ctx.getId());
     }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugContext.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/debugger/DebugContext.java
@@ -29,6 +29,8 @@ public class DebugContext {
 
     private LineNumberInfo lastLine;
 
+    private int framePointer;
+
     private boolean strandPaused;
 
     private boolean cmdChanged = false;
@@ -54,11 +56,17 @@ public class DebugContext {
         return lastLine;
     }
 
-    public void setLastLine(LineNumberInfo lastLine) {
+    public void updateContext(LineNumberInfo lastLine, int framePointer) {
+        this.framePointer= framePointer;
         this.lastLine = lastLine;
     }
 
-    public void clearLastDebugLine() {
+    public int getFramePointer() {
+        return framePointer;
+    }
+
+    public void clearContext() {
+        this.framePointer = -1;
         this.lastLine = null;
     }
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -53,7 +53,6 @@ import static org.ballerinalang.test.utils.debug.Util.createBreakNodeLocations;
 /**
  * Test Cases for {@link Debugger}.
  */
-@Test(groups = "broken")
 public class VMDebuggerTest {
 
     private static final String FILE = "test-debug.bal";
@@ -129,7 +128,6 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 14, RESUME, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 8, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", FILE, 25, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 26, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 27, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 28, STEP_IN, 1));
@@ -137,6 +135,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", FILE, 31, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 37, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 38, STEP_IN, 1));
+        debugPoints.add(Util.createDebugPoint(".", FILE, 41, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 42, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", FILE, 43, STEP_IN, 1));
 
@@ -251,7 +250,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/while-statement.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Testing try catch finally scenario for path")
+    @Test(enabled = false, description = "Testing try catch finally scenario for path")
     public void testTryCatchScenarioForPath() {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "try-catch-finally.bal", 19);
 
@@ -285,7 +284,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/try-catch-finally.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Testing debug paths in workers")
+    @Test(enabled = false, description = "Testing debug paths in workers")
     public void testDebuggingWorkers() {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test-worker.bal", 3, 9, 10, 18, 19, 23, 48);
 
@@ -322,7 +321,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/test-worker.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Testing debug paths in package init")
+    @Test(enabled = false, description = "Testing debug paths in package init")
     public void testDebuggingPackageInit() {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test-package-init.bal", 3, 9);
 
@@ -370,28 +369,25 @@ public class VMDebuggerTest {
         List<DebugPoint> debugPoints = new ArrayList<>();
         debugPoints.add(Util.createDebugPoint(".", file, 3, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 7, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 23, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 8, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 37, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 51, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 29, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_IN, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 40, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 40, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 51, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 11, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 12, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 36, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 42, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 43, STEP_OVER, 1));
@@ -404,14 +400,15 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 66, RESUME, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 54, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 67, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 37, 0, new ArrayList<>(), false);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 35, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test_object_and_match.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Testing global variables availability in debug hit message")
+    @Test(enabled = false, description = "Testing global variables availability in debug hit message")
     public void testGlobalVarAvailability() {
         String file = "test_variables.bal";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 13);
@@ -438,7 +435,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Testing local variables scopes")
+    @Test(enabled = false, description = "Testing local variables scopes")
     public void testLocalVarScope() {
         String file = "test_variables.bal";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 12);
@@ -468,7 +465,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/test_variables.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Test debugging when multi-packages available")
+    @Test(enabled = false, description = "Test debugging when multi-packages available")
     public void testMultiPackage() {
         String file = "apple.bal";
         String packagePath = "abc/fruits:0.0.1";
@@ -486,7 +483,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/multi-package/main.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Test evaluating global variables from other packages")
+    @Test(enabled = false, description = "Test evaluating global variables from other packages")
     public void testEvaluatingOtherPackageGlobalVars() {
         String file = "apple.bal";
         String packagePath = "abc/fruits:0.0.1";
@@ -510,7 +507,7 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/multi-package/main.bal", breakPoints, expRes);
     }
 
-    @Test(description = "Test ignoring non-nullable global variables with null values")
+    @Test(enabled = false, description = "Test ignoring non-nullable global variables with null values")
     public void testGlobalVariableNullability() {
         String file = "test_variables.bal";
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", file, 31);

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_object_and_match.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_object_and_match.bal
@@ -19,40 +19,40 @@ public function testObjectWithInterface () returns (int, string) {
 
 type Person object {
 
-    public int age = 10;
+    public int age;
     public string name;
 
 
     string month = "february";
 
 
-    new (age = 6, string n = "llll") {
-        self.name = n;
-        int value  = 8 + 7;
+    function __init () {
+        self.name = "llll";
+        self.age  = 6;
     }
 
     function init(int | string | boolean | Foo inVal) {
-        match inVal {
-            int a => {
-                age = age + a;
-            }
-            string b => {
-                name = name + b;
-            }
-            boolean c => {
-                age = age + 10;
-                name = name + " hello";
-            }
-            Foo d => {
-                age = age + d.count;
-                name = name + d.last;
-            }
+        if inVal is int {
+
+            self.age = self.age + inVal;
         }
+        else if inVal is string {
+            self.name = self.name + inVal;
+        }
+        else if inVal is boolean {
+            self.age = self.age + 10;
+            self.name = self.name + " hello";
+        }
+        else if inVal is Foo {
+            self.age = self.age + inVal.count;
+            self.name = self.name + inVal.last;
+        }
+
     }
 
     function incrementCount(int increment) returns int {
-        int retVal = age;
-        if (age > increment) {
+        int retVal = self.age;
+        if (self.age > increment) {
             retVal = retVal + increment;
         }
         return retVal;
@@ -62,7 +62,7 @@ type Person object {
 };
 
 
-function Person::attachInterface(int add) returns int {
+function Person.attachInterface(int add) returns int {
     int count = self.age + add;
     count  = count + self.incrementCount(100);
     return count;


### PR DESCRIPTION
## Purpose
This PR fixes the basic debugger functionalities like `step_in`, `step_out`, `step_over` which were failing due to the latest worker and strand related changes. This PR also fixes some failing test cases.
