### PR TITLE
Convert time:Time to a record with util functions

### DIFF
--- a/benchmarks/benchmarktypes/benchmark-type-time.bal
+++ b/benchmarks/benchmarktypes/benchmark-type-time.bal
@@ -102,13 +102,13 @@ public function benchmarkToTimezoneFunction() {
     time:Timezone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     string timeStrBefore = time.toString();
-    time = time.toTimezone("Asia/Colombo");
+    time = time.toTimeZone("Asia/Colombo");
     string timeStrAfter = time.toString();
 }
 
 public function benchmarkToTimezoneFunctionWithDateTime() {
     time:Time time = time:parse("2016-03-01T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    time = time.toTimezone("Asia/Colombo");
+    time = time.toTimeZone("Asia/Colombo");
     string timeString = time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 

--- a/benchmarks/benchmarktypes/benchmark-type-time.bal
+++ b/benchmarks/benchmarktypes/benchmark-type-time.bal
@@ -17,7 +17,7 @@ public function benchmarkCreateTimeWithZoneIDFunction() {
 
 public function benchmarkCreateTimeWithOffsetFunction() {
     time:Timezone zoneValue = { zoneId: "-05:00" };
-    time:Time time = new(1498488382000, zoneValue);
+    time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
     int zoneoffset = time.zone.zoneOffset;
@@ -25,7 +25,7 @@ public function benchmarkCreateTimeWithOffsetFunction() {
 
 public function benchmarkCreateTimeWithNoZoneFunction() {
     time:Timezone zoneValue = { zoneId: "" };
-    time:Time time = new(1498488382000, zoneValue);
+    time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
     int zoneoffset = time.zone.zoneOffset;
@@ -44,13 +44,13 @@ public function benchmarkParseTimeFunction() {
 
 public function benchmarkToStringWithCreateTimeFunction() {
     time:Timezone zoneValue = { zoneId: "America/Panama" };
-    time:Time time = new(1498488382000, zoneValue);
+    time:Time time = { time: 1498488382000, zone: zoneValue };
     string timeString = time.toString();
 }
 
 public function benchmarkFormatTimeFunction() {
     time:Timezone zoneValue = { zoneId: "America/Panama" };
-    time:Time time = new(1498488382444, zoneValue);
+    time:Time time = { time: 1498488382444, zone: zoneValue };
     string timeString = time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 

--- a/benchmarks/benchmarktypes/benchmark-type-time.bal
+++ b/benchmarks/benchmarktypes/benchmark-type-time.bal
@@ -3,32 +3,32 @@ import ballerina/time;
 public function benchmarkCurrentTimeFunction() {
     time:Time time = time:currentTime();
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
 }
 
 public function benchmarkCreateTimeWithZoneIDFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = new(1498488382000, zoneValue);
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
 }
 
 public function benchmarkCreateTimeWithOffsetFunction() {
-    time:TimeZone zoneValue = { zoneId: "-05:00" };
+    time:TimeZone zoneValue = { id: "-05:00" };
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
 }
 
 public function benchmarkCreateTimeWithNoZoneFunction() {
-    time:TimeZone zoneValue = { zoneId: "" };
+    time:TimeZone zoneValue = { id: "" };
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
 }
 
 public function benchmarkCreateDateTimeFunction() {
@@ -38,24 +38,24 @@ public function benchmarkCreateDateTimeFunction() {
 public function benchmarkParseTimeFunction() {
     time:Time time = time:parse("2017-06-26T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
 }
 
 public function benchmarkToStringWithCreateTimeFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = { time: 1498488382000, zone: zoneValue };
     string timeString = time.toString();
 }
 
 public function benchmarkFormatTimeFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = { time: 1498488382444, zone: zoneValue };
     string timeString = time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 public function benchmarkTimeGetFunctions() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     int year = time.year();
     int month = time.month();
@@ -68,7 +68,7 @@ public function benchmarkTimeGetFunctions() {
 }
 
 public function benchmarkGetDateFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     int year;
     int month;
@@ -77,7 +77,7 @@ public function benchmarkGetDateFunction() {
 }
 
 public function benchmarkGetTimeFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     int hour;
     int minute;
@@ -99,7 +99,7 @@ public function benchmarkSubtractDurationFunction() {
 }
 
 public function benchmarkToTimezoneFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     string timeStrBefore = time.toString();
     time = time.toTimeZone("Asia/Colombo");
@@ -113,19 +113,19 @@ public function benchmarkToTimezoneFunctionWithDateTime() {
 }
 
 public function benchmarkManualTimeCreateFunction() {
-    time:TimeZone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { id: "America/Panama" };
     time:Time time = new(1498488382000, zoneValue);
     string timeString = time.toString();
 }
 
 public function benchmarkManualTimeCreateFunctionWithNoZone() {
-    time:TimeZone zoneValue = { zoneId: "" };
+    time:TimeZone zoneValue = { id: "" };
     time:Time time = new(1498488382555, zoneValue);
     int year = time.year();
 }
 
 public function benchmarkManualTimeCreateFunctionWithEmptyZone() {
-    time:TimeZone zoneValue = { zoneId: "" };
+    time:TimeZone zoneValue = { id: "" };
     time:Time time = new(1498488382555, zoneValue);
     int yesr = time.year();
 }

--- a/benchmarks/benchmarktypes/benchmark-type-time.bal
+++ b/benchmarks/benchmarktypes/benchmark-type-time.bal
@@ -8,7 +8,7 @@ public function benchmarkCurrentTimeFunction() {
 }
 
 public function benchmarkCreateTimeWithZoneIDFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1498488382000, zoneValue);
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
@@ -16,7 +16,7 @@ public function benchmarkCreateTimeWithZoneIDFunction() {
 }
 
 public function benchmarkCreateTimeWithOffsetFunction() {
-    time:Timezone zoneValue = { zoneId: "-05:00" };
+    time:TimeZone zoneValue = { zoneId: "-05:00" };
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
@@ -24,7 +24,7 @@ public function benchmarkCreateTimeWithOffsetFunction() {
 }
 
 public function benchmarkCreateTimeWithNoZoneFunction() {
-    time:Timezone zoneValue = { zoneId: "" };
+    time:TimeZone zoneValue = { zoneId: "" };
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
@@ -43,19 +43,19 @@ public function benchmarkParseTimeFunction() {
 }
 
 public function benchmarkToStringWithCreateTimeFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = { time: 1498488382000, zone: zoneValue };
     string timeString = time.toString();
 }
 
 public function benchmarkFormatTimeFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = { time: 1498488382444, zone: zoneValue };
     string timeString = time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 public function benchmarkTimeGetFunctions() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     int year = time.year();
     int month = time.month();
@@ -68,7 +68,7 @@ public function benchmarkTimeGetFunctions() {
 }
 
 public function benchmarkGetDateFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     int year;
     int month;
@@ -77,7 +77,7 @@ public function benchmarkGetDateFunction() {
 }
 
 public function benchmarkGetTimeFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     int hour;
     int minute;
@@ -99,7 +99,7 @@ public function benchmarkSubtractDurationFunction() {
 }
 
 public function benchmarkToTimezoneFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1456876583555, zoneValue);
     string timeStrBefore = time.toString();
     time = time.toTimeZone("Asia/Colombo");
@@ -113,19 +113,19 @@ public function benchmarkToTimezoneFunctionWithDateTime() {
 }
 
 public function benchmarkManualTimeCreateFunction() {
-    time:Timezone zoneValue = { zoneId: "America/Panama" };
+    time:TimeZone zoneValue = { zoneId: "America/Panama" };
     time:Time time = new(1498488382000, zoneValue);
     string timeString = time.toString();
 }
 
 public function benchmarkManualTimeCreateFunctionWithNoZone() {
-    time:Timezone zoneValue = { zoneId: "" };
+    time:TimeZone zoneValue = { zoneId: "" };
     time:Time time = new(1498488382555, zoneValue);
     int year = time.year();
 }
 
 public function benchmarkManualTimeCreateFunctionWithEmptyZone() {
-    time:Timezone zoneValue = { zoneId: "" };
+    time:TimeZone zoneValue = { zoneId: "" };
     time:Time time = new(1498488382555, zoneValue);
     int yesr = time.year();
 }

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_search/packaging_search.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_search/packaging_search.bal
@@ -242,8 +242,8 @@ function getDateCreated(json jsonObj) returns string {
     string jsonTime = jsonObj.time.toString();
     var timeInMillis = int.convert(jsonTime);
     if (timeInMillis is int) {
-        time:Time timeStruct = new(timeInMillis, { zoneId: "UTC", zoneOffset: 0 });
-        string customTimeString = timeStruct.format("yyyy-MM-dd-E");
+        time:Time timeStruct = { time: timeInMillis, zone: { zoneId: "UTC", zoneOffset: 0 } };
+        string customTimeString = time:format(timeStruct, "yyyy-MM-dd-E");
         return customTimeString;
     } else if (timeInMillis is error) {
         panic timeInMillis;

--- a/cli/ballerina-cli-utils/src/main/ballerina/packaging_search/packaging_search.bal
+++ b/cli/ballerina-cli-utils/src/main/ballerina/packaging_search/packaging_search.bal
@@ -242,8 +242,8 @@ function getDateCreated(json jsonObj) returns string {
     string jsonTime = jsonObj.time.toString();
     var timeInMillis = int.convert(jsonTime);
     if (timeInMillis is int) {
-        time:Time timeStruct = { time: timeInMillis, zone: { zoneId: "UTC", zoneOffset: 0 } };
-        string customTimeString = time:format(timeStruct, "yyyy-MM-dd-E");
+        time:Time timeRecord = { time: timeInMillis, zone: { id: "UTC", offset: 0 } };
+        string customTimeString = time:format(timeRecord, "yyyy-MM-dd-E");
         return customTimeString;
     } else if (timeInMillis is error) {
         panic timeInMillis;

--- a/examples/date-time/date_time.bal
+++ b/examples/date-time/date_time.bal
@@ -11,63 +11,63 @@ public function main() {
     // time, and timezone information.
     time:Time timeCreated = time:createTime(2017, 3, 28, 23, 42, 45, 554,
                                             "America/Panama");
-    io:println("Created Time: " + timeCreated.toString());
+    io:println("Created Time: " + time:toString(timeCreated));
     // This retrieves the time for a given string representation
     // based on the specified string format.
     time:Time t1 = time:parse("2017-06-26T09:46:22.444-0500",
                               "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    io:println("Parsed Time: " + t1.toString());
+    io:println("Parsed Time: " + time:toString(t1));
     // You can retrieve the string representation of the time via the `toString()` function or the `format()` function.
     // This fetches the ISO 8601 formatted string of a given time.
-    string standardTimeString = time.toString();
+    string standardTimeString = time:toString(time);
     io:println("Current system time in ISO format: " + standardTimeString);
     // This fetches the formatted string of a given time.
-    string customTimeString = time.format("yyyy-MM-dd-E");
+    string customTimeString = time:format(time, "yyyy-MM-dd-E");
     io:println("Current system time in custom format: " + customTimeString);
     // These functions retrieve information relating to a time object.
     // This fetches the year of a given time.
-    int year = time.year();
+    int year = time:getYear(time);
     io:println("Year: " + year);
     // This fetches the month of a given time.
-    int month = time.month();
+    int month = time:getMonth(time);
     io:println("Month: " + month);
     // This fetches the day of a given time.
-    int day = time.day();
+    int day = time:getDay(time);
     io:println("Day: " + day);
     // This fetches the hour value of a given time.
-    int hour = time.hour();
+    int hour = time:getHour(time);
     io:println("Hour: " + hour);
     // This fetches the minute value of a given time.
-    int minute = time.minute();
+    int minute = time:getMinute(time);
     io:println("Minute: " + minute);
     // This fetches the seconds value of a given time.
-    int second = time.second();
+    int second = time:getSecond(time);
     io:println("Second: " + second);
     // This fetches the millisecond value of a given time.
-    int milliSecond = time.milliSecond();
+    int milliSecond = time:getMilliSecond(time);
     io:println("Millisecond: " + milliSecond);
     // This fetches the day of the week of a given time.
-    string weekday = time.weekday();
+    string weekday = time:getWeekday(time);
     io:println("Weekday: " + weekday);
     // This fetches the date component of time using a single function.
-    (year, month, day) = time.getDate();
+    (year, month, day) = time:getDate(time);
     io:println("Date: " + year + ":" + month + ":" + day);
     // This fetches the time component using a single function.
-    (hour, minute, second, milliSecond) = time.getTime();
+    (hour, minute, second, milliSecond) = time:getTime(time);
     io:println("Time:" + hour + ":" + minute + ":" + second + ":"
                     + milliSecond);
     // This adds a given duration to a time. In this example, let's add
     // one year, one month, and one second to the current time.
-    time:Time tmAdd = time.addDuration(1, 1, 0, 0, 0, 1, 0);
-    io:println("After adding a duration: " + tmAdd.toString());
+    time:Time tmAdd = time:addDuration(time, 1, 1, 0, 0, 0, 1, 0);
+    io:println("After adding a duration: " + time:toString(tmAdd));
     // This subtracts a given duration from a time. In this example, let's subtract one year,
     // one month, and one second from the current time.
-    time:Time tmSub = time.subtractDuration(1, 1, 0, 0, 0, 1, 0);
-    io:println("After subtracting a duration: " + tmSub.toString());
+    time:Time tmSub = time:subtractDuration(time, 1, 1, 0, 0, 0, 1, 0);
+    io:println("After subtracting a duration: " + time:toString(tmSub));
     // This converts the time to a different timezone.
     time:Time t2 = time:createTime(2017, 3, 28, 23, 42, 45, 554,
                                     "America/Panama");
-    io:println("Before converting the time zone: " + t2.toString());
-    time:Time t3 = t2.toTimeZone("Asia/Colombo");
-    io:println("After converting the time zone:" + t3.toString());
+    io:println("Before converting the time zone: " + time:toString(t2));
+    time:Time t3 = time:toTimeZone(t2, "Asia/Colombo");
+    io:println("After converting the time zone:" + time:toString(t3));
 }

--- a/examples/date-time/date_time.bal
+++ b/examples/date-time/date_time.bal
@@ -68,6 +68,6 @@ public function main() {
     time:Time t2 = time:createTime(2017, 3, 28, 23, 42, 45, 554,
                                     "America/Panama");
     io:println("Before converting the time zone: " + t2.toString());
-    time:Time t3 = t2.toTimezone("Asia/Colombo");
+    time:Time t3 = t2.toTimeZone("Asia/Colombo");
     io:println("After converting the time zone:" + t3.toString());
 }

--- a/stdlib/http/src/main/ballerina/http/caching/http_caching_client.bal
+++ b/stdlib/http/src/main/ballerina/http/caching/http_caching_client.bal
@@ -750,7 +750,7 @@ function getDateValue(Response inboundResponse) returns int {
     if (!inboundResponse.hasHeader(DATE)) {
         log:printDebug("Date header not found. Using current time for the Date header.");
         time:Time currentT = time:currentTime();
-        inboundResponse.setHeader(DATE, currentT.format(time:TIME_FORMAT_RFC_1123));
+        inboundResponse.setHeader(DATE, time:format(currentT, time:TIME_FORMAT_RFC_1123));
         return currentT.time;
     }
 

--- a/stdlib/http/src/main/ballerina/http/http_response.bal
+++ b/stdlib/http/src/main/ballerina/http/http_response.bal
@@ -315,7 +315,7 @@ function Response.setETag(json|xml|string|byte[] payload) {
 
 function Response.setLastModified() {
     time:Time currentT = time:currentTime();
-    string lastModified = currentT.format(time:TIME_FORMAT_RFC_1123);
+    string lastModified = time:format(currentT, time:TIME_FORMAT_RFC_1123);
     self.setHeader(LAST_MODIFIED, lastModified);
 }
 

--- a/stdlib/internal/src/test/resources/test-src/file/file-test.bal
+++ b/stdlib/internal/src/test/resources/test-src/file/file-test.bal
@@ -104,7 +104,7 @@ function testFolderContent(string rootPathValue) returns boolean|error {
 function testGetModifiedTime(string pathValue) returns string|error {
     internal:Path path = new(pathValue);
     time:Time modifiedTime = check path.getModifiedTime();
-    return modifiedTime.toString();
+    return time:toString(modifiedTime);
 }
 
 function testCopyToFunction(string source, string target) returns boolean {

--- a/stdlib/time/src/main/ballerina/time/timelib.bal
+++ b/stdlib/time/src/main/ballerina/time/timelib.bal
@@ -20,11 +20,11 @@ public type TimeFormat "RFC_1123";
 
 # Ballerina TimeZone represents the time-zone information associated with a particular time.
 #
-# + zoneId - Zone short ID or offset string
-# + zoneOffset - The offset in seconds
+# + is - Zone short ID or offset string
+# + offset - The offset in seconds
 public type TimeZone record {
-    string zoneId;
-    int zoneOffset = 0;
+    string id;
+    int offset = 0;
     !...;
 };
 
@@ -35,7 +35,7 @@ public type TimeZone record {
 public type Time record {
     int time;
     TimeZone zone;
-    !...
+    !...;
 };
 # Returns ISO 8601 string representation of the given time.
 #

--- a/stdlib/time/src/main/ballerina/time/timelib.bal
+++ b/stdlib/time/src/main/ballerina/time/timelib.bal
@@ -12,7 +12,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
-// under the License
+// under the License.
+
 public const TIME_FORMAT_RFC_1123 = "RFC_1123";
 
 public type TimeFormat "RFC_1123";
@@ -44,6 +45,7 @@ public extern function toString(Time time) returns string;
 
 # Returns formatted string representation of the given time.
 #
+# + time - The Time record to be formatted
 # + timeFormat - The format which is used to format the time represented by this object
 # + return - The formatted string of the given time
 public extern function format(Time time, string|TimeFormat timeFormat) returns string;
@@ -62,6 +64,7 @@ public extern function getMonth(Time time) returns int;
 
 # Returns the date representation of the given time.
 #
+# + time - The Time record to get the date representation from
 # + return - The day-of-month, from 1 to 31
 public extern function getDay(Time time) returns int;
 
@@ -124,7 +127,7 @@ public extern function getTime(Time time) returns (int, int, int, int);
 # + milliSeconds - The milli-of-second to represent, from 0 to 999
 # + return - Time object containing time and zone information after the addition
 public extern function addDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
-                                   int milliSeconds) returns (Time);
+                                   int milliSeconds) returns Time;
 
 # Subtract specified durations from the given time value.
 #

--- a/stdlib/time/src/main/ballerina/time/timelib.bal
+++ b/stdlib/time/src/main/ballerina/time/timelib.bal
@@ -12,8 +12,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
-// under the License.
-
+// under the License
 public const TIME_FORMAT_RFC_1123 = "RFC_1123";
 
 public type TimeFormat "RFC_1123";
@@ -32,115 +31,122 @@ public type Timezone record {
 #
 # + time - Time value as milliseconds since epoch
 # + zone - The time zone of the time
-public type Time object {
-
-    public int time;
-    public Timezone zone;
-
-    public function __init(int time, Timezone zone) {
-        self.time = time;
-        self.zone = zone;
-    }
-
-    # Returns ISO 8601 string representation of the given time.
-    #
-    # + return - The ISO 8601 formatted string of the given time
-    public extern function toString() returns (string);
-
-    # Returns formatted string representation of the given time.
-    #
-    # + format - The format which is used to format the time represented by this object
-    # + return - The formatted string of the given time
-    public extern function format(string|TimeFormat format) returns (string);
-
-    # Returns the year representation of the given time.
-    #
-    # + return - The year representation
-    public extern function year() returns (int);
-
-    # Returns the month representation of the given time.
-    #
-    # + return - The month-of-year, from 1 (January) to 12 (December)
-    public extern function month() returns (int);
-
-    # Returns the date representation of the given time.
-    #
-    # + return - The day-of-month, from 1 to 31
-    public extern function day() returns (int);
-
-    # Returns the weekday representation of the given time.
-    #
-    # + return - The weekday representation from SUNDAY to SATURDAY
-    public extern function weekday() returns (string);
-
-    # Returns the hour representation of the given time.
-    #
-    # + return - The hour-of-day, from 0 to 23
-    public extern function hour() returns (int);
-
-    # Returns the minute representation of the given time.
-    #
-    # + return - The minute-of-hour to represent, from 0 to 59
-    public extern function minute() returns (int);
-
-    # Returns the second representation of the given time.
-    #
-    # + return - The second-of-minute, from 0 to 59
-    public extern function second() returns (int);
-
-    # Returns the millisecond representation of the given time.
-    #
-    # + return - The milli-of-second, from 0 to 999
-    public extern function milliSecond() returns (int);
-
-    # Returns the date representation of the given time.
-    #
-    # + return - The year representation.
-    #            The month-of-year, from 1 (January) to 12 (December).
-    #            The day-of-month, from 1 to 31.
-    public extern function getDate() returns (int, int, int);
-
-    # Returns the time representation of the given time.
-    #
-    # + return - The hour-of-day, from 0 to 23.
-    #            The minute-of-hour to represent, from 0 to 59.
-    #            The second-of-minute, from 0 to 59.
-    #            The milli-of-second, from 0 to 999.
-    public extern function getTime() returns (int, int, int, int);
-
-    # Add specified durations to the given time value.
-    #
-    # + years - The year representation
-    # + months - The month-of-year to represent, from 1 (January) to 12 (December)
-    # + days - The day-of-month to represent, from 1 to 31
-    # + hours - The hour-of-day to represent, from 0 to 23
-    # + minutes - The minute-of-hour to represent, from 0 to 59
-    # + seconds - The second-of-minute to represent, from 0 to 59
-    # + milliSeconds - The milli-of-second to represent, from 0 to 999
-    # + return - Time object containing time and zone information after the addition
-
-    public extern function addDuration(int years, int months, int days, int hours, int minutes, int seconds,
-                                       int milliSeconds) returns (Time);
-
-    # Subtract specified durations from the given time value.
-    #
-    # + years - The year representation
-    # + months - The month-of-year to represent, from 1 (January) to 12 (December)
-    # + days - The day-of-month to represent, from 1 to 31
-    # + hours - The hour-of-day to represent, from 0 to 23
-    # + minutes - The minute-of-hour to represent, from 0 to 59
-    # + seconds - The second-of-minute to represent, from 0 to 59
-    # + milliSeconds - The milli-of-second to represent, from 0 to 999
-    # + return - Time object containing time and zone information after the subtraction
-    public extern function subtractDuration(int years, int months, int days, int hours, int minutes, int seconds,
-                                            int milliSeconds) returns (Time);
-
-    # Change the timezone of the given time.
-    #
-    # + zoneId - The new timezone id
-    # + return - Time object containing time and zone information after the conversion
-    public extern function toTimezone(string zoneId) returns (Time);
+public type Time record {
+    int time;
+    Timezone zone;
+    !...
 };
+# Returns ISO 8601 string representation of the given time.
+#
+# + time - The Time record to be converted to string
+# + return - The ISO 8601 formatted string of the given time
+public extern function toString(Time time) returns (string);
+
+# Returns formatted string representation of the given time.
+#
+# + timeFormat - The format which is used to format the time represented by this object
+# + return - The formatted string of the given time
+public extern function format(Time time, string|TimeFormat timeFormat) returns (string);
+
+# Returns the year representation of the given time.
+#
+# + time - The Time record to retrieve the year representation from
+# + return - The year representation
+public extern function getYear(Time time) returns (int);
+
+# Returns the month representation of the given time.
+#
+# + time - The Time record to get the month representation from
+# + return - The month-of-year, from 1 (January) to 12 (December)
+public extern function getMonth(Time time) returns (int);
+
+# Returns the date representation of the given time.
+#
+# + return - The day-of-month, from 1 to 31
+public extern function getDay(Time time) returns (int);
+
+# Returns the weekday representation of the given time.
+#
+# + time - The Time record to get the weekday representation from
+# + return - The weekday representation from SUNDAY to SATURDAY
+public extern function getWeekday(Time time) returns (string);
+
+# Returns the hour representation of the given time.
+#
+# + time - The Time record to get the  hour representation from
+# + return - The hour-of-day, from 0 to 23
+public extern function getHour(Time time) returns (int);
+
+# Returns the minute representation of the given time.
+#
+# + time - The Time record to get the  minute representation from
+# + return - The minute-of-hour to represent, from 0 to 59
+public extern function getMinute(Time time) returns (int);
+
+# Returns the second representation of the given time.
+#
+# + time - The Time record to get the second representation from
+# + return - The second-of-minute, from 0 to 59
+public extern function getSecond(Time time) returns (int);
+
+# Returns the millisecond representation of the given time.
+#
+# + time - The Time record to get the millisecond representation from
+# + return - The milli-of-second, from 0 to 999
+public extern function getMilliSecond(Time time) returns (int);
+
+# Returns the date representation of the given time.
+#
+# + time - The Time record to get the date representation from
+# + return - The year representation.
+#            The month-of-year, from 1 (January) to 12 (December).
+#            The day-of-month, from 1 to 31.
+public extern function getDate(Time time) returns (int, int, int);
+
+# Returns the time representation of the given time.
+#
+# + time - The Time record
+# + return - The hour-of-day, from 0 to 23.
+#            The minute-of-hour to represent, from 0 to 59.
+#            The second-of-minute, from 0 to 59.
+#            The milli-of-second, from 0 to 999.
+public extern function getTime(Time time) returns (int, int, int, int);
+
+# Add specified durations to the given time value.
+#
+# + time - The Time record to add the duration to
+# + years - The year representation
+# + months - The month-of-year to represent, from 1 (January) to 12 (December)
+# + days - The day-of-month to represent, from 1 to 31
+# + hours - The hour-of-day to represent, from 0 to 23
+# + minutes - The minute-of-hour to represent, from 0 to 59
+# + seconds - The second-of-minute to represent, from 0 to 59
+# + milliSeconds - The milli-of-second to represent, from 0 to 999
+# + return - Time object containing time and zone information after the addition
+
+public extern function addDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
+                                   int milliSeconds) returns (Time);
+
+# Subtract specified durations from the given time value.
+#
+# + time - The Time record to subtract the duration from
+# + years - The year representation
+# + months - The month-of-year to represent, from 1 (January) to 12 (December)
+# + days - The day-of-month to represent, from 1 to 31
+# + hours - The hour-of-day to represent, from 0 to 23
+# + minutes - The minute-of-hour to represent, from 0 to 59
+# + seconds - The second-of-minute to represent, from 0 to 59
+# + milliSeconds - The milli-of-second to represent, from 0 to 999
+# + return - Time object containing time and zone information after the subtraction
+public extern function subtractDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
+                                        int milliSeconds) returns (Time);
+
+# Change the timezone of the given time.
+#
+# + time - The Time record of which the timezone to be changed
+# + zoneId - The new timezone id
+# + return - Time object containing time and zone information after the conversion
+public extern function toTimezone(Time time, string zoneId) returns (Time);
 
 # Returns the current time value with the system default timezone.
 #
@@ -169,6 +175,6 @@ public extern function createTime(int year, int month, int date, int hour, int m
 # Returns the time for the given string representation based on the given format string.
 #
 # + data - The time text to parse
-# + format - The format which is used to parse the given text
+# + timeFormat - The format which is used to parse the given text
 # + return - Time object containing time and zone information
-public extern function parse(string data, string|TimeFormat format) returns (Time);
+public extern function parse(string data, string|TimeFormat timeFormat) returns (Time);

--- a/stdlib/time/src/main/ballerina/time/timelib.bal
+++ b/stdlib/time/src/main/ballerina/time/timelib.bal
@@ -17,23 +17,23 @@ public const TIME_FORMAT_RFC_1123 = "RFC_1123";
 
 public type TimeFormat "RFC_1123";
 
-# Ballerina Timezone represents the timezone information associated with a particular time.
+# Ballerina TimeZone represents the time-zone information associated with a particular time.
 #
 # + zoneId - Zone short ID or offset string
 # + zoneOffset - The offset in seconds
-public type Timezone record {
+public type TimeZone record {
     string zoneId;
     int zoneOffset = 0;
     !...;
 };
 
-# Ballerina Time represents a particular time with its associated timezone.
+# Ballerina Time represents a particular time with its associated time-zone.
 #
 # + time - Time value as milliseconds since epoch
 # + zone - The time zone of the time
 public type Time record {
     int time;
-    Timezone zone;
+    TimeZone zone;
     !...
 };
 # Returns ISO 8601 string representation of the given time.
@@ -140,14 +140,14 @@ public extern function addDuration(Time time, int years, int months, int days, i
 public extern function subtractDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
                                         int milliSeconds) returns Time;
 
-# Change the timezone of the given time.
+# Change the time-zone of the given time.
 #
-# + time - The Time record of which the timezone to be changed
-# + zoneId - The new timezone id
+# + time - The Time record of which the time-zone to be changed
+# + zoneId - The new time-zone id
 # + return - Time object containing time and zone information after the conversion
-public extern function toTimezone(Time time, string zoneId) returns Time;
+public extern function toTimeZone(Time time, string zoneId) returns Time;
 
-# Returns the current time value with the system default timezone.
+# Returns the current time value with the system default time-zone.
 #
 # + return - Time object containing the time and zone information
 public extern function currentTime() returns Time;
@@ -157,7 +157,7 @@ public extern function currentTime() returns Time;
 # + return - Int value of the current system time in nano seconds
 public extern function nanoTime() returns int;
 
-# Returns the Time object correspoding to the given time components and timezone.
+# Returns the Time object correspoding to the given time components and time-zone.
 #
 # + year - The year representation
 # + month - The month-of-year to represent, from 1 (January) to 12 (December)
@@ -166,7 +166,7 @@ public extern function nanoTime() returns int;
 # + minute - The minute-of-hour to represent, from 0 to 59
 # + second - The second-of-minute to represent, from 0 to 59
 # + milliSecond - The milli-of-second to represent, from 0 to 999
-# + zoneId - The zone id of the required timezone.If empty the system local timezone will be used
+# + zoneId - The zone id of the required time-zone.If empty the system local time-zone will be used
 # + return - Time object containing time and zone information
 public extern function createTime(int year, int month, int date, int hour, int minute, int second, int milliSecond,
                                   string zoneId) returns Time;

--- a/stdlib/time/src/main/ballerina/time/timelib.bal
+++ b/stdlib/time/src/main/ballerina/time/timelib.bal
@@ -40,60 +40,60 @@ public type Time record {
 #
 # + time - The Time record to be converted to string
 # + return - The ISO 8601 formatted string of the given time
-public extern function toString(Time time) returns (string);
+public extern function toString(Time time) returns string;
 
 # Returns formatted string representation of the given time.
 #
 # + timeFormat - The format which is used to format the time represented by this object
 # + return - The formatted string of the given time
-public extern function format(Time time, string|TimeFormat timeFormat) returns (string);
+public extern function format(Time time, string|TimeFormat timeFormat) returns string;
 
 # Returns the year representation of the given time.
 #
 # + time - The Time record to retrieve the year representation from
 # + return - The year representation
-public extern function getYear(Time time) returns (int);
+public extern function getYear(Time time) returns int;
 
 # Returns the month representation of the given time.
 #
 # + time - The Time record to get the month representation from
 # + return - The month-of-year, from 1 (January) to 12 (December)
-public extern function getMonth(Time time) returns (int);
+public extern function getMonth(Time time) returns int;
 
 # Returns the date representation of the given time.
 #
 # + return - The day-of-month, from 1 to 31
-public extern function getDay(Time time) returns (int);
+public extern function getDay(Time time) returns int;
 
 # Returns the weekday representation of the given time.
 #
 # + time - The Time record to get the weekday representation from
 # + return - The weekday representation from SUNDAY to SATURDAY
-public extern function getWeekday(Time time) returns (string);
+public extern function getWeekday(Time time) returns string;
 
 # Returns the hour representation of the given time.
 #
 # + time - The Time record to get the  hour representation from
 # + return - The hour-of-day, from 0 to 23
-public extern function getHour(Time time) returns (int);
+public extern function getHour(Time time) returns int;
 
 # Returns the minute representation of the given time.
 #
 # + time - The Time record to get the  minute representation from
 # + return - The minute-of-hour to represent, from 0 to 59
-public extern function getMinute(Time time) returns (int);
+public extern function getMinute(Time time) returns int;
 
 # Returns the second representation of the given time.
 #
 # + time - The Time record to get the second representation from
 # + return - The second-of-minute, from 0 to 59
-public extern function getSecond(Time time) returns (int);
+public extern function getSecond(Time time) returns int;
 
 # Returns the millisecond representation of the given time.
 #
 # + time - The Time record to get the millisecond representation from
 # + return - The milli-of-second, from 0 to 999
-public extern function getMilliSecond(Time time) returns (int);
+public extern function getMilliSecond(Time time) returns int;
 
 # Returns the date representation of the given time.
 #
@@ -123,7 +123,6 @@ public extern function getTime(Time time) returns (int, int, int, int);
 # + seconds - The second-of-minute to represent, from 0 to 59
 # + milliSeconds - The milli-of-second to represent, from 0 to 999
 # + return - Time object containing time and zone information after the addition
-
 public extern function addDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
                                    int milliSeconds) returns (Time);
 
@@ -139,24 +138,24 @@ public extern function addDuration(Time time, int years, int months, int days, i
 # + milliSeconds - The milli-of-second to represent, from 0 to 999
 # + return - Time object containing time and zone information after the subtraction
 public extern function subtractDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
-                                        int milliSeconds) returns (Time);
+                                        int milliSeconds) returns Time;
 
 # Change the timezone of the given time.
 #
 # + time - The Time record of which the timezone to be changed
 # + zoneId - The new timezone id
 # + return - Time object containing time and zone information after the conversion
-public extern function toTimezone(Time time, string zoneId) returns (Time);
+public extern function toTimezone(Time time, string zoneId) returns Time;
 
 # Returns the current time value with the system default timezone.
 #
 # + return - Time object containing the time and zone information
-public extern function currentTime() returns (Time);
+public extern function currentTime() returns Time;
 
 # Returns the current system time in nano seconds.
 #
 # + return - Int value of the current system time in nano seconds
-public extern function nanoTime() returns (int);
+public extern function nanoTime() returns int;
 
 # Returns the Time object correspoding to the given time components and timezone.
 #
@@ -170,11 +169,11 @@ public extern function nanoTime() returns (int);
 # + zoneId - The zone id of the required timezone.If empty the system local timezone will be used
 # + return - Time object containing time and zone information
 public extern function createTime(int year, int month, int date, int hour, int minute, int second, int milliSecond,
-                                  string zoneId) returns (Time);
+                                  string zoneId) returns Time;
 
 # Returns the time for the given string representation based on the given format string.
 #
 # + data - The time text to parse
 # + timeFormat - The format which is used to parse the given text
 # + return - Time object containing time and zone information
-public extern function parse(string data, string|TimeFormat timeFormat) returns (Time);
+public extern function parse(string data, string|TimeFormat timeFormat) returns Time;

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/AbstractTimeFunction.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/AbstractTimeFunction.java
@@ -45,7 +45,7 @@ public abstract class AbstractTimeFunction extends BlockingNativeCallableUnit {
     public static final String KEY_ZONED_DATETIME = "ZonedDateTime";
     public static final String TIME_FIELD = "time";
     public static final String ZONE_FIELD = "zone";
-    public static final String ZONE_ID_FIELD = "zoneId";
+    public static final String ZONE_ID_FIELD = "id";
     
     private StructureTypeInfo timeStructInfo;
     private StructureTypeInfo zoneStructInfo;

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/AddDuration.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/AddDuration.java
@@ -23,10 +23,7 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Add given durations to the time.
@@ -36,15 +33,15 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "addDuration",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
         args = {@Argument(name = "years", type = TypeKind.INT),
                 @Argument(name = "months", type = TypeKind.INT),
                 @Argument(name = "days", type = TypeKind.INT),
                 @Argument(name = "hours", type = TypeKind.INT),
                 @Argument(name = "minutes", type = TypeKind.INT),
                 @Argument(name = "seconds", type = TypeKind.INT),
-                @Argument(name = "milliseconds", type = TypeKind.INT)},
-        returnType = {@ReturnType(type = TypeKind.OBJECT, structType = "Time",
+                @Argument(name = "milliseconds", type = TypeKind.INT),
+                @Argument(name = "time", type = TypeKind.RECORD)},
+        returnType = {@ReturnType(type = TypeKind.RECORD, structType = "Time",
                                   structPackage = "ballerina/time")},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/CreateTime.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/CreateTime.java
@@ -39,7 +39,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
                 @Argument(name = "seconds", type = TypeKind.INT),
                 @Argument(name = "milliseconds", type = TypeKind.INT),
                 @Argument(name = "zoneID", type = TypeKind.STRING)},
-        returnType = {@ReturnType(type = TypeKind.OBJECT, structType = "Time",
+        returnType = {@ReturnType(type = TypeKind.RECORD, structType = "Time",
                                   structPackage = "ballerina/time")},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/CurrentTime.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/CurrentTime.java
@@ -30,7 +30,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "currentTime",
-        returnType = {@ReturnType(type = TypeKind.OBJECT, structType = "Time",
+        returnType = {@ReturnType(type = TypeKind.RECORD, structType = "Time",
                                   structPackage = "ballerina.time")},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Day.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Day.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the day value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "day",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getDay",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Format.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Format.java
@@ -25,13 +25,10 @@ import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Convert a Time to string in the given format.
@@ -41,8 +38,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "format",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
-        args = {@Argument(name = "pattern", type = TypeKind.UNION)},
+        args = {@Argument(name = "pattern", type = TypeKind.UNION),
+                @Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/GetDate.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/GetDate.java
@@ -25,13 +25,11 @@ import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BValueArray;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 
 import java.util.Arrays;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the year,month and date value for the given time.
@@ -41,7 +39,7 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "getDate",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT),
                       @ReturnType(type = TypeKind.INT),
                       @ReturnType(type = TypeKind.INT)},

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/GetTime.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/GetTime.java
@@ -25,13 +25,11 @@ import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BValueArray;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 
 import java.util.Arrays;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the hour, minute, second and millisecond value for the given time.
@@ -41,7 +39,7 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "getTime",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.INT),

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Hour.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Hour.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the hour value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "hour",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getHour",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/MilliSecond.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/MilliSecond.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the milli second value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "milliSecond",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getMilliSecond",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Minute.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Minute.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the minute value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "minute",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getMinute",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Month.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Month.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the month value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "month",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getMonth",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Second.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Second.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the second value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "second",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getSecond",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/SubtractDuration.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/SubtractDuration.java
@@ -23,10 +23,7 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Subtract given durations from the time.
@@ -36,15 +33,15 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "subtractDuration",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
         args = {@Argument(name = "years", type = TypeKind.INT),
                 @Argument(name = "months", type = TypeKind.INT),
                 @Argument(name = "days", type = TypeKind.INT),
                 @Argument(name = "hours", type = TypeKind.INT),
                 @Argument(name = "minutes", type = TypeKind.INT),
                 @Argument(name = "seconds", type = TypeKind.INT),
-                @Argument(name = "milliseconds", type = TypeKind.INT)},
-        returnType = {@ReturnType(type = TypeKind.OBJECT, structType = "Time",
+                @Argument(name = "milliseconds", type = TypeKind.INT),
+                @Argument(name = "time", type = TypeKind.RECORD)},
+        returnType = {@ReturnType(type = TypeKind.RECORD, structType = "Time",
                                   structPackage = "ballerina/time")},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ToString.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ToString.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Convert a Time to ISO 8601 formatted string.
@@ -36,7 +34,7 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "toString",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ToTimeZone.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ToTimeZone.java
@@ -32,14 +32,14 @@ import org.ballerinalang.natives.annotations.ReturnType;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "toTimezone",
+        functionName = "toTimeZone",
         args = {@Argument(name = "zoneId", type = TypeKind.STRING),
                 @Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.RECORD, structType = "Time",
                                   structPackage = "ballerina/time")},
         isPublic = true
 )
-public class ToTimezone extends AbstractTimeFunction {
+public class ToTimeZone extends AbstractTimeFunction {
 
     @Override
     public void execute(Context context) {

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ToTimezone.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ToTimezone.java
@@ -23,10 +23,7 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Change the timezone associated with the given time.
@@ -36,9 +33,9 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
         functionName = "toTimezone",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
-        args = {@Argument(name = "zoneId", type = TypeKind.STRING)},
-        returnType = {@ReturnType(type = TypeKind.OBJECT, structType = "Time",
+        args = {@Argument(name = "zoneId", type = TypeKind.STRING),
+                @Argument(name = "time", type = TypeKind.RECORD)},
+        returnType = {@ReturnType(type = TypeKind.RECORD, structType = "Time",
                                   structPackage = "ballerina/time")},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/WeekDay.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/WeekDay.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the week day of the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "weekday",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getWeekday",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Year.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/Year.java
@@ -22,11 +22,9 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-
-import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
 
 /**
  * Get the year value for the given time.
@@ -35,8 +33,8 @@ import static org.ballerinalang.stdlib.time.util.TimeUtils.STRUCT_TYPE_TIME;
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "time",
-        functionName = "year",
-        receiver = @Receiver(type = TypeKind.OBJECT, structType = STRUCT_TYPE_TIME, structPackage = "ballerina/time"),
+        functionName = "getYear",
+        args = {@Argument(name = "time", type = TypeKind.RECORD)},
         returnType = {@ReturnType(type = TypeKind.INT)},
         isPublic = true
 )

--- a/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/util/TimeUtils.java
+++ b/stdlib/time/src/main/java/org/ballerinalang/stdlib/time/util/TimeUtils.java
@@ -39,7 +39,7 @@ public class TimeUtils {
 
     public static final String PACKAGE_TIME = "ballerina/time";
     public static final String STRUCT_TYPE_TIME = "Time";
-    public static final String STRUCT_TYPE_TIMEZONE = "Timezone";
+    public static final String STRUCT_TYPE_TIMEZONE = "TimeZone";
     public static final int READABLE_BUFFER_SIZE = 8192; //8KB
 
     public static BMap<String, BValue> createTimeZone(StructureTypeInfo timezoneStructInfo, String zoneIdValue) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
@@ -213,7 +213,7 @@ function testMappingDatesToNillableTimeType() returns (int, int, int,
 
     time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
 
-    time:Timezone zoneValue = { zoneId: "UTC" };
+    time:TimeZone zoneValue = { zoneId: "UTC" };
     time:Time timeStruct = { time: 51323000, zone: zoneValue };
 
     time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
@@ -213,7 +213,7 @@ function testMappingDatesToNillableTimeType() returns (int, int, int,
 
     time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
 
-    time:TimeZone zoneValue = { zoneId: "UTC" };
+    time:TimeZone zoneValue = { id: "UTC" };
     time:Time timeStruct = { time: 51323000, zone: zoneValue };
 
     time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_nillable_mapping.bal
@@ -214,7 +214,7 @@ function testMappingDatesToNillableTimeType() returns (int, int, int,
     time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
 
     time:Timezone zoneValue = { zoneId: "UTC" };
-    time:Time timeStruct = new(51323000, zoneValue);
+    time:Time timeStruct = { time: 51323000, zone: zoneValue };
 
     time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");
     time:Time datetimeStruct = time:createTime(2017, 1, 31, 16, 12, 23, 332, "UTC");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -649,7 +649,7 @@ function testDateTimeAsTimeStruct() returns (int, int, int, int, int,
     time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
 
     time:Timezone zoneValue = { zoneId: "UTC" };
-    time:Time timeStruct = new(51323000, zoneValue);
+    time:Time timeStruct = { time: 51323000, zone: zoneValue };
 
     time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");
     time:Time datetimeStruct = time:createTime(2017, 1, 31, 16, 12, 23, 332, "UTC");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -648,7 +648,7 @@ function testDateTimeAsTimeStruct() returns (int, int, int, int, int,
 
     time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
 
-    time:TimeZone zoneValue = { zoneId: "UTC" };
+    time:TimeZone zoneValue = { id: "UTC" };
     time:Time timeStruct = { time: 51323000, zone: zoneValue };
 
     time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -648,7 +648,7 @@ function testDateTimeAsTimeStruct() returns (int, int, int, int, int,
 
     time:Time dateStruct = time:createTime(2017, 5, 23, 0, 0, 0, 0, "");
 
-    time:Timezone zoneValue = { zoneId: "UTC" };
+    time:TimeZone zoneValue = { zoneId: "UTC" };
     time:Time timeStruct = { time: 51323000, zone: zoneValue };
 
     time:Time timestampStruct = time:createTime(2017, 1, 25, 16, 12, 23, 0, "UTC");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
@@ -3,8 +3,8 @@ import ballerina/time;
 function testCurrentTime() returns (int, string, int) {
     time:Time time = time:currentTime();
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
@@ -14,29 +14,29 @@ function testNanoTime() returns (int) {
 }
 
 function testCreateTimeWithZoneID() returns (int, string, int) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
 function testCreateTimeWithOffset() returns (int, string, int) {
-    time:TimeZone zoneValue = {zoneId:"-05:00"};
+    time:TimeZone zoneValue = {id:"-05:00"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
 function testCreateTimeWithNoZone() returns (int, string, int) {
-    time:TimeZone zoneValue = {zoneId:""};
+    time:TimeZone zoneValue = {id:""};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
@@ -49,39 +49,39 @@ function testCreateDateTime() returns (string) {
 function testParseTime() returns (int, string, int) {
     time:Time time = time:parse("2017-06-26T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
 function testParseRFC1123Time(string timestamp) returns (int, string, int) {
     time:Time time = time:parse(timestamp, time:TIME_FORMAT_RFC_1123);
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
 function testToStringWithCreateTime() returns (string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     return time:toString(time);
 }
 
 function testFormatTime() returns (string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1498488382444, zone: zoneValue };
     return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testFormatTimeToRFC1123() returns (string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1498488382444, zone: zoneValue };
     return time:format(time, time:TIME_FORMAT_RFC_1123);
 }
 
 function testGetFunctions() returns (int, int, int, int, int, int, int, string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     int year = time:getYear(time);
     int month = time:getMonth(time);
@@ -95,7 +95,7 @@ function testGetFunctions() returns (int, int, int, int, int, int, int, string) 
 }
 
 function testGetDateFunction() returns (int, int, int) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     int year; int month; int day;
     (year, month, day) = time:getDate(time);
@@ -103,7 +103,7 @@ function testGetDateFunction() returns (int, int, int) {
 }
 
 function testGetTimeFunction() returns (int, int, int, int) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     int hour; int minute; int second; int milliSecond;
     (hour, minute, second, milliSecond) = time:getTime(time);
@@ -123,7 +123,7 @@ function testSubtractDuration() returns (string) {
 }
 
 function testToTimezone() returns (string, string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     string timeStrBefore = time:toString(time);
     time = time:toTimeZone(time, "Asia/Colombo");
@@ -132,7 +132,7 @@ function testToTimezone() returns (string, string) {
 }
 
 function testToTimezoneWithInvalidZone() returns (string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     time = time:toTimeZone(time, "test");
     return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
@@ -145,25 +145,25 @@ function testToTimezoneWithDateTime() returns (string) {
 }
 
 function testManualTimeCreate() returns (string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     return time:toString(time);
 }
 
 function testManualTimeCreateWithNoZone() returns (int) {
-    time:TimeZone zoneValue = {zoneId:""};
+    time:TimeZone zoneValue = {id:""};
     time:Time time = { time: 1498488382555, zone: zoneValue };
     return time:getYear(time);
 }
 
 function testManualTimeCreateWithEmptyZone() returns (int) {
-    time:TimeZone zoneValue = {zoneId:""};
+    time:TimeZone zoneValue = {id:""};
     time:Time time = { time: 1498488382555, zone: zoneValue };
     return time:getYear(time);
 }
 
 function testManualTimeCreateWithInvalidZone() returns (int) {
-    time:TimeZone zoneValue = {zoneId:"test"};
+    time:TimeZone zoneValue = {id:"test"};
     time:Time time = { time: 1498488382555, zone: zoneValue };
     return time:getYear(time);
 }
@@ -171,21 +171,21 @@ function testManualTimeCreateWithInvalidZone() returns (int) {
 function testParseTimenvalidPattern() returns (int, string, int) {
     time:Time time = time:parse("2017-06-26T09:46:22.444-0500", "test");
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
 function testParseTimenFormatMismatch() returns (int, string, int) {
     time:Time time = time:parse("2017-06-26T09:46:22.444-0500", "yyyy-MM-dd");
     int timeValue = time.time;
-    string zoneId = time.zone.zoneId;
-    int zoneoffset = time.zone.zoneOffset;
+    string zoneId = time.zone.id;
+    int zoneoffset = time.zone.offset;
     return (timeValue, zoneId, zoneoffset);
 }
 
 function testFormatTimeInvalidPattern() returns (string) {
-    time:TimeZone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {id:"America/Panama"};
     time:Time time = { time: 1498488382444, zone: zoneValue };
     return time:format(time, "test");
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
@@ -14,7 +14,7 @@ function testNanoTime() returns (int) {
 }
 
 function testCreateTimeWithZoneID() returns (int, string, int) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
@@ -23,7 +23,7 @@ function testCreateTimeWithZoneID() returns (int, string, int) {
 }
 
 function testCreateTimeWithOffset() returns (int, string, int) {
-    time:Timezone zoneValue = {zoneId:"-05:00"};
+    time:TimeZone zoneValue = {zoneId:"-05:00"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
@@ -32,7 +32,7 @@ function testCreateTimeWithOffset() returns (int, string, int) {
 }
 
 function testCreateTimeWithNoZone() returns (int, string, int) {
-    time:Timezone zoneValue = {zoneId:""};
+    time:TimeZone zoneValue = {zoneId:""};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
@@ -63,25 +63,25 @@ function testParseRFC1123Time(string timestamp) returns (int, string, int) {
 }
 
 function testToStringWithCreateTime() returns (string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     return time:toString(time);
 }
 
 function testFormatTime() returns (string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1498488382444, zone: zoneValue };
     return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testFormatTimeToRFC1123() returns (string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1498488382444, zone: zoneValue };
     return time:format(time, time:TIME_FORMAT_RFC_1123);
 }
 
 function testGetFunctions() returns (int, int, int, int, int, int, int, string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     int year = time:getYear(time);
     int month = time:getMonth(time);
@@ -95,7 +95,7 @@ function testGetFunctions() returns (int, int, int, int, int, int, int, string) 
 }
 
 function testGetDateFunction() returns (int, int, int) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     int year; int month; int day;
     (year, month, day) = time:getDate(time);
@@ -103,7 +103,7 @@ function testGetDateFunction() returns (int, int, int) {
 }
 
 function testGetTimeFunction() returns (int, int, int, int) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     int hour; int minute; int second; int milliSecond;
     (hour, minute, second, milliSecond) = time:getTime(time);
@@ -123,7 +123,7 @@ function testSubtractDuration() returns (string) {
 }
 
 function testToTimezone() returns (string, string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     string timeStrBefore = time:toString(time);
     time = time:toTimeZone(time, "Asia/Colombo");
@@ -132,7 +132,7 @@ function testToTimezone() returns (string, string) {
 }
 
 function testToTimezoneWithInvalidZone() returns (string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     time = time:toTimeZone(time, "test");
     return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
@@ -145,25 +145,25 @@ function testToTimezoneWithDateTime() returns (string) {
 }
 
 function testManualTimeCreate() returns (string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1498488382000, zone: zoneValue };
     return time:toString(time);
 }
 
 function testManualTimeCreateWithNoZone() returns (int) {
-    time:Timezone zoneValue = {zoneId:""};
+    time:TimeZone zoneValue = {zoneId:""};
     time:Time time = { time: 1498488382555, zone: zoneValue };
     return time:getYear(time);
 }
 
 function testManualTimeCreateWithEmptyZone() returns (int) {
-    time:Timezone zoneValue = {zoneId:""};
+    time:TimeZone zoneValue = {zoneId:""};
     time:Time time = { time: 1498488382555, zone: zoneValue };
     return time:getYear(time);
 }
 
 function testManualTimeCreateWithInvalidZone() returns (int) {
-    time:Timezone zoneValue = {zoneId:"test"};
+    time:TimeZone zoneValue = {zoneId:"test"};
     time:Time time = { time: 1498488382555, zone: zoneValue };
     return time:getYear(time);
 }
@@ -185,7 +185,7 @@ function testParseTimenFormatMismatch() returns (int, string, int) {
 }
 
 function testFormatTimeInvalidPattern() returns (string) {
-    time:Timezone zoneValue = {zoneId:"America/Panama"};
+    time:TimeZone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1498488382444, zone: zoneValue };
     return time:format(time, "test");
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
@@ -126,7 +126,7 @@ function testToTimezone() returns (string, string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
     string timeStrBefore = time:toString(time);
-    time = time:toTimezone(time, "Asia/Colombo");
+    time = time:toTimeZone(time, "Asia/Colombo");
     string timeStrAfter = time:toString(time);
     return (timeStrBefore, timeStrAfter);
 }
@@ -134,13 +134,13 @@ function testToTimezone() returns (string, string) {
 function testToTimezoneWithInvalidZone() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
     time:Time time = { time: 1456876583555, zone: zoneValue };
-    time = time:toTimezone(time, "test");
+    time = time:toTimeZone(time, "test");
     return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testToTimezoneWithDateTime() returns (string) {
     time:Time time = time:parse("2016-03-01T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    time = time:toTimezone(time, "Asia/Colombo");
+    time = time:toTimeZone(time, "Asia/Colombo");
     return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/time/time-type.bal
@@ -15,7 +15,7 @@ function testNanoTime() returns (int) {
 
 function testCreateTimeWithZoneID() returns (int, string, int) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1498488382000, zoneValue);
+    time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
     int zoneoffset = time.zone.zoneOffset;
@@ -24,7 +24,7 @@ function testCreateTimeWithZoneID() returns (int, string, int) {
 
 function testCreateTimeWithOffset() returns (int, string, int) {
     time:Timezone zoneValue = {zoneId:"-05:00"};
-    time:Time time = new(1498488382000, zoneValue);
+    time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
     int zoneoffset = time.zone.zoneOffset;
@@ -33,7 +33,7 @@ function testCreateTimeWithOffset() returns (int, string, int) {
 
 function testCreateTimeWithNoZone() returns (int, string, int) {
     time:Timezone zoneValue = {zoneId:""};
-    time:Time time = new(1498488382000, zoneValue);
+    time:Time time = { time: 1498488382000, zone: zoneValue };
     int timeValue = time.time;
     string zoneId = time.zone.zoneId;
     int zoneoffset = time.zone.zoneOffset;
@@ -42,7 +42,7 @@ function testCreateTimeWithNoZone() returns (int, string, int) {
 
 function testCreateDateTime() returns (string) {
     time:Time time = time:createTime(2017, 3, 28, 23, 42, 45, 554, "America/Panama");
-    return time.toString();
+    return time:toString(time);
 }
 
 
@@ -64,108 +64,108 @@ function testParseRFC1123Time(string timestamp) returns (int, string, int) {
 
 function testToStringWithCreateTime() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1498488382000, zoneValue);
-    return time.toString();
+    time:Time time = { time: 1498488382000, zone: zoneValue };
+    return time:toString(time);
 }
 
 function testFormatTime() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1498488382444, zoneValue);
-    return time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    time:Time time = { time: 1498488382444, zone: zoneValue };
+    return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testFormatTimeToRFC1123() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1498488382444, zoneValue);
-    return time.format(time:TIME_FORMAT_RFC_1123);
+    time:Time time = { time: 1498488382444, zone: zoneValue };
+    return time:format(time, time:TIME_FORMAT_RFC_1123);
 }
 
 function testGetFunctions() returns (int, int, int, int, int, int, int, string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1456876583555, zoneValue);
-    int year = time.year();
-    int month = time.month();
-    int day = time.day();
-    int hour = time.hour();
-    int minute = time.minute();
-    int second = time.second();
-    int milliSecond = time.milliSecond();
-    string weekday = time.weekday();
+    time:Time time = { time: 1456876583555, zone: zoneValue };
+    int year = time:getYear(time);
+    int month = time:getMonth(time);
+    int day = time:getDay(time);
+    int hour = time:getHour(time);
+    int minute = time:getMinute(time);
+    int second = time:getSecond(time);
+    int milliSecond = time:getMilliSecond(time);
+    string weekday = time:getWeekday(time);
     return (year, month, day, hour, minute, second, milliSecond, weekday);
 }
 
 function testGetDateFunction() returns (int, int, int) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1456876583555, zoneValue);
+    time:Time time = { time: 1456876583555, zone: zoneValue };
     int year; int month; int day;
-    (year, month, day) = time.getDate();
+    (year, month, day) = time:getDate(time);
     return (year, month, day);
 }
 
 function testGetTimeFunction() returns (int, int, int, int) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1456876583555, zoneValue);
+    time:Time time = { time: 1456876583555, zone: zoneValue };
     int hour; int minute; int second; int milliSecond;
-    (hour, minute, second, milliSecond) = time.getTime();
+    (hour, minute, second, milliSecond) = time:getTime(time);
     return (hour, minute, second, milliSecond);
 }
 
 function testAddDuration() returns (string) {
     time:Time time = time:parse("2017-06-26T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    time = time.addDuration(1, 1, 1, 1, 1, 1, 1);
-    return time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    time = time:addDuration(time, 1, 1, 1, 1, 1, 1, 1);
+    return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testSubtractDuration() returns (string) {
     time:Time time = time:parse("2016-03-01T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    time = time.subtractDuration(1, 1, 1, 1, 1, 1, 1);
-    return time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    time = time:subtractDuration(time, 1, 1, 1, 1, 1, 1, 1);
+    return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testToTimezone() returns (string, string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1456876583555, zoneValue);
-    string timeStrBefore = time.toString();
-    time = time.toTimezone("Asia/Colombo");
-    string timeStrAfter = time.toString();
+    time:Time time = { time: 1456876583555, zone: zoneValue };
+    string timeStrBefore = time:toString(time);
+    time = time:toTimezone(time, "Asia/Colombo");
+    string timeStrAfter = time:toString(time);
     return (timeStrBefore, timeStrAfter);
 }
 
 function testToTimezoneWithInvalidZone() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1456876583555, zoneValue);
-    time = time.toTimezone("test");
-    return time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    time:Time time = { time: 1456876583555, zone: zoneValue };
+    time = time:toTimezone(time, "test");
+    return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testToTimezoneWithDateTime() returns (string) {
     time:Time time = time:parse("2016-03-01T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    time = time.toTimezone("Asia/Colombo");
-    return time.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    time = time:toTimezone(time, "Asia/Colombo");
+    return time:format(time, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 }
 
 function testManualTimeCreate() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1498488382000, zoneValue);
-    return time.toString();
+    time:Time time = { time: 1498488382000, zone: zoneValue };
+    return time:toString(time);
 }
 
 function testManualTimeCreateWithNoZone() returns (int) {
     time:Timezone zoneValue = {zoneId:""};
-    time:Time time = new(1498488382555, zoneValue);
-    return time.year();
+    time:Time time = { time: 1498488382555, zone: zoneValue };
+    return time:getYear(time);
 }
 
 function testManualTimeCreateWithEmptyZone() returns (int) {
     time:Timezone zoneValue = {zoneId:""};
-    time:Time time = new(1498488382555, zoneValue);
-    return time.year();
+    time:Time time = { time: 1498488382555, zone: zoneValue };
+    return time:getYear(time);
 }
 
 function testManualTimeCreateWithInvalidZone() returns (int) {
     time:Timezone zoneValue = {zoneId:"test"};
-    time:Time time = new(1498488382555, zoneValue);
-    return time.year();
+    time:Time time = { time: 1498488382555, zone: zoneValue };
+    return time:getYear(time);
 }
 
 function testParseTimenvalidPattern() returns (int, string, int) {
@@ -186,33 +186,33 @@ function testParseTimenFormatMismatch() returns (int, string, int) {
 
 function testFormatTimeInvalidPattern() returns (string) {
     time:Timezone zoneValue = {zoneId:"America/Panama"};
-    time:Time time = new(1498488382444, zoneValue);
-    return time.format("test");
+    time:Time time = { time: 1498488382444, zone: zoneValue };
+    return time:format(time, "test");
 }
 
 function testParseTimeWithDifferentFormats() returns (int, int, int, int, int, int, int, string, string, string,
         string) {
     time:Time time = time:parse("2017", "yyyy");
-    int year = time.year();
+    int year = time:getYear(time);
     time = time:parse("03", "MM");
-    int month = time.month();
+    int month = time:getMonth(time);
     time = time:parse("31", "dd");
-    int day = time.day();
+    int day = time:getDay(time);
     time = time:parse("16", "HH");
-    int hour = time.hour();
+    int hour = time:getHour(time);
     time = time:parse("59", "mm");
-    int minute = time.minute();
+    int minute = time:getMinute(time);
     time = time:parse("58", "ss");
-    int second = time.second();
+    int second = time:getSecond(time);
     time = time:parse("999", "SSS");
-    int milliSecond = time.milliSecond();
+    int milliSecond = time:getMilliSecond(time);
     time = time:parse("2017/09/23", "yyyy/MM/dd");
-    string dateStr = time.format("yyyy-MM-dd");
+    string dateStr = time:format(time, "yyyy-MM-dd");
     time = time:parse("2015/02/15+0800", "yyyy/MM/ddZ");
-    string dateZoneStr = time.format("yyyy-MM-ddZ");
+    string dateZoneStr = time:format(time, "yyyy-MM-ddZ");
     time = time:parse("08/23/59.544+0700", "HH/mm/ss.SSSZ");
-    string timeZoneStr = time.format("HH-mm-ss-SSS:Z");
+    string timeZoneStr = time:format(time, "HH-mm-ss-SSS:Z");
     time = time:parse("2014/05/29-23:44:59.544", "yyyy/MM/dd-HH:mm:ss.SSS");
-    string datetimeStr = time.format("yyyy-MM-dd-HH:mm:ss.SSS");
+    string datetimeStr = time:format(time, "yyyy-MM-dd-HH:mm:ss.SSS");
     return (year, month, day, hour, minute, second, milliSecond, dateStr, dateZoneStr, timeZoneStr, datetimeStr);
 }


### PR DESCRIPTION
## Purpose
time:Time is currently an Object with a set of methods. But time:Time should rather be a record as it represent a point in time. Also the methods in the current time:Time object are more like util functions which shouldn't be changing the state of a given time:Time instance.
This PR converts time:Time from object->record and moves the methods of time:Time object out as util functions in the time library.