### PR TITLE
Fix windows issue in language-server not starting up for the zip distro

### DIFF
--- a/distribution/zip/ballerina-tools/resources/language-server-launcher.bat
+++ b/distribution/zip/ballerina-tools/resources/language-server-launcher.bat
@@ -42,12 +42,12 @@ rem -------------------------- set BALLERINA_HOME -----------------------------
 rem TODO: Validate BALLERINA_HOME
 rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
 set BALLERINA_HOME=%~sdp0..\..\..\..
-goto setJava
+if exist "%BALLERINA_HOME%\bre\lib\jre1.8.0_172" goto setJava
+goto checkJava
 
 :setJava
 set JAVA_HOME="%BALLERINA_HOME%\bre\lib\jre1.8.0_172"
-if not exist "%JAVA_HOME%\bin\java.exe" goto checkJava
-goto updateClasspath
+goto checkJava
 
 :checkJava
 if "%JAVA_HOME%" == "" goto noJavaHome


### PR DESCRIPTION
## Purpose
> language-server-launcher.bat in zip distribution always overrides JAVA_HOME variable with the internal JDK path. Internal JDK is not shipped with the zip distributions(only available in platform distros).

## Approach
> Thus added a fix to override the JAVA_HOME variable only when internal JDK is available.