### PR TITLE
Optimize instruction codes

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -244,30 +244,6 @@ public class BVM {
                     i = operands[0];
                     sf.longRegs[i] = 5;
                     break;
-                case InstructionCodes.FCONST_0:
-                    i = operands[0];
-                    sf.doubleRegs[i] = 0;
-                    break;
-                case InstructionCodes.FCONST_1:
-                    i = operands[0];
-                    sf.doubleRegs[i] = 1;
-                    break;
-                case InstructionCodes.FCONST_2:
-                    i = operands[0];
-                    sf.doubleRegs[i] = 2;
-                    break;
-                case InstructionCodes.FCONST_3:
-                    i = operands[0];
-                    sf.doubleRegs[i] = 3;
-                    break;
-                case InstructionCodes.FCONST_4:
-                    i = operands[0];
-                    sf.doubleRegs[i] = 4;
-                    break;
-                case InstructionCodes.FCONST_5:
-                    i = operands[0];
-                    sf.doubleRegs[i] = 5;
-                    break;
                 case InstructionCodes.BCONST_0:
                     i = operands[0];
                     sf.intRegs[i] = 0;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -34,12 +34,6 @@ public interface InstructionCodes {
     int ICONST_3 = 8;
     int ICONST_4 = 9;
     int ICONST_5 = 10;
-    int FCONST_0 = 11;
-    int FCONST_1 = 12;
-    int FCONST_2 = 13;
-    int FCONST_3 = 14;
-    int FCONST_4 = 15;
-    int FCONST_5 = 16;
     int BCONST_0 = 17;
     int BCONST_1 = 18;
     int RCONST_NULL = 19;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -33,12 +33,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.ICONST_3] = "iconst_3";
         mnemonics[InstructionCodes.ICONST_4] = "iconst_4";
         mnemonics[InstructionCodes.ICONST_5] = "iconst_5";
-        mnemonics[InstructionCodes.FCONST_0] = "fconst_0";
-        mnemonics[InstructionCodes.FCONST_1] = "fconst_1";
-        mnemonics[InstructionCodes.FCONST_2] = "fconst_2";
-        mnemonics[InstructionCodes.FCONST_3] = "fconst_3";
-        mnemonics[InstructionCodes.FCONST_4] = "fconst_4";
-        mnemonics[InstructionCodes.FCONST_5] = "fconst_5";
         mnemonics[InstructionCodes.BCONST_0] = "bconst_0";
         mnemonics[InstructionCodes.BCONST_1] = "bconst_1";
         mnemonics[InstructionCodes.RCONST_NULL] = "rconst_null";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfoReader.java
@@ -1129,12 +1129,6 @@ public class PackageInfoReader {
                 case InstructionCodes.ICONST_3:
                 case InstructionCodes.ICONST_4:
                 case InstructionCodes.ICONST_5:
-                case InstructionCodes.FCONST_0:
-                case InstructionCodes.FCONST_1:
-                case InstructionCodes.FCONST_2:
-                case InstructionCodes.FCONST_3:
-                case InstructionCodes.FCONST_4:
-                case InstructionCodes.FCONST_5:
                 case InstructionCodes.BCONST_0:
                 case InstructionCodes.BCONST_1:
                 case InstructionCodes.RCONST_NULL:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -628,14 +628,8 @@ public class CodeGenerator extends BLangNodeVisitor {
                 double doubleVal = literalExpr.value instanceof String ?
                         Double.parseDouble((String) literalExpr.value) :
                         (Double) literalExpr.value;
-                if (doubleVal == 0 || doubleVal == 1 || doubleVal == 2 ||
-                        doubleVal == 3 || doubleVal == 4 || doubleVal == 5) {
-                    opcode = InstructionCodes.FCONST_0 + (int) doubleVal;
-                    emit(opcode, regIndex);
-                } else {
-                    int floatCPEntryIndex = currentPkgInfo.addCPEntry(new FloatCPEntry(doubleVal));
-                    emit(InstructionCodes.FCONST, getOperand(floatCPEntryIndex), regIndex);
-                }
+                int floatCPEntryIndex = currentPkgInfo.addCPEntry(new FloatCPEntry(doubleVal));
+                emit(InstructionCodes.FCONST, getOperand(floatCPEntryIndex), regIndex);
                 break;
 
             case TypeTags.DECIMAL:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -34,12 +34,6 @@ public interface InstructionCodes {
     int ICONST_3 = 8;
     int ICONST_4 = 9;
     int ICONST_5 = 10;
-    int FCONST_0 = 11;
-    int FCONST_1 = 12;
-    int FCONST_2 = 13;
-    int FCONST_3 = 14;
-    int FCONST_4 = 15;
-    int FCONST_5 = 16;
     int BCONST_0 = 17;
     int BCONST_1 = 18;
     int RCONST_NULL = 19;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -33,12 +33,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.ICONST_3] = "iconst_3";
         mnemonics[InstructionCodes.ICONST_4] = "iconst_4";
         mnemonics[InstructionCodes.ICONST_5] = "iconst_5";
-        mnemonics[InstructionCodes.FCONST_0] = "fconst_0";
-        mnemonics[InstructionCodes.FCONST_1] = "fconst_1";
-        mnemonics[InstructionCodes.FCONST_2] = "fconst_2";
-        mnemonics[InstructionCodes.FCONST_3] = "fconst_3";
-        mnemonics[InstructionCodes.FCONST_4] = "fconst_4";
-        mnemonics[InstructionCodes.FCONST_5] = "fconst_5";
         mnemonics[InstructionCodes.BCONST_0] = "bconst_0";
         mnemonics[InstructionCodes.BCONST_1] = "bconst_1";
         mnemonics[InstructionCodes.RCONST_NULL] = "rconst_null";


### PR DESCRIPTION
## Purpose
This PR optimizes the instruction codes by removing a few insignificant instructions related to float values. 
The removed instructions are `FCONST_0`, `FCONST_1`, `FCONST_2`, `FCONST_3`, `FCONST_4` and `FCONST_5`. 

The reason why we have special instructions for some integer and float values is for optimization purpose. For trivial values, which are expected to be frequently used it is better to have separate instructions rather than loading them from the constant pool. 

For integer values 0, 1, 2, 3, 4, 5 it is significant that these values will be used as most. However, in case of float it is insignificant to say 0.0, 1.0, 2.0, 3.0, 4.0, 5.0 will be the most used values. Hence, removing the special instructions correspond to the above float values is worthwhile as we can save few instruction codes.