### PR TITLE
Fix windows test failure for workers

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllWorkersTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllWorkersTest.java
@@ -60,7 +60,8 @@ public class WaitForAllWorkersTest {
     public void sendToFork() {
         BRunUtil.invoke(result, "testWaitForAllWorkers", new BValue[0]);
         String s = getSysOut();
-        Assert.assertEquals(s, "Finishing Default Worker\nFinishing Worker w2\n");
+        Assert.assertEquals(s, "Finishing Default Worker" + System.lineSeparator() + "Finishing Worker w2"
+                + System.lineSeparator());
     }
 
     @AfterMethod


### PR DESCRIPTION
## Purpose
WaitForAllWorkersTest failed in windows due to a string mismatch as expected string has `\n` as line separator but in windows the actual string returns has `\r\n` as line separator. This commit will add the system line separator in to the expected value.