### PR TITLE
Add maxFrameSize config for client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2250,7 +2250,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.247</transport.http.version>
+        <transport.http.version>6.0.249</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/http/src/main/ballerina/http/annotation.bal
+++ b/stdlib/http/src/main/ballerina/http/annotation.bal
@@ -79,7 +79,8 @@ public type Versioning record {
 # + subProtocols - Negotiable sub protocol by the service
 # + idleTimeoutInSeconds - Idle timeout for the client connection. This can be triggered by putting
 #                          an `onIdleTimeout` resource in the WebSocket service.
-# + maxFrameSize - The maximum payload size of a WebSocket frame in bytes
+# + maxFrameSize - The maximum payload size of a WebSocket frame in bytes.
+#                  If this is not set or is negative or zero the default frame size of 65536 will be used.
 public type WSServiceConfig record {
     Listener[] endpoints = [];
     string path = "";

--- a/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
+++ b/stdlib/http/src/main/ballerina/http/websocket/websocket_client.bal
@@ -110,9 +110,12 @@ public type WebSocketClient client object {
 # + subProtocols - Negotiable sub protocols for the client
 # + customHeaders - Custom headers which should be sent to the server
 # + idleTimeoutInSeconds - Idle timeout of the client. Upon timeout, onIdleTimeout resource in the client service will be triggered (if there is one defined)
-# + readyOnConnect - true if the client is ready to recieve messages as soon as the connection is established. This is true by default. If changed to false the function ready() of the
+# + readyOnConnect - `true` if the client is ready to recieve messages as soon as the connection is established.
+#                    This is true by default. If changed to false the function ready() of the
 #                    `WebSocketClient`needs to be called once to start receiving messages.
 # + secureSocket - SSL/TLS related options
+# + maxFrameSize - The maximum payload size of a WebSocket frame in bytes.
+#                  If this is not set or is negative  or zero the default frame size of 65536 will be used.
 public type WebSocketClientEndpointConfig record {
     service? callbackService = ();
     string[] subProtocols = [];
@@ -120,5 +123,6 @@ public type WebSocketClientEndpointConfig record {
     int idleTimeoutInSeconds = -1;
     boolean readyOnConnect = true;
     SecureSocket? secureSocket = ();
+    int maxFrameSize = 0;
     !...
 };

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -37,7 +37,6 @@ public class WebSocketConstants {
     public static final String ANNOTATION_ATTR_SUB_PROTOCOLS = "subProtocols";
     public static final String ANNOTATION_ATTR_IDLE_TIMEOUT = "idleTimeoutInSeconds";
     public static final String ANNOTATION_ATTR_MAX_FRAME_SIZE = "maxFrameSize";
-    public static final String ANN_CONFIG_ATTR_WSS_PORT = "wssPort";
 
     public static final String RESOURCE_NAME_ON_OPEN = "onOpen";
     public static final String RESOURCE_NAME_ON_TEXT = "onText";
@@ -52,15 +51,10 @@ public class WebSocketConstants {
 
     public static final String NATIVE_DATA_WEBSOCKET_CONNECTION_INFO = "NATIVE_DATA_WEBSOCKET_CONNECTION_INFO";
 
-    public static final String NATIVE_DATA_QUERY_PARAMS = "NATIVE_DATA_QUERY_PARAMS";
-
     public static final String CLIENT_URL_CONFIG = "url";
     public static final String CLIENT_SERVICE_CONFIG = "callbackService";
-    public static final String CLIENT_SUB_PROTOCOLS_CONFIG = "subProtocols";
     public static final String CLIENT_CUSTOM_HEADERS_CONFIG = "customHeaders";
-    public static final String CLIENT_IDLE_TIMOUT_CONFIG = "idleTimeoutInSeconds";
     public static final String CLIENT_READY_ON_CONNECT = "readyOnConnect";
-    public static final String CLIENT_CONNECTOR_CONFIGS = "clientEndpointConfigs";
     public static final String WEBSOCKET_UPGRADE_SERVICE_CONFIG = "upgradeService";
 
     // WebSocketListener struct field names
@@ -68,8 +62,6 @@ public class WebSocketConstants {
     public static final String LISTENER_NEGOTIATED_SUBPROTOCOLS_FIELD = "negotiatedSubProtocol";
     public static final String LISTENER_IS_SECURE_FIELD = "isSecure";
     public static final String LISTENER_IS_OPEN_FIELD = "isOpen";
-    public static final String LISTENER_ATTRIBUTES_FIELD = "attributes";
-    public static final String LISTENER_CONFIG_FIELD = "config";
     public static final String LISTENER_CONNECTOR_FIELD = "conn";
     public static final int LISTENER_HTTP_ENDPOINT_FIELD = 3;
 
@@ -82,6 +74,8 @@ public class WebSocketConstants {
 
     public static final int STATUS_CODE_ABNORMAL_CLOSURE = 1006;
     public static final int STATUS_CODE_FOR_NO_STATUS_CODE_PRESENT = 1005;
+
+    public static final int DEFAULT_MAX_FRAME_SIZE = 65536;
 
     private WebSocketConstants() {
     }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketService.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketService.java
@@ -23,7 +23,6 @@ import org.ballerinalang.connector.api.ParamDetail;
 import org.ballerinalang.connector.api.Resource;
 import org.ballerinalang.connector.api.Service;
 import org.ballerinalang.connector.api.Struct;
-import org.ballerinalang.connector.api.Value;
 import org.ballerinalang.util.codegen.ServiceInfo;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -41,8 +40,7 @@ public class WebSocketService {
     private final Map<String, Resource> resourceMap = new ConcurrentHashMap<>();
     private String basePath;
     private HttpResource upgradeResource;
-    private static final int DEFAULT_MAX_FRAME_SIZE = 65536;
-    private int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
+    private int maxFrameSize = WebSocketConstants.DEFAULT_MAX_FRAME_SIZE;
 
     public WebSocketService() {
         service = null;
@@ -54,16 +52,17 @@ public class WebSocketService {
             resourceMap.put(resource.getName(), resource);
         }
 
+        ParamDetail param = service.getResources()[0].getParamDetails().get(0);
         Annotation configAnnotation = WebSocketUtil.getServiceConfigAnnotation(service);
 
-        Struct configAnnotationStruct = null;
-        if (configAnnotation != null && (configAnnotationStruct = configAnnotation.getValue()) != null) {
-            negotiableSubProtocols = findNegotiableSubProtocols(configAnnotationStruct);
-            idleTimeoutInSeconds = findIdleTimeoutInSeconds(configAnnotationStruct);
-            maxFrameSize = findMaxFrameSize(configAnnotationStruct);
-        }
-        ParamDetail param = service.getResources()[0].getParamDetails().get(0);
         if (param != null && WebSocketConstants.WEBSOCKET_CALLER_NAME.equals(param.getVarType().toString())) {
+            Struct configAnnotationStruct = null;
+            if (configAnnotation != null && (configAnnotationStruct = configAnnotation.getValue()) != null) {
+                negotiableSubProtocols = WebSocketUtil.findNegotiableSubProtocols(configAnnotationStruct);
+                idleTimeoutInSeconds = WebSocketUtil.findIdleTimeoutInSeconds(configAnnotationStruct);
+                maxFrameSize = WebSocketUtil.findMaxFrameSize(configAnnotationStruct);
+            }
+
             basePath = findFullWebSocketUpgradePath(configAnnotationStruct);
         }
 
@@ -113,33 +112,6 @@ public class WebSocketService {
 
     public int getMaxFrameSize() {
         return maxFrameSize;
-    }
-
-    private String[] findNegotiableSubProtocols(Struct annAttrSubProtocols) {
-        Value[] subProtocolsInAnnotation = annAttrSubProtocols.getArrayField(
-                WebSocketConstants.ANNOTATION_ATTR_SUB_PROTOCOLS);
-
-        if (subProtocolsInAnnotation == null) {
-            return new String[0];
-        }
-
-        String[] subProtoCols = new String[subProtocolsInAnnotation.length];
-        for (int i = 0; i < subProtocolsInAnnotation.length; i++) {
-            subProtoCols[i] = subProtocolsInAnnotation[i].getStringValue();
-        }
-        return subProtoCols;
-    }
-
-    private int findIdleTimeoutInSeconds(Struct annAttrIdleTimeout) {
-        return (int) annAttrIdleTimeout.getIntField(WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT);
-    }
-
-    private int findMaxFrameSize(Struct annotation) {
-        int size = (int) annotation.getIntField(WebSocketConstants.ANNOTATION_ATTR_MAX_FRAME_SIZE);
-        if (size <= 0) {
-            size = DEFAULT_MAX_FRAME_SIZE;
-        }
-        return size;
     }
 
     public String getBasePath() {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -30,18 +30,24 @@ import org.ballerinalang.connector.api.Executor;
 import org.ballerinalang.connector.api.ParamDetail;
 import org.ballerinalang.connector.api.Resource;
 import org.ballerinalang.connector.api.Service;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.connector.api.Value;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.http.actions.httpclient.AbstractHTTPAction;
 import org.ballerinalang.services.ErrorHandlerUtils;
 import org.ballerinalang.util.codegen.ProgramFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeFuture;
 import org.wso2.transport.http.netty.contract.websocket.ServerHandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketHandshaker;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.ballerinalang.net.http.HttpConstants.PROTOCOL_PACKAGE_HTTP;
@@ -51,6 +57,8 @@ import static org.ballerinalang.net.http.HttpConstants.PROTOCOL_PACKAGE_HTTP;
  * Utility class for websockets.
  */
 public class WebSocketUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractHTTPAction.class);
 
     public static ProgramFile getProgramFile(Resource resource) {
         return resource.getResourceInfo().getPackageInfo().getProgramFile();
@@ -193,6 +201,45 @@ public class WebSocketUtil {
     public static void setListenerOpenField(WebSocketOpenConnectionInfo connectionInfo) throws IllegalAccessException {
         connectionInfo.getWebSocketEndpoint().put(WebSocketConstants.LISTENER_IS_OPEN_FIELD,
                                                   new BBoolean(connectionInfo.getWebSocketConnection().isOpen()));
+    }
+
+    public static int findMaxFrameSize(Struct annotation) {
+        long size = annotation.getIntField(WebSocketConstants.ANNOTATION_ATTR_MAX_FRAME_SIZE);
+        if (size <= 0) {
+            return WebSocketConstants.DEFAULT_MAX_FRAME_SIZE;
+        }
+        try {
+            return Math.toIntExact(size);
+        } catch (ArithmeticException e) {
+            logger.warn("The value set for maxFrameSize needs to be less than " + Integer.MAX_VALUE +
+                                ". The maxFrameSize value is set to " + Integer.MAX_VALUE);
+            return Integer.MAX_VALUE;
+        }
+
+    }
+
+    public static int findIdleTimeoutInSeconds(Struct annAttrIdleTimeout) {
+        long timeout = annAttrIdleTimeout.getIntField(WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT);
+        if (timeout <= 0) {
+            return 0;
+        }
+        try {
+            return Math.toIntExact(timeout);
+        } catch (ArithmeticException e) {
+            logger.warn("The value set for idleTimeoutInSeconds needs to be less than" + Integer.MAX_VALUE +
+                                ". The idleTimeoutInSeconds value is set to " + Integer.MAX_VALUE);
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    public static String[] findNegotiableSubProtocols(Struct annAttrSubProtocols) {
+        Value[] subProtocolsInAnnotation = annAttrSubProtocols.getArrayField(
+                WebSocketConstants.ANNOTATION_ATTR_SUB_PROTOCOLS);
+        if (subProtocolsInAnnotation == null) {
+            return new String[0];
+        }
+        return  Arrays.stream(subProtocolsInAnnotation).map(Value::getStringValue)
+                .toArray(String[]::new);
     }
 
     private WebSocketUtil() {


### PR DESCRIPTION
## Purpose
> The maxFrameSize config was available for WebSocket server but was missing from the client configs. This adds this feature.
Also the service configs are useless for clients. This makes sure they are ignored when initiating the client.

**Need to update transport version**