### PR TITLE
Fix type guard of match not adding to json node tree

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/MatchNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/MatchNode.java
@@ -69,6 +69,8 @@ public interface MatchNode {
     interface MatchStructuredBindingPatternNode extends MatchBindingPatternNode {
 
         VariableNode getVariableNode();
+
+        BLangExpression getTypeGuardExpr();
     }
 
     ExpressionNode getExpression();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangMatch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangMatch.java
@@ -143,7 +143,7 @@ public class BLangMatch extends BLangStatement implements MatchNode {
         public void accept(BLangNodeVisitor visitor) {
             visitor.visit(this);
         }
-        
+
         @Override
         public String toString() {
             return String.valueOf(variable) + " => " + String.valueOf(body);
@@ -213,6 +213,11 @@ public class BLangMatch extends BLangStatement implements MatchNode {
         @Override
         public BLangVariable getVariableNode() {
             return bindingPatternVariable;
+        }
+
+        @Override
+        public BLangExpression getTypeGuardExpr() {
+            return typeGuardExpr;
         }
 
         @Override


### PR DESCRIPTION
## Purpose
This will add type guard expression in math patterns when generating JSON AST from the java AST.