### PR TITLE
[Do not merge] Include constraint type in cursor tables

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
@@ -67,6 +67,16 @@ public class BTable implements BRefType<Object>, BCollection {
         this.type = BTypes.typeTable;
     }
 
+    public BTable(BStructureType constraintType) {
+        this.iterator = null;
+        this.tableProvider = null;
+        this.nextPrefetched = false;
+        this.hasNextVal = false;
+        this.tableName = null;
+        this.constraintType = constraintType;
+        this.type = new BTableType(this.constraintType);
+    }
+
     public BTable(String tableName, BStructureType constraintType) {
         this.nextPrefetched = false;
         this.hasNextVal = false;

--- a/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
+++ b/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/actions/AbstractSQLAction.java
@@ -953,7 +953,8 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
     private BTable constructTable(TableResourceManager rm, Context context, ResultSet rs, BStructureType structType,
              List<ColumnDefinition> columnDefinitions, String databaseProductName) {
         return new BCursorTable(new SQLDataIterator(rm, rs, utcCalendar, columnDefinitions, structType,
-                TimeUtils.getTimeStructInfo(context), TimeUtils.getTimeZoneStructInfo(context), databaseProductName));
+                TimeUtils.getTimeStructInfo(context), TimeUtils.getTimeZoneStructInfo(context), databaseProductName),
+                structType);
     }
 
     private BTable constructTable(TableResourceManager rm, Context context, ResultSet rs, BStructureType structType,

--- a/stdlib/database/sql/src/main/java/org/ballerinalang/database/table/BCursorTable.java
+++ b/stdlib/database/sql/src/main/java/org/ballerinalang/database/table/BCursorTable.java
@@ -19,6 +19,7 @@ package org.ballerinalang.database.table;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.DataIterator;
+import org.ballerinalang.model.types.BStructureType;
 import org.ballerinalang.model.values.BFunctionPointer;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BTable;
@@ -35,8 +36,8 @@ import java.util.Map;
  */
 public class BCursorTable extends BTable {
 
-    public BCursorTable(DataIterator dataIterator) {
-        super();
+    public BCursorTable(DataIterator dataIterator, BStructureType constraintType) {
+        super(constraintType);
         this.iterator = dataIterator;
     }
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -96,6 +96,19 @@ public class TableTest {
         Assert.assertEquals(returns[5].stringValue(), "Hello");
     }
 
+    @Test(groups = TABLE_TEST,
+          description = "Test type checking constrained cursor table with closed constraint")
+    public void testTypeCheckingConstrainedCursorTableWithClosedConstraint() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeCheckingConstrainedCursorTableWithClosedConstraint");
+        Assert.assertEquals(returns.length, 6);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 9223372036854774807L);
+        Assert.assertEquals(((BFloat) returns[2]).floatValue(), 123.34D, DELTA);
+        Assert.assertEquals(((BFloat) returns[3]).floatValue(), 2139095039D);
+        Assert.assertEquals(((BBoolean) returns[4]).booleanValue(), true);
+        Assert.assertEquals(returns[5].stringValue(), "Hello");
+    }
+
     @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.")
     public void testToJson() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJson");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -342,16 +342,6 @@ public class TableTest {
     }
 
     @Test(groups = TABLE_TEST, description = "Check date time operation")
-    public void testDateTimeAsTimeStruct() {
-        BValue[] returns = BRunUtil.invoke(result,  "testDateTimeAsTimeStruct");
-        Assert.assertEquals(returns.length, 8);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), ((BInteger) returns[1]).intValue());
-        Assert.assertEquals(((BInteger) returns[2]).intValue(), ((BInteger) returns[3]).intValue());
-        Assert.assertEquals(((BInteger) returns[4]).intValue(), ((BInteger) returns[5]).intValue());
-        Assert.assertEquals(((BInteger) returns[6]).intValue(), ((BInteger) returns[7]).intValue());
-    }
-
-    @Test(groups = TABLE_TEST, description = "Check date time operation")
     public void testDateTimeInt() {
         BValue[] args = new BValue[3];
         Calendar cal = Calendar.getInstance();
@@ -701,17 +691,6 @@ public class TableTest {
     }
 
     @Test(groups = TABLE_TEST,
-          description = "Test mapping date to nillable Time field")
-    public void testMapptingDatesToNillableTime() {
-        BValue[] returns = BRunUtil.invoke(nillableMappingResult, "testMappingDatesToNillableTimeType");
-        Assert.assertEquals(returns.length, 8);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), ((BInteger) returns[1]).intValue());
-        Assert.assertEquals(((BInteger) returns[2]).intValue(), ((BInteger) returns[3]).intValue());
-        Assert.assertEquals(((BInteger) returns[4]).intValue(), ((BInteger) returns[5]).intValue());
-        Assert.assertEquals(((BInteger) returns[6]).intValue(), ((BInteger) returns[7]).intValue());
-    }
-
-    @Test(groups = TABLE_TEST,
           description = "Test mapping date to nillable int field")
     public void testMappingDatesToNillableIntType() {
         BValue[] args = new BValue[3];
@@ -787,7 +766,7 @@ public class TableTest {
     public void testMappingNullToNillableTypes() {
         BValue[] returns = BRunUtil.invoke(nillableMappingResult, "testMappingNullToNillableTypes");
         Assert.assertNotNull(returns);
-        Assert.assertEquals(returns.length, 17);
+        Assert.assertEquals(returns.length, 21);
         for (BValue returnVal : returns) {
             Assert.assertNull(returnVal);
         }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
@@ -25,20 +25,6 @@ type ResultDatesWithNillableStringType record {
     string? DATETIME_TYPE;
 };
 
-type ResultDatesWithTimeType record {
-    time:Time DATE_TYPE;
-    time:Time TIME_TYPE;
-    time:Time TIMESTAMP_TYPE;
-    time:Time DATETIME_TYPE;
-};
-
-type ResultDatesWithNillableTimeType record {
-    time:Time? DATE_TYPE;
-    time:Time? TIME_TYPE;
-    time:Time? TIMESTAMP_TYPE;
-    time:Time? DATETIME_TYPE;
-};
-
 type ResultDatesWithIntType record {
     int DATE_TYPE;
     int TIME_TYPE;
@@ -67,10 +53,14 @@ type NillableDataTypesAll record {
     int? smallint_type;
     string? clob_type;
     byte[]? binary_type;
-    time:Time? date_type;
-    time:Time? time_type;
-    time:Time? datetime_type;
-    time:Time? timestamp_type;
+    int? date_type;
+    int? time_type;
+    int? datetime_type;
+    int? timestamp_type;
+    string? date_type_str;
+    string? time_type_str;
+    string? datetime_type_str;
+    string? timestamp_type_str;
 };
 
 type NillableDataTypes record {
@@ -192,65 +182,6 @@ function testMappingToNillableTypeFieldsBlob() returns (byte[]?) {
     return blob_type;
 }
 
-function testMappingDatesToNillableTimeType() returns (int, int, int,
-            int, int, int, int, int) {
-    h2:Client testDB = new({
-        path: "./target/tempdb/",
-        name: "TEST_DATA_TABLE_H2",
-        username: "SA",
-        password: "",
-        poolOptions: { maximumPoolSize: 1 }
-    });
-
-    int dateInserted = -1;
-    int dateRetrieved = -1;
-    int timeInserted = -1;
-    int timeRetrieved = -1;
-    int timestampInserted = -1;
-    int timestampRetrieved = -1;
-    int datetimeInserted = -1;
-    int datetimeRetrieved = -1;
-
-    time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
-
-    time:Timezone zoneValue = { zoneId: "UTC" };
-    time:Time timeStruct = new(51323000, zoneValue);
-
-    time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");
-    time:Time datetimeStruct = time:createTime(2017, 1, 31, 16, 12, 23, 332, "UTC");
-    dateInserted = dateStruct.time;
-    timeInserted = timeStruct.time;
-    timestampInserted = timestampStruct.time;
-    datetimeInserted = datetimeStruct.time;
-
-    sql:Parameter para0 = { sqlType: sql:TYPE_INTEGER, value: 150 };
-    sql:Parameter para1 = { sqlType: sql:TYPE_DATE, value: dateStruct };
-    sql:Parameter para2 = { sqlType: sql:TYPE_TIME, value: timeStruct };
-    sql:Parameter para3 = { sqlType: sql:TYPE_TIMESTAMP, value: timestampStruct };
-    sql:Parameter para4 = { sqlType: sql:TYPE_DATETIME, value: datetimeStruct };
-
-    _ = testDB->update("Insert into DateTimeTypes
-        (row_id, date_type, time_type, timestamp_type, datetime_type) values (?,?,?,?,?)",
-        para0, para1, para2, para3, para4);
-    var dt = testDB->select("SELECT date_type, time_type, timestamp_type, datetime_type
-                from DateTimeTypes where row_id = 150", ResultDatesWithNillableTimeType);
-
-    if (dt is table<ResultDatesWithNillableTimeType>) {
-        while (dt.hasNext()) {
-            var rs = dt.getNext();
-            if (rs is ResultDatesWithNillableTimeType) {
-                dateRetrieved = rs.DATE_TYPE.time ?: -1;
-                timeRetrieved = rs.TIME_TYPE.time ?: -1;
-                timestampRetrieved = rs.TIMESTAMP_TYPE.time ?: -1;
-                datetimeRetrieved = rs.DATETIME_TYPE.time ?: -1;
-            }
-        }
-    }
-    testDB.stop();
-    return (dateInserted, dateRetrieved, timeInserted, timeRetrieved, timestampInserted, timestampRetrieved,
-    datetimeInserted, datetimeRetrieved);
-}
-
 function testMappingDatesToNillableIntType(int datein, int timein,
                                            int timestampin) returns (int, int, int, int) {
     h2:Client testDB = new({
@@ -338,8 +269,8 @@ timein, int timestampin) returns (string, string, string,
 }
 
 function testMappingNullToNillableTypes() returns (int?, int?, float?,
-            float?, boolean?, string?, float?, float?, float?, int?, int?, string?, byte[]?, time:Time?, time:Time?
-            , time:Time?, time:Time?) {
+            float?, boolean?, string?, float?, float?, float?, int?, int?, string?, byte[]?, int?, int?
+            ,int?, int?, string?, string?, string?, string?) {
     h2:Client testDB = new({
         path: "./target/tempdb/",
         name: "TEST_DATA_TABLE_H2",
@@ -349,8 +280,8 @@ function testMappingNullToNillableTypes() returns (int?, int?, float?,
     });
     var dt = testDB->select("SELECT int_type, long_type, float_type, double_type,
     boolean_type, string_type, numeric_type, decimal_type, real_type, tinyint_type, smallint_type, clob_type,
-    binary_type, date_type, time_type, datetime_type, timestamp_type from DataTypeTableNillable where
-    row_id=2", NillableDataTypesAll);
+    binary_type, date_type, time_type, datetime_type, timestamp_type, date_type, time_type, datetime_type, timestamp_type
+     from DataTypeTableNillable where row_id=2", NillableDataTypesAll);
 
     int? int_type = ();
     int? long_type = ();
@@ -365,10 +296,14 @@ function testMappingNullToNillableTypes() returns (int?, int?, float?,
     int? smallint_type = ();
     string? clob_type = ();
     byte[]? binary_type = ();
-    time:Time? date_type = ();
-    time:Time? time_type = ();
-    time:Time? datetime_type = ();
-    time:Time? timestamp_type = ();
+    int? date_type = ();
+    int? time_type = ();
+    int? datetime_type = ();
+    int? timestamp_type = ();
+    string? date_type_str = ();
+    string? time_type_str = ();
+    string? datetime_type_str = ();
+    string? timestamp_type_str = ();
 
     if (dt is table<NillableDataTypesAll>) {
         while (dt.hasNext()) {
@@ -391,13 +326,17 @@ function testMappingNullToNillableTypes() returns (int?, int?, float?,
                 time_type = rs.time_type;
                 datetime_type = rs.datetime_type;
                 timestamp_type = rs.timestamp_type;
+                date_type_str = rs.date_type_str;
+                time_type_str = rs.time_type_str;
+                datetime_type_str = rs.datetime_type_str;
+                timestamp_type_str = rs.timestamp_type_str;
             }
         }
     }
     testDB.stop();
     return (int_type, long_type, float_type, double_type, boolean_type, string_type, numeric_type, decimal_type,
     real_type, tinyint_type, smallint_type, clob_type, binary_type, date_type, time_type, datetime_type,
-    timestamp_type);
+    timestamp_type, date_type_str, time_type_str, datetime_type_str, timestamp_type_str);
 }
 
 function testMappingNullToNillableTypesBlob() returns byte[]? {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping_negative.bal
@@ -16,6 +16,7 @@
 
 import ballerina/h2;
 import ballerina/time;
+import ballerina/io;
 
 type NonNillableInt record {
     int val;
@@ -74,19 +75,19 @@ type NonNillableBinary record {
 };
 
 type NonNillableDate record {
-    time:Time val;
+    int val;
 };
 
 type NonNillableTime record {
-    time:Time val;
+    int val;
 };
 
 type NonNillableDateTime record {
-    time:Time val;
+    int val;
 };
 
 type NonNillableTimeStamp record {
-    time:Time val;
+    int val;
 };
 
 type InvalidUnion record {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -63,13 +63,6 @@ type ResultDates record {
     string DATETIME_TYPE;
 };
 
-type ResultDatesStruct record {
-    time:Time DATE_TYPE;
-    time:Time TIME_TYPE;
-    time:Time TIMESTAMP_TYPE;
-    time:Time DATETIME_TYPE;
-};
-
 type ResultDatesInt record {
     int DATE_TYPE;
     int TIME_TYPE;
@@ -560,65 +553,6 @@ function testDateTime(int datein, int timein, int timestampin)
     }
     testDB.stop();
     return (date, time, timestamp, datetime);
-}
-
-function testDateTimeAsTimeStruct() returns (int, int, int, int, int,
-            int, int, int) {
-    h2:Client testDB = new({
-        path: "./target/tempdb/",
-        name: "TEST_DATA_TABLE_H2",
-        username: "SA",
-        password: "",
-        poolOptions: { maximumPoolSize: 1 }
-    });
-
-    int dateInserted = -1;
-    int dateRetrieved = -1;
-    int timeInserted = -1;
-    int timeRetrieved = -1;
-    int timestampInserted = -1;
-    int timestampRetrieved = -1;
-    int datetimeInserted = -1;
-    int datetimeRetrieved = -1;
-
-    time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
-
-    time:Timezone zoneValue = { zoneId: "UTC" };
-    time:Time timeStruct = new(51323000, zoneValue);
-
-    time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");
-    time:Time datetimeStruct = time:createTime(2017, 1, 31, 16, 12, 23, 332, "UTC");
-    dateInserted = dateStruct.time;
-    timeInserted = timeStruct.time;
-    timestampInserted = timestampStruct.time;
-    datetimeInserted = datetimeStruct.time;
-
-    sql:Parameter para0 = { sqlType: sql:TYPE_INTEGER, value: 31 };
-    sql:Parameter para1 = { sqlType: sql:TYPE_DATE, value: dateStruct };
-    sql:Parameter para2 = { sqlType: sql:TYPE_TIME, value: timeStruct };
-    sql:Parameter para3 = { sqlType: sql:TYPE_TIMESTAMP, value: timestampStruct };
-    sql:Parameter para4 = { sqlType: sql:TYPE_DATETIME, value: datetimeStruct };
-
-    _ = testDB->update("Insert into DateTimeTypes
-        (row_id, date_type, time_type, timestamp_type, datetime_type) values (?,?,?,?,?)",
-        para0, para1, para2, para3, para4);
-
-    var selectRet = testDB->select("SELECT date_type, time_type, timestamp_type, datetime_type
-                from DateTimeTypes where row_id = 31", ResultDatesStruct);
-    if (selectRet is table<ResultDatesStruct>) {
-        while (selectRet.hasNext()) {
-            var rs =selectRet.getNext();
-            if (rs is ResultDatesStruct) {
-                dateRetrieved = rs.DATE_TYPE.time;
-                timeRetrieved = rs.TIME_TYPE.time;
-                timestampRetrieved = rs.TIMESTAMP_TYPE.time;
-                datetimeRetrieved = rs.DATETIME_TYPE.time;
-            }
-        }
-    }
-    testDB.stop();
-    return (dateInserted, dateRetrieved, timeInserted, timeRetrieved, timestampInserted, timestampRetrieved,
-    datetimeInserted, datetimeRetrieved);
 }
 
 function testDateTimeInt(int datein, int timein, int timestampin)

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -28,6 +28,16 @@ type ResultPrimitive record {
     string STRING_TYPE;
 };
 
+type ResultClosed record {
+    int INT_TYPE;
+    int LONG_TYPE;
+    float FLOAT_TYPE;
+    float DOUBLE_TYPE;
+    boolean BOOLEAN_TYPE;
+    string STRING_TYPE;
+    !...
+};
+
 type ResultSetTestAlias record {
     int INT_TYPE;
     int LONG_TYPE;
@@ -1521,4 +1531,39 @@ function testJoinQueryWithCursorTable() returns (int | error) {
 
     testDB.stop();
     return 0;
+}
+
+function testTypeCheckingConstrainedCursorTableWithClosedConstraint() returns (int, int, float, float, boolean,
+    string) {
+    h2:Client testDB = new({
+            path: "./target/tempdb/",
+            name: "TEST_DATA_TABLE_H2",
+            username: "SA",
+            password: "",
+            poolOptions: { maximumPoolSize: 1 }
+        });
+
+    int i = -1;
+    int l = -1;
+    float f = -1;
+    float d = -1;
+    boolean b = false;
+    string s = "";
+    var dtRet = testDB->select("SELECT int_type, long_type, float_type, double_type,
+                  boolean_type, string_type from DataTable WHERE row_id = 1", ResultClosed);
+    if (dtRet is table<ResultClosed>) {
+        while (dtRet.hasNext()) {
+            var rs = dtRet.getNext();
+            if (rs is ResultClosed) {
+                i = rs.INT_TYPE;
+                l = rs.LONG_TYPE;
+                f = rs.FLOAT_TYPE;
+                d = rs.DOUBLE_TYPE;
+                b = rs.BOOLEAN_TYPE;
+                s = rs.STRING_TYPE;
+            }
+        }
+    }
+    testDB.stop();
+    return (i, l, f, d, b, s);
 }


### PR DESCRIPTION
## Purpose
Along with this, the ability to mapping results set rows to records which has time:Time as a field also removed. From now on, users will have to obtain the int time value and convert it to time using the functions provided by time lib.

Resolves #12667 
Resolves #12661 