### PR TITLE
Ignore appveyor build status for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  ci:
+    - travis
+    - !appveyor                # ignore CI builds by AppVeyor


### PR DESCRIPTION
## Purpose
Ignore appveyor build status  for codecov because we dont upload coverage reports during appveyor build