### PR TITLE
Fix invalid cursor type for svg dropdown

### DIFF
--- a/composer/packages/theme/src/definitions/elements/svg-button.less
+++ b/composer/packages/theme/src/definitions/elements/svg-button.less
@@ -2,6 +2,7 @@
 @element : "button";
 
 .ui.button.svg {
+   cursor: pointer;
    text {
       fill: @textColor;
       text-anchor: middle;

--- a/composer/packages/theme/src/definitions/views/diagram.less
+++ b/composer/packages/theme/src/definitions/views/diagram.less
@@ -200,6 +200,7 @@
                         fill: ~"@{@{color}-diagram-menu-item-background-color}";
 
                         text {
+                            cursor: pointer;
                             fill: ~"@{@{color}-diagram-menu-item-text-color}";
                         }
                         &:hover {


### PR DESCRIPTION
## Purpose
> This PR will fix the invalid cursor when hovered over the svg dropdown element.