### PR TITLE
Fix nested if statement flow problem in debugger

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -3090,8 +3090,7 @@ public class BVM {
             return false;
         }
 
-        int opcode = ctx.currentFrame.code[ctx.currentFrame.ip].getOpcode();
-        if (isIgnorableInstruction(opcode)) {
+        if (isIgnorableInstruction(ctx)) {
             return false;
         }
         
@@ -3137,7 +3136,8 @@ public class BVM {
         return false;
     }
 
-    private static boolean isIgnorableInstruction(int opcode) {
+    private static boolean isIgnorableInstruction(Strand ctx) {
+        int opcode = ctx.currentFrame.code[ctx.currentFrame.ip].getOpcode();
         return opcode == InstructionCodes.GOTO;
     }
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -3090,6 +3090,11 @@ public class BVM {
             return false;
         }
 
+        int opcode = ctx.currentFrame.code[ctx.currentFrame.ip].getOpcode();
+        if (isIgnorableInstruction(opcode)) {
+            return false;
+        }
+        
         LineNumberInfo currentExecLine = debugger
                 .getLineNumber(ctx.currentFrame.callableUnitInfo.getPackageInfo().getPkgPath(), ctx.currentFrame.ip);
         /*
@@ -3130,6 +3135,10 @@ public class BVM {
                 debugger.stopDebugging();
         }
         return false;
+    }
+
+    private static boolean isIgnorableInstruction(int opcode) {
+        return opcode == InstructionCodes.GOTO;
     }
 
     /**

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/emitter/BalxEmitter.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/emitter/BalxEmitter.java
@@ -20,12 +20,14 @@ package org.ballerinalang.bre.emitter;
 import org.ballerinalang.util.codegen.ErrorTableEntry;
 import org.ballerinalang.util.codegen.FunctionInfo;
 import org.ballerinalang.util.codegen.Instruction;
+import org.ballerinalang.util.codegen.LineNumberInfo;
 import org.ballerinalang.util.codegen.LocalVariableInfo;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.codegen.attributes.AttributeInfo;
 import org.ballerinalang.util.codegen.attributes.CodeAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.ErrorTableAttributeInfo;
+import org.ballerinalang.util.codegen.attributes.LineNumberTableAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.LocalVariableAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.ParameterAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.VarTypeCountAttributeInfo;
@@ -240,10 +242,19 @@ public class BalxEmitter {
                 }
                 println(tabs + "}");
                 break;
+            case LINE_NUMBER_TABLE_ATTRIBUTE:
+                LineNumberTableAttributeInfo lineInfo = (LineNumberTableAttributeInfo) attr;
+                println(" {");
+                for (LineNumberInfo lineNumberInfo : lineInfo.getLineNumberInfoEntries()) {
+                    println(tabs + "\t" + "fileName - " + lineNumberInfo.getFileName() +
+                            tabs + "\t" + "lineNumber - " + lineNumberInfo.getLineNumber() +
+                            tabs + "\t" + "ip - " + lineNumberInfo.getIp());
+                }
+                println(tabs + "}");
+                break;
             case TAINT_TABLE:
             case ANNOTATIONS_ATTRIBUTE:
             case DEFAULT_VALUE_ATTRIBUTE:
-            case LINE_NUMBER_TABLE_ATTRIBUTE:
             case PARAMETER_DEFAULTS_ATTRIBUTE:
             case DOCUMENT_ATTACHMENT_ATTRIBUTE:
             case PARAMETER_ANNOTATIONS_ATTRIBUTE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1430,7 +1430,7 @@ public class Desugar extends BLangNodeVisitor {
         ifNode.body = rewrite(ifNode.body, env);
 
         if (ifNode.elseStmt != null && ifNode.elseStmt.getKind() == NodeKind.BLOCK) {
-            defineTypeGuards(ifNode.pos, ifNode.elseTypeGuards, (BLangBlockStmt) ifNode.elseStmt);
+            defineTypeGuards(ifNode.elseStmt.pos, ifNode.elseTypeGuards, (BLangBlockStmt) ifNode.elseStmt);
         }
         ifNode.elseStmt = rewrite(ifNode.elseStmt, env);
         result = ifNode;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -208,6 +208,22 @@ public class VMDebuggerTest {
         VMDebuggerUtil.startDebug("test-src/debugger/test-debug.bal", breakPoints, expRes);
     }
 
+    @Test(description = "Testing nested IfCondition.")
+    public void testNestedIf() {
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test_nested_if.bal", 2);
+        String file = "test_nested_if.bal";
+
+        List<DebugPoint> debugPoints = new ArrayList<>();
+        debugPoints.add(Util.createDebugPoint(".", file, 2, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 4, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 5, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1));
+
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 4, 0, new ArrayList<>(), false);
+
+        VMDebuggerUtil.startDebug("test-src/debugger/test_nested_if.bal", breakPoints, expRes);
+    }
+
     @Test(description = "Testing Step over in WhileStmt.")
     public void testStepOverWhileStmt() {
         BreakPointDTO[] breakPoints = createBreakNodeLocations(".", FILE, 13, 14, 20, 22);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -210,14 +210,14 @@ public class VMDebuggerTest {
 
     @Test(description = "Testing nested IfCondition.")
     public void testNestedIf() {
-        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test_nested_if.bal", 2);
+        BreakPointDTO[] breakPoints = createBreakNodeLocations(".", "test_nested_if.bal", 18);
         String file = "test_nested_if.bal";
 
         List<DebugPoint> debugPoints = new ArrayList<>();
-        debugPoints.add(Util.createDebugPoint(".", file, 2, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 4, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 5, STEP_OVER, 1));
-        debugPoints.add(Util.createDebugPoint(".", file, 13, RESUME, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 18, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 20, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 21, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 29, RESUME, 1));
 
         ExpectedResults expRes = new ExpectedResults(debugPoints, 4, 0, new ArrayList<>(), false);
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_nested_if.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_nested_if.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 public function main(string... args) {
     any x = 4;
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_nested_if.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/debugger/test_nested_if.bal
@@ -1,0 +1,13 @@
+public function main(string... args) {
+    any x = 4;
+
+    if (3 + 3 == 6) {
+        if (4 + 4 == 7) {
+            float f = 21.0;
+            int c = 34;
+            int c1 = 32;
+        }
+    } else {
+        int y = 34;
+    }
+}


### PR DESCRIPTION
## Purpose
This PR fixes #13040. The root cause for the aforementioned issue is `GOTO` instructions got assigned the line number of the last statement of the `if block` it belongs. Hence, the debugger shows the last line of the inner if block as a line hit. This issue is resolved by ignoring the `GOTO` instructions during the debugging process.

## Automation tests
 - Unit tests 
   > Added
