### PR TITLE
Fix issue #12492

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -87,7 +87,6 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
     private Map<DefinitionID, List<CompilerPlugin>> processorMap;
     private Map<CompilerPlugin, List<DefinitionID>> resourceTypeProcessorMap;
     private Map<CompilerPlugin, BType> serviceListenerMap;
-    private boolean pluginLoaded = false;
 
 
     public static CompilerPluginRunner getInstance(CompilerContext context) {
@@ -114,6 +113,9 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         this.processorMap = new HashMap<>();
         this.resourceTypeProcessorMap = new HashMap<>();
         this.serviceListenerMap = new HashMap<>();
+
+        ServiceLoader<CompilerPlugin> pluginLoader = ServiceLoader.load(CompilerPlugin.class);
+        pluginLoader.forEach(this::initPlugin);
     }
 
     public BLangPackage runPlugins(BLangPackage pkgNode) {
@@ -204,18 +206,10 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
     // private methods
 
     private void loadPlugins() {
-        if (pluginLoaded) {
-            return;
-        }
-        ServiceLoader<CompilerPlugin> pluginLoader = ServiceLoader.load(CompilerPlugin.class);
-        pluginLoader.forEach(this::initPlugin);
-        pluginLoaded = true;
+        pluginList.forEach(this::initPlugin);
     }
 
     private void initPlugin(CompilerPlugin plugin) {
-        // Cache the plugin implementation class
-        pluginList.add(plugin);
-
         handleAnnotationProcesses(plugin);
         handleServiceTypeProcesses(plugin);
         plugin.setCompilerContext(context);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -115,7 +115,7 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         this.serviceListenerMap = new HashMap<>();
 
         ServiceLoader<CompilerPlugin> pluginLoader = ServiceLoader.load(CompilerPlugin.class);
-        pluginLoader.forEach(this::initPlugin);
+        pluginLoader.forEach(plugin -> pluginList.add(plugin));
     }
 
     public BLangPackage runPlugins(BLangPackage pkgNode) {


### PR DESCRIPTION
## Purpose
> Fix the issue #12492. When there are 2 modules in the project, 1 module does not have any tests and 2nd module has tests. At the project level "ballerina test" is issued but outputs as no tests found in all of the modules.

## Goals
> Fix the issue #12492.

## Approach
> Load all the CompilerPlugins in the CompilerPluginRunner at once in the constructor and filter them out as necessary than restricting the plugin loading.

## User stories
> N/A

## Release note
> 0.990.0 patch release

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information N/A
 - Integration tests
   > Details about the test cases and coverage N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A