### PR TITLE
Disallow naming a worker as default

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -79,6 +79,7 @@ public enum DiagnosticCode {
     INVALID_WORKER_INTERACTION("worker.invalid.worker.interaction"),
     WORKER_SEND_AFTER_RETURN("worker.send.after.return"),
     WORKER_RECEIVE_AFTER_RETURN("worker.receive.after.return"),
+    INVALID_WORKER_NAME("worker.name.cannot.be.default"),
     INVALID_MULTIPLE_FORK_JOIN_SEND("worker.multiple.fork.join.send"),
     INCOMPATIBLE_TYPE_REFERENCE("incompatible.type.reference"),
     INCOMPATIBLE_RECORD_TYPE_REFERENCE("incompatible.record.type.reference"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -79,7 +79,7 @@ public enum DiagnosticCode {
     INVALID_WORKER_INTERACTION("worker.invalid.worker.interaction"),
     WORKER_SEND_AFTER_RETURN("worker.send.after.return"),
     WORKER_RECEIVE_AFTER_RETURN("worker.receive.after.return"),
-    INVALID_WORKER_NAME("worker.name.cannot.be.default"),
+    EXPLICIT_WORKER_CANNOT_BE_DEFAULT("explicit.worker.cannot.be.default"),
     INVALID_MULTIPLE_FORK_JOIN_SEND("worker.multiple.fork.join.send"),
     INCOMPATIBLE_TYPE_REFERENCE("incompatible.type.reference"),
     INCOMPATIBLE_RECORD_TYPE_REFERENCE("incompatible.record.type.reference"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1629,8 +1629,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             if (workerVarName.startsWith(WORKER_LAMBDA_VAR_PREFIX)) {
                 String workerName = workerVarName.substring(1);
                 // Check if the worker name is default, if so log an error
+                // TODO Remove this after the default worker node is defined in SymbolEnter.
                 if (workerName.equalsIgnoreCase(DEFAULT_WORKER_NAME)) {
-                    dlog.error(bLangLambdaFunction.pos, DiagnosticCode.INVALID_WORKER_NAME);
+                    dlog.error(bLangLambdaFunction.pos, DiagnosticCode.EXPLICIT_WORKER_CANNOT_BE_DEFAULT);
                 }
                 isWorker = true;
                 this.workerActionSystemStack.peek().startWorkerActionStateMachine(workerName,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1628,6 +1628,10 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             String workerVarName = ((BLangSimpleVariable) bLangLambdaFunction.parent).name.value;
             if (workerVarName.startsWith(WORKER_LAMBDA_VAR_PREFIX)) {
                 String workerName = workerVarName.substring(1);
+                // Check if the worker name is default, if so log an error
+                if (workerName.equalsIgnoreCase(DEFAULT_WORKER_NAME)) {
+                    dlog.error(bLangLambdaFunction.pos, DiagnosticCode.INVALID_WORKER_NAME);
+                }
                 isWorker = true;
                 this.workerActionSystemStack.peek().startWorkerActionStateMachine(workerName,
                                                                                   bLangLambdaFunction.function.pos,

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -78,7 +78,7 @@ error.atleast.one.worker.must.return=\
   at least one worker in the {0} must return a result
 
 error.explicit.worker.cannot.be.default=\
-  explicit workers cannot be ''default'' since the function already hsa an implicit worker named ''default''
+  explicit workers cannot be named as ''default'' since the function already has an implicit worker named ''default''
 
 error.fork.join.worker.cannot.return=\
   cannot return from a worker in fork/join

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -77,6 +77,9 @@ error.main.should.be.public=\
 error.atleast.one.worker.must.return=\
   at least one worker in the {0} must return a result
 
+error.worker.name.cannot.be.default=\
+  worker name cannot be ''default''
+
 error.fork.join.worker.cannot.return=\
   cannot return from a worker in fork/join
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -77,8 +77,8 @@ error.main.should.be.public=\
 error.atleast.one.worker.must.return=\
   at least one worker in the {0} must return a result
 
-error.worker.name.cannot.be.default=\
-  worker name cannot be ''default''
+error.explicit.worker.cannot.be.default=\
+  explicit workers cannot be ''default'' since the function already hsa an implicit worker named ''default''
 
 error.fork.join.worker.cannot.return=\
   cannot return from a worker in fork/join

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
@@ -216,11 +216,14 @@ public class WorkerFailTest {
     public void invalidWorkerNameAsDefault() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-worker-as-default.bal");
         Assert.assertEquals(result.getErrorCount(), 4);
-        BAssertUtil.validateError(result, 0, "worker name cannot be 'default'", 4, 5);
-        BAssertUtil.validateError(result, 1, "worker name cannot be 'default'", 15, 5);
+        BAssertUtil.validateError(result, 0, "explicit workers cannot be 'default' since the " +
+                "function already hsa an implicit worker named 'default'", 4, 5);
+        BAssertUtil.validateError(result, 1, "explicit workers cannot be 'default' since the " +
+                "function already hsa an implicit worker named 'default'", 15, 5);
         BAssertUtil.validateError(result, 2, "worker send/receive interactions are invalid; worker(s) cannot " +
                 "move onwards from the state: '[x -> default,  <- default]'", 15, 5);
-        BAssertUtil.validateError(result, 3, "worker name cannot be 'default'", 25, 9);
+        BAssertUtil.validateError(result, 3, "explicit workers cannot be 'default' since the " +
+                "function already hsa an implicit worker named 'default'", 25, 9);
 
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
@@ -216,14 +216,14 @@ public class WorkerFailTest {
     public void invalidWorkerNameAsDefault() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-worker-as-default.bal");
         Assert.assertEquals(result.getErrorCount(), 4);
-        BAssertUtil.validateError(result, 0, "explicit workers cannot be 'default' since the " +
-                "function already hsa an implicit worker named 'default'", 4, 5);
-        BAssertUtil.validateError(result, 1, "explicit workers cannot be 'default' since the " +
-                "function already hsa an implicit worker named 'default'", 15, 5);
+        BAssertUtil.validateError(result, 0, "explicit workers cannot be named as 'default' " +
+                "since the function already has an implicit worker named 'default'", 4, 5);
+        BAssertUtil.validateError(result, 1, "explicit workers cannot be named as 'default' " +
+                "since the function already has an implicit worker named 'default'", 15, 5);
         BAssertUtil.validateError(result, 2, "worker send/receive interactions are invalid; worker(s) cannot " +
                 "move onwards from the state: '[x -> default,  <- default]'", 15, 5);
-        BAssertUtil.validateError(result, 3, "explicit workers cannot be 'default' since the " +
-                "function already hsa an implicit worker named 'default'", 25, 9);
+        BAssertUtil.validateError(result, 3, "explicit workers cannot be named as 'default' " +
+                "since the function already has an implicit worker named 'default'", 25, 9);
 
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
@@ -211,4 +211,16 @@ public class WorkerFailTest {
         Assert.assertTrue(message.contains("invalid worker receive statement position, must be a top level statement " +
                                                    "in a worker"), message);
     }
+
+    @Test
+    public void invalidWorkerNameAsDefault() {
+        CompileResult result = BCompileUtil.compile("test-src/workers/invalid-worker-as-default.bal");
+        Assert.assertEquals(result.getErrorCount(), 4);
+        BAssertUtil.validateError(result, 0, "worker name cannot be 'default'", 4, 5);
+        BAssertUtil.validateError(result, 1, "worker name cannot be 'default'", 15, 5);
+        BAssertUtil.validateError(result, 2, "worker send/receive interactions are invalid; worker(s) cannot " +
+                "move onwards from the state: '[x -> default,  <- default]'", 15, 5);
+        BAssertUtil.validateError(result, 3, "worker name cannot be 'default'", 25, 9);
+
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/workers/invalid-worker-as-default.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/workers/invalid-worker-as-default.bal
@@ -1,0 +1,30 @@
+import ballerina/io;
+
+function workerTest1() {
+    worker default {
+        int i =100;
+        io:println("default worker --> " + 100);
+    }
+
+    worker w1 {
+        io:println("worker w1");
+    }
+}
+
+function workerTest2() returns int{
+    worker default {
+        int x = 50;
+        x -> default;
+    }
+    int y = <- default;
+    return y + 1;
+}
+
+function workerTest3() {
+    fork {
+        worker default {
+            int i =100;
+            io:println("default worker --> " + 100);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> $subject

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12251

## Automation tests
 - Unit tests 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes