### PR TITLE
Add `listener` keyword for the top-level completions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetGenerator.java
@@ -145,6 +145,16 @@ public class SnippetGenerator {
     }
 
     /**
+     * Get Listener Keyword Snippet Block.
+     *
+     * @return {@link SnippetBlock}     Generated Snippet Block
+     */
+    public static SnippetBlock getListenerKeywordSnippet() {
+        return new SnippetBlock(ItemResolverConstants.LISTENER_KEYWORD, "listener ", ItemResolverConstants.KEYWORD_TYPE,
+                                SnippetType.KEYWORD);
+    }
+
+    /**
      * Get Foreach Snippet Block.
      *
      * @return {@link SnippetBlock}     Generated Snippet Block

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
@@ -98,6 +98,7 @@ public class TopLevelResolver extends AbstractItemResolver {
         completionItems.add(getStaticItem(Snippet.KW_CONST, snippetCapability));
         completionItems.add(getStaticItem(Snippet.KW_EXTERN, snippetCapability));
         completionItems.add(getStaticItem(Snippet.DEF_ERROR, snippetCapability));
+        completionItems.add(getStaticItem(Snippet.KW_LISTENER, snippetCapability));
         return completionItems;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
@@ -87,6 +87,7 @@ public class ItemResolverConstants {
     public static final String CHECK_KEYWORD = "check";
     public static final String WAIT_KEYWORD = "wait";
     public static final String EXTERN_KEYWORD = "extern";
+    public static final String LISTENER_KEYWORD = "listener";
     public static final String TRUE_KEYWORD = "true";
     public static final String FALSE_KEYWORD = "false";
     public static final String PUBLIC_KEYWORD = "public";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -79,8 +79,9 @@ public enum Snippet {
     KW_TYPE(SnippetGenerator.getTypeKeywordSnippet()),
 
     KW_VAR(SnippetGenerator.getVarKeywordSnippet()),
-    
-    
+
+    KW_LISTENER(SnippetGenerator.getListenerKeywordSnippet()),
+
     // Statement Snippets
     STMT_ABORT(SnippetGenerator.getAbortSnippet()),
 


### PR DESCRIPTION
## Purpose
> Adding `listener` keyword for the top-level completions.
> This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/12581