### PR TITLE
Add locks to stream and table joins

### DIFF
--- a/stdlib/streams/src/main/ballerina/streams/stream-join-processor.bal
+++ b/stdlib/streams/src/main/ballerina/streams/stream-join-processor.bal
@@ -23,6 +23,7 @@ public type StreamJoinProcessor object {
     public string? rhsStream;
     public string? unidirectionalStream;
     public JoinType joinType;
+    public int lockField = 0;
 
     public function __init(function (StreamEvent[]) nextProcessor, JoinType joinType,
                            (function (map<anydata> e1Data, map<anydata> e2Data) returns boolean)? onConditionFunc) {
@@ -37,74 +38,77 @@ public type StreamJoinProcessor object {
     }
 
     public function process(StreamEvent[] streamEvents) {
-        StreamEvent?[] joinedEvents = [];
-        int i = 0;
-        foreach var event in streamEvents {
-            string originStream = event.data.keys()[0].split("\\.")[0];
-            // resolve trigger according to join direction
-            boolean triggerJoin = false;
-            var s = self.unidirectionalStream;
-            if (s is string) {
-                // unidirectional
-                if (s.equalsIgnoreCase(originStream)) {
-                    triggerJoin = true;
-                }
-            } else {
-                // bidirectional
-                triggerJoin = true;
-            }
-
-            if (triggerJoin) {
-                (StreamEvent?, StreamEvent?)[] candidateEvents = [];
-                // join events according to the triggered side
-                if (self.lhsStream.equalsIgnoreCase(originStream) ?: false) {
-                    // triggered from LHS
-                    var evtArr = self.rhsWindow.getCandidateEvents(event, self.onConditionFunc);
-                    if (evtArr is (StreamEvent?, StreamEvent?)[]) {
-                        candidateEvents = evtArr;
-                        // with left/full joins, we need to emit an event even there's no candidate events in rhs.
-                        if (candidateEvents.length() == 0 && (self.joinType == "LEFTOUTERJOIN"
-                                || self.joinType == "FULLOUTERJOIN")) {
-                            candidateEvents[0] = (event, ());
-                        }
-                    } else {
-                        if (self.joinType == "LEFTOUTERJOIN" || self.joinType == "FULLOUTERJOIN") {
-                            candidateEvents[0] = (event, ());
-                        }
-                    }
-
-                    foreach var evtTuple in candidateEvents {
-                        joinedEvents[i] = self.joinEvents(evtTuple[0], evtTuple[1]);
-                        i += 1;
+        lock {
+            StreamEvent?[] joinedEvents = [];
+            int i = 0;
+            self.lockField += 1;
+            foreach var event in streamEvents {
+                string originStream = event.data.keys()[0].split("\\.")[0];
+                // resolve trigger according to join direction
+                boolean triggerJoin = false;
+                var s = self.unidirectionalStream;
+                if (s is string) {
+                    // unidirectional
+                    if (s.equalsIgnoreCase(originStream)) {
+                        triggerJoin = true;
                     }
                 } else {
-                    var evtArr = self.lhsWindow.getCandidateEvents(event, self.onConditionFunc, isLHSTrigger = false);
-                    if (evtArr is (StreamEvent?, StreamEvent?)[]) {
-                        candidateEvents = evtArr;
-                        // with right/full joins, we need to emit an event even there's no candidate events in rhs.
-                        if (candidateEvents.length() == 0 && (self.joinType == "RIGHTOUTERJOIN"
-                                || self.joinType == "FULLOUTERJOIN")) {
-                            candidateEvents[0] = ((), event);
+                    // bidirectional
+                    triggerJoin = true;
+                }
+
+                if (triggerJoin) {
+                    (StreamEvent?, StreamEvent?)[] candidateEvents = [];
+                    // join events according to the triggered side
+                    if (self.lhsStream.equalsIgnoreCase(originStream) ?: false) {
+                        // triggered from LHS
+                        var evtArr = self.rhsWindow.getCandidateEvents(event, self.onConditionFunc);
+                        if (evtArr is (StreamEvent?, StreamEvent?)[]) {
+                            candidateEvents = evtArr;
+                            // with left/full joins, we need to emit an event even there's no candidate events in rhs.
+                            if (candidateEvents.length() == 0 && (self.joinType == "LEFTOUTERJOIN"
+                                    || self.joinType == "FULLOUTERJOIN")) {
+                                candidateEvents[0] = (event, ());
+                            }
+                        } else {
+                            if (self.joinType == "LEFTOUTERJOIN" || self.joinType == "FULLOUTERJOIN") {
+                                candidateEvents[0] = (event, ());
+                            }
+                        }
+
+                        foreach var evtTuple in candidateEvents {
+                            joinedEvents[i] = self.joinEvents(evtTuple[0], evtTuple[1]);
+                            i += 1;
                         }
                     } else {
-                        if (self.joinType == "RIGHTOUTERJOIN" || self.joinType == "FULLOUTERJOIN") {
-                            candidateEvents[0] = ((), event);
+                        var evtArr = self.lhsWindow.getCandidateEvents(event, self.onConditionFunc, isLHSTrigger = false);
+                        if (evtArr is (StreamEvent?, StreamEvent?)[]) {
+                            candidateEvents = evtArr;
+                            // with right/full joins, we need to emit an event even there's no candidate events in rhs.
+                            if (candidateEvents.length() == 0 && (self.joinType == "RIGHTOUTERJOIN"
+                                    || self.joinType == "FULLOUTERJOIN")) {
+                                candidateEvents[0] = ((), event);
+                            }
+                        } else {
+                            if (self.joinType == "RIGHTOUTERJOIN" || self.joinType == "FULLOUTERJOIN") {
+                                candidateEvents[0] = ((), event);
+                            }
                         }
-                    }
-                    foreach var evtTuple in candidateEvents {
-                        joinedEvents[i] = self.joinEvents(evtTuple[0], evtTuple[1], lhsTriggered = false);
-                        i += 1;
+                        foreach var evtTuple in candidateEvents {
+                            joinedEvents[i] = self.joinEvents(evtTuple[0], evtTuple[1], lhsTriggered = false);
+                            i += 1;
+                        }
                     }
                 }
             }
-        }
 
-        StreamEvent[] outputEvents = [];
-        i = 0;
-        foreach var e in joinedEvents {
-            if (e is StreamEvent) {
-                outputEvents[i] = e;
-                i += 1;
+            StreamEvent[] outputEvents = [];
+            i = 0;
+            foreach var e in joinedEvents {
+                if (e is StreamEvent) {
+                    outputEvents[i] = e;
+                    i += 1;
+                }
             }
         }
         self.nextProcessor.call(outputEvents);

--- a/stdlib/streams/src/main/ballerina/streams/stream-join-processor.bal
+++ b/stdlib/streams/src/main/ballerina/streams/stream-join-processor.bal
@@ -39,7 +39,7 @@ public type StreamJoinProcessor object {
 
     public function process(StreamEvent[] streamEvents) {
         StreamEvent?[] joinedEvents = [];
-        StreamEvent[] outputEvents;
+        StreamEvent[] outputEvents = [];
         lock {
             self.lockField += 1;
             int i = 0;

--- a/stdlib/streams/src/main/ballerina/streams/stream-join-processor.bal
+++ b/stdlib/streams/src/main/ballerina/streams/stream-join-processor.bal
@@ -38,10 +38,11 @@ public type StreamJoinProcessor object {
     }
 
     public function process(StreamEvent[] streamEvents) {
+        StreamEvent?[] joinedEvents = [];
+        StreamEvent[] outputEvents;
         lock {
-            StreamEvent?[] joinedEvents = [];
-            int i = 0;
             self.lockField += 1;
+            int i = 0;
             foreach var event in streamEvents {
                 string originStream = event.data.keys()[0].split("\\.")[0];
                 // resolve trigger according to join direction
@@ -102,7 +103,7 @@ public type StreamJoinProcessor object {
                 }
             }
 
-            StreamEvent[] outputEvents = [];
+            outputEvents = [];
             i = 0;
             foreach var e in joinedEvents {
                 if (e is StreamEvent) {

--- a/stdlib/streams/src/main/ballerina/streams/table-join-processor.bal
+++ b/stdlib/streams/src/main/ballerina/streams/table-join-processor.bal
@@ -35,7 +35,7 @@ public type TableJoinProcessor object {
 
     public function process(StreamEvent[] streamEvents) {
         StreamEvent?[] joinedEvents = [];
-        StreamEvent[] outputEvents;
+        StreamEvent[] outputEvents = [];
         lock {
             self.lockField += 1;
             int j = 0;

--- a/stdlib/streams/src/main/ballerina/streams/table-join-processor.bal
+++ b/stdlib/streams/src/main/ballerina/streams/table-join-processor.bal
@@ -34,9 +34,10 @@ public type TableJoinProcessor object {
     }
 
     public function process(StreamEvent[] streamEvents) {
+        StreamEvent?[] joinedEvents = [];
+        StreamEvent[] outputEvents;
         lock {
             self.lockField += 1;
-            StreamEvent?[] joinedEvents = [];
             int j = 0;
             foreach var event in streamEvents {
                 (StreamEvent?, StreamEvent?)[] candidateEvents = [];
@@ -56,7 +57,7 @@ public type TableJoinProcessor object {
                     j += 1;
                 }
             }
-            StreamEvent[] outputEvents = [];
+            outputEvents = [];
             int i = 0;
             foreach var e in joinedEvents {
                 if (e is StreamEvent) {

--- a/stdlib/streams/src/main/ballerina/streams/table-join-processor.bal
+++ b/stdlib/streams/src/main/ballerina/streams/table-join-processor.bal
@@ -21,6 +21,7 @@ public type TableJoinProcessor object {
     public string streamName;
     public string tableName;
     public JoinType joinType;
+    public int lockField = 0;
 
     public function __init(function (StreamEvent[]) nextProcessor, JoinType joinType,
                            function (StreamEvent s) returns map<anydata>[] tableQuery) {
@@ -33,32 +34,35 @@ public type TableJoinProcessor object {
     }
 
     public function process(StreamEvent[] streamEvents) {
-        StreamEvent?[] joinedEvents = [];
-        int j = 0;
-        foreach var event in streamEvents {
-            (StreamEvent?, StreamEvent?)[] candidateEvents = [];
-            int i = 0;
-            foreach var m in self.tableQuery.call(event) {
-                StreamEvent resultEvent = new((self.tableName, m), "CURRENT", time:currentTime().time);
-                candidateEvents[i] = (event, resultEvent);
-                i += 1;
-            }
-            // with right/left/full joins, we need to emit an event even there're no candidate events in table.
-            if (candidateEvents.length() == 0 && (self.joinType != "JOIN")) {
-                candidateEvents[0] = (event, ());
-            }
+        lock {
+            self.lockField += 1;
+            StreamEvent?[] joinedEvents = [];
+            int j = 0;
+            foreach var event in streamEvents {
+                (StreamEvent?, StreamEvent?)[] candidateEvents = [];
+                int i = 0;
+                foreach var m in self.tableQuery.call(event) {
+                    StreamEvent resultEvent = new((self.tableName, m), "CURRENT", time:currentTime().time);
+                    candidateEvents[i] = (event, resultEvent);
+                    i += 1;
+                }
+                // with right/left/full joins, we need to emit an event even there're no candidate events in table.
+                if (candidateEvents.length() == 0 && (self.joinType != "JOIN")) {
+                    candidateEvents[0] = (event, ());
+                }
 
-            foreach var e in candidateEvents {
-                joinedEvents[j] = self.joinEvents(e[0], e[1]);
-                j += 1;
+                foreach var e in candidateEvents {
+                    joinedEvents[j] = self.joinEvents(e[0], e[1]);
+                    j += 1;
+                }
             }
-        }
-        StreamEvent[] outputEvents = [];
-        int i = 0;
-        foreach var e in joinedEvents {
-            if (e is StreamEvent) {
-                outputEvents[i] = e;
-                i += 1;
+            StreamEvent[] outputEvents = [];
+            int i = 0;
+            foreach var e in joinedEvents {
+                if (e is StreamEvent) {
+                    outputEvents[i] = e;
+                    i += 1;
+                }
             }
         }
         self.nextProcessor.call(outputEvents);


### PR DESCRIPTION
## Purpose
This PR will add newly introduced ballerina locks (instance level) to stream & table join processors, in order to get rid of concurrency issues within joins.