### PR TITLE
Fix config-api unit test failure in windows

### DIFF
--- a/bvm/ballerina-config/src/main/java/org/ballerinalang/config/ConfigProcessor.java
+++ b/bvm/ballerina-config/src/main/java/org/ballerinalang/config/ConfigProcessor.java
@@ -21,6 +21,7 @@ package org.ballerinalang.config;
 import org.antlr.v4.runtime.ANTLRFileStream;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.ballerinalang.bcl.parser.BConfig;
 import org.ballerinalang.bcl.parser.BConfigLangListener;
 import org.ballerinalang.toml.antlr4.TomlProcessor;
@@ -166,7 +167,7 @@ public class ConfigProcessor {
                 (key, val) -> stringBuilder.append(key)
                                             .append('=')
                                             // TODO: need to handle this in a better way
-                                            .append('\"').append(val).append('\"')
+                                            .append('\"').append(StringEscapeUtils.escapeJava(val)).append('\"')
                                             .append('\n'));
         ANTLRInputStream runtimeConfigsStream = new ANTLRInputStream(stringBuilder.toString());
         BConfig runtimeConfigEntries = new BConfig();

--- a/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/EncryptedConfigsTest.java
+++ b/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/EncryptedConfigsTest.java
@@ -143,6 +143,7 @@ public class EncryptedConfigsTest {
     }
 
     private void copySecret(String from, String to) throws IOException {
+        Files.deleteIfExists(Paths.get(resourceRoot, "datafiles", to));
         Files.copy(Paths.get(resourceRoot, "datafiles", from),
                    Paths.get(resourceRoot, "datafiles", to));
     }


### PR DESCRIPTION
## Purpose
$subject. Test failures are due to special characters in windows file path.