### PR TITLE
Fix for when no WebSocket service name

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketService.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketService.java
@@ -84,7 +84,11 @@ public class WebSocketService {
     }
 
     public String getName() {
-        return service != null ? service.getName() : null;
+        if (service != null) {
+            String name = service.getName();
+            return !name.startsWith(HttpConstants.DOLLAR) ? name : "";
+        }
+        return null;
     }
 
     public ServiceInfo getServiceInfo() {

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketAutoPingPongTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketAutoPingPongTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class WebSocketAutoPingPongTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9100/test/without/ping/resource";
+    private static final String URL = "ws://localhost:9100";
     private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
 
     @BeforeClass(description = "Initializes Ballerina with the simple_server_without_ping_resource.bal file")

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/17_simple_proxy_server.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/17_simple_proxy_server.bal
@@ -21,9 +21,8 @@ final string REMOTE_BACKEND_URL = "ws://localhost:15300/websocket";
 final string ASSOCIATED_CONNECTION5 = "ASSOCIATED_CONNECTION";
 
 @http:WebSocketServiceConfig {
-    path: "/"
 }
-service simpleProxy9 on new http:WebSocketListener(9099) {
+service on new http:WebSocketListener(9099) {
 
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new(

--- a/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/18_simple_server_without_ping_resource.bal
+++ b/tests/ballerina-integration-test/src/test/resources/websocket/wsservices/18_simple_server_without_ping_resource.bal
@@ -17,11 +17,7 @@
 import ballerina/http;
 import ballerina/io;
 
-@http:WebSocketServiceConfig {
-    path: "/test/without/ping/resource"
-}
-service SimpleServerWithoutPingResource on new http:WebSocketListener(9100) {
-
+service on new http:WebSocketListener(9100) {
     resource function onOpen(http:WebSocketCaller wsEp) {
         io:println("New Client Connected");
     }


### PR DESCRIPTION
## Purpose
> When service does not have a name an anonymous name is generated. This makes sure in that case the path is as "/".