### PR TITLE
Make vscode plugin warn only on major and minor versions do not match

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -173,7 +173,10 @@ export class BallerinaExtension {
     }
 
     checkCompatibleVersion(pluginVersion: string, ballerinaVersion: string): void {
-        const versionCheck = compareVersions(pluginVersion, ballerinaVersion);
+        const pluginVersionParts = pluginVersion.split(".");
+        pluginVersionParts[2] = "*"; // Match with any patch version
+        const pluginMinorVersion = pluginVersionParts.join(".");
+        const versionCheck = compareVersions(pluginMinorVersion, ballerinaVersion);
 
         if (versionCheck > 0) {
             // Plugin version is greater


### PR DESCRIPTION
## Purpose 
Vscode plugin will not warn when only the patch versions of the plugin and ballerina does not match
