### PR TITLE
Model returning an error from a resource as a failure

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/StrandResourceCallback.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/StrandResourceCallback.java
@@ -18,6 +18,9 @@
 package org.ballerinalang.bre.bvm;
 
 import org.ballerinalang.model.types.BType;
+import org.ballerinalang.model.types.TypeTags;
+import org.ballerinalang.model.values.BError;
+import org.ballerinalang.model.values.BRefType;
 
 /**
  * VM callback implementation which can be used for resource execution.
@@ -38,6 +41,11 @@ public class StrandResourceCallback extends StrandCallback {
         super.signal();
         if (super.getErrorVal() != null) {
             resourceCallback.notifyFailure(super.getErrorVal());
+            return;
+        }
+        BRefType<?> retValue = super.getRefRetVal();
+        if (retValue != null && retValue.getType().getTag() == TypeTags.ERROR_TAG) {
+            resourceCallback.notifyFailure((BError) getRefRetVal());
             return;
         }
         resourceCallback.notifySuccess();

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -38,7 +38,7 @@ public class HttpBaseTest extends BaseTest {
     public void start() throws BallerinaTestException {
         int[] requiredPorts = new int[]{9090, 9224, 9091, 9092, 9093, 9094, 9095, 9096, 9097, 9098, 9099, 9100, 9101,
                 9102, 9103, 9104, 9105, 9106, 9107, 9108, 9109, 9110, 9111, 9112, 9113, 9114, 9115, 9116, 9117, 9118,
-                9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225, 9226, 9227};
+                9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225, 9226, 9227, 9228};
         String balFile = Paths.get("src", "test", "resources", "http").toAbsolutePath().toString();
         String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
                                                                    "private.key").toAbsolutePath().toString());

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/ResourceFunctionReturnTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/ResourceFunctionReturnTestCase.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.service.http.sample;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.ballerinalang.test.service.http.HttpBaseTest;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.TestConstant;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Testing the resource function return.
+ */
+@Test(groups = "http-test")
+public class ResourceFunctionReturnTestCase extends HttpBaseTest {
+
+    @Test(description = "Returning error from a resource function generate 500")
+    public void testErrorTypeReturnedFromAResourceFunction() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9228, "manualErrorReturn"));
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString()),
+                TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), "simulated error", "Message content mismatched");
+    }
+
+    @Test(description = "Returning error from a resource function due to 'check' generate 500")
+    public void testErrorReturnedFromACheckExprInResourceFunction() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9228, "checkErrorReturn"));
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString()),
+                TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
+        Assert.assertEquals(response.getData(), "simulated error", "Message content mismatched");
+    }
+}

--- a/tests/ballerina-integration-test/src/test/resources/http/httpservices/28_resource_function_return.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http/httpservices/28_resource_function_return.bal
@@ -1,0 +1,39 @@
+import ballerina/http;
+
+@http:ServiceConfig {
+    basePath:"/"
+}
+service resourceReturnService on new http:Listener(9228) {
+
+    resource function manualErrorReturn(http:Caller caller, http:Request request) returns error? {
+        http:Response response = new;
+        response.setTextPayload("Hello Ballerina!");
+
+        // Manually return error.
+        if (1 == 1) {
+            error e = error("Simulated error");
+            return e;
+        }
+        _ = caller -> respond(response);
+        return;
+    }
+
+    resource function checkErrorReturn(http:Caller caller, http:Request request) returns error? {
+        http:Response response = new;
+
+        // Check expression returns error.
+        int i = check getError();
+        response.setTextPayload("i = " + i);
+        _ = caller -> respond(response);
+        return;
+    }
+
+}
+
+function getError() returns error|int {
+    if (1 == 1) {
+        error e = error("Simulated error");
+        return e;
+    }
+    return 1;
+}

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -57,6 +57,7 @@
             <class name="org.ballerinalang.test.service.http.sample.HttpPipeliningTestCase"/>
             <class name="org.ballerinalang.test.service.http.sample.HttpStatusCodeTestCase"/>
             <class name="org.ballerinalang.test.service.http.sample.CipherStrengthSSLTestCase"/>
+            <class name="org.ballerinalang.test.service.http.sample.ResourceFunctionReturnTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Model returning an error from a resource as a failure, and signal it as a failure to the transport layer.

This partially fixes https://github.com/ballerina-platform/ballerina-lang/issues/12613

