### PR TITLE
Improve error messages given when attempting to build/run a module without a ballerina project

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -113,9 +113,9 @@ public class LauncherUtils {
                     experimentalFlag);
         } else if (Files.isDirectory(sourceRootPath)) {
             if (Files.isDirectory(fullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
-                throw createLauncherException("did you mean to run the module ? If so, either run from the project " +
-                                              "folder or use --sourceroot to specify the project path and run the " +
-                                              "module");
+                throw createLauncherException("you are trying to run a module that is not inside " +
+                        "a project. Run `ballerina init` from " + sourceRootPath + " to initialize it as a " +
+                        "project and then run the module.");
             }
             if (Files.exists(fullPath)) {
                 if (Files.isRegularFile(fullPath) && !srcPathStr.endsWith(BLANG_SRC_FILE_SUFFIX)) {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -138,8 +138,9 @@ public class BuildCommand implements BLauncherCmd {
             } else if (Files.isDirectory(sourceRootPath)) { // If the source is a module from a project
                 // Checks if the source is a module and if its inside a project (with a .ballerina folder)
                 if (Files.isDirectory(resolvedFullPath) && !RepoUtils.hasProjectRepo(sourceRootPath)) {
-                    throw LauncherUtils.createLauncherException("did you mean to build the module ? If so build " +
-                                                                        "from the project folder");
+                    throw LauncherUtils.createLauncherException("you are trying to build a module that is not inside " +
+                            "a project. Run `ballerina init` from " + sourceRootPath + " to initialize it as a " +
+                            "project and then build the module.");
                 }
                 if (Files.isRegularFile(resolvedFullPath) && !sourcePath.toString().endsWith(BLANG_SRC_FILE_SUFFIX)) {
                     throw LauncherUtils.createLauncherException("only modules and " + BLANG_SRC_FILE_SUFFIX + " " +

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleBuildTestCase.java
@@ -314,6 +314,22 @@ public class ModuleBuildTestCase extends BaseTest {
                           projectPath.toString());
     }
 
+    @Test(description = "Test building a module which is not inside a project")
+    public void testBuildingModuleWithoutProject() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("moduleWithoutProject");
+        initProject(projectPath, SINGLE_PKG_PROJECT_OPTS);
+
+        // Remove the .ballerina folder
+        FileUtils.deleteDirectory(projectPath.resolve(".ballerina").toFile());
+
+        String msg = "error: you are trying to build a module that is not inside a project. Run `ballerina init` " +
+                "from " + projectPath.toString() + " to initialize it as a project and then build the module.";
+        LogLeecher leecher = new LogLeecher(msg, LeecherType.ERROR);
+        balClient.runMain("build", new String[] {"foo"}, envVariables, new String[0], new LogLeecher[]{leecher},
+                projectPath.toString());
+        leecher.waitForText(3000);
+    }
+
     /**
      * Init project.
      *

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleRunTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleRunTestCase.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.packaging;
 
+import org.apache.commons.io.FileUtils;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.context.LogLeecher;
@@ -83,6 +84,30 @@ public class ModuleRunTestCase extends BaseTest {
         balClient.runMain("run", new String[]{"otherpkg"}, envVariables, new String[0],
                           new LogLeecher[]{clientLeecher}, projectPath.toString());
         clientLeecher.waitForText(3000);
+    }
+
+    /**
+     * Test running a module that is not inside a project.
+     *
+     * @throws BallerinaTestException When an error occurs executing the command.
+     * @throws IOException            When an error occurs when creating directories.
+     */
+    @Test(description = "Test running a module with text files")
+    public void testRunModuleWithoutProject() throws BallerinaTestException, IOException {
+        Path projectPath = tempProjectDirectory.resolve("moduleWithoutProject");
+        Files.createDirectories(projectPath);
+        String[] options = {"\n", "\n", "\n", "m\n", "foo\n", "f\n"};
+        balClient.runMain("init", new String[]{"-i"}, envVariables, options, new LogLeecher[0], projectPath.toString());
+
+        // Remove the .ballerina folder
+        FileUtils.deleteDirectory(projectPath.resolve(".ballerina").toFile());
+
+        String msg = "error: you are trying to run a module that is not inside a project. Run `ballerina init` " +
+                "from " + projectPath.toString() + " to initialize it as a project and then run the module.";
+        LogLeecher leecher = new LogLeecher(msg, LeecherType.ERROR);
+        balClient.runMain("run", new String[] {"foo"}, envVariables, new String[0], new LogLeecher[]{leecher},
+                projectPath.toString());
+        leecher.waitForText(3000);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> $subject

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12943

## Automation tests
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes