### PR TITLE
Make network logs enabled when no config file is present

### DIFF
--- a/tool-plugins/vscode/src/debugger/config-provider.ts
+++ b/tool-plugins/vscode/src/debugger/config-provider.ts
@@ -41,12 +41,16 @@ const debugConfigProvider: DebugConfigurationProvider = {
             config.script = window.activeTextEditor.document.uri.path;
         }
 
+        
 
         let langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
         if (langClient.initializeResult) {
             const { experimental } = langClient.initializeResult!.capabilities;
             if (experimental && experimental.introspection && experimental.introspection.port > 0) {
                 config.networkLogsPort = experimental.introspection.port;
+                if (config.networkLogs === undefined) {
+                    config.networkLogs = true;
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose
When a bal file is run from vscode, if there is no config file present (zero config mode) network logs will not be enabled. This is to fix this and make it enabled by default. 