### PR TITLE
Add support for labeling function types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -1232,8 +1232,10 @@ public class CompiledPackageSymbolEnter {
             if (retType == null) {
                 retType = symTable.nilType;
             }
-            //TODO need to consider a symbol for lambda functions for type definitions.
-            return new BInvokableType(funcParams, retType, null);
+            BTypeSymbol tsymbol = Symbols.createTypeSymbol(SymTag.FUNCTION_TYPE, Flags.asMask(EnumSet.of(Flag.PUBLIC)),
+                                                           Names.EMPTY, env.pkgSymbol.pkgID, null,
+                                                           env.pkgSymbol.owner);
+            return new BInvokableType(funcParams, retType, tsymbol);
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -513,10 +513,9 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         if (typeDefinition.typeNode.getKind() == NodeKind.FUNCTION_TYPE && definedType.tsymbol == null) {
-            BTypeSymbol tsymbol = Symbols.createTypeSymbol(SymTag.FUNCTION_TYPE, Flags.asMask(typeDefinition.flagSet),
+            definedType.tsymbol = Symbols.createTypeSymbol(SymTag.FUNCTION_TYPE, Flags.asMask(typeDefinition.flagSet),
                                                            Names.EMPTY, env.enclPkg.symbol.pkgID, definedType,
                                                            env.scope.owner);
-            definedType.tsymbol = tsymbol;
         }
 
         typeDefinition.precedence = this.typePrecedence++;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -512,6 +512,13 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
         }
 
+        if (typeDefinition.typeNode.getKind() == NodeKind.FUNCTION_TYPE && definedType.tsymbol == null) {
+            BTypeSymbol tsymbol = Symbols.createTypeSymbol(SymTag.FUNCTION_TYPE, Flags.asMask(typeDefinition.flagSet),
+                                                           Names.EMPTY, env.enclPkg.symbol.pkgID, definedType,
+                                                           env.scope.owner);
+            definedType.tsymbol = tsymbol;
+        }
+
         typeDefinition.precedence = this.typePrecedence++;
         BTypeSymbol typeDefSymbol;
         if (definedType.tsymbol.name != Names.EMPTY) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
@@ -49,4 +49,5 @@ public class SymTag {
     public static final int SCOPE = 1 << 26;
     public static final int CHANNEL = 1 << 27;
     public static final int CONSTANT = 1 << 28 | VARIABLE_NAME;
+    public static final int FUNCTION_TYPE = 1 << 29 | TYPE | VARIABLE_NAME;
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/FiniteTypeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/FiniteTypeTest.java
@@ -273,6 +273,18 @@ public class FiniteTypeTest {
         Assert.assertEquals((((BFloat) returns[1]).floatValue()), 4.5);
     }
 
+    @Test
+    public void testTypeDefWithFunctions() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeDefWithFunctions");
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), "Hello".length());
+    }
+
+    @Test
+    public void testTypeDefWithFunctions2() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeDefWithFunctions2");
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), "Hello".length());
+    }
+
     @AfterClass
     public void tearDown() {
         BaloCreator.clearPackageFromRepository("finiteTypeTest", "foo");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.types.finite;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.launcher.util.BAssertUtil.validateError;
+
+/**
+ * Negative tests for finite types.
+ *
+ * @since 0.990.0
+ */
+public class FiniteTypeNegativeTest {
+
+    @Test()
+    public void finiteAssignmentStateType() {
+        CompileResult result = BCompileUtil.compile("test-src/types/finite/func_type_labeling_negative.bal");
+        validateError(result, 0,
+                      "incompatible types: expected 'function (string) returns (int)', found 'function (int) returns " +
+                              "(int)'", 20, 19);
+        validateError(result, 1, "incompatible types: expected 'string', found 'int'", 23, 21);
+        validateError(result, 2,
+                      "incompatible types: expected 'function (string) returns (int)', found 'function (string) " +
+                              "returns (string)'", 27, 19);
+    }
+}

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 
 package org.ballerinalang.test.types.finite;
 
@@ -236,6 +236,18 @@ public class FiniteTypeTest {
         Assert.assertTrue(returns[1] instanceof BInteger);
         Assert.assertEquals((((BInteger) returns[0]).intValue()), 2);
         Assert.assertEquals((((BInteger) returns[1]).intValue()), 23);
+    }
+
+    @Test
+    public void testTypeDefWithFunctions() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeDefWithFunctions");
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), "Hello".length());
+    }
+
+    @Test
+    public void testTypeDefWithFunctions2() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeDefWithFunctions2");
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), "Hello".length());
     }
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/finite_type_test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/finite_type_test.bal
@@ -199,3 +199,22 @@ function testByteTypeDefinitionWithVarArgs() returns (foo:BFType, foo:BFType) {
 function testVarByteArgs(foo:BFType... p1) returns foo:BFType {
     return p1[0];
 }
+
+function testTypeDefWithFunctions() returns int {
+    foo:BFuncType fn = function (string s) returns int {
+        return s.length();
+    };
+    return fn.call("Hello");
+}
+
+function testTypeDefWithFunctions2() returns int {
+    foo:BFuncType2 fn = function (string s) returns int {
+        return s.length();
+    };
+
+    if (fn is function (string) returns int) {
+        return fn.call("Hello");
+    }
+
+    return -1;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_projects/finite_type_project/foo/finite_type_definitions.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/balo/test_projects/finite_type_project/foo/finite_type_definitions.bal
@@ -46,3 +46,7 @@ public type ByteType byte;
 public type ByteArrayType byte[];
 
 public type BFType byte|float;
+
+public type BFuncType function (string) returns int;
+
+public type BFuncType2 (function (string) returns int)|string;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -214,3 +214,27 @@ function testTypeDefinitionWithArray() returns (int, int) {
     ArrayCustom val = [34, 23];
     return (val.length() , val[1]);
 }
+
+type FuncType function (string) returns int;
+
+function testTypeDefWithFunctions() returns int {
+    FuncType fn = function (string s) returns int {
+        return s.length();
+    };
+    return fn.call("Hello");
+}
+
+type FuncType2 (function (string) returns int)|string;
+
+function testTypeDefWithFunctions2() returns int {
+    FuncType2 fn = function (string s) returns int {
+        return s.length();
+    };
+
+    if (fn is function (string) returns int) {
+        return fn.call("Hello");
+    }
+
+    return -1;
+}
+

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/func_type_labeling_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/func_type_labeling_negative.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type FuncType function (string) returns int;
+
+function invalidFuncDefinition() {
+    FuncType fn = function (int i) returns int {
+        return i + 10;
+    };
+    int x = fn.call(10);
+}
+
+function invalidFuncDefinition2() {
+    FuncType fn = function (string s) returns string {
+        return s + s;
+    };
+    _ = fn.call("asdf");
+}


### PR DESCRIPTION
## Purpose
> Fix #10887 
>
> With this change, the following is now possible.
```ballerina
import ballerina/io;

type FuncType function (string) returns int;

public function main() {
    FuncType fn = function (string s) returns int {
        return s.length();
    };
    io:println(fn.call("Hello"));
}
```