### PR TITLE
Disable TableTest#testCloseConnectionPool

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -535,7 +535,7 @@ public class TableTest {
     }
 
     @Test(dependsOnGroups = TABLE_TEST,
-          description = "Check whether all sql connectors are closed properly.")
+          description = "Check whether all sql connectors are closed properly.", enabled = false) //Issue #9048
     public void testCloseConnectionPool() {
         BValue connectionCountQuery = new BString("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SESSIONS");
         BValue[] args = { connectionCountQuery };


### PR DESCRIPTION
## Purpose
$Subject. Tracked by #9048
#9048 was observed again in Jenkins released build but not locally. Only one connection seems to be kept open unnecessarily.
