### PR TITLE
Fix df analysis failure for object init method as outside method def and disallow extern object init methods

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -62,6 +62,7 @@ public enum DiagnosticCode {
     INVALID_INTERFACE_ON_NON_ABSTRACT_OBJECT("invalid.interface.of.non.abstract.object"),
     CANNOT_ATTACH_FUNCTIONS_TO_ABSTRACT_OBJECT("cannot.attach.functions.to.abstract.object"),
     ABSTRACT_OBJECT_FUNCTION_CANNOT_HAVE_BODY("abstract.object.function.cannot.have.body"),
+    OBJECT_INIT_FUNCTION_CANNOT_BE_EXTERN("object.init.function.cannot.be.extern"),
 
     INCOMPATIBLE_TYPES("incompatible.types"),
     INCOMPATIBLE_TYPES_EXP_TUPLE("incompatible.types.exp.tuple"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -183,6 +183,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -839,12 +840,16 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         if (objectTypeNode.initFunction != null) {
             if (objectTypeNode.initFunction.body == null) {
                 // if the __init() function is defined as an outside function definition
-                objectTypeNode.initFunction = objectEnv.enclPkg.functions.stream()
-                        .filter(f -> f.symbol.name.equals((objectTypeNode.initFunction).symbol.name))
-                        .findFirst()
-                        .get(); // the function should exist in the enclosed package, or would have failed earlier
+                Optional<BLangFunction> outerFuncDef =
+                        objectEnv.enclPkg.functions.stream()
+                                .filter(f -> f.symbol.name.equals((objectTypeNode.initFunction).symbol.name))
+                                .findFirst();
+                outerFuncDef.ifPresent(bLangFunction -> objectTypeNode.initFunction = bLangFunction);
             }
-            objectTypeNode.initFunction.body.stmts.forEach(statement -> analyzeNode(statement, objectEnv));
+
+            if (objectTypeNode.initFunction.body != null) {
+                objectTypeNode.initFunction.body.stmts.forEach(statement -> analyzeNode(statement, objectEnv));
+            }
         }
 
         if (!anonymousModelHelper.isAnonymousType(objectTypeNode.symbol) &&

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -837,6 +837,13 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
         // Visit the constructor with the same scope as the object
         if (objectTypeNode.initFunction != null) {
+            if (objectTypeNode.initFunction.body == null) {
+                // if the __init() function is defined as an outside function definition
+                objectTypeNode.initFunction = objectEnv.enclPkg.functions.stream()
+                        .filter(f -> f.symbol.name.equals((objectTypeNode.initFunction).symbol.name))
+                        .findFirst()
+                        .get(); // the function should exist in the enclosed package, or would have failed earlier
+            }
             objectTypeNode.initFunction.body.stmts.forEach(statement -> analyzeNode(statement, objectEnv));
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -323,6 +323,12 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             return;
         }
 
+        if (objectTypeNode.initFunction.flagSet.contains(Flag.NATIVE)) {
+            this.dlog.error(objectTypeNode.initFunction.pos, DiagnosticCode.OBJECT_INIT_FUNCTION_CANNOT_BE_EXTERN,
+                            objectTypeNode.symbol.name);
+            return;
+        }
+
         analyzeDef(objectTypeNode.initFunction, env);
     }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -616,6 +616,9 @@ error.cannot.attach.functions.to.abstract.object=\
 error.abstract.object.function.cannot.have.body=\
   function ''{0}'' in abstract object ''{1}'' cannot have a body
 
+error.object.init.function.cannot.be.extern=\
+  object ''__init()'' function cannot be an ''extern'' function
+
 error.incompatible.type.reference=\
   incompatible types: ''{0}'' is not an abstract object
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
@@ -33,7 +33,7 @@ public class DataflowAnalysisTest {
     @Test(description = "Test uninitialized variables")
     public void testUninitializedVariables() {
         CompileResult result = BCompileUtil.compile("test-src/dataflow/analysis/dataflow-analysis-negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 50);
+        Assert.assertEquals(result.getErrorCount(), 52);
         int i = 0;
         BAssertUtil.validateError(result, i++, "variable 'msg' may not have been initialized", 53, 12);
         BAssertUtil.validateError(result, i++, "variable 'msg' may not have been initialized", 70, 12);
@@ -85,5 +85,7 @@ public class DataflowAnalysisTest {
         BAssertUtil.validateError(result, i++, "missing non-defaultable required record field 'extra'", 585, 12);
         BAssertUtil.validateError(result, i++, "variable 'fa' is not initialized", 611, 13);
         BAssertUtil.validateError(result, i++, "variable 'fb' is not initialized", 612, 13);
+        BAssertUtil.validateError(result, i++, "uninitialized field 'b'", 620, 5);
+        BAssertUtil.validateError(result, i, "uninitialized field 'c'", 621, 5);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
@@ -527,6 +527,14 @@ public class ObjectTest {
         BAssertUtil.validateError(result, 0, "undefined symbol 'abc'", 6, 9);
     }
 
+    @Test (description = "Negative test to test invalid object init functions")
+    public void testObjectInitFunctionNegative() {
+        CompileResult result = BCompileUtil.compile("test-src/object/object_init_function_negative.bal");
+        Assert.assertEquals(result.getErrorCount(), 2);
+        BAssertUtil.validateError(result, 0, "object '__init()' function cannot be an 'extern' function", 19, 5);
+        BAssertUtil.validateError(result, 1, "object '__init()' function cannot be an 'extern' function", 23, 5);
+    }
+
     @Test (description = "Negative test to test nillable initialization")
     public void testNillableInitialization() {
         CompileResult result = BCompileUtil.compile("test-src/object/object_nillable_init.bal");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
@@ -614,3 +614,15 @@ function testDataflow_13() returns (int, int) {
 }
 
 (function () returns (int)) fb;
+
+type F object {
+    public int a;
+    public int b;
+    string c;
+
+    function __init();
+};
+
+function F.__init() {
+    self.a = 1;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/object_init_function_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/object_init_function_negative.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+type ObjectOne object {
+    public int age = 0;
+
+    extern function __init(int age);
+};
+
+public type ObjectTwo object {
+    public extern function __init();
+};


### PR DESCRIPTION
## Purpose
This PR
- fixes the failure at data flow analysis phase when an object init method is defined as an outside method
- disallows extern object init methods

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12812
