### PR TITLE
Fix assertion failure on out of order union constraint and fix error messages with union constraints

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BUnionType.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BUnionType.java
@@ -89,7 +89,7 @@ public class BUnionType extends BType {
             return false;
         }
         BUnionType that = (BUnionType) o;
-        return Objects.equals(memberTypes, that.memberTypes);
+        return memberTypes.containsAll(that.memberTypes) && that.memberTypes.containsAll(memberTypes);
     }
 
     @Override

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BUnionType.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BUnionType.java
@@ -46,7 +46,8 @@ public class BUnionType extends BType {
      * @param memberTypes of the union type
      */
     public BUnionType(List<BType> memberTypes) {
-        super(null, null, BValue.class);
+        super(String.join("|", memberTypes.stream().map(BType::toString).collect(Collectors.toList())), null,
+              BValue.class);
         this.memberTypes = memberTypes;
         this.nullable = memberTypes.contains(BTypes.typeNull);
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeassertion/TypeAssertionExpressionsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeassertion/TypeAssertionExpressionsTest.java
@@ -173,6 +173,13 @@ public class TypeAssertionExpressionsTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina\\}TypeAssertionError \\{\"message\":\"assertion " +
+                    "error: expected 'stream<null>', found 'stream<null>'\"\\}.*")
+    public void testOutOfOrderUnionConstraintAssertionNegative() {
+        BRunUtil.invoke(result, "testOutOfOrderUnionConstraintAssertionNegative");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = ".*assertion error: expected 'int', found 'string'.*")
     public void testStringAsInvalidBasicType() {
         BRunUtil.invoke(result, "testStringAsInvalidBasicType");
@@ -228,7 +235,8 @@ public class TypeAssertionExpressionsTest {
                 {"testStreamAssertionPositive"},
                 {"testTypedescAssertionPositive"},
                 {"testMapElementAssertionPositive"},
-                {"testListElementAssertionPositive"}
+                {"testListElementAssertionPositive"},
+                {"testOutOfOrderUnionConstraintAssertionPositive"}
         };
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeassertion/TypeAssertionExpressionsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeassertion/TypeAssertionExpressionsTest.java
@@ -174,7 +174,7 @@ public class TypeAssertionExpressionsTest {
 
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = "error: \\{ballerina\\}TypeAssertionError \\{\"message\":\"assertion " +
-                    "error: expected 'stream<null>', found 'stream<null>'\"\\}.*")
+                    "error: expected 'stream<float\\|json>', found 'stream<int\\|float>'\"\\}.*")
     public void testOutOfOrderUnionConstraintAssertionNegative() {
         BRunUtil.invoke(result, "testOutOfOrderUnionConstraintAssertionNegative");
     }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typeassertion/type_assertion_expr.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/typeassertion/type_assertion_expr.bal
@@ -486,6 +486,19 @@ function testListElementAssertionNegative() {
     int iValTwo = <int> anyArrTwo[0];
 }
 
+function testOutOfOrderUnionConstraintAssertionPositive() returns boolean {
+    map<int|string> m = { one: 1, two: "2" };
+    anydata a = m;
+    map<string|int> m2 = <map<string|int>> a;
+    return m === m2;
+}
+
+function testOutOfOrderUnionConstraintAssertionNegative() {
+    stream<int|float> s1 = new;
+    any a = s1;
+    stream<float|json> s2 = <stream<float|json>> a;
+}
+
 function testStringAsInvalidBasicType() {
     string|int u1 = "I'm not an int!";
     any a = u1;


### PR DESCRIPTION
## Purpose
- This PR fixes assertion failures for union type constrained types, if the constraint types are in different orders
```ballerina
import ballerina/io;

public function main(string... args) {
    map<string|int> m = { one: "1" };
    any a = m;

    map<int|string> m2 = <map<int|string>> a;
}
```

- Fixes error messages printing `null` when the constraint is a union type
```cmd
{ballerina}StampError {"message":"incompatible stamp operation: 'map<null>' value cannot be stamped as 'map<int>'"}
```

Fixes #12683 
Fixes #12684