### PR TITLE
Handle network logs listener connection reset error

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/traces/Listener.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/traces/Listener.java
@@ -55,8 +55,8 @@ public class Listener {
             return 0;
         }
         Runnable listener = () -> {
-            try {
-                while (!listenSocket.isClosed()) {
+            while (!listenSocket.isClosed()) {
+                try {
                     Socket dataSocket = listenSocket.accept();
                     logReader = new BufferedReader(new InputStreamReader(dataSocket.getInputStream(), "UTF-8"));
                     String line;
@@ -71,10 +71,11 @@ public class Listener {
                         TraceRecord traceRecord = new TraceRecord(LogParser.fromString(rawMessage), record, rawMessage);
                         ballerinaTraceService.pushLogToClient(traceRecord);
                     }
+                } catch (IOException e) {
+                    logger.error("Error listening to network logs", e);
                 }
-            } catch (IOException e) {
-                logger.error("Error listening to network logs", e);
             }
+
         };
         Thread serverThread = new Thread(listener);
         serverThread.start();


### PR DESCRIPTION
In windows network logs client throws a connection reset exception when launcher is terminated. 