### PR TITLE
Remove 'Window' from window names

### DIFF
--- a/examples/join-multiple-streams/join_multiple_streams.bal
+++ b/examples/join-multiple-streams/join_multiple_streams.bal
@@ -31,8 +31,8 @@ function initRealtimeProductionAlert() returns () {
     // production outcome. This `forever` block is executed once, when initializing the service. The processing happens
     // asynchronously each time the `requestStream` or `productionInputStream` receives an event.
     forever {
-        from productionInputStream window timeWindow(10000) as p
-        join rawMaterialStream window timeWindow(10000) as r
+        from productionInputStream window time(10000) as p
+        join rawMaterialStream window time(10000) as r
         on r.name == p.name
         select r.name, sum(r.amount) as totalRawMaterial,
                 sum(p.amount) as totalConsumption

--- a/examples/join-tables-and-streams/join_tables_and_streams.bal
+++ b/examples/join-tables-and-streams/join_tables_and_streams.bal
@@ -42,7 +42,7 @@ function initOutOfStockAlert() {
     // Whenever an order event is published to `orderStream`, it is matched against the `itemStockTable` through
     //the `queryItemTable` function. If there is a match, an alert event is published to `oredrAlertStream`.
     forever {
-        from orderStream window lengthWindow(1) as itemOrder
+        from orderStream window length(1) as itemOrder
         join queryItemTable(itemOrder.itemName, itemOrder.orderingAmount) as item
         select item.name as itemName, item.stockAmount
         => (OutOfStockAlert[] alerts) {

--- a/examples/temporal-aggregations-and-windows/temporal_aggregations_and_windows.bal
+++ b/examples/temporal-aggregations-and-windows/temporal_aggregations_and_windows.bal
@@ -24,7 +24,7 @@ function initRealtimeRequestCounter() returns () {
     // the `requestCountStream` stream as an alert. This `forever` block is executed once, when initializing the service.
     // The processing happens asynchronously each time the `requestStream` receives an event.
     forever {
-        from requestStream window timeBatchWindow(10000)
+        from requestStream window timeBatc(10000)
         select requestStream.host, count() as count
             group by requestStream.host
             having count > 6

--- a/examples/temporal-aggregations-and-windows/temporal_aggregations_and_windows.bal
+++ b/examples/temporal-aggregations-and-windows/temporal_aggregations_and_windows.bal
@@ -24,7 +24,7 @@ function initRealtimeRequestCounter() returns () {
     // the `requestCountStream` stream as an alert. This `forever` block is executed once, when initializing the service.
     // The processing happens asynchronously each time the `requestStream` receives an event.
     forever {
-        from requestStream window timeBatc(10000)
+        from requestStream window timeBatch(10000)
         select requestStream.host, count() as count
             group by requestStream.host
             having count > 6

--- a/stdlib/streams/src/main/ballerina/streams/windows.bal
+++ b/stdlib/streams/src/main/ballerina/streams/windows.bal
@@ -110,7 +110,7 @@ public type LengthWindow object {
     }
 };
 
-public function lengthWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function length(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     LengthWindow lengthWindow1 = new(nextProcessPointer, windowParameters);
     return lengthWindow1;
@@ -254,7 +254,7 @@ public type TimeWindow object {
     }
 };
 
-public function timeWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function time(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     TimeWindow timeWindow1 = new(nextProcessPointer, windowParameters);
     return timeWindow1;
@@ -386,10 +386,10 @@ public type LengthBatchWindow object {
     }
 };
 
-public function lengthBatchWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function lengthBatch(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
-    LengthBatchWindow lengthBatch = new(nextProcessPointer, windowParameters);
-    return lengthBatch;
+    LengthBatchWindow lengthBatchWindow = new(nextProcessPointer, windowParameters);
+    return lengthBatchWindow;
 }
 
 
@@ -533,10 +533,10 @@ public type TimeBatchWindow object {
     }
 };
 
-public function timeBatchWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function timeBatch(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
-    TimeBatchWindow timeBatch = new(nextProcessPointer, windowParameters);
-    return timeBatch;
+    TimeBatchWindow timeBatchWindow = new(nextProcessPointer, windowParameters);
+    return timeBatchWindow;
 }
 
 public type ExternalTimeWindow object {
@@ -667,7 +667,7 @@ public type ExternalTimeWindow object {
     }
 };
 
-public function externalTimeWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function externalTime(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
 
     ExternalTimeWindow timeWindow1 = new(nextProcessPointer, windowParameters);
@@ -1076,7 +1076,7 @@ public type ExternalTimeBatchWindow object {
     }
 };
 
-public function externalTimeBatchWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function externalTimeBatch(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     ExternalTimeBatchWindow timeWindow1 = new(nextProcessPointer, windowParameters);
     return timeWindow1;
@@ -1237,7 +1237,7 @@ public type TimeLengthWindow object {
 
 };
 
-public function timeLengthWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function timeLength(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     TimeLengthWindow timeLengthWindow1 = new(nextProcessPointer, windowParameters);
     return timeLengthWindow1;
@@ -1390,7 +1390,7 @@ public type UniqueLengthWindow object {
     }
 };
 
-public function uniqueLengthWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function uniqueLength(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     UniqueLengthWindow uniqueLengthWindow1 = new(nextProcessPointer, windowParameters);
     return uniqueLengthWindow1;
@@ -1465,10 +1465,10 @@ public type DelayWindow object {
 
                     if (self.lastTimestamp < streamEvent.timestamp) {
                         //calculate the remaining time to delay the current event
-                        int delay = self.delayInMilliSeconds - (currentTime - streamEvent.timestamp);
+                        int delayInMillis = self.delayInMilliSeconds - (currentTime - streamEvent.timestamp);
                         self.timer = new
                         task:Timer(function () returns error? {return self.invokeProcess();},
-                            function (error e) {self.handleError(e);}, delay);
+                            function (error e) {self.handleError(e);}, delayInMillis);
                         _ = self.timer.start();
                         self.lastTimestamp = streamEvent.timestamp;
                     }
@@ -1534,7 +1534,7 @@ public type DelayWindow object {
     }
 };
 
-public function delayWindow(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+public function delay(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     DelayWindow delayWindow1 = new(nextProcessPointer, windowParameters);
     return delayWindow1;
@@ -1709,7 +1709,7 @@ public type SortWindow object {
     }
 };
 
-public function sortWindow(any[] windowParameters, function(StreamEvent[])? nextProcessPointer = ())
+public function sort(any[] windowParameters, function(StreamEvent[])? nextProcessPointer = ())
                     returns Window {
     SortWindow sortWindow1 = new(nextProcessPointer, windowParameters);
     return sortWindow1;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/BallerinaStreamsV2TimeWindowTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/BallerinaStreamsV2TimeWindowTest.java
@@ -80,10 +80,10 @@ public class BallerinaStreamsV2TimeWindowTest {
     public void testForWindowFunction() {
         Assert.assertEquals(resultNegative.getErrorCount(), 2);
         BAssertUtil.validateError(resultNegative, 0,
-                "invalid streaming 'Window' type 'time232' found",
+                "invalid streaming 'Window' type 'undefinedWindow' found",
                 62, 47);
         BAssertUtil.validateError(resultNegative, 1,
-                "undefined function 'time232'",
+                "undefined function 'undefinedWindow'",
                 62, 47);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/BallerinaStreamsV2TimeWindowTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/streaming/BallerinaStreamsV2TimeWindowTest.java
@@ -80,10 +80,10 @@ public class BallerinaStreamsV2TimeWindowTest {
     public void testForWindowFunction() {
         Assert.assertEquals(resultNegative.getErrorCount(), 2);
         BAssertUtil.validateError(resultNegative, 0,
-                "invalid streaming 'Window' type 'time' found",
+                "invalid streaming 'Window' type 'time232' found",
                 62, 47);
         BAssertUtil.validateError(resultNegative, 1,
-                "undefined function 'time'",
+                "undefined function 'time232'",
                 62, 47);
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-aggregate-with-groupby-and-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-aggregate-with-groupby-and-window-test.bal
@@ -83,7 +83,7 @@ function startAggregationWithGroupByQuery() returns TeacherOutput[] {
 
 function foo() {
     forever {
-        from inputStream where inputStream.age > 25 window lengthWindow(5) as input
+        from inputStream where inputStream.age > 25 window length(5) as input
         select input.name, input.age, sum (input.age) as sumAge, count() as count
         group by input.name
         => (TeacherOutput[] teachers) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-join-test.bal
@@ -44,8 +44,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery() {
 
     forever {
-        from stockStream window lengthWindow(1) as stock
-        join twitterStream window lengthWindow(1) as twitter
+        from stockStream window length(1) as stock
+        join twitterStream window length(1) as twitter
         on stock.symbol == twitter.company
         select stock.symbol as symbol, twitter.tweet as tweet, stock.price as price
         => (StockWithPrice[] prices) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-orderby-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-orderby-test.bal
@@ -71,7 +71,7 @@ function startOrderByQuery() returns TeacherOutput[] {
 
 function foo() {
     forever {
-        from inputStream where inputStream.age > 2 window lengthBatchWindow(5) as input
+        from inputStream where inputStream.age > 2 window lengthBatch(5) as input
         select input.name, input.age, input.status, sum (input.age) as sumAge, count() as count
         group by input.name order by status ascending, age descending => (TeacherOutput [] o) {
             foreach var x in o {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-orderby-with-functions-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-orderby-with-functions-test.bal
@@ -74,7 +74,7 @@ function startOrderByQuery() returns TeacherOutput[] {
 
 function foo() {
     forever {
-        from inputStream where inputStream.age > 2 window lengthBatchWindow(5)
+        from inputStream where inputStream.age > 2 window lengthBatch(5)
         select inputStream.name, inputStream.age, inputStream.status, sum (inputStream.age) as sumAge, count() as count
         group by inputStream.name order by status ascending, getAge(age, getAge(age, 2)) descending => (TeacherOutput
         [] o) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-unique-length-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/alias/streamingv2-unique-length-window-test.bal
@@ -66,7 +66,7 @@ function startUniqueLengthwindowTest3() returns TeacherOutput[] {
 function testUniqueLengthwindow() {
 
     forever {
-        from inputStreamUniqueLengthTest3 window uniqueLengthWindow(inputStreamUniqueLengthTest3.age, 4) as input
+        from inputStreamUniqueLengthTest3 window uniqueLength(inputStreamUniqueLengthTest3.age, 4) as input
         select input.name, count() as count
         group by input.school
         => (TeacherOutput [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/inline.streams/alias/streamingv2-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/inline.streams/alias/streamingv2-join-test.bal
@@ -43,8 +43,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery(stream<Stock> ss, stream<Twitter> tt) {
 
     forever {
-        from ss window lengthWindow(1) as stock
-        join tt window lengthWindow(1) as twitter
+        from ss window length(1) as stock
+        join tt window length(1) as twitter
         on stock.symbol == twitter.company
         select stock.symbol as symbol, twitter.tweet as tweet, stock.price as price
         => (StockWithPrice[] prices) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/inline.streams/streamingv2-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/inline.streams/streamingv2-join-test.bal
@@ -42,8 +42,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery(stream<Stock> ss, stream<Twitter> tt) {
 
     forever {
-        from ss window lengthWindow(1)
-        join tt window lengthWindow(1)
+        from ss window length(1)
+        join tt window length(1)
         on ss.symbol == tt.company
         select ss.symbol as symbol, tt.tweet as tweet, ss.price as price
         => (StockWithPrice[] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/inline.streams/streamingv2-join-without-on-condition-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/inline.streams/streamingv2-join-without-on-condition-test.bal
@@ -42,8 +42,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery(stream<Stock> stStream, stream<Twitter> twitStream) {
 
     forever {
-        from stStream window lengthWindow(1)
-        join twitStream window lengthWindow(1)
+        from stStream window length(1)
+        join twitStream window length(1)
         select stStream.symbol as symbol, twitStream.tweet as tweet, stStream.price as price
         => (StockWithPrice[] emp) {
             foreach var e in emp {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-aggregation-groupby-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-aggregation-groupby-test.bal
@@ -129,7 +129,7 @@ function createStreamingConstruct() {
         }
     );
 
-    streams:Window tmpWindow = streams:timeWindow([1000],
+    streams:Window tmpWindow = streams:time([1000],
         nextProcessPointer = function (streams:StreamEvent[] e) {select.process(e);});
     streams:Filter filter = streams:createFilter(function (streams:StreamEvent[] e) {tmpWindow.process(e);},
         function (map<anydata> m) returns boolean {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-external-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-external-window-test.bal
@@ -115,7 +115,7 @@ function createStreamingConstruct() {
             };
         });
 
-    streams:Window tmpWindow = streams:externalTimeWindow(["inputStream.timeStamp", 1000],
+    streams:Window tmpWindow = streams:externalTime(["inputStream.timeStamp", 1000],
         nextProcessPointer = function (streams:StreamEvent[] e) {select.process(e);});
 
     inputStream.subscribe(function (Teacher t) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-orderby-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-orderby-test.bal
@@ -133,7 +133,7 @@ function foo() {
         }
     );
 
-    streams:Window tmpWindow = streams:lengthBatchWindow([5], nextProcessPointer = function (streams:StreamEvent[] e)
+    streams:Window tmpWindow = streams:lengthBatch([5], nextProcessPointer = function (streams:StreamEvent[] e)
         {select.process(e);});
 
     streams:Filter filter = streams:createFilter(function (streams:StreamEvent[] e) {tmpWindow.process(e);},

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-stream-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-stream-join-test.bal
@@ -117,9 +117,9 @@ function joinFunc() {
         conditionFunc = conditionFunc);
 
     // Window processors
-    streams:Window lengthWindowA = streams:lengthWindow([1],
+    streams:Window lengthWindowA = streams:length([1],
         nextProcessPointer = function (streams:StreamEvent[] e) {joinProcessor.process(e);});
-    streams:Window lengthWindowB = streams:lengthWindow([1],
+    streams:Window lengthWindowB = streams:length([1],
         nextProcessPointer = function (streams:StreamEvent[] e) {joinProcessor.process(e);});
 
     // Set the window processors to the join processor

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-table-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/native/streamingv2-native-table-join-test.bal
@@ -116,7 +116,7 @@ function tableJoinFunc() {
         });
 
     // Window processor
-    streams:Window lengthWindow = streams:lengthWindow([1], nextProcessPointer =
+    streams:Window lengthWindow = streams:length([1], nextProcessPointer =
                                     function (streams:StreamEvent[] e) {tableJoinProcessor.process(e);});
 
     // Set the tableName, streamName, windowProcessors to the table join processor

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/incompatible-args-in-window-negative-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/incompatible-args-in-window-negative-test.bal
@@ -59,7 +59,7 @@ function startTimeWindowTest() returns (Teacher[]) {
 function testTimeWindow() {
 
     forever {
-        from inputStreamTimeWindowTest window timeWindow("1000")
+        from inputStreamTimeWindowTest window time("1000")
         select inputStreamTimeWindowTest.name, inputStreamTimeWindowTest.age, inputStreamTimeWindowTest.status, inputStreamTimeWindowTest
         .school
         => (Teacher [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/stream-with-alias-not-defined.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/stream-with-alias-not-defined.bal
@@ -45,8 +45,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery() {
 
     forever {
-        from stockSream window lengthWindow(1) as x
-        join twitterSream window lengthWindow(1) as y
+        from stockSream window length(1) as x
+        join twitterSream window length(1) as y
         on x.symbol == y.company
         select x.symbol as symbol, y.tweet as tweet, x.price as price
         => (StockWithPrice[] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/streamingv2-window-negative-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/streamingv2-window-negative-test.bal
@@ -59,7 +59,7 @@ function startTimeWindowTest() returns (Teacher[]) {
 function testTimeWindow() {
 
     forever {
-        from inputStreamTimeWindowTest window time(1000) as tWindow
+        from inputStreamTimeWindowTest window time232(1000) as tWindow
         select tWindow.name, tWindow.age, tWindow.status, tWindow.school
         => (Teacher [] emp) {
             foreach var e in emp {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/streamingv2-window-negative-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/negative/streamingv2-window-negative-test.bal
@@ -59,7 +59,7 @@ function startTimeWindowTest() returns (Teacher[]) {
 function testTimeWindow() {
 
     forever {
-        from inputStreamTimeWindowTest window time232(1000) as tWindow
+        from inputStreamTimeWindowTest window undefinedWindow(1000) as tWindow
         select tWindow.name, tWindow.age, tWindow.status, tWindow.school
         => (Teacher [] emp) {
             foreach var e in emp {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-aggregate-with-groupby-and-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-aggregate-with-groupby-and-window-test.bal
@@ -84,7 +84,7 @@ function startAggregationWithGroupByQuery() returns TeacherOutput[] {
 
 function foo() {
     forever {
-        from inputStream where inputStream.age > 25 window lengthWindow(5)
+        from inputStream where inputStream.age > 25 window length(5)
         select inputStream.name, inputStream.age, sum (inputStream.age) as sumAge, count() as count
         group by inputStream.name => (TeacherOutput [] teachers) {
             foreach var t in teachers {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-alerts-with-services.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-alerts-with-services.bal
@@ -45,8 +45,8 @@ function initRealtimeProductionAlert() returns () {
     // production outcome. This `forever` block is executed once, when initializing the service. The processing happens
     // asynchronously each time the `requestStream` or `productionInputStream` receives an event.
     forever {
-        from productionInputStream window timeWindow(10000) as p
-        join rawMaterialStream window timeWindow(10000) as r
+        from productionInputStream window time(10000) as p
+        join rawMaterialStream window time(10000) as r
         on r.name == p.name
         select r.name, sum(r.amount) as totalRawMaterial,
         sum(p.amount) as totalConsumption

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test.bal
@@ -73,7 +73,7 @@ function startExternalTimeBatchwindowTest1() returns (TeacherOutput[]) {
 function testExternalTimeBatchwindow1() {
 
     forever {
-        from inputStreamExternalTimeBatchTest1 window externalTimeBatchWindow(
+        from inputStreamExternalTimeBatchTest1 window externalTimeBatch(
                                                           inputStreamExternalTimeBatchTest1.timestamp, 1000)
         select inputStreamExternalTimeBatchTest1.timestamp, inputStreamExternalTimeBatchTest1.name, count() as count
         group by inputStreamExternalTimeBatchTest1.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test2.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test2.bal
@@ -71,7 +71,7 @@ function startExternalTimeBatchwindowTest2() returns (TeacherOutput[]) {
 function testExternalTimeBatchwindow2() {
 
     forever {
-        from inputStreamExternalTimeBatchTest2 window externalTimeBatchWindow(
+        from inputStreamExternalTimeBatchTest2 window externalTimeBatch(
                             inputStreamExternalTimeBatchTest2.timestamp, 1000, (), 1200)
         select inputStreamExternalTimeBatchTest2.timestamp, inputStreamExternalTimeBatchTest2.name, count() as count
         group by inputStreamExternalTimeBatchTest2.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test3.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test3.bal
@@ -69,7 +69,7 @@ function startExternalTimeBatchwindowTest3() returns (TeacherOutput[]) {
 function testExternalTimeBatchwindow3() {
 
     forever {
-        from inputStreamExternalTimeBatchTest3 window externalTimeBatchWindow(
+        from inputStreamExternalTimeBatchTest3 window externalTimeBatch(
                                                           inputStreamExternalTimeBatchTest3.timestamp, 1000, (),3000)
         select inputStreamExternalTimeBatchTest3.timestamp, inputStreamExternalTimeBatchTest3.name, count() as count
         group by inputStreamExternalTimeBatchTest3.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test4.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test4.bal
@@ -72,7 +72,7 @@ function startExternalTimeBatchwindowTest4() returns (TeacherOutput[]) {
 function testExternalTimeBatchwindow4() {
 
     forever {
-        from inputStreamExternalTimeBatchTest4 window externalTimeBatchWindow(
+        from inputStreamExternalTimeBatchTest4 window externalTimeBatch(
                                                           inputStreamExternalTimeBatchTest4.timestamp, 1000, (),1200)
         select inputStreamExternalTimeBatchTest4.timestamp, inputStreamExternalTimeBatchTest4.name, count() as count
         group by inputStreamExternalTimeBatchTest4.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test5.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test5.bal
@@ -72,7 +72,7 @@ function startExternalTimeBatchwindowTest5() returns (TeacherOutput[]) {
 function testExternalTimeBatchwindow5() {
 
     forever {
-        from inputStreamExternalTimeBatchTest5 window externalTimeBatchWindow(
+        from inputStreamExternalTimeBatchTest5 window externalTimeBatch(
                                                           inputStreamExternalTimeBatchTest5.timestamp, 1000, 1000, 1200)
         select inputStreamExternalTimeBatchTest5.timestamp, inputStreamExternalTimeBatchTest5.name, count() as count
         group by inputStreamExternalTimeBatchTest5.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test6.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-batch-window-test6.bal
@@ -72,7 +72,7 @@ function startExternalTimeBatchwindowTest6() returns (TeacherOutput[]) {
 function testExternalTimeBatchwindow6() {
 
     forever {
-        from inputStreamExternalTimeBatchTest6 window externalTimeBatchWindow(
+        from inputStreamExternalTimeBatchTest6 window externalTimeBatch(
                                                           inputStreamExternalTimeBatchTest6.timestamp, 1000, 500, 1200)
         select inputStreamExternalTimeBatchTest6.timestamp, inputStreamExternalTimeBatchTest6.name, count() as count
         group by inputStreamExternalTimeBatchTest6.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-external-time-window-test.bal
@@ -73,7 +73,7 @@ function startExternalTimeWindowTest() returns (TeacherOutput[]) {
 
 function testExternalTimeWindow() {
     forever {
-        from inputStreamExternalTimeTest window externalTimeWindow(inputStreamExternalTimeTest.timestamp, 1000)
+        from inputStreamExternalTimeTest window externalTime(inputStreamExternalTimeTest.timestamp, 1000)
         select inputStreamExternalTimeTest.timestamp, inputStreamExternalTimeTest.name, count() as count
         group by inputStreamExternalTimeTest.school
         => (TeacherOutput [] teachers) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-join-test.bal
@@ -44,8 +44,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery() {
 
     forever {
-        from stockStream window lengthWindow(1)
-        join twitterStream window lengthWindow(1)
+        from stockStream window length(1)
+        join twitterStream window length(1)
         on stockStream.symbol == twitterStream.company
         select stockStream.symbol as symbol, twitterStream.tweet as tweet, stockStream.price as price
         => (StockWithPrice[] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-join-without-on-condition-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-join-without-on-condition-test.bal
@@ -44,8 +44,8 @@ stream<StockWithPrice> stockWithPriceStream = new;
 function testJoinQuery() {
 
     forever {
-        from stockStream window lengthWindow(1)
-        join twitterStream window lengthWindow(1)
+        from stockStream window length(1)
+        join twitterStream window length(1)
         select stockStream.symbol as symbol, twitterStream.tweet as tweet, stockStream.price as price
         => (StockWithPrice[] emp) {
             foreach var e in emp {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-length-batch-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-length-batch-window-test.bal
@@ -64,7 +64,7 @@ function startLengthBatchwindowTest1() returns (TeacherOutput[]) {
 function testLengthBatchwindow() {
 
     forever {
-        from inputStreamLengthBatchTest1 window lengthBatchWindow(2)
+        from inputStreamLengthBatchTest1 window lengthBatch(2)
         select inputStreamLengthBatchTest1.name, count() as count
         group by inputStreamLengthBatchTest1.school
         => (TeacherOutput [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-length-batch-window-test2.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-length-batch-window-test2.bal
@@ -72,7 +72,7 @@ function startLengthBatchwindowTest2() returns (TeacherOutput[]) {
 function testLengthBatchwindow() {
 
     forever {
-        from inputStreamLengthbatchTest2 window lengthBatchWindow(2)
+        from inputStreamLengthbatchTest2 window lengthBatch(2)
         select inputStreamLengthbatchTest2.name, count() as count
         group by inputStreamLengthbatchTest2.school
         => (TeacherOutput [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-length-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-length-window-test.bal
@@ -67,7 +67,7 @@ function startLengthWindowTest() returns (Teacher[]) {
 function testLengthWindow() {
 
     forever {
-        from inputStreamLengthWindowTest window lengthWindow(2)
+        from inputStreamLengthWindowTest window length(2)
         select inputStreamLengthWindowTest.name, inputStreamLengthWindowTest.age, inputStreamLengthWindowTest.status, inputStreamLengthWindowTest
         .school, count() as count
         group by inputStreamLengthWindowTest.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-orderby-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-orderby-test.bal
@@ -71,7 +71,7 @@ function startOrderByQuery() returns TeacherOutput[] {
 
 function foo() {
     forever {
-        from inputStream where inputStream.age > 2 window lengthBatchWindow(5)
+        from inputStream where inputStream.age > 2 window lengthBatch(5)
         select inputStream.name, inputStream.age, inputStream.status, sum (inputStream.age) as sumAge, count() as count
         group by inputStream.name order by status ascending, age descending => (TeacherOutput [] o) {
             foreach var x in o {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-orderby-with-functions-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-orderby-with-functions-test.bal
@@ -74,7 +74,7 @@ function startOrderByQuery() returns TeacherOutput[] {
 
 function foo() {
     forever {
-        from inputStream where inputStream.age > 2 window lengthBatchWindow(5)
+        from inputStream where inputStream.age > 2 window lengthBatch(5)
         select inputStream.name, inputStream.age, inputStream.status, sum (inputStream.age) as sumAge, count() as count
         group by inputStream.name
         order by status ascending, getAge(age, getAge(age, 2)) descending => (TeacherOutput[] o) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-sort-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-sort-window-test.bal
@@ -74,7 +74,7 @@ function startSortWindowTest1() returns TeacherOutput[] {
 function testSortWindow() {
 
     forever {
-        from inputStreamSortWindowTest1 window sortWindow(3, inputStreamSortWindowTest1.age, "ascending",
+        from inputStreamSortWindowTest1 window sort(3, inputStreamSortWindowTest1.age, "ascending",
             inputStreamSortWindowTest1.name, "descending")
         select inputStreamSortWindowTest1.name, inputStreamSortWindowTest1.age
         group by inputStreamSortWindowTest1.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-table-join-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-table-join-test.bal
@@ -50,7 +50,7 @@ table<Stock> stocksTable = table {
 
 function testJoinQuery() {
     forever {
-        from twitterStream window lengthWindow(1) as tw
+        from twitterStream window length(1) as tw
         join queryStocksTable(tw.company, 1) as tb
         select tb.symbol, tw.tweet, tb.price
         => (StockWithPrice[] stocks) {
@@ -63,7 +63,7 @@ function testJoinQuery() {
 
 function testOuterJoinQuery() {
     forever {
-        from twitterStream window lengthWindow(1) as tw
+        from twitterStream window length(1) as tw
         full outer join queryStocksTable(tw.company, 1) as tb
         select tb.symbol, tw.tweet, tb.price
         => (StockWithPrice[] stocks) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-batch-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-batch-window-test.bal
@@ -64,7 +64,7 @@ function startTimeBatchwindowTest1() returns (TeacherOutput[]) {
 function testTimeBatchwindow() {
 
     forever {
-        from inputStreamTimeBatchTest1 window timeBatchWindow(1000)
+        from inputStreamTimeBatchTest1 window timeBatch(1000)
         select inputStreamTimeBatchTest1.name, count() as count
         group by inputStreamTimeBatchTest1.school
         => (TeacherOutput [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-batch-window-test2.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-batch-window-test2.bal
@@ -69,7 +69,7 @@ function startTimeBatchwindowTest2() returns (TeacherOutput[]) {
 function testTimeBatchwindow() {
 
     forever {
-        from inputStreamTimeBatchTest2 window timeBatchWindow(1000)
+        from inputStreamTimeBatchTest2 window timeBatch(1000)
         select inputStreamTimeBatchTest2.name, count() as count
         group by inputStreamTimeBatchTest2.school
         => (TeacherOutput [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-length-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-length-window-test.bal
@@ -67,7 +67,7 @@ function startTimeLengthwindowTest1() returns (TeacherOutput[]) {
 function testTimeLengthwindow() {
 
     forever {
-        from inputStreamTimeLengthWindowTest1 window timeLengthWindow(2000, 10)
+        from inputStreamTimeLengthWindowTest1 window timeLength(2000, 10)
         select inputStreamTimeLengthWindowTest1.name, count() as count
         group by inputStreamTimeLengthWindowTest1.school
         => (TeacherOutput [] teachers) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-length-window-test2.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-length-window-test2.bal
@@ -75,7 +75,7 @@ function startTimeLengthwindowTest2() returns (TeacherOutput[]) {
 function testTimeLengthwindow() {
 
     forever {
-        from inputStreamTimeLengthWindowTest2 window timeLengthWindow(2000, 3)
+        from inputStreamTimeLengthWindowTest2 window timeLength(2000, 3)
         select inputStreamTimeLengthWindowTest2.timestamp, inputStreamTimeLengthWindowTest2.name, count() as count
         group by inputStreamTimeLengthWindowTest2.school
         => (TeacherOutput [] teachers) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-window-test.bal
@@ -59,7 +59,7 @@ function startTimeWindowTest() returns (Teacher[]) {
 function testTimeWindow() {
 
     forever {
-        from inputStreamTimeWindowTest window timeWindow(1000)
+        from inputStreamTimeWindowTest window time(1000)
         select inputStreamTimeWindowTest.name, inputStreamTimeWindowTest.age, inputStreamTimeWindowTest.status, inputStreamTimeWindowTest
         .school
         => (Teacher [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-window-test2.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-time-window-test2.bal
@@ -81,7 +81,7 @@ function startTimeWindowTest2() returns (Teacher[]) {
 function testTimeWindow() {
 
     forever {
-        from inputStreamTimeWindowTest2 window timeWindow(1000)
+        from inputStreamTimeWindowTest2 window time(1000)
         select inputStreamTimeWindowTest2.name, inputStreamTimeWindowTest2.age, inputStreamTimeWindowTest2.status,
             inputStreamTimeWindowTest2.school, count() as count
         group by inputStreamTimeWindowTest2.school

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-unique-length-window-test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-unique-length-window-test.bal
@@ -67,7 +67,7 @@ function startUniqueLengthwindowTest1() returns TeacherOutput[] {
 function testUniqueLengthwindow() {
 
     forever {
-        from inputStreamUniqueLengthTest1 window uniqueLengthWindow(inputStreamUniqueLengthTest1.age, 4)
+        from inputStreamUniqueLengthTest1 window uniqueLength(inputStreamUniqueLengthTest1.age, 4)
         select inputStreamUniqueLengthTest1.name, count() as count
         group by inputStreamUniqueLengthTest1.school
         => (TeacherOutput [] emp) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-unique-length-window-test2.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/streaming/streamingv2-unique-length-window-test2.bal
@@ -73,7 +73,7 @@ function startUniqueLengthwindowTest2() returns TeacherOutput[] {
 function testUniqueLengthwindow() {
 
     forever {
-        from inputStreamUniqueLengthTest2 window uniqueLengthWindow(inputStreamUniqueLengthTest2.age, 3)
+        from inputStreamUniqueLengthTest2 window uniqueLength(inputStreamUniqueLengthTest2.age, 3)
         select inputStreamUniqueLengthTest2.name, count() as count
         group by inputStreamUniqueLengthTest2.school
         => (TeacherOutput [] emp) {


### PR DESCRIPTION
## Purpose
In Streaming grammar, window name follows by the keyword 'window'. Hence 'Window' postfix for window names (e.g. sortWindow, legnthWindow) is redundant.