### PR TITLE
 Fix package prefix not added automatically for some BTypes

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.command.testgen;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.ballerinalang.langserver.command.testgen.TestGenerator.TestFunctionGenerator;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
@@ -184,13 +185,7 @@ public class ValueSpaceGenerator {
             });
 
             IntStream.range(0, template.length).forEach(index -> {
-                String pkgPrefix = "";
-                if (!bStructSymbol.pkgID.equals(currentPkgId)) {
-                    pkgPrefix = bStructSymbol.pkgID.name.value + ":";
-                    if (importsAcceptor != null) {
-                        importsAcceptor.accept(bStructSymbol.pkgID.orgName.value, bStructSymbol.pkgID.name.value);
-                    }
-                }
+                String pkgPrefix = CommonUtil.getPackagePrefix(importsAcceptor, currentPkgId, bStructSymbol.pkgID);
                 String paramsStr = String.join(", ", list[index]);
                 String newObjStr = "new " + pkgPrefix + bStructSymbol.name.getValue() + "(" + paramsStr + ")";
                 template[index] = template[index].replace(PLACE_HOLDER, newObjStr);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -1240,13 +1240,7 @@ public class CommonUtil {
                 for (BVarSymbol param : bStruct.initializerFunc.symbol.params) {
                     list.add(generateReturnValue(param.type.tsymbol, "{%1}"));
                 }
-                String pkgPrefix = "";
-                if (!bStruct.pkgID.equals(currentPkgId)) {
-                    pkgPrefix = bStruct.pkgID.name.value + ":";
-                    if (importsAcceptor != null) {
-                        importsAcceptor.accept(bStruct.pkgID.orgName.value, bStruct.pkgID.name.value);
-                    }
-                }
+                String pkgPrefix = getPackagePrefix(importsAcceptor, currentPkgId, bStruct.pkgID);
                 String paramsStr = String.join(", ", list);
                 String newObjStr = "new " + pkgPrefix + bStruct.name.getValue() + "(" + paramsStr + ")";
                 return template.replace("{%1}", newObjStr);
@@ -1405,18 +1399,8 @@ public class CommonUtil {
         private static String generateTypeDefinition(BiConsumer<String, String> importsAcceptor,
                                                      PackageID currentPkgId, BTypeSymbol tSymbol) {
             if (tSymbol != null) {
-                if (tSymbol instanceof BObjectTypeSymbol) {
-                    BObjectTypeSymbol objectType = (BObjectTypeSymbol) tSymbol;
-                    String pkgPrefix = "";
-                    if (!objectType.pkgID.equals(currentPkgId)) {
-                        pkgPrefix = objectType.pkgID.name.value + ":";
-                        if (importsAcceptor != null) {
-                            importsAcceptor.accept(objectType.pkgID.orgName.value, objectType.pkgID.name.value);
-                        }
-                    }
-                    return pkgPrefix + objectType.name.getValue();
-                }
-                return tSymbol.name.getValue();
+                String pkgPrefix = getPackagePrefix(importsAcceptor, currentPkgId, tSymbol.pkgID);
+                return pkgPrefix + tSymbol.name.getValue();
             }
             return "any";
         }
@@ -1508,6 +1492,19 @@ public class CommonUtil {
             return (parent != null && parent.parent != null)
                     ? lookupFunctionReturnType(functionName, parent.parent) : "any";
         }
+    }
+
+    public static String getPackagePrefix(BiConsumer<String, String> importsAcceptor, PackageID currentPkgId,
+                                          PackageID typePkgId) {
+        String pkgPrefix = "";
+        if (!typePkgId.equals(currentPkgId) &&
+                !(typePkgId.orgName.value.equals("ballerina") && typePkgId.name.value.equals("builtin"))) {
+            pkgPrefix = typePkgId.name.value + ":";
+            if (importsAcceptor != null) {
+                importsAcceptor.accept(typePkgId.orgName.value, typePkgId.name.value);
+            }
+        }
+        return pkgPrefix;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation1.json
@@ -110,11 +110,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation2.json
@@ -110,11 +110,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation3.json
@@ -231,11 +231,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation4.json
@@ -78,11 +78,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation5.json
@@ -114,11 +114,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation6.json
@@ -78,11 +78,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions1.json
@@ -245,11 +245,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"120",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions2.json
@@ -78,11 +78,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"121",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions4.json
@@ -245,11 +245,11 @@
       "insertTextFormat":"Snippet"
     },
     {
-      "label":"create(anydata a)",
+      "label":"convert(anydata a)",
       "kind":"Function",
       "detail":"Function",
       "sortText":"120",
-      "insertText":"create(${1});",
+      "insertText":"convert(${1});",
       "insertTextFormat":"Snippet"
     }
   ]


### PR DESCRIPTION
## Purpose
> Fix package prefix not added automatically for some BTypes.
> For example;
 >```ballerina
 >reflect:getServiceAnnotations(serviceName);
>```
> Code action `create variable` should create left-hand side variable as below;
>```ballerina
>reflect:annotationData[] a = reflect:getServiceAnnotations(serviceName);
>```
> But currently; it provides;
>```balerina
>annotationData[] a = reflect:getServiceAnnotations(serviceName);
>```

## Approach
> Fixed not adding package prefix for some BTypes.