### PR TITLE
Restrict private visibility in abstract objects

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -63,6 +63,8 @@ public enum DiagnosticCode {
     CANNOT_ATTACH_FUNCTIONS_TO_ABSTRACT_OBJECT("cannot.attach.functions.to.abstract.object"),
     ABSTRACT_OBJECT_FUNCTION_CANNOT_HAVE_BODY("abstract.object.function.cannot.have.body"),
     PRIVATE_OBJECT_CONSTRUCTOR("private.object.constructor"),
+    PRIVATE_FIELD_ABSTRACT_OBJECT("private.field.abstract.object"),
+    PRIVATE_FUNC_ABSTRACT_OBJECT("private.function.abstract.object"),
     OBJECT_INIT_FUNCTION_CANNOT_BE_EXTERN("object.init.function.cannot.be.extern"),
 
     INCOMPATIBLE_TYPES("incompatible.types"),

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -622,6 +622,12 @@ error.object.init.function.cannot.be.extern=\
 error.private.object.constructor=\
   object initializer function can not be declared as private
 
+error.private.field.abstract.object=\
+  abstract object field: ''{0}'' can not be declared as private
+
+error.private.function.abstract.object=\
+  abstract object method: ''{0}'' can not be declared as private
+
 error.incompatible.type.reference=\
   incompatible types: ''{0}'' is not an abstract object
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/object/AbstractObjectTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/object/AbstractObjectTest.java
@@ -49,6 +49,10 @@ public class AbstractObjectTest {
                 "function 'getName' in abstract object 'Person4' cannot have a body", 51, 5);
         BAssertUtil.validateError(negativeResult, index++,
                 "cannot attach function 'getName' to abstract object 'Person5'", 67, 1);
+        BAssertUtil.validateError(negativeResult, index++, "abstract object field: 'age' can not be declared as " +
+                "private", 73, 5);
+        BAssertUtil.validateError(negativeResult, index++, "abstract object method: 'getName' can not be declared as "
+                + "private", 76, 5);
     }
 
     @Test

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/abstract-object-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/abstract-object-negative.bal
@@ -67,3 +67,11 @@ type Person5 abstract object {
 function Person5.getName() returns string {
     return "my name";
 }
+
+// Abstract object with private field
+type Person6 abstract object {
+    private int age = 0;
+    public string name = "";
+
+    private function getName() returns string;
+};


### PR DESCRIPTION
Private fields and methods are not allowed in an abstract object.