### PR TITLE
Fix intermittent ballerina example test failure in service streaming

### DIFF
--- a/examples/grpc-server-streaming/tests/grpc_server_streaming_test.bal
+++ b/examples/grpc-server-streaming/tests/grpc_server_streaming_test.bal
@@ -21,7 +21,7 @@ function testServerStreamingService() {
     }
 
     int waitCount = 0;
-    while(!completed) {
+    while(!completed && (responseMsgs.length() < 3)) {
         runtime:sleep(1000);
         if (waitCount > 10) {
             break;


### PR DESCRIPTION
## Purpose
Fix intermittent ballerina example test failure in gRPC service streaming 