### PR TITLE
 Fix using consecutive trap operations

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/emitter/BalxEmitter.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/emitter/BalxEmitter.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.bre.emitter;
 
+import org.ballerinalang.util.codegen.ErrorTableEntry;
 import org.ballerinalang.util.codegen.FunctionInfo;
 import org.ballerinalang.util.codegen.Instruction;
 import org.ballerinalang.util.codegen.LocalVariableInfo;
@@ -24,6 +25,7 @@ import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.codegen.attributes.AttributeInfo;
 import org.ballerinalang.util.codegen.attributes.CodeAttributeInfo;
+import org.ballerinalang.util.codegen.attributes.ErrorTableAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.LocalVariableAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.ParameterAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.VarTypeCountAttributeInfo;
@@ -230,6 +232,14 @@ public class BalxEmitter {
                 println(tabs + "}");
                 break;
             case ERROR_TABLE:
+                ErrorTableAttributeInfo errAttr = (ErrorTableAttributeInfo) attr;
+                println(" {");
+                for (ErrorTableEntry ete : errAttr.getErrorTableEntriesList()) {
+                    println(tabs + "\t" + "ipFrom " + tabs + "\t" + "ipTo " +
+                            tabs + "\t" + "ipTarget " + tabs + "\t" + "regIndex " + tabs + "\t" + ete.toString());
+                }
+                println(tabs + "}");
+                break;
             case TAINT_TABLE:
             case ANNOTATIONS_ATTRIBUTE:
             case DEFAULT_VALUE_ATTRIBUTE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1474,7 +1474,7 @@ public class CodeGenerator extends BLangNodeVisitor {
         RegIndex regIndex = calcAndGetExprRegIndex(trapExpr);
         emit(InstructionCodes.RMOVE, trapExpr.expr.regIndex, regIndex);
         int toIP = nextIP();
-        errorTable.addErrorTableEntry(new ErrorTableEntry(fromIP, toIP, toIP, regIndex));
+        errorTable.addErrorTableEntry(new ErrorTableEntry(fromIP, toIP - 1, toIP, regIndex));
     }
 
     public void visit(BLangTypedescExpr accessExpr) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -147,4 +147,11 @@ public class ErrorTest {
         Assert.assertEquals(returns[0].stringValue(), "{callableName:\"getCallStack\", " +
                 "moduleName:\"ballerina/runtime\", fileName:\"<native>\", lineNumber:0}");
     }
+
+    @Test
+    public void testConsecutiveTraps() {
+        BValue[] returns = BRunUtil.invoke(basicErrorTest, "testConsecutiveTraps");
+        Assert.assertEquals(returns[0].stringValue(), "Error");
+        Assert.assertEquals(returns[1].stringValue(), "Error");
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/error/basicErrorTest.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/error/basicErrorTest.bal
@@ -73,3 +73,19 @@ public function testErrorWithErrorConstructor() returns string {
 function getCallStackTest() returns runtime:CallStackElement[] {
     return runtime:getCallStack();
 }
+
+function testConsecutiveTraps() returns (string, string) {
+    error? e1 = trap generatePanic();
+    error? e2 = trap generatePanic();
+    if e1 is error {
+        if e2 is error {
+            return (e1.reason(), e2.reason());
+        }
+    }
+    return ("Failed", "Failed");
+}
+
+function generatePanic() {
+    error e = error("Error");
+    panic e;
+}


### PR DESCRIPTION
Fixes #12771

## Approach
Decrement by 1 the `toIP` in codegenerator so that the range that the trap covers does not include the targetIP which is the instruction after the trap.