### PR TITLE
Add formatting support for markdown doc

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingNodeTree.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingNodeTree.java
@@ -899,8 +899,38 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatDocumentationParameterNode(JsonObject node) {
-        // TODO: fix formatting for documentation node.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+
+            // Calculate indentation for the documentation parameter.
+            String indentation = (formatConfig.get(FormattingConstants.DO_INDENT).getAsBoolean()
+                    ? (this.getWhiteSpaces(formatConfig.get(FormattingConstants.INDENTED_START_COLUMN).getAsInt()) +
+                    FormattingConstants.SPACE_TAB)
+                    : this.getWhiteSpaces(formatConfig.get(FormattingConstants.INDENTED_START_COLUMN).getAsInt()));
+
+            // Save new lines of a whitespace if available.
+            this.preserveHeight(ws, indentation);
+
+            // Iterate through whitespaces and update accordingly.
+            for (int i = 0; i < ws.size(); i++) {
+                JsonObject currentWS = ws.get(i).getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                    String[] splitText = text.split(" ");
+
+                    // If text equals `#` or has `#` and `+` in order or has `#`, `+`, `return` and `-`
+                    // Change the whitespace for the current whitespace.
+                    if (text.equals("#")
+                            || (splitText.length == 2 && splitText[0].equals("#") && splitText[1].equals("+"))
+                            || (splitText.length == 4 && splitText[0].equals("#")
+                            && splitText[1].equals("+") && splitText[2].equals("return") && splitText[3].equals("-"))) {
+                        currentWS.addProperty(FormattingConstants.WS, this.getNewLines(formatConfig
+                                .get(FormattingConstants.NEW_LINE_COUNT).getAsInt()) + indentation);
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -909,8 +939,44 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatMarkdownDocumentationNode(JsonObject node) {
-        // TODO: fix formatting for documentation node.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+
+            // Calculate indentation for the documentation parameter.
+            String indentation = (formatConfig.get(FormattingConstants.DO_INDENT).getAsBoolean()
+                    ? (this.getWhiteSpaces(formatConfig.get(FormattingConstants.INDENTED_START_COLUMN).getAsInt()) +
+                    FormattingConstants.SPACE_TAB)
+                    : this.getWhiteSpaces(formatConfig.get(FormattingConstants.INDENTED_START_COLUMN).getAsInt()));
+
+            // Save new lines of a whitespace if available.
+            this.preserveHeight(ws, indentation);
+
+            // Iterate through whitespaces and update accordingly.
+            for (int i = 0; i < ws.size(); i++) {
+                JsonObject currentWS = ws.get(i).getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                    if (text.equals("#")) {
+                        currentWS.addProperty(FormattingConstants.WS, this.getNewLines(formatConfig
+                                .get(FormattingConstants.NEW_LINE_COUNT).getAsInt()) + indentation);
+                    }
+                }
+            }
+
+            if (node.has("parameters")
+                    && node.getAsJsonArray("parameters").size() > 0) {
+                JsonArray parameters = node.getAsJsonArray("parameters");
+                for (JsonElement parameter : parameters) {
+                    parameter.getAsJsonObject().add(FormattingConstants.FORMATTING_CONFIG, formatConfig);
+                }
+            }
+
+            if (node.has("returnParameter")) {
+                JsonObject returnParameter = node.getAsJsonObject("returnParameter");
+                returnParameter.getAsJsonObject().add(FormattingConstants.FORMATTING_CONFIG, formatConfig);
+            }
+        }
     }
 
     /**
@@ -1342,6 +1408,9 @@ public class FormattingNodeTree {
 
             // Update whitespaces of annotation attachments.
             modifyAnnotationAttachments(node, formatConfig, indentation);
+
+            // Update whitespaces of markdown documentation attachments.
+            modifyMarkdownDocumentation(node, formatConfig, indentation);
 
             // Update whitespaces for rest parameters.
             if (node.has("restParameters")) {
@@ -3441,6 +3510,12 @@ public class FormattingNodeTree {
                     node.getAsJsonObject("typeNode").add(FormattingConstants.FORMATTING_CONFIG, typeNodeFormatConfig);
                 }
             }
+
+            // Update whitespaces of annotation attachments.
+            modifyAnnotationAttachments(node, formatConfig, indentation);
+
+            // Update whitespaces of markdown documentation attachments.
+            modifyMarkdownDocumentation(node, formatConfig, indentation);
         }
     }
 
@@ -4282,6 +4357,20 @@ public class FormattingNodeTree {
 
                 annotationAttachment.add(FormattingConstants.FORMATTING_CONFIG, annotationFormattingConfig);
             }
+        }
+    }
+
+    private void modifyMarkdownDocumentation(JsonObject node, JsonObject formatConfig, String indentation) {
+        if (node.has("markdownDocumentationAttachment")) {
+            JsonObject markdownDocumentationAttachment = node.getAsJsonObject("markdownDocumentationAttachment");
+            JsonObject markdownDocumentationAttachmentConfig = this.getFormattingConfig(
+                    formatConfig.get(FormattingConstants.NEW_LINE_COUNT).getAsInt(), 0,
+                    formatConfig.get(FormattingConstants.START_COLUMN).getAsInt(),
+                    false,
+                    this.getWhiteSpaceCount(indentation));
+            markdownDocumentationAttachment.add(FormattingConstants.FORMATTING_CONFIG,
+                    markdownDocumentationAttachmentConfig);
+
         }
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -112,6 +112,7 @@ public class FormattingTest {
                 {"expectedArrowExpr.bal", "arrowExpr.bal"},
                 {"expectedAsyncExpr.bal", "asyncExpr.bal"},
                 {"expectedBindingPatterns.bal", "bindingPatterns.bal"},
+                {"expectedDocumentation.bal", "documentation.bal"},
 //                {"expectedImportOrder.bal", "importOrder.bal"},
         };
     }

--- a/language-server/modules/langserver-core/src/test/resources/formatting/documentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/documentation.bal
@@ -1,0 +1,44 @@
+ // This is the documentation attachment for function `doThatOnObject`.
+  # `doThatOnObject` is an attached function for the object `DummyObject`.
+  #
+ # + paramOne - This is the description for the parameter of
+   #              `doThatOnObject` function.
+ # + return - This is the description for the return value of
+  #            `doThatOnObject` function.
+public function doThatOnObject(string paramOne) returns (boolean) {
+    return true;
+}
+
+   // This is the documentation attachment for the `DummyRecord` record.
+   # `DummyRecord` is a user defined record.
+    # This `DummyRecord` has a `string` data field and an `int` data field.
+  #
+    # + fieldOne - This is the description for `DummyRecord`'s field `fieldOne`.
+   # + fieldTwo - This is the description for `DummyRecord`'s field `fieldTwo`.
+public type DummyRecord record {
+    string fieldOne;
+    int fieldTwo;
+};
+
+// This is the documentation attachment for the `DummyObject` object.
+      # `DummyObject` is a user defined object.
+   # This `DummyObject` has two `string` data fields and one attached
+    # function definition `doThatOnObject` that performs a certain functionality
+    # on the associated `DummyObject` instance.
+   #
+    # + fieldOne - This is the description for the `DummyObject`'s field `fieldOne`.
+   # + fieldTwo - This is the description for the `DummyObject`'s field `fieldTwo`.
+public type DummyObject abstract object {
+
+    public string fieldOne;
+    public string fieldTwo;
+
+// This is the documentation attachment for function `doThatOnObjectAgain`.
+# `doThatOnObjectAgain` is an attached function for the object `DummyObject`.
+       #
+          # + paramOne - This is the description for the parameter of
+       #              `doThatOnObjectAgain` function.
+         # + return - This is the description for the return value of
+      #            `doThatOnObjectAgain` function.
+    public function doThatOnObjectAgain(string paramOne) returns (boolean);
+};

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedDocumentation.bal
@@ -1,0 +1,44 @@
+// This is the documentation attachment for function `doThatOnObject`.
+# `doThatOnObject` is an attached function for the object `DummyObject`.
+#
+# + paramOne - This is the description for the parameter of
+#              `doThatOnObject` function.
+# + return - This is the description for the return value of
+#            `doThatOnObject` function.
+public function doThatOnObject(string paramOne) returns (boolean) {
+    return true;
+}
+
+// This is the documentation attachment for the `DummyRecord` record.
+# `DummyRecord` is a user defined record.
+# This `DummyRecord` has a `string` data field and an `int` data field.
+#
+# + fieldOne - This is the description for `DummyRecord`'s field `fieldOne`.
+# + fieldTwo - This is the description for `DummyRecord`'s field `fieldTwo`.
+public type DummyRecord record {
+    string fieldOne;
+    int fieldTwo;
+};
+
+// This is the documentation attachment for the `DummyObject` object.
+# `DummyObject` is a user defined object.
+# This `DummyObject` has two `string` data fields and one attached
+# function definition `doThatOnObject` that performs a certain functionality
+# on the associated `DummyObject` instance.
+#
+# + fieldOne - This is the description for the `DummyObject`'s field `fieldOne`.
+# + fieldTwo - This is the description for the `DummyObject`'s field `fieldTwo`.
+public type DummyObject abstract object {
+
+    public string fieldOne;
+    public string fieldTwo;
+
+    // This is the documentation attachment for function `doThatOnObjectAgain`.
+    # `doThatOnObjectAgain` is an attached function for the object `DummyObject`.
+    #
+    # + paramOne - This is the description for the parameter of
+    #              `doThatOnObjectAgain` function.
+    # + return - This is the description for the return value of
+    #            `doThatOnObjectAgain` function.
+    public function doThatOnObjectAgain(string paramOne) returns (boolean);
+};


### PR DESCRIPTION
## Purpose
This will add formatting support for markdown documentation in ballerina. For now we only fix the indentation of the documentation. 