### PR TITLE
Update the testgrid yamls' scenario config names

### DIFF
--- a/.testgrid-data.yaml
+++ b/.testgrid-data.yaml
@@ -27,7 +27,7 @@ scenarioConfigs:
 - testType: JMETER
   remoteRepository: "https://github.com/ballerina-platform/ballerina-lang.git"
   remoteBranch: "ballerina-scenarios"
-  name: "ballerina-scenarios"
+  name: "ballerinaScenarios"
   description: "ballerina-scenarios"
   file: product-scenarios/test-data.sh
 deploymentConfig:

--- a/.testgrid-http.yaml
+++ b/.testgrid-http.yaml
@@ -27,6 +27,6 @@ scenarioConfigs:
 - testType: TESTNG
   remoteRepository: "https://github.com/ballerina-platform/ballerina-lang.git"
   remoteBranch: "ballerina-scenarios"
-  name: "ballerina-scenarios"
+  name: "ballerinaScenarios"
   description: "ballerina-scenarios"
   file: product-scenarios/test-http.sh


### PR DESCRIPTION
## Purpose
$Subject
TestGrid creates the test output directories using this name, and for some reason the non alpha-numeric charactors are discarded at some stage casuing file paths to be inconsistent with the actual directory name. Not known whether it is a bug or not yet
