### PR TITLE
Show a message when no documented constructs are present

### DIFF
--- a/composer/packages/documentation/src/components/DocPreview.jsx
+++ b/composer/packages/documentation/src/components/DocPreview.jsx
@@ -146,6 +146,10 @@ export default class DocPreview extends React.Component {
                 console.error(e);
             }
         });
-        return docElements;
+        if (docElements.length > 0) {
+            return docElements;
+        } else {
+            return <p>{"No documentation to show"}</p>
+        }
     }
 }


### PR DESCRIPTION
## Purpose
Show a message "No documentations to show", when no documented constructs present

![image](https://user-images.githubusercontent.com/3872221/49938472-009a5f80-ff00-11e8-9875-048c8752895d.png)
