### PR TITLE
Replace foreach with a while loop in cache expiry

### DIFF
--- a/stdlib/cache/src/main/ballerina/cache/cache.bal
+++ b/stdlib/cache/src/main/ballerina/cache/cache.bal
@@ -211,8 +211,18 @@ function runCacheExpiry() returns error? {
     string[] emptyCacheKeys = [];
 
     // Iterate through all caches.
-    foreach var (currentCacheKey, currentCache) in cacheMap {
+    int keyIndex = 0;
+    string[] currentCacheKeys = cacheMap.keys();
+    while (keyIndex < currentCacheKeys.length()) {
 
+        Cache currentCache;
+        string currentCacheKey = currentCacheKeys[keyIndex];
+        Cache? cache = cacheMap[currentCacheKey];
+        if (cache is Cache) {
+            currentCache = cache;
+        } else {
+            return ();
+        }
         // Get the expiry time of the current cache
         int currentCacheExpiryTime = currentCache.expiryTimeMillis;
 
@@ -221,8 +231,18 @@ function runCacheExpiry() returns error? {
 
         int cachesToBeRemovedIndex = 0;
         // Iterate through all keys.
-        foreach var (key, entry) in currentCache.entries {
+        int entrykeyIndex = 0;
+        string[] entryKeys = currentCache.entries.keys();
+        while (entrykeyIndex < entryKeys.length()) {
 
+            CacheEntry entry;
+            var key = entryKeys[entrykeyIndex];
+            CacheEntry? cacheEntry = currentCache.entries[key];
+            if (cacheEntry is CacheEntry) {
+                entry = cacheEntry;
+            } else {
+                return ();
+            }
             // Get the current system time.
             int currentSystemTime = time:currentTime().time;
 
@@ -231,13 +251,16 @@ function runCacheExpiry() returns error? {
                 cachesToBeRemoved[cachesToBeRemovedIndex] = key;
                 cachesToBeRemovedIndex = cachesToBeRemovedIndex + 1;
             }
+            entrykeyIndex = entrykeyIndex +1;
         }
 
         // Iterate through the key list which needs to be removed.
-        foreach var currentKeyIndex in 0..<cachesToBeRemovedIndex {
+        int currentKeyIndex = 0;
+        while(currentKeyIndex < cachesToBeRemovedIndex) {
             string key = cachesToBeRemoved[currentKeyIndex];
             // Remove the cache entry.
             _ = currentCache.entries.remove(key);
+            currentKeyIndex = currentKeyIndex + 1;
         }
 
         // If there are no entries, we add that cache key to the `emptyCacheKeys`.
@@ -246,6 +269,7 @@ function runCacheExpiry() returns error? {
             emptyCacheKeys[emptyCacheCount] = currentCacheKey;
             emptyCacheCount += 1;
         }
+        keyIndex = keyIndex + 1;
     }
 
     // We iterate though all empty cache keys and remove them from the `cacheMap`.

--- a/stdlib/cache/src/main/ballerina/cache/cache.bal
+++ b/stdlib/cache/src/main/ballerina/cache/cache.bal
@@ -213,7 +213,8 @@ function runCacheExpiry() returns error? {
     // Iterate through all caches.
     int keyIndex = 0;
     string[] currentCacheKeys = cacheMap.keys();
-    while (keyIndex < currentCacheKeys.length()) {
+    int cacheKeysLength = currentCacheKeys.length();
+    while (keyIndex < cacheKeysLength) {
 
         string currentCacheKey = currentCacheKeys[keyIndex];
         keyIndex += 1;
@@ -231,7 +232,8 @@ function runCacheExpiry() returns error? {
             // Iterate through all keys.
             int entrykeyIndex = 0;
             string[] entryKeys = currentCache.entries.keys();
-            while (entrykeyIndex < entryKeys.length()) {
+            int entryKeysLength = entryKeys.length();
+            while (entrykeyIndex < entryKeysLength) {
 
                 var key = entryKeys[entrykeyIndex];
                 entrykeyIndex += 1;


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12689
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12687
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12647

## Approach
> Replacing foreach with a while loop doesn’t directly affect to the OOM. But that avoids the concurrent modification exceptions occurs during the iterations.
Due to that exception, the clean up task crashes. So that exception has led to an OOM situation. Therefore the fix is applied to avoid the exception mentioned in the [issue](https://github.com/ballerina-platform/ballerina-lang/issues/12687)

## Load test result
> Concurrency - 100
> Payload - 50B
> Scenario - Passthrough service uses HTTP caching client to call  an echo back end (Find the service bal in [here](https://github.com/ballerina-platform/ballerina-lang/issues/12689))

![selection_051](https://user-images.githubusercontent.com/8381003/49803469-efbde280-fd75-11e8-8de8-41914dc49f18.png)

![selection_050](https://user-images.githubusercontent.com/8381003/49803489-fd736800-fd75-11e8-8371-95319bce5999.png)
