### PR TITLE
Add compile time flag to enable siddhi based stream processing

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -67,6 +67,7 @@ import static org.ballerinalang.compiler.CompilerOptionName.EXPERIMENTAL_FEATURE
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.PRESERVE_WHITESPACE;
 import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
+import static org.ballerinalang.compiler.CompilerOptionName.SIDDHI_RUNTIME_ENABLED;
 import static org.ballerinalang.util.BLangConstants.BLANG_EXEC_FILE_SUFFIX;
 import static org.ballerinalang.util.BLangConstants.BLANG_SRC_FILE_SUFFIX;
 import static org.ballerinalang.util.BLangConstants.MAIN_FUNCTION_NAME;
@@ -83,19 +84,20 @@ public class LauncherUtils {
     public static void runProgram(Path sourceRootPath, Path sourcePath, Map<String, String> runtimeParams,
                                   String configFilePath, String[] args, boolean offline, boolean observeFlag) {
         runProgram(sourceRootPath, sourcePath, MAIN_FUNCTION_NAME, runtimeParams, configFilePath, args, offline,
-                observeFlag, false, true);
+                observeFlag, false, false, true);
     }
 
     public static void runProgram(Path sourceRootPath, Path sourcePath, String functionName,
                                   Map<String, String> runtimeParams, String configFilePath, String[] args,
                                   boolean offline, boolean observeFlag, boolean printReturn) {
         runProgram(sourceRootPath, sourcePath, functionName, runtimeParams, configFilePath, args, offline, observeFlag,
-                printReturn, true);
+                printReturn, false, true);
     }
 
     public static void runProgram(Path sourceRootPath, Path sourcePath, String functionName,
                                   Map<String, String> runtimeParams, String configFilePath, String[] args,
-                                  boolean offline, boolean observeFlag, boolean printReturn, boolean experimentalFlag) {
+                                  boolean offline, boolean observeFlag, boolean printReturn, boolean siddhiRuntimeFlag,
+                                  boolean experimentalFlag) {
         ProgramFile programFile;
         String srcPathStr = sourcePath.toString();
         Path fullPath = sourceRootPath.resolve(sourcePath);
@@ -107,7 +109,8 @@ public class LauncherUtils {
             programFile = BLangProgramLoader.read(sourcePath);
         } else if (Files.isRegularFile(fullPath) && srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX) &&
                 !RepoUtils.hasProjectRepo(sourceRootPath)) {
-            programFile = compile(fullPath.getParent(), fullPath.getFileName(), offline, experimentalFlag);
+            programFile = compile(fullPath.getParent(), fullPath.getFileName(), offline, siddhiRuntimeFlag,
+                    experimentalFlag);
         } else if (Files.isDirectory(sourceRootPath)) {
             if (Files.isDirectory(fullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
                 throw createLauncherException("did you mean to run the module ? If so, either run from the project " +
@@ -131,7 +134,7 @@ public class LauncherUtils {
                 throw createLauncherException("you are trying to run a ballerina file inside a module within a " +
                                                       "project. Try running 'ballerina run <module-name>'");
             }
-            programFile = compile(sourceRootPath, sourcePath, offline, experimentalFlag);
+            programFile = compile(sourceRootPath, sourcePath, offline, siddhiRuntimeFlag, experimentalFlag);
         } else {
             throw createLauncherException("only modules, " + BLANG_SRC_FILE_SUFFIX + " and " + BLANG_EXEC_FILE_SUFFIX
                                                   + " files can be used with the 'ballerina run' command.");
@@ -311,6 +314,40 @@ public class LauncherUtils {
         options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
         options.put(PRESERVE_WHITESPACE, "false");
         options.put(OFFLINE, Boolean.toString(offline));
+        options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExpFeatures));
+
+        // compile
+        Compiler compiler = Compiler.getInstance(context);
+        BLangPackage entryPkgNode = compiler.compile(sourcePath.toString());
+        CompiledBinaryFile.ProgramFile programFile = compiler.getExecutableProgram(entryPkgNode);
+        if (programFile == null) {
+            throw new BLangCompilerException("compilation contains errors");
+        }
+
+        ProgramFile progFile = getExecutableProgram(programFile);
+        progFile.setProgramFilePath(sourcePath);
+        return progFile;
+    }
+
+    /**
+     * Compile and get the executable program file.
+     *
+     * @param sourceRootPath Path to the source root
+     * @param sourcePath Path to the source from the source root
+     * @param offline Should the build call remote repos
+     * @param siddhiRuntimeFlag Flag to enable siddhi runtime based stream processing
+     * @param enableExpFeatures Flag indicating to enable the experimental feature
+     * @return Executable program
+     */
+    public static ProgramFile compile(Path sourceRootPath, Path sourcePath, boolean offline,
+                                      boolean siddhiRuntimeFlag, boolean enableExpFeatures) {
+        CompilerContext context = new CompilerContext();
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        options.put(PROJECT_DIR, sourceRootPath.toString());
+        options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
+        options.put(PRESERVE_WHITESPACE, "false");
+        options.put(OFFLINE, Boolean.toString(offline));
+        options.put(SIDDHI_RUNTIME_ENABLED, Boolean.toString(siddhiRuntimeFlag));
         options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExpFeatures));
 
         // compile

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -236,6 +236,9 @@ public class Main {
         @CommandLine.Option(names = "--experimental", description = "enable experimental language features")
         private boolean experimentalFlag;
 
+        @CommandLine.Option(names = "--siddhiruntime", description = "enable siddhi runtime for stream processing")
+        private boolean siddhiRuntimeFlag;
+
         public void execute() {
             if (helpFlag) {
                 printUsageInfo(BallerinaCliCommands.RUN);
@@ -297,7 +300,8 @@ public class Main {
 
             // Normalize the source path to remove './' or '.\' characters that can appear before the name
             LauncherUtils.runProgram(sourceRootPath, sourcePath.normalize(), functionName, runtimeParams,
-                    configFilePath, programArgs, offline, observeFlag, printReturn, experimentalFlag);
+                    configFilePath, programArgs, offline, observeFlag, printReturn, siddhiRuntimeFlag,
+                    experimentalFlag);
         }
 
         @Override

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
@@ -126,7 +126,7 @@ public class BCompileUtil {
         Path sourcePath = Paths.get(sourceFilePath);
         String packageName = sourcePath.getFileName().toString();
         Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
-        return compile(sourceRoot.toString(), packageName, CompilerPhase.CODE_GEN, true, true);
+        return compile(sourceRoot.toString(), packageName, CompilerPhase.CODE_GEN, isSiddhiRuntimeEnabled, true);
     }
 
     /**

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
@@ -122,6 +122,13 @@ public class BCompileUtil {
         return compile(sourceFilePath, CompilerPhase.CODE_GEN, false);
     }
 
+    public static CompileResult compile(String sourceFilePath, boolean isSiddhiRuntimeEnabled) {
+        Path sourcePath = Paths.get(sourceFilePath);
+        String packageName = sourcePath.getFileName().toString();
+        Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
+        return compile(sourceRoot.toString(), packageName, CompilerPhase.CODE_GEN, true, true);
+    }
+
     /**
      * Compile and return the semantic errors.
      *
@@ -234,6 +241,29 @@ public class BCompileUtil {
         options.put(PROJECT_DIR, sourceRoot);
         options.put(COMPILER_PHASE, compilerPhase.toString());
         options.put(PRESERVE_WHITESPACE, "false");
+        options.put(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExpFeatures));
+
+        return compile(context, packageName, compilerPhase, false);
+    }
+
+    /**
+     * Compile and return the semantic errors.
+     *
+     * @param sourceRoot root path of the modules
+     * @param packageName name of the module to compile
+     * @param compilerPhase Compiler phase
+     * @param isSiddhiRuntimeEnabled Flag indicating to enable siddhi runtime for stream processing
+     * @param enableExpFeatures Flag indicating to enable the experimental features
+     * @return Semantic errors
+     */
+    public static CompileResult compile(String sourceRoot, String packageName, CompilerPhase compilerPhase,
+                                        boolean isSiddhiRuntimeEnabled, boolean enableExpFeatures) {
+        CompilerContext context = new CompilerContext();
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        options.put(PROJECT_DIR, sourceRoot);
+        options.put(COMPILER_PHASE, compilerPhase.toString());
+        options.put(PRESERVE_WHITESPACE, "false");
+        options.put(CompilerOptionName.SIDDHI_RUNTIME_ENABLED, Boolean.toString(isSiddhiRuntimeEnabled));
         options.put(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExpFeatures));
 
         return compile(context, packageName, compilerPhase, false);

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
@@ -46,6 +46,8 @@ public enum CompilerOptionName {
 
     LOCK_ENABLED("lockEnabled"),
 
+    SIDDHI_RUNTIME_ENABLED("siddhiRuntimeEnabled"),
+
     EXPERIMENTAL_FEATURES_ENABLED("experimentalFeaturesEnabled");
 
     public final String name;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
@@ -802,8 +802,8 @@ public class TreeBuilder {
         return new BLangStreamingQueryStatement();
     }
 
-    public static ForeverNode createForeverNode() {
-        return new BLangForever();
+    public static ForeverNode createForeverNode(boolean isSiddhiRuntimeEnabled) {
+        return new BLangForever(isSiddhiRuntimeEnabled);
     }
 
     public static WithinClause createWithinClause() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -3523,8 +3523,8 @@ public class BLangPackageBuilder {
         }
     }
 
-    void startForeverNode(DiagnosticPos pos) {
-        ForeverNode foreverNode = TreeBuilder.createForeverNode();
+    void startForeverNode(DiagnosticPos pos, boolean isSiddhiRuntimeEnabled) {
+        ForeverNode foreverNode = TreeBuilder.createForeverNode(isSiddhiRuntimeEnabled);
         ((BLangForever) foreverNode).pos = pos;
         this.foreverNodeStack.push(foreverNode);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -69,6 +69,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
     private String pkgVersion;
     private boolean isInErrorState = false;
     private boolean enableExperimentalFeatures;
+    private boolean isSiddhiRuntimeEnabled;
 
     BLangParserListener(CompilerContext context, CompilationUnitNode compUnit, BDiagnosticSource diagnosticSource) {
         this.pkgBuilder = new BLangPackageBuilder(context, compUnit);
@@ -76,6 +77,8 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.enableExperimentalFeatures = Boolean.parseBoolean(
                 CompilerOptions.getInstance(context).get(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED));
+        this.isSiddhiRuntimeEnabled = Boolean.parseBoolean(
+                CompilerOptions.getInstance(context).get(CompilerOptionName.SIDDHI_RUNTIME_ENABLED));
     }
 
     @Override
@@ -3083,7 +3086,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        this.pkgBuilder.startForeverNode(getCurrentPos(ctx));
+        this.pkgBuilder.startForeverNode(getCurrentPos(ctx), isSiddhiRuntimeEnabled);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangForever.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangForever.java
@@ -39,11 +39,8 @@ public class BLangForever extends BLangExpressionStmt implements ForeverNode {
     private boolean isSiddhiRuntimeEnabled = false;
     public List<BLangSimpleVariable> params;
 
-    public BLangForever() {
-        String siddhiRuntimeEnabledProperty = System.getProperty("enable.siddhiRuntime");
-        if (siddhiRuntimeEnabledProperty != null) {
-            isSiddhiRuntimeEnabled = Boolean.parseBoolean(siddhiRuntimeEnabledProperty);
-        }
+    public BLangForever(boolean isSiddhiRuntimeEnabled) {
+        this.isSiddhiRuntimeEnabled = isSiddhiRuntimeEnabled;
     }
 
     @Override

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/AggregationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/AggregationTest.java
@@ -38,15 +38,12 @@ public class AggregationTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/aggregation-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/aggregation-streaming-test.bal", true);
     }
 
     @Test(description = "Test streaming aggregation query.")
     public void testAggregationQuery() {
         BValue[] outputStatusCountArray = BRunUtil.invoke(result, "startAggregationQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
-
         Assert.assertNotNull(outputStatusCountArray);
 
         Assert.assertEquals(outputStatusCountArray.length, 1, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/BooleanTypeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/BooleanTypeTest.java
@@ -39,14 +39,12 @@ public class BooleanTypeTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/boolean-type-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/boolean-type-test.bal", true);
     }
 
     @Test(description = "Test Boolean types in streaming query")
     public void testFilterQuery() {
         BValue[] outputRequestCountObjs = BRunUtil.invoke(result, "startStreamingQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputRequestCountObjs);
 
         Assert.assertEquals(outputRequestCountObjs.length, 1, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/FilterTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/FilterTest.java
@@ -39,16 +39,14 @@ public class FilterTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/filter-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/filter-streaming-test.bal", true);
         resultWithReference = BCompileUtil.
-                compile("test-src/streaming/legacy/filter-streaming-with-reference-test.bal");
+                compile("test-src/streaming/legacy/filter-streaming-with-reference-test.bal", true);
     }
 
     @Test(description = "Test filter streaming query")
     public void testFilterQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startFilterQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 2, "Expected events are not received");
@@ -64,7 +62,6 @@ public class FilterTest {
     @Test(description = "Test filter streaming query")
     public void testFilterQueryWithFuntionParam() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(resultWithReference, "startFilterQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 2, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/FilterWithInlineStreamTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/FilterWithInlineStreamTest.java
@@ -38,14 +38,12 @@ public class FilterWithInlineStreamTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/filter-streaming-test-v2.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/filter-streaming-test-v2.bal", true);
     }
 
     @Test(description = "Test filter streaming query")
     public void testFilterQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startFilterQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 2, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/OrderByTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/OrderByTest.java
@@ -38,14 +38,12 @@ public class OrderByTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/orderby-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/orderby-streaming-test.bal", true);
     }
 
     @Test(description = "Test order by in streaming query - a simple one")
     public void testOrderBy() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startOrderBy");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
         Assert.assertEquals(outputEmployeeEvents.length, 10, "Expected events are not received");
         for (int i = 1; i < outputEmployeeEvents.length; i++) {
@@ -60,7 +58,6 @@ public class OrderByTest {
     @Test(description = "Test order by streaming query with ascending")
     public void testOrderBy2() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startOrderBy2");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
         Assert.assertEquals(outputEmployeeEvents.length, 10, "Expected events are not received");
         for (int i = 1; i < outputEmployeeEvents.length; i++) {
@@ -75,7 +72,6 @@ public class OrderByTest {
     @Test(description = "Test order by streaming query with descending")
     public void testOrderBy3() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startOrderBy3");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
         Assert.assertEquals(outputEmployeeEvents.length, 10, "Expected events are not received");
         for (int i = 1; i < outputEmployeeEvents.length; i++) {
@@ -90,7 +86,6 @@ public class OrderByTest {
     @Test(description = "Test order by streaming query with multiple attributes")
     public void testOrderBy4() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startOrderBy4");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
         Assert.assertEquals(outputEmployeeEvents.length, 10, "Expected events are not received");
         for (int i = 1; i < outputEmployeeEvents.length; i++) {
@@ -110,7 +105,6 @@ public class OrderByTest {
     @Test(description = "Test order by streaming query with multiple attributes with multiple order types")
     public void testOrderBy5() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startOrderBy5");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
         Assert.assertEquals(outputEmployeeEvents.length, 10, "Expected events are not received");
         for (int i = 1; i < outputEmployeeEvents.length; i++) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/OutputRateLimitTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/OutputRateLimitTest.java
@@ -38,16 +38,14 @@ public class OutputRateLimitTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/output-rate-limiting-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/output-rate-limiting-test.bal", true);
         resultForTimeBasedRateLimiting = BCompileUtil.
-                compile("test-src/streaming/legacy/output-rate-limiting-time-test.bal");
+                compile("test-src/streaming/legacy/output-rate-limiting-time-test.bal", true);
     }
 
     @Test(description = "Test output rate limiting query")
     public void testOutputRateLimitQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startOutputRateLimitQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 2, "Expected events are not received");
@@ -62,7 +60,6 @@ public class OutputRateLimitTest {
     @Test(description = "Test output rate limiting query based on time")
     public void testOutputRateLimitWithTimeQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(resultForTimeBasedRateLimiting, "startOutputRateLimitQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
         Assert.assertEquals(outputEmployeeEvents.length, 1, "Expected events are not received");
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PassthroughTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PassthroughTest.java
@@ -39,15 +39,13 @@ public class PassthroughTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/passthrough-streaming-test.bal");
-        result2 = BCompileUtil.compile("test-src/streaming/legacy/passthrough-streaming-without-select-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/passthrough-streaming-test.bal", true);
+        result2 = BCompileUtil.compile("test-src/streaming/legacy/passthrough-streaming-without-select-test.bal", true);
     }
 
     @Test(description = "Test passthrough streaming query")
     public void testPassthroughQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startPassthroughQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 3, "Expected events are not received");
@@ -64,7 +62,6 @@ public class PassthroughTest {
     @Test(description = "Test passthrough streaming query without select")
     public void testPassthroughQueryWithoutSelect() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startPassthroughQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 3, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PatternTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PatternTest.java
@@ -38,14 +38,12 @@ public class PatternTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/pattern-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/pattern-streaming-test.bal", true);
     }
 
     @Test(description = "Test pattern streaming query with followed by pattern")
     public void testPatternQuery1() {
         BValue[] tempDifferences = BRunUtil.invoke(result, "runPatternQuery1");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(tempDifferences);
         Assert.assertEquals(tempDifferences.length, 1);
         BMap<String, BValue> tempDifference = (BMap<String, BValue>) tempDifferences[0];
@@ -55,7 +53,6 @@ public class PatternTest {
     @Test(description = "Test pattern streaming query with 'Or'")
     public void testPatternQuery2() {
         BValue[] roomActions = BRunUtil.invoke(result, "runPatternQuery2");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(roomActions);
 
         BMap<String, BValue> tempDifference = (BMap<String, BValue>) roomActions[0];
@@ -65,7 +62,6 @@ public class PatternTest {
     @Test(enabled = false, description = "Test pattern streaming query with 'And'")
     public void testPatternQuery3() {
         BValue[] roomActions = BRunUtil.invoke(result, "runPatternQuery3");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(roomActions);
 
         BMap<String, BValue> tempDifference = (BMap<String, BValue>) roomActions[0];
@@ -75,7 +71,6 @@ public class PatternTest {
     @Test(enabled = false, description = "Test pattern streaming query with 'Not' and 'And'")
     public void testPatternQuery4() {
         BValue[] roomActions = BRunUtil.invoke(result, "runPatternQuery4");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(roomActions);
 
         BMap<String, BValue> tempDifference = (BMap<String, BValue>) roomActions[0];
@@ -85,7 +80,6 @@ public class PatternTest {
     @Test(description = "Test pattern streaming query with 'Not' and 'For'")
     public void testPatternQuery5() {
         BValue[] roomActions = BRunUtil.invoke(result, "runPatternQuery5");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(roomActions);
 
         BMap<String, BValue> tempDifference = (BMap<String, BValue>) roomActions[0];
@@ -95,7 +89,6 @@ public class PatternTest {
     @Test(description = "Test pattern streaming query with within clause")
     public void testPatternQuery6() {
         BValue[] tempDifferences = BRunUtil.invoke(result, "runPatternQuery6");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(tempDifferences);
         Assert.assertEquals(0, tempDifferences.length);
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PipelineQueryTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PipelineQueryTest.java
@@ -38,15 +38,12 @@ public class PipelineQueryTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/pipeline-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/pipeline-streaming-test.bal", true);
     }
 
     @Test(description = "Test streaming pipeline query.")
     public void testPipelineQuery() {
         BValue[] outputStatusCountArray = BRunUtil.invoke(result, "startPipelineQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
-
         Assert.assertNotNull(outputStatusCountArray);
 
         Assert.assertEquals(outputStatusCountArray.length, 1, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PipelineQueryWithinSameForeverTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/PipelineQueryWithinSameForeverTest.java
@@ -38,15 +38,12 @@ public class PipelineQueryWithinSameForeverTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/pipeline-streaming-test-v2.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/pipeline-streaming-test-v2.bal", true);
     }
 
     @Test(description = "Test streaming pipeline query.")
     public void testPipelineQuery() {
         BValue[] outputStatusCountArray = BRunUtil.invoke(result, "startPipelineQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
-
         Assert.assertNotNull(outputStatusCountArray);
 
         Assert.assertEquals(outputStatusCountArray.length, 1, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/ProjectionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/ProjectionTest.java
@@ -40,16 +40,14 @@ public class ProjectionTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/projection-streaming-test.bal");
-        resultNegative = BCompileUtil.compile("test-src/streaming/negative/projection-streaming-negative-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/projection-streaming-test.bal", true);
+        resultNegative = BCompileUtil.
+                compile("test-src/streaming/negative/projection-streaming-negative-test.bal", true);
     }
 
     @Test(description = "Test projection streaming query")
     public void testProjectionQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startProjectionQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
-
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 3, "Expected events are not received");
@@ -66,7 +64,6 @@ public class ProjectionTest {
     @Test(description = "Test streaming projection query with errors")
     public void testProjectionNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 1);
-        System.setProperty("enable.siddhiRuntime", "false");
         BAssertUtil.validateError(resultNegative, 0,
                 "incompatible stream action argument type 'Employee' defined",
                 44, 9);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/SequenceTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/SequenceTest.java
@@ -36,15 +36,12 @@ public class SequenceTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/sequence-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/sequence-streaming-test.bal", true);
     }
 
     @Test(description = "Test sequence streaming query")
     public void testSequenceQuery1() {
         BValue[] initialAndPeakTemps = BRunUtil.invoke(result, "runSequenceQuery1");
-        System.setProperty("enable.siddhiRuntime", "false");
-
         Assert.assertNotNull(initialAndPeakTemps);
 
         BMap<String, BValue> initialAndPeakTemp1 = (BMap<String, BValue>) initialAndPeakTemps[0];

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamFunctionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamFunctionTest.java
@@ -38,14 +38,12 @@ public class StreamFunctionTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/stream-functions-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/stream-functions-test.bal", true);
     }
 
     @Test(description = "Test stream functions")
     public void testFilterQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startStreamingQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 2, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamJoiningTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamJoiningTest.java
@@ -38,15 +38,13 @@ public class StreamJoiningTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/join-streaming-test.bal");
-        resultNegative = BCompileUtil.compile("test-src/streaming/negative/join-streaming-negative-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/join-streaming-test.bal", true);
+        resultNegative = BCompileUtil.compile("test-src/streaming/negative/join-streaming-negative-test.bal", true);
     }
 
     @Test(description = "Test streaming join query.")
     public void testStreamJoinQuery() {
         BValue[] outputStatusCountArray = BRunUtil.invoke(result, "startJoinQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputStatusCountArray);
 
         Assert.assertEquals(outputStatusCountArray.length, 2, "Expected events are not received");
@@ -55,7 +53,6 @@ public class StreamJoiningTest {
     @Test(description = "Test streaming join query with errors")
     public void testJoinNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 3);
-        System.setProperty("enable.siddhiRuntime", "false");
         BAssertUtil.validateError(resultNegative, 0,
                 "undefined stream name (or alias) 'stockStream' found in select clause",
                 50, 9);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamingActionTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamingActionTest.java
@@ -36,16 +36,14 @@ public class StreamingActionTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
         resultNegativeInvalidType = BCompileUtil.
-                compile("test-src/streaming/negative/streaming-action-negative-test-v1.bal");
+                compile("test-src/streaming/negative/streaming-action-negative-test-v1.bal", true);
         resultNegativeInvalidArgumentCount = BCompileUtil.
-                compile("test-src/streaming/negative/streaming-action-negative-test-v2.bal");
+                compile("test-src/streaming/negative/streaming-action-negative-test-v2.bal", true);
     }
 
     @Test(description = "Test streaming action query with errors")
     public void testStreamingActionNegativeType() {
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertEquals(resultNegativeInvalidType.getErrorCount(), 2);
         BAssertUtil.validateError(resultNegativeInvalidType, 1, "undefined symbol 'emp'",
                 44, 37);
@@ -53,7 +51,6 @@ public class StreamingActionTest {
 
     @Test(description = "Test streaming action query with errors", enabled = false)
     public void testStreamingActionNegativeArgumentCount() {
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertEquals(resultNegativeInvalidArgumentCount.getErrorCount(), 1);
         BAssertUtil.validateError(resultNegativeInvalidArgumentCount, 0,
                                   "mismatched input ','. expecting ')'", 43, 27);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamingInlineOperationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/StreamingInlineOperationTest.java
@@ -38,14 +38,12 @@ public class StreamingInlineOperationTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/streaming-inline-operations-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/streaming-inline-operations-test.bal", true);
     }
 
     @Test(description = "Test streaming query for inline operations within streaming action")
     public void testStreamingInlineOperationQuery() {
         BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startInlineOperationQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertNotNull(outputEmployeeEvents);
 
         Assert.assertEquals(outputEmployeeEvents.length, 2, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/WindowTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/legacy/WindowTest.java
@@ -38,15 +38,12 @@ public class WindowTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
-        result = BCompileUtil.compile("test-src/streaming/legacy/window-streaming-test.bal");
+        result = BCompileUtil.compile("test-src/streaming/legacy/window-streaming-test.bal", true);
     }
 
     @Test(description = "Test window streaming query with groupby and aggregation function.")
     public void testWindowQuery() {
         BValue[] outputStatusCountArray = BRunUtil.invoke(result, "startWindowQuery");
-        System.setProperty("enable.siddhiRuntime", "false");
-
         Assert.assertNotNull(outputStatusCountArray);
 
         Assert.assertEquals(outputStatusCountArray.length, 2, "Expected events are not received");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/negative/IncompatibleRecordTypeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/negative/IncompatibleRecordTypeTest.java
@@ -36,16 +36,14 @@ public class IncompatibleRecordTypeTest {
 
     @BeforeClass
     public void setup() {
-        System.setProperty("enable.siddhiRuntime", "true");
         resultNegative = BCompileUtil.
-                compile("test-src/streaming/negative/streaming-invalid-record-type-negative-test.bal");
+                compile("test-src/streaming/negative/streaming-invalid-record-type-negative-test.bal", true);
         resultNegativeForInvalidOrder = BCompileUtil.
-                compile("test-src/streaming/negative/streaming-output-attribute-order-negative-test.bal");
+                compile("test-src/streaming/negative/streaming-output-attribute-order-negative-test.bal", true);
     }
 
     @Test(description = "Test filter streaming query with invalid stream attribute type")
     public void testFilterQueryWithInvalidStreamAttributeType() {
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertEquals(resultNegative.getErrorCount(), 1);
         BAssertUtil.validateError(resultNegative, 0,
                 "invalid stream attribute type found. it should be either integer or long or " +
@@ -55,7 +53,6 @@ public class IncompatibleRecordTypeTest {
 
     @Test(description = "Test filter streaming query with invalid stream attribute order")
     public void testFilterQueryWithInvalidStreamAttributeOrder() {
-        System.setProperty("enable.siddhiRuntime", "false");
         Assert.assertEquals(resultNegativeForInvalidOrder.getErrorCount(), 3);
         BAssertUtil.validateError(resultNegativeForInvalidOrder, 0,
                 "incompatible stream action argument type 'Employee' defined",


### PR DESCRIPTION
## Purpose
> In Ballerina there are two types of streaming runtimes are available. They are Siddhi based streaming runtime & Ballerin native streaming runtimes. So far, Siddhi runtime was the default streaming runtime for stream processing queries. In this release, we have changed the default runtime as the Ballerina native impl. Due to this reason, we wanted to introduce a flag which allows users to enable siddhi based streaming runtime if they wanted patterns/sequences which are not supported in Ballerina native impl at the moment. 
