### PR TITLE
Remove single quote from example

### DIFF
--- a/examples/grpc-bidirectional-streaming/tests/grpc_bidirectional_streaming_test.bal
+++ b/examples/grpc-bidirectional-streaming/tests/grpc_bidirectional_streaming_test.bal
@@ -41,7 +41,7 @@ function testBidiStreamingService() {
     test:assertEquals(received, true, msg = "Server message didn't receive.");
     string expected = "Sam: Hi";
     test:assertEquals(responseMsg, expected);
-    // Once all messages are sent, client send complete message to notify the server, I’m done.
+    // Once all messages are sent, client send complete message to notify the server, I am done.
     _ = ep->complete();
 }
 


### PR DESCRIPTION
## Purpose
Jenkins fails due to a Unicode issue which doesn't render single quote. Until find a solution remove the single quote from the test case.