### PR TITLE
Update the immutable values BBE to demonstrate that an is check on a frozen value is the same as an is like check

### DIFF
--- a/examples/immutable-values/immutable_values.bal
+++ b/examples/immutable-values/immutable_values.bal
@@ -72,6 +72,21 @@ public function main() {
     } else {
         io:println("'.freeze()' successful for m4");
     }
+
+    // An `is` check for a frozen value becomes an `is like` check.
+    // In other words, storage type is not considered.
+    // Define a `map` of constraint type `string` or `int`, but with
+    // values of type `string` only.
+    map<string|int> m5 = { valueType: "map", constraint: "string" };
+    // Freeze the `map`. The `.freeze()` attempt will be successful
+    // since the constraint is `anydata`. The frozen `map` only
+    // contains values of type `string`.
+    var frozenVal = m5.freeze();
+    // Checking if the frozen value is of type `map<string>` would
+    // evaluate to `true`.
+    if (frozenVal is map<string>) {
+        io:println("frozenVal is map<string>");
+    }
 }
 
 // Function to add an entry to a map.

--- a/examples/immutable-values/immutable_values.out
+++ b/examples/immutable-values/immutable_values.out
@@ -6,3 +6,4 @@ Frozen status of m1: true
 Error occurred on update: Invalid map insertion: modification not allowed on frozen value
 '.freeze()' successful for m3
 '.freeze()' failed for m4: 'freeze()' not allowed on 'Employee'
+frozenVal is map<string>

--- a/examples/immutable-values/tests/immutable_values_test.bal
+++ b/examples/immutable-values/tests/immutable_values_test.bal
@@ -30,4 +30,5 @@ function testFunc() {
     test:assertEquals(outputs[7], "'.freeze()' failed for m4: ");
     string output8 = <string> outputs[8];
     test:assertTrue(output8.hasPrefix("'freeze()' not allowed on '") && output8.hasSuffix("Employee'"));
+    test:assertEquals(outputs[9], "frozenVal is map<string>");
 }


### PR DESCRIPTION
## Purpose
Update the immutable values BBE to demonstrate that an is check on a frozen value is the same as an is like check.

Resolves https://github.com/ballerina-platform/ballerina-lang/issues/12931