### PR TITLE
Fix for generating API docs with docerina

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
@@ -44,8 +44,18 @@ public class BLangErrorType extends BLangType implements ErrorTypeNode {
 
     @Override
     public String toString() {
-        return this.type.toString() + "<" + this.reasonType.toString() + Optional.ofNullable(detailType)
-                .map(type -> "," + type.toString()) + ">";
+        StringBuilder val = new StringBuilder(this.type.toString());
+        val.append("<");
+        
+        if (this.reasonType != null) {
+            val.append(this.reasonType.toString());
+        }
+        if (this.detailType != null) {
+            val.append(",");
+            val.append(detailType.toString());
+        }
+        val.append(">");
+        return val.toString();
     }
 
     @Override

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -284,6 +284,9 @@ public class Generator {
             String value = userDefinedType.typeName.value;
             union.add(new EnumDoc(typeName, description(typeDefinition), new ArrayList<>(), value));
             added = true;
+        } else if (kind == NodeKind.ERROR_TYPE) {
+            // TODO: Add errors section in API docs
+            added = true;
         }
         if (!added) {
             throw new UnsupportedOperationException("Type def not supported for " + kind);


### PR DESCRIPTION
## Purpose
> Fix generating API docs with docerina.

## Goals
> Fix docerina.

## Approach
Fix 1: BLangErrorType is used in return types. Example:
```
public function sayHello() returns string|error {}
```
In such cases the BLangErrorType does not have reason or detail. This caused a null pointer exception. Created issue to track - https://github.com/ballerina-platform/ballerina-lang/issues/12410

Fix 2: Error Types are not supported for API docs. As of now this is skipped. Created issue to track - https://github.com/ballerina-platform/ballerina-lang/issues/12411