### PR TITLE
Disallow use of var with non-reducing iterable ops

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
@@ -592,7 +592,7 @@ public class IterableAnalyzer {
             } else if (expectedType.tag == TypeTags.TUPLE) {
                 context.resultType = symTable.semanticError;
                 return;
-            } else if (expectedType.tag == TypeTags.ANY) {
+            } else if (expectedType.tag == TypeTags.ANY || expectedType.tag == TypeTags.ANYDATA) {
                 context.resultType = symTable.semanticError;
                 dlog.error(lastOperation.pos, DiagnosticCode.ITERABLE_RETURN_TYPE_MISMATCH, lastOperation.kind);
                 return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -75,6 +75,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangBracedOrTupleExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
@@ -509,6 +510,16 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
         BLangExpression varRefExpr = variable.expr;
         BType rhsType = typeChecker.checkExpr(varRefExpr, this.env, symTable.noType);
+
+        if (varRefExpr.getKind() == NodeKind.INVOCATION) {
+            BLangInvocation iterableInv = (BLangInvocation) varRefExpr;
+            if (iterableInv.iterableOperationInvocation &&
+                    iterableInv.iContext.getLastOperation().resultType.tag == TypeTags.INTERMEDIATE_COLLECTION) {
+                dlog.error(variable.pos, DiagnosticCode.ITERABLE_RETURN_TYPE_MISMATCH,
+                           iterableInv.iContext.getLastOperation().kind);
+                return;
+            }
+        }
 
         if (NodeKind.VARIABLE == variable.getKind()) {
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
@@ -51,7 +51,7 @@ public class IterableOperationsTests {
 
     @Test
     public void testNegative() {
-        Assert.assertEquals(negative.getErrorCount(), 26);
+        Assert.assertEquals(negative.getErrorCount(), 31);
 
         int index = 0;
         BAssertUtil.validateError(negative, index++, "undefined function 'int.foreach'", 6, 5);
@@ -93,8 +93,21 @@ public class IterableOperationsTests {
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'int[]', found 'string[]'", 93, 30);
         BAssertUtil.validateError(negative, index++, "not enough variables are defined for iterable type 'map', " +
                 "require at least '2' variables", 99, 27);
-        BAssertUtil.validateError(negative, index, "not enough variables are defined for iterable type 'map', require" +
+        BAssertUtil.validateError(negative, index++,
+                                  "not enough variables are defined for iterable type 'map', require" +
                 " at least '2' variables", 103, 22);
+        BAssertUtil.validateError(negative, index++,
+                                  "cannot assign return value of 'filter' operation here, use a reduce operation",
+                                  110, 5);
+        BAssertUtil.validateError(negative, index++, "undefined symbol 'filtered'", 113, 17);
+        BAssertUtil.validateError(negative, index++,
+                                  "cannot assign return value of 'map' operation here, use a reduce operation",
+                                  118, 5);
+        BAssertUtil.validateError(negative, index++,
+                                  "invalid operation: type '(int) collection' does not support indexing", 129, 13);
+        BAssertUtil.validateError(negative, index,
+                                  "cannot assign return value of 'map' operation here, use a reduce operation",
+                                  141, 19);
     }
 
     @Test

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/iterable-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/iterable-negative.bal
@@ -104,3 +104,41 @@ function test11() {
          return s == null;
     });
 }
+
+function testVarInLHS() {
+    int[] numbers = [-5, -3, 2, 7, 12];
+    var filtered = numbers.filter(function (int i) returns boolean {
+            return i >= 0;
+        });
+    float avg = filtered.average();
+}
+
+function testVarInLHS2() {
+    int[] numbers = [-5, -3, 2, 7, 12];
+    var mapped = numbers.map(function(int value) returns float {
+            return float.convert(value);
+        }).filter(function (float value) returns boolean {
+            return value > 0;
+        }).map(function (float value) returns (string, float) {
+            return (string.convert(value), value);
+        });
+}
+
+function testIndexBasedAccess() {
+    int[] numbers = [-5, -3, 2, 7, 12];
+    var x = numbers.filter(function (int i) returns boolean {
+            return i >= 0;
+        })[0];
+}
+
+int[] globalNumbers = [-5, -3, 2, 7, 12];
+
+function testAnydataInLHS() {
+    anydata mapped = globalNumbers.map(function(int value) returns float {
+               return float.convert(value);
+           }).filter(function (float value) returns boolean {
+               return value > 0;
+           }).map(function (float value) returns (string, float) {
+               return (string.convert(value), value);
+           });
+}


### PR DESCRIPTION
## Purpose
>With this PR, use of `var` with iterable op chains ending with `map()` and `filter()` is disallowed. This is because we use the type of the LHS variable to determine the type to which we should reduce the intermediate collection generated by `map()` and `filter()` ops. This also disallows the use of `anydata` in the LHS as well. Fix #12923 