### PR TITLE
Fix whitespace capturing issue in binding patterns and disable formatting on AST did change

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/RecordVariableNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/RecordVariableNode.java
@@ -40,6 +40,10 @@ public interface RecordVariableNode extends VariableNode, AnnotatableNode, Docum
 
     List<? extends BLangRecordVariable.BLangRecordVariableKeyValueNode> getVariables();
 
+    VariableNode getRestParam();
+
+    boolean isClosed();
+
     /**
      * Interface for key and value of a record variable.
      */

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/ConstantNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/ConstantNode.java
@@ -17,9 +17,14 @@
  */
 package org.ballerinalang.model.tree.expressions;
 
+import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
+import org.wso2.ballerinalang.compiler.tree.types.BLangType;
+
 /**
  * @since 0.985.0
  */
 public interface ConstantNode extends LiteralNode {
+    BLangType getTypeNode();
 
+    BLangTypeDefinition getAssociatedTypeDefinition();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TransactionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TransactionNode.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.model.tree.statements;
 
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 
 /**
  * {@code TransactionNode} represents the transaction statement in Ballerina.
@@ -30,6 +31,10 @@ public interface TransactionNode extends StatementNode {
     BlockNode getOnRetryBody();
 
     ExpressionNode getRetryCount();
+
+    BLangBlockStmt getAbortedBody();
+
+    BLangBlockStmt getCommittedBody();
 
     void setTransactionBody(BlockNode body);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -820,6 +820,7 @@ public class BLangPackageBuilder {
             addBindingPatternMemberVariable(pos, ws, identifier);
         }
         recordKeyValue.valueBindingPattern = this.varStack.pop();
+        recordKeyValue.valueBindingPattern.addWS(ws);
         this.recordVarListStack.peek().add(recordKeyValue);
     }
 
@@ -1007,13 +1008,12 @@ public class BLangPackageBuilder {
             markVariableAsFinal(var);
         }
         BLangTupleVariableDef varDefNode = (BLangTupleVariableDef) TreeBuilder.createTupleVariableDefinitionNode();
-        Set<Whitespace> wsOfSemiColon = removeNthFromLast(ws, 0);
         if (isExpressionAvailable) {
             var.setInitialExpression(this.exprNodeStack.pop());
         }
         varDefNode.pos = pos;
         varDefNode.setVariable(var);
-        varDefNode.addWS(wsOfSemiColon);
+        varDefNode.addWS(ws);
         var.isDeclaredWithVar = isDeclaredWithVar;
         if (!isDeclaredWithVar) {
             var.setTypeNode(this.typeNodeStack.pop());
@@ -2202,7 +2202,7 @@ public class BLangPackageBuilder {
         stmt.addWS(ws);
         stmt.expr = (BLangExpression) exprNodeStack.pop();
         stmt.varRef = (BLangTupleVarRef) exprNodeStack.pop();
-        stmt.addWS(ws);
+        stmt.addWS(stmt.varRef.getWS());
         addStmtToCurrentBlock(stmt);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangRecordVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangRecordVariable.java
@@ -62,6 +62,16 @@ public class BLangRecordVariable extends BLangVariable implements RecordVariable
     }
 
     @Override
+    public VariableNode getRestParam() {
+        return restParam;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    @Override
     public void accept(BLangNodeVisitor visitor) {
         visitor.visit(this);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
@@ -157,4 +157,14 @@ public class BLangConstant extends BLangExpression implements ConstantNode, Anno
         return (typeNode == null ? String.valueOf(type) : String.valueOf(typeNode)) + " " + symbol.name.value +
                 " = " + String.valueOf(value);
     }
+
+    @Override
+    public BLangType getTypeNode() {
+        return typeNode;
+    }
+
+    @Override
+    public BLangTypeDefinition getAssociatedTypeDefinition() {
+        return associatedTypeDefinition;
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTransaction.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTransaction.java
@@ -61,6 +61,16 @@ public class BLangTransaction extends BLangStatement implements TransactionNode 
     }
 
     @Override
+    public BLangBlockStmt getAbortedBody() {
+        return abortedBody;
+    }
+
+    @Override
+    public BLangBlockStmt getCommittedBody() {
+        return committedBody;
+    }
+
+    @Override
     public void setTransactionBody(BlockNode body) {
         this.transactionBody = (BLangBlockStmt) body;
     }

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/TextDocumentFormatUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/TextDocumentFormatUtil.java
@@ -46,6 +46,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangRecordVariable;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordVarRef;
 
@@ -267,6 +268,11 @@ public class TextDocumentFormatUtil {
                                 .getVariableName(), anonStructs, symbolMetaInfoMap));
                         listPropJson.add(generateJSON(((BLangRecordVarRef.BLangRecordVarRefKeyValue) listPropItem)
                                 .getBindingPattern(), anonStructs, symbolMetaInfoMap));
+                    } else if (listPropItem instanceof BLangRecordVariable.BLangRecordVariableKeyValue) {
+                        listPropJson.add(generateJSON(((BLangRecordVariable.BLangRecordVariableKeyValue) listPropItem)
+                                .getKey(), anonStructs, symbolMetaInfoMap));
+                        listPropJson.add(generateJSON(((BLangRecordVariable.BLangRecordVariableKeyValue) listPropItem)
+                                .getValue(), anonStructs, symbolMetaInfoMap));
                     } else if (listPropItem instanceof String) {
                         listPropJson.add((String) listPropItem);
                     } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -67,8 +67,8 @@ import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MarkedString;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
+//import org.eclipse.lsp4j.Position;
+//import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.SignatureHelp;
@@ -95,8 +95,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.Lock;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+//import java.util.regex.Matcher;
+//import java.util.regex.Pattern;
 import java.util.zip.ZipError;
 
 import static org.ballerinalang.langserver.command.CommandUtil.getCommandForNodeType;
@@ -449,7 +449,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
     @Override
     public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
         return CompletableFuture.supplyAsync(() -> {
-            String textEditContent = null;
+//            String textEditContent = null;
             TextEdit textEdit = new TextEdit();
 
             String fileUri = params.getTextDocument().getUri();
@@ -469,19 +469,19 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 // formattingUtil.accept(ast.getAsJsonObject("model"));
 
                 // Generate source for the ast.
-                textEditContent = FormattingSourceGen.getSourceOf(ast.getAsJsonObject("model"));
-                Matcher matcher = Pattern.compile("\r\n|\r|\n").matcher(textEditContent);
-                int totalLines = 0;
-                while (matcher.find()) {
-                    totalLines++;
-                }
+                // textEditContent = FormattingSourceGen.getSourceOf(ast.getAsJsonObject("model"));
+                // Matcher matcher = Pattern.compile("\r\n|\r|\n").matcher(textEditContent);
+                // int totalLines = 0;
+                // while (matcher.find()) {
+                //    totalLines++;
+                // }
 
-                int lastNewLineCharIndex = Math.max(textEditContent.lastIndexOf("\n"),
-                        textEditContent.lastIndexOf("\r"));
-                int lastCharCol = textEditContent.substring(lastNewLineCharIndex + 1).length();
+                // int lastNewLineCharIndex = Math.max(textEditContent.lastIndexOf("\n"),
+                //        textEditContent.lastIndexOf("\r"));
+                // int lastCharCol = textEditContent.substring(lastNewLineCharIndex + 1).length();
 
-                Range range = new Range(new Position(0, 0), new Position(totalLines, lastCharCol));
-                textEdit = new TextEdit(range, textEditContent);
+                // Range range = new Range(new Position(0, 0), new Position(totalLines, lastCharCol));
+                // textEdit = new TextEdit(range, textEditContent);
                 return Collections.singletonList(textEdit);
             } catch (Exception e) {
                 if (CommonUtil.LS_DEBUG_ENABLED) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -37,7 +37,7 @@ import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentExceptio
 import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.langserver.extensions.OASGenerationException;
 import org.ballerinalang.langserver.formatting.FormattingSourceGen;
-import org.ballerinalang.langserver.formatting.FormattingVisitorEntry;
+//import org.ballerinalang.langserver.formatting.FormattingVisitorEntry;
 import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.model.tree.TopLevelNode;
 import org.ballerinalang.swagger.CodeGenerator;
@@ -281,8 +281,8 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
             FormattingSourceGen.build(ast, "CompilationUnit");
             // we are reformatting entire document upon each astChange
             // until partial formatting is supported
-            FormattingVisitorEntry formattingUtil = new FormattingVisitorEntry();
-            formattingUtil.accept(ast);
+            // FormattingVisitorEntry formattingUtil = new FormattingVisitorEntry();
+            // formattingUtil.accept(ast);
             String textEditContent = FormattingSourceGen.getSourceOf(ast);
 
             // create text edit


### PR DESCRIPTION
## Purpose
This will fix whitespace capturing issues in const type, transaction type, foreach, and tuple destructure. Disable formatting on ast did change event.
