### PR TITLE
Introduce NaN, Infinity concepts in decimal type

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -1949,8 +1949,8 @@ public class BVM {
         int i;
         int j;
         int k;
-        BigDecimal lhsValue;
-        BigDecimal rhsValue;
+        BDecimal lhsValue;
+        BDecimal rhsValue;
 
         switch (opcode) {
             case InstructionCodes.IADD:
@@ -1975,9 +1975,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                sf.refRegs[k] = new BDecimal(lhsValue.add(rhsValue, MathContext.DECIMAL128));
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.refRegs[k] = lhsValue.add(rhsValue);
                 break;
             case InstructionCodes.XMLADD:
                 i = operands[0];
@@ -2005,9 +2005,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                sf.refRegs[k] = new BDecimal(lhsValue.subtract(rhsValue, MathContext.DECIMAL128));
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.refRegs[k] = lhsValue.subtract(rhsValue);
                 break;
             case InstructionCodes.IMUL:
                 i = operands[0];
@@ -2025,9 +2025,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                sf.refRegs[k] = new BDecimal(lhsValue.multiply(rhsValue, MathContext.DECIMAL128));
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.refRegs[k] = lhsValue.multiply(rhsValue);
                 break;
             case InstructionCodes.IDIV:
                 i = operands[0];
@@ -2052,16 +2052,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                if (rhsValue.compareTo(BigDecimal.ZERO) == 0) {
-                    ctx.setError(BLangVMErrors.createError(ctx, BallerinaErrorReasons.DIVISION_BY_ZERO_ERROR,
-                                                           " / by zero"));
-                    handleError(ctx);
-                    break;
-                }
-
-                sf.refRegs[k] = new BDecimal(lhsValue.divide(rhsValue, MathContext.DECIMAL128));
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.refRegs[k] = lhsValue.divide(rhsValue);
                 break;
             case InstructionCodes.IMOD:
                 i = operands[0];
@@ -2086,16 +2079,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                if (rhsValue.compareTo(BigDecimal.ZERO) == 0) {
-                    ctx.setError(BLangVMErrors.createError(ctx, BallerinaErrorReasons.DIVISION_BY_ZERO_ERROR,
-                                                           " / by zero"));
-                    handleError(ctx);
-                    break;
-                }
-
-                sf.refRegs[k] = new BDecimal(lhsValue.remainder(rhsValue, MathContext.DECIMAL128));
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.refRegs[k] = lhsValue.remainder(rhsValue);
                 break;
             case InstructionCodes.INEG:
                 i = operands[0];
@@ -2146,9 +2132,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                sf.intRegs[k] = lhsValue.compareTo(rhsValue) == 0 ? 1 : 0;
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.intRegs[k] = lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) == 0 ? 1 : 0;
                 break;
             case InstructionCodes.REQ:
                 i = operands[0];
@@ -2205,9 +2191,9 @@ public class BVM {
                 i = operands[0];
                 j = operands[1];
                 k = operands[2];
-                lhsValue = ((BDecimal) sf.refRegs[i]).decimalValue();
-                rhsValue = ((BDecimal) sf.refRegs[j]).decimalValue();
-                sf.intRegs[k] = lhsValue.compareTo(rhsValue) != 0 ? 1 : 0;
+                lhsValue = (BDecimal) sf.refRegs[i];
+                rhsValue = (BDecimal) sf.refRegs[j];
+                sf.intRegs[k] = lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) != 0 ? 1 : 0;
                 break;
             case InstructionCodes.RNE:
                 i = operands[0];

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -45,6 +45,7 @@ import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.model.types.BUnionType;
 import org.ballerinalang.model.types.TypeConstants;
 import org.ballerinalang.model.types.TypeTags;
+import org.ballerinalang.model.util.DecimalValueKind;
 import org.ballerinalang.model.util.Flags;
 import org.ballerinalang.model.util.JSONUtils;
 import org.ballerinalang.model.util.ListUtils;
@@ -2770,10 +2771,11 @@ public class BVM {
             case InstructionCodes.D2I:
                 i = operands[0];
                 j = operands[1];
-                if (!isDecimalWithinIntRange(((BDecimal) sf.refRegs[i]).decimalValue())) {
+                BDecimal decimal = (BDecimal) sf.refRegs[i];
+                if (decimal.valueKind == DecimalValueKind.NOT_A_NUMBER ||
+                        !isDecimalWithinIntRange((decimal.decimalValue()))) {
                     ctx.setError(BLangVMErrors.createError(ctx, BallerinaErrorReasons.NUMBER_CONVERSION_ERROR,
-                                                           "out of range 'decimal' value '" + sf.refRegs[i] +
-                                                                   "' cannot be converted to 'int'"));
+                            "out of range 'decimal' value '" + decimal + "' cannot be converted to 'int'"));
                     handleError(ctx);
                     break;
                 }
@@ -2881,8 +2883,8 @@ public class BVM {
     }
 
     public static boolean isDecimalWithinIntRange(BigDecimal decimalValue) {
-        return decimalValue.compareTo(BINT_MAX_VALUE_BIG_DECIMAL_RANGE_MAX) == -1 &&
-                decimalValue.compareTo(BINT_MIN_VALUE_BIG_DECIMAL_RANGE_MIN) == 1;
+        return decimalValue.compareTo(BINT_MAX_VALUE_BIG_DECIMAL_RANGE_MAX) < 0 &&
+                decimalValue.compareTo(BINT_MIN_VALUE_BIG_DECIMAL_RANGE_MIN) > 0;
     }
 
     private static void execIteratorOperation(Strand ctx, StackFrame sf, Instruction instruction) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/DecimalValueKind.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/DecimalValueKind.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.model.util;
+
+/**
+ * Possible kinds of a decimal value
+ */
+public enum DecimalValueKind {
+    ZERO,
+    POSITIVE_INFINITY,
+    NEGATIVE_INFINITY,
+    NOT_A_NUMBER,
+    OTHER
+}

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/DecimalValueKind.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/DecimalValueKind.java
@@ -19,7 +19,9 @@
 package org.ballerinalang.model.util;
 
 /**
- * Possible kinds of a decimal value
+ * Possible kinds of a decimal value.
+ *
+ * @since 0.991
  */
 public enum DecimalValueKind {
     ZERO,

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/DecimalValueKind.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/util/DecimalValueKind.java
@@ -24,9 +24,19 @@ package org.ballerinalang.model.util;
  * @since 0.991
  */
 public enum DecimalValueKind {
-    ZERO,
-    POSITIVE_INFINITY,
-    NEGATIVE_INFINITY,
-    NOT_A_NUMBER,
-    OTHER
+    ZERO("0.0"),
+    POSITIVE_INFINITY("Infinity"),
+    NEGATIVE_INFINITY("-Infinity"),
+    NOT_A_NUMBER("NaN"),
+    OTHER("Other");
+
+    private String value;
+
+    DecimalValueKind(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
@@ -101,17 +101,8 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
     @Override
     public String stringValue() {
-        if (this.valueKind == DecimalValueKind.POSITIVE_INFINITY) {
-            return "Infinity";
-        }
-        if (this.valueKind == DecimalValueKind.NEGATIVE_INFINITY) {
-            return "-Infinity";
-        }
-        if (this.valueKind == DecimalValueKind.NOT_A_NUMBER) {
-            return "NaN";
-        }
-        if (this.valueKind == DecimalValueKind.ZERO) {
-            return "0.0";
+        if (this.valueKind != DecimalValueKind.OTHER) {
+            return this.valueKind.getValue();
         }
         return value.toString();
     }
@@ -156,7 +147,10 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                 return NaN;
 
             default:
-                if (augend.valueKind == DecimalValueKind.ZERO || augend.valueKind == DecimalValueKind.OTHER) {
+                if (augend.valueKind == DecimalValueKind.ZERO) {
+                    return this;
+                }
+                if (augend.valueKind == DecimalValueKind.OTHER) {
                     return new BDecimal(this.decimalValue().add(augend.decimalValue(), MathContext.DECIMAL128));
                 }
                 return augend;
@@ -190,12 +184,12 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                 return NaN;
 
             default:
-                if (subtrahend.valueKind == DecimalValueKind.ZERO || subtrahend.valueKind == DecimalValueKind.OTHER) {
+                if (subtrahend.valueKind == DecimalValueKind.ZERO) {
+                    return this;
+                }
+                if (subtrahend.valueKind == DecimalValueKind.OTHER) {
                     return new BDecimal(this.decimalValue().subtract(subtrahend.decimalValue(),
                             MathContext.DECIMAL128));
-                }
-                if (subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
-                    return NaN;
                 }
                 return subtrahend.negate();
         }
@@ -234,13 +228,11 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                 return NaN;
 
             default:
-                if (multiplicand.valueKind == DecimalValueKind.ZERO ||
-                        multiplicand.valueKind == DecimalValueKind.OTHER) {
+                if (multiplicand.valueKind == DecimalValueKind.OTHER) {
                     return new BDecimal(this.decimalValue().multiply(multiplicand.decimalValue(),
                             MathContext.DECIMAL128));
                 }
-                if (multiplicand.valueKind == DecimalValueKind.NOT_A_NUMBER ||
-                        this.decimalValue().compareTo(BigDecimal.ZERO) > 0) {
+                if (this.decimalValue().compareTo(BigDecimal.ZERO) > 0) {
                     return multiplicand;
                 }
                 return multiplicand.negate();

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
@@ -21,10 +21,12 @@ package org.ballerinalang.model.values;
 import org.ballerinalang.bre.bvm.BVM;
 import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
+import org.ballerinalang.model.util.DecimalValueKind;
 import org.ballerinalang.util.exceptions.BallerinaErrorReasons;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.Map;
 
 /**
@@ -34,10 +36,30 @@ import java.util.Map;
  */
 public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
+    public static final BDecimal POSITIVE_INF =
+            new BDecimal("9.999999999999999999999999999999999E6144", DecimalValueKind.POSITIVE_INFINITY);
+
+    public static final BDecimal NEGATIVE_INF =
+            new BDecimal("-9.999999999999999999999999999999999E6144", DecimalValueKind.NEGATIVE_INFINITY);
+
+    public static final BDecimal NaN =
+            new BDecimal(POSITIVE_INF.add(NEGATIVE_INF).stringValue(), DecimalValueKind.NOT_A_NUMBER);
+
+    // Variable used to track the kind of a decimal value.
+    public DecimalValueKind valueKind = DecimalValueKind.OTHER;
+
     private BigDecimal value;
 
     public BDecimal(BigDecimal value) {
         this.value = value;
+        if (!this.booleanValue()) {
+            this.valueKind = DecimalValueKind.ZERO;
+        }
+    }
+
+    public BDecimal(String value, DecimalValueKind valueKind) {
+        this.value = new BigDecimal(value, MathContext.DECIMAL128);
+        this.valueKind = valueKind;
     }
 
     @Override
@@ -93,6 +115,203 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
     public BValue copy(Map<BValue, BValue> refs) {
         return this;
     }
+
+    //========================= Mathematical operations supported ===============================
+
+    public BDecimal add(BDecimal augend) {
+        switch (this.valueKind) {
+            case ZERO:
+                return augend;
+
+            case POSITIVE_INFINITY:
+                if (augend.valueKind == DecimalValueKind.NEGATIVE_INFINITY ||
+                        augend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return POSITIVE_INF;
+
+            case NEGATIVE_INFINITY:
+                if (augend.valueKind == DecimalValueKind.POSITIVE_INFINITY ||
+                        augend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return NEGATIVE_INF;
+
+            case NOT_A_NUMBER:
+                return NaN;
+
+            default:
+                if (augend.valueKind == DecimalValueKind.ZERO || augend.valueKind == DecimalValueKind.OTHER) {
+                    return new BDecimal(this.decimalValue().add(augend.decimalValue(), MathContext.DECIMAL128));
+                }
+                return augend;
+        }
+    }
+
+    public BDecimal subtract(BDecimal subtrahend) {
+        switch (this.valueKind) {
+            case ZERO:
+                if (subtrahend.valueKind == DecimalValueKind.ZERO ||
+                        subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return subtrahend;
+                }
+                return subtrahend.negate();
+
+            case POSITIVE_INFINITY:
+                if (subtrahend.valueKind == DecimalValueKind.POSITIVE_INFINITY ||
+                        subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return POSITIVE_INF;
+
+            case NEGATIVE_INFINITY:
+                if (subtrahend.valueKind == DecimalValueKind.NEGATIVE_INFINITY ||
+                        subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return NEGATIVE_INF;
+
+            case NOT_A_NUMBER:
+                return NaN;
+
+            default:
+                if (subtrahend.valueKind == DecimalValueKind.ZERO || subtrahend.valueKind == DecimalValueKind.OTHER) {
+                    return new BDecimal(this.decimalValue().subtract(subtrahend.decimalValue(),
+                            MathContext.DECIMAL128));
+                }
+                if (subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return subtrahend.negate();
+        }
+    }
+
+    public BDecimal multiply(BDecimal multiplicand) {
+        switch (this.valueKind) {
+            case ZERO:
+                if (multiplicand.valueKind == DecimalValueKind.ZERO ||
+                        multiplicand.valueKind == DecimalValueKind.OTHER) {
+                    return this;
+                }
+                return NaN;
+
+            case POSITIVE_INFINITY:
+                if (multiplicand.valueKind == DecimalValueKind.ZERO ||
+                        multiplicand.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                if (multiplicand.decimalValue().compareTo(BigDecimal.ZERO) > 0) {
+                    return POSITIVE_INF;
+                }
+                return NEGATIVE_INF;
+
+            case NEGATIVE_INFINITY:
+                if (multiplicand.valueKind == DecimalValueKind.ZERO ||
+                        multiplicand.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                if (multiplicand.decimalValue().compareTo(BigDecimal.ZERO) > 0) {
+                    return NEGATIVE_INF;
+                }
+                return POSITIVE_INF;
+
+            case NOT_A_NUMBER:
+                return NaN;
+
+            default:
+                if (multiplicand.valueKind == DecimalValueKind.ZERO ||
+                        multiplicand.valueKind == DecimalValueKind.OTHER) {
+                    return new BDecimal(this.decimalValue().multiply(multiplicand.decimalValue(),
+                            MathContext.DECIMAL128));
+                }
+                if (multiplicand.valueKind == DecimalValueKind.NOT_A_NUMBER ||
+                        this.decimalValue().compareTo(BigDecimal.ZERO) > 0) {
+                    return multiplicand;
+                }
+                return multiplicand.negate();
+        }
+    }
+
+    public BDecimal divide(BDecimal divisor) {
+        switch (this.valueKind) {
+            case ZERO:
+                if (divisor.valueKind == DecimalValueKind.ZERO || divisor.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return this;
+
+            case POSITIVE_INFINITY:
+                if (divisor.valueKind == DecimalValueKind.ZERO ||
+                        (divisor.valueKind == DecimalValueKind.OTHER &&
+                                divisor.decimalValue().compareTo(BigDecimal.ZERO) > 0)) {
+                    return POSITIVE_INF;
+                }
+                if (divisor.valueKind == DecimalValueKind.OTHER &&
+                        divisor.decimalValue().compareTo(BigDecimal.ZERO) < 0) {
+                    return NEGATIVE_INF;
+                }
+                return NaN;
+
+            case NEGATIVE_INFINITY:
+                if (divisor.valueKind == DecimalValueKind.ZERO ||
+                        (divisor.valueKind == DecimalValueKind.OTHER &&
+                                divisor.decimalValue().compareTo(BigDecimal.ZERO) > 0)) {
+                    return NEGATIVE_INF;
+                }
+                if (divisor.valueKind == DecimalValueKind.OTHER &&
+                        divisor.decimalValue().compareTo(BigDecimal.ZERO) < 0) {
+                    return POSITIVE_INF;
+                }
+                return NaN;
+
+            case NOT_A_NUMBER:
+                return NaN;
+
+            default:
+                if (divisor.valueKind == DecimalValueKind.OTHER) {
+                    return new BDecimal(this.decimalValue().divide(divisor.decimalValue(), MathContext.DECIMAL128));
+                }
+                if (divisor.valueKind == DecimalValueKind.POSITIVE_INFINITY ||
+                        divisor.valueKind == DecimalValueKind.NEGATIVE_INFINITY) {
+                    return new BDecimal(BigDecimal.ZERO);
+                }
+                if (divisor.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return this.decimalValue().compareTo(BigDecimal.ZERO) > 0 ? POSITIVE_INF : NEGATIVE_INF;
+        }
+    }
+
+    public BDecimal remainder(BDecimal divisor) {
+        switch (this.valueKind) {
+            case ZERO:
+            case OTHER:
+                if (divisor.valueKind == DecimalValueKind.OTHER) {
+                    return new BDecimal(this.decimalValue().remainder(divisor.decimalValue(), MathContext.DECIMAL128));
+                }
+                if (divisor.valueKind == DecimalValueKind.ZERO || divisor.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+                    return NaN;
+                }
+                return this;
+            default:
+                return NaN;
+        }
+    }
+
+    public BDecimal negate() {
+        switch (this.valueKind) {
+            case OTHER:
+                return new BDecimal(this.decimalValue().negate());
+            case POSITIVE_INFINITY:
+                return NEGATIVE_INF;
+            case NEGATIVE_INFINITY:
+                return POSITIVE_INF;
+            default:
+                return this;
+        }
+    }
+
+    //===========================================================================================
 
     @Override
     public boolean equals(Object obj) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
@@ -70,8 +70,7 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
     public long intValue() {
         if (this.valueKind == DecimalValueKind.NOT_A_NUMBER || !BVM.isDecimalWithinIntRange(value)) {
             throw new BallerinaException(BallerinaErrorReasons.NUMBER_CONVERSION_ERROR,
-                                         "out of range 'decimal' value '" + this.stringValue() +
-                                                 "' cannot be converted to 'int'");
+                    "out of range 'decimal' value '" + this.stringValue() + "' cannot be converted to 'int'");
         }
         return Math.round(value.doubleValue());
     }
@@ -128,24 +127,20 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
         switch (this.valueKind) {
             case ZERO:
                 return augend;
-
             case POSITIVE_INFINITY:
                 if (augend.valueKind == DecimalValueKind.NEGATIVE_INFINITY ||
                         augend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
                     return NaN;
                 }
                 return POSITIVE_INF;
-
             case NEGATIVE_INFINITY:
                 if (augend.valueKind == DecimalValueKind.POSITIVE_INFINITY ||
                         augend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
                     return NaN;
                 }
                 return NEGATIVE_INF;
-
             case NOT_A_NUMBER:
                 return NaN;
-
             default:
                 if (augend.valueKind == DecimalValueKind.ZERO) {
                     return this;
@@ -165,24 +160,20 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return subtrahend;
                 }
                 return subtrahend.negate();
-
             case POSITIVE_INFINITY:
                 if (subtrahend.valueKind == DecimalValueKind.POSITIVE_INFINITY ||
                         subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
                     return NaN;
                 }
                 return POSITIVE_INF;
-
             case NEGATIVE_INFINITY:
                 if (subtrahend.valueKind == DecimalValueKind.NEGATIVE_INFINITY ||
                         subtrahend.valueKind == DecimalValueKind.NOT_A_NUMBER) {
                     return NaN;
                 }
                 return NEGATIVE_INF;
-
             case NOT_A_NUMBER:
                 return NaN;
-
             default:
                 if (subtrahend.valueKind == DecimalValueKind.ZERO) {
                     return this;
@@ -203,7 +194,6 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return this;
                 }
                 return NaN;
-
             case POSITIVE_INFINITY:
                 if (multiplicand.valueKind == DecimalValueKind.ZERO ||
                         multiplicand.valueKind == DecimalValueKind.NOT_A_NUMBER) {
@@ -213,7 +203,6 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return POSITIVE_INF;
                 }
                 return NEGATIVE_INF;
-
             case NEGATIVE_INFINITY:
                 if (multiplicand.valueKind == DecimalValueKind.ZERO ||
                         multiplicand.valueKind == DecimalValueKind.NOT_A_NUMBER) {
@@ -223,10 +212,8 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return NEGATIVE_INF;
                 }
                 return POSITIVE_INF;
-
             case NOT_A_NUMBER:
                 return NaN;
-
             default:
                 if (multiplicand.valueKind == DecimalValueKind.OTHER) {
                     return new BDecimal(this.decimalValue().multiply(multiplicand.decimalValue(),
@@ -246,7 +233,6 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return NaN;
                 }
                 return this;
-
             case POSITIVE_INFINITY:
                 if (divisor.valueKind == DecimalValueKind.ZERO ||
                         (divisor.valueKind == DecimalValueKind.OTHER &&
@@ -258,7 +244,6 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return NEGATIVE_INF;
                 }
                 return NaN;
-
             case NEGATIVE_INFINITY:
                 if (divisor.valueKind == DecimalValueKind.ZERO ||
                         (divisor.valueKind == DecimalValueKind.OTHER &&
@@ -270,10 +255,8 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
                     return POSITIVE_INF;
                 }
                 return NaN;
-
             case NOT_A_NUMBER:
                 return NaN;
-
             default:
                 if (divisor.valueKind == DecimalValueKind.OTHER) {
                     return new BDecimal(this.decimalValue().divide(divisor.decimalValue(), MathContext.DECIMAL128));

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
@@ -68,7 +68,7 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
     @Override
     public long intValue() {
-        if (!BVM.isDecimalWithinIntRange(value) || this.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+        if (this.valueKind == DecimalValueKind.NOT_A_NUMBER || !BVM.isDecimalWithinIntRange(value)) {
             throw new BallerinaException(BallerinaErrorReasons.NUMBER_CONVERSION_ERROR,
                                          "out of range 'decimal' value '" + this.stringValue() +
                                                  "' cannot be converted to 'int'");
@@ -339,7 +339,7 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
         }
 
         BDecimal bDecimal = (BDecimal) obj;
-        return (value.compareTo(bDecimal.value) == 0);
+        return ((value.compareTo(bDecimal.value) == 0) && (this.valueKind == bDecimal.valueKind));
     }
 
     @Override

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
@@ -42,8 +42,7 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
     public static final BDecimal NEGATIVE_INF =
             new BDecimal("-9.999999999999999999999999999999999E6144", DecimalValueKind.NEGATIVE_INFINITY);
 
-    public static final BDecimal NaN =
-            new BDecimal(POSITIVE_INF.add(NEGATIVE_INF).stringValue(), DecimalValueKind.NOT_A_NUMBER);
+    public static final BDecimal NaN = new BDecimal("-1", DecimalValueKind.NOT_A_NUMBER);
 
     // Variable used to track the kind of a decimal value.
     public DecimalValueKind valueKind = DecimalValueKind.OTHER;
@@ -69,9 +68,10 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
     @Override
     public long intValue() {
-        if (!BVM.isDecimalWithinIntRange(value)) {
+        if (!BVM.isDecimalWithinIntRange(value) || this.valueKind == DecimalValueKind.NOT_A_NUMBER) {
             throw new BallerinaException(BallerinaErrorReasons.NUMBER_CONVERSION_ERROR,
-                                         "out of range 'decimal' value '" + value + "' cannot be converted to 'int'");
+                                         "out of range 'decimal' value '" + this.stringValue() +
+                                                 "' cannot be converted to 'int'");
         }
         return Math.round(value.doubleValue());
     }
@@ -83,6 +83,9 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
     @Override
     public double floatValue() {
+        if (this.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+            return Double.NaN;
+        }
         return value.doubleValue();
     }
 
@@ -98,6 +101,18 @@ public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
     @Override
     public String stringValue() {
+        if (this.valueKind == DecimalValueKind.POSITIVE_INFINITY) {
+            return "Infinity";
+        }
+        if (this.valueKind == DecimalValueKind.NEGATIVE_INFINITY) {
+            return "-Infinity";
+        }
+        if (this.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+            return "NaN";
+        }
+        if (this.valueKind == DecimalValueKind.ZERO) {
+            return "0.0";
+        }
         return value.toString();
     }
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BDecimal.java
@@ -36,13 +36,13 @@ import java.util.Map;
  */
 public final class BDecimal extends BValueType implements BRefType<BigDecimal> {
 
-    public static final BDecimal POSITIVE_INF =
+    private static final BDecimal POSITIVE_INF =
             new BDecimal("9.999999999999999999999999999999999E6144", DecimalValueKind.POSITIVE_INFINITY);
 
-    public static final BDecimal NEGATIVE_INF =
+    private static final BDecimal NEGATIVE_INF =
             new BDecimal("-9.999999999999999999999999999999999E6144", DecimalValueKind.NEGATIVE_INFINITY);
 
-    public static final BDecimal NaN = new BDecimal("-1", DecimalValueKind.NOT_A_NUMBER);
+    private static final BDecimal NaN = new BDecimal("-1", DecimalValueKind.NOT_A_NUMBER);
 
     // Variable used to track the kind of a decimal value.
     public DecimalValueKind valueKind = DecimalValueKind.OTHER;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3035,72 +3035,134 @@ public class Desugar extends BLangNodeVisitor {
     private void visitBuiltInMethodInvocation(BLangInvocation iExpr) {
         switch (iExpr.builtInMethod) {
             case IS_NAN:
-                BOperatorSymbol notEqSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
-                        OperatorKind.NOT_EQUAL, symTable.floatType, symTable.floatType);
-                BLangBinaryExpr binaryExprNaN = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, iExpr.expr,
-                                                                             symTable.booleanType,
-                                                                             OperatorKind.NOT_EQUAL, notEqSymbol);
-                result = rewriteExpr(binaryExprNaN);
+                if (iExpr.expr.type.tag == TypeTags.FLOAT) {
+                    BOperatorSymbol notEqSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.NOT_EQUAL, symTable.floatType, symTable.floatType);
+                    BLangBinaryExpr binaryExprNaN = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, iExpr.expr,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.NOT_EQUAL,
+                                                                                    notEqSymbol);
+                    result = rewriteExpr(binaryExprNaN);
+                } else {
+                    BOperatorSymbol greaterEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.GREATER_EQUAL, symTable.decimalType, symTable.decimalType);
+                    BOperatorSymbol lessThanSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.LESS_THAN, symTable.decimalType, symTable.decimalType);
+                    BOperatorSymbol orSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.OR, symTable.booleanType, symTable.booleanType);
+                    BOperatorSymbol notSymbol = (BOperatorSymbol) symResolver.resolveUnaryOperator(
+                            iExpr.pos, OperatorKind.NOT, symTable.booleanType);
+                    BLangLiteral literalZero = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.decimalType, "0");
+                    // v >= 0
+                    BLangBinaryExpr binaryExprLHS = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, literalZero,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.GREATER_EQUAL,
+                                                                                    greaterEqualSymbol);
+                    // v < 0
+                    BLangBinaryExpr binaryExprRHS = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, literalZero,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.LESS_THAN,
+                                                                                    lessThanSymbol);
+                    // v >= 0 || v < 0
+                    BLangBinaryExpr binaryExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, binaryExprLHS,
+                                                                                    binaryExprRHS,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.OR, orSymbol);
+                    // Final expression: !(v >= 0 || v < 0)
+                    BLangUnaryExpr finalExprNaN = ASTBuilderUtil.createUnaryExpr(iExpr.pos, binaryExpr,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.NOT, notSymbol);
+                    result = rewriteExpr(finalExprNaN);
+                }
                 break;
             case IS_FINITE:
-                BOperatorSymbol equalSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.EQUAL,
-                                                                                                  symTable.floatType,
-                                                                                                  symTable.floatType);
-                BOperatorSymbol notEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
-                        OperatorKind.NOT_EQUAL, symTable.floatType, symTable.floatType);
-                BOperatorSymbol andEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
-                        OperatorKind.AND, symTable.booleanType, symTable.booleanType);
-                // v==v
-                BLangBinaryExpr binaryExprLHS = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, iExpr.expr,
-                                                                                symTable.booleanType,
-                                                                                OperatorKind.EQUAL, equalSymbol);
-                // v != positive_infinity
-                BLangLiteral posInfLiteral = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
-                                                                          Double.POSITIVE_INFINITY);
-                BLangBinaryExpr nestedLHSExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, posInfLiteral, iExpr.expr,
-                                                                                symTable.booleanType,
-                                                                                OperatorKind.NOT_EQUAL, notEqualSymbol);
+                if (iExpr.expr.type.tag == TypeTags.FLOAT) {
+                    BOperatorSymbol equalSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.EQUAL, symTable.floatType, symTable.floatType);
+                    BOperatorSymbol notEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.NOT_EQUAL, symTable.floatType, symTable.floatType);
+                    BOperatorSymbol andEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.AND, symTable.booleanType, symTable.booleanType);
+                    // v==v
+                    BLangBinaryExpr binaryExprLHS = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, iExpr.expr,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.EQUAL, equalSymbol);
+                    // v != positive_infinity
+                    BLangLiteral posInfLiteral = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
+                                                                                    Double.POSITIVE_INFINITY);
+                    BLangBinaryExpr nestedLHSExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, posInfLiteral,
+                                                                                    iExpr.expr, symTable.booleanType,
+                                                                                    OperatorKind.NOT_EQUAL,
+                                                                                    notEqualSymbol);
 
-                // v != negative_infinity
-                BLangLiteral negInfLiteral = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
-                                                                          Double.NEGATIVE_INFINITY);
-                BLangBinaryExpr nestedRHSExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, negInfLiteral, iExpr.expr,
-                                                                                symTable.booleanType,
-                                                                                OperatorKind.NOT_EQUAL, notEqualSymbol);
-                // v != positive_infinity && v != negative_infinity
-                BLangBinaryExpr binaryExprRHS = ASTBuilderUtil.createBinaryExpr(iExpr.pos, nestedLHSExpr, nestedRHSExpr,
-                                                                                symTable.booleanType, OperatorKind.AND,
-                                                                                andEqualSymbol);
-                // Final expression : v==v && v != positive_infinity && v != negative_infinity
-                BLangBinaryExpr binaryExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, binaryExprLHS, binaryExprRHS,
-                                                                             symTable.booleanType, OperatorKind.AND,
-                                                                             andEqualSymbol);
-                result = rewriteExpr(binaryExpr);
+                    // v != negative_infinity
+                    BLangLiteral negInfLiteral = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
+                                                                                    Double.NEGATIVE_INFINITY);
+                    BLangBinaryExpr nestedRHSExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, negInfLiteral,
+                                                                                    iExpr.expr, symTable.booleanType,
+                                                                                    OperatorKind.NOT_EQUAL,
+                                                                                    notEqualSymbol);
+                    // v != positive_infinity && v != negative_infinity
+                    BLangBinaryExpr binaryExprRHS = ASTBuilderUtil.createBinaryExpr(iExpr.pos, nestedLHSExpr,
+                                                                                    nestedRHSExpr,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.AND, andEqualSymbol);
+                    // Final expression : v==v && v != positive_infinity && v != negative_infinity
+                    BLangBinaryExpr binaryExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, binaryExprLHS,
+                                                                                    binaryExprRHS, symTable.booleanType,
+                                                                                    OperatorKind.AND, andEqualSymbol);
+                    result = rewriteExpr(binaryExpr);
+                } else {
+                    BOperatorSymbol isEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.EQUAL, symTable.decimalType, symTable.decimalType);
+                    // v == v
+                    BLangBinaryExpr finalExprFinite = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, iExpr.expr,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.EQUAL, isEqualSymbol);
+                    result = rewriteExpr(finalExprFinite);
+                }
                 break;
             case IS_INFINITE:
-                BOperatorSymbol eqSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.EQUAL,
-                                                                                                  symTable.floatType,
-                                                                                                  symTable.floatType);
-                BOperatorSymbol orSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.OR,
-                                                                                               symTable.booleanType,
-                                                                                               symTable.booleanType);
-                // v == positive_infinity
-                BLangLiteral posInflitExpr = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
-                                                                          Double.POSITIVE_INFINITY);
-                BLangBinaryExpr binaryExprPosInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, posInflitExpr,
-                                                                                symTable.booleanType,
-                                                                                OperatorKind.EQUAL, eqSymbol);
-                // v == negative_infinity
-                BLangLiteral negInflitExpr = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
-                                                                          Double.NEGATIVE_INFINITY);
-                BLangBinaryExpr binaryExprNegInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr, negInflitExpr,
-                                                                                symTable.booleanType,
-                                                                                OperatorKind.EQUAL, eqSymbol);
-                // v == positive_infinity || v == negative_infinity
-                BLangBinaryExpr binaryExprInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, binaryExprPosInf,
-                                                                                binaryExprNegInf, symTable.booleanType,
-                                                                                OperatorKind.OR, orSymbol);
-                result = rewriteExpr(binaryExprInf);
+                if (iExpr.expr.type.tag == TypeTags.FLOAT) {
+                    BOperatorSymbol eqSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.EQUAL, symTable.floatType, symTable.floatType);
+                    BOperatorSymbol orSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.OR, symTable.booleanType, symTable.booleanType);
+                    // v == positive_infinity
+                    BLangLiteral posInflitExpr = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
+                                                                                    Double.POSITIVE_INFINITY);
+                    BLangBinaryExpr binaryExprPosInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr,
+                                                                                    posInflitExpr, symTable.booleanType,
+                                                                                    OperatorKind.EQUAL, eqSymbol);
+                    // v == negative_infinity
+                    BLangLiteral negInflitExpr = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.floatType,
+                                                                                    Double.NEGATIVE_INFINITY);
+                    BLangBinaryExpr binaryExprNegInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, iExpr.expr,
+                                                                                    negInflitExpr, symTable.booleanType,
+                                                                                    OperatorKind.EQUAL, eqSymbol);
+                    // v == positive_infinity || v == negative_infinity
+                    BLangBinaryExpr binaryExprInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, binaryExprPosInf,
+                                                                                    binaryExprNegInf,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.OR, orSymbol);
+                    result = rewriteExpr(binaryExprInf);
+                } else {
+                    BLangLiteral literalZero = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.decimalType, "0");
+                    BLangLiteral literalOne = ASTBuilderUtil.createLiteral(iExpr.pos, symTable.decimalType, "1");
+                    BOperatorSymbol isEqualSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.EQUAL, symTable.decimalType, symTable.decimalType);
+                    BOperatorSymbol divideSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
+                            OperatorKind.DIV, symTable.decimalType, symTable.decimalType);
+                    // 1/v
+                    BLangBinaryExpr divideExpr = ASTBuilderUtil.createBinaryExpr(iExpr.pos, literalOne, iExpr.expr,
+                                                                                    symTable.decimalType,
+                                                                                    OperatorKind.DIV, divideSymbol);
+                    // Final expression: 1/v == 0
+                    BLangBinaryExpr finalExprInf = ASTBuilderUtil.createBinaryExpr(iExpr.pos, divideExpr, literalZero,
+                                                                                    symTable.booleanType,
+                                                                                    OperatorKind.EQUAL, isEqualSymbol);
+                    result = rewriteExpr(finalExprInf);
+                }
                 break;
             case CLONE:
                 if (types.isValueType(iExpr.expr.type)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -544,6 +544,11 @@ public class SymbolTable {
         defineBuiltinMethod(BLangBuiltInMethod.IS_FINITE, floatType, booleanType, InstructionCodes.NOP);
         defineBuiltinMethod(BLangBuiltInMethod.IS_INFINITE, floatType, booleanType, InstructionCodes.NOP);
 
+        // Decimal related methods.
+        defineBuiltinMethod(BLangBuiltInMethod.IS_NAN, decimalType, booleanType, InstructionCodes.NOP);
+        defineBuiltinMethod(BLangBuiltInMethod.IS_FINITE, decimalType, booleanType, InstructionCodes.NOP);
+        defineBuiltinMethod(BLangBuiltInMethod.IS_INFINITE, decimalType, booleanType, InstructionCodes.NOP);
+
         //clone related methods
         defineBuiltinMethod(BLangBuiltInMethod.CLONE, anydataType, anydataType, InstructionCodes.CLONE);
         defineBuiltinMethod(BLangBuiltInMethod.CLONE, intType, intType, InstructionCodes.CLONE);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalNaNInfinityTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalNaNInfinityTest.java
@@ -337,7 +337,7 @@ public class BDecimalNaNInfinityTest {
         for (int i = 0; i < 6; i++) {
             Assert.assertSame(returns[i].getClass(), BBoolean.class);
             BBoolean value = (BBoolean) returns[i];
-            if(i < 2) {
+            if (i < 2) {
                 Assert.assertTrue(value.booleanValue(), "Invalid boolean value returned.");
             } else {
                 Assert.assertFalse(value.booleanValue(), "Invalid boolean value returned.");
@@ -352,7 +352,7 @@ public class BDecimalNaNInfinityTest {
         for (int i = 0; i < 6; i++) {
             Assert.assertSame(returns[i].getClass(), BBoolean.class);
             BBoolean value = (BBoolean) returns[i];
-            if(i < 3) {
+            if (i < 3) {
                 Assert.assertFalse(value.booleanValue(), "Invalid boolean value returned.");
             } else {
                 Assert.assertTrue(value.booleanValue(), "Invalid boolean value returned.");
@@ -367,7 +367,7 @@ public class BDecimalNaNInfinityTest {
         for (int i = 0; i < 6; i++) {
             Assert.assertSame(returns[i].getClass(), BBoolean.class);
             BBoolean value = (BBoolean) returns[i];
-            if(i < 3) {
+            if (i < 3) {
                 Assert.assertFalse(value.booleanValue(), "Invalid boolean value returned.");
             } else {
                 Assert.assertTrue(value.booleanValue(), "Invalid boolean value returned.");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalNaNInfinityTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalNaNInfinityTest.java
@@ -1,0 +1,377 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.types.decimaltype;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.util.DecimalValueKind;
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BDecimal;
+import org.ballerinalang.model.values.BValue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This test class will test the NaN, Infinity concepts of decimal type. This also includes tests for the decimal
+ * builtin functions isNaN, isInfinite and isFinite.
+ *
+ * @since 0.991
+ */
+public class BDecimalNaNInfinityTest {
+    private CompileResult result;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() {
+        result = BCompileUtil.compile("test-src/types/decimal/decimal_nan_infinity.bal");
+    }
+
+    @Test(description = "Test decimal zero divided by zero")
+    public void testZeroDividedByZero() {
+        BValue[] returns = BRunUtil.invoke(result, "testZeroDividedByZero", new BValue[]{});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BDecimal.class);
+        BDecimal value = (BDecimal) returns[0];
+        Assert.assertTrue(value.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test positive decimal number divided by zero")
+    public void testPositiveNumberDividedByZero() {
+        BValue[] returns = BRunUtil.invoke(result, "testPositiveNumberDividedByZero", new BValue[]{});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BDecimal.class);
+        BDecimal value = (BDecimal) returns[0];
+        Assert.assertTrue(value.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test negative decimal number divided by zero")
+    public void testNegativeNumberDividedByZero() {
+        BValue[] returns = BRunUtil.invoke(result, "testNegativeNumberDividedByZero", new BValue[]{});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BDecimal.class);
+        BDecimal value = (BDecimal) returns[0];
+        Assert.assertTrue(value.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test addition with LHS operand zero")
+    public void testZeroAddition() {
+        BValue[] returns = BRunUtil.invoke(result, "testZeroAddition", new BValue[]{});
+        Assert.assertEquals(returns.length, 3);
+        for (int i = 0; i < 3; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test subtraction with LHS operand zero")
+    public void testZeroSubtraction() {
+        BValue[] returns = BRunUtil.invoke(result, "testZeroSubtraction", new BValue[]{});
+        Assert.assertEquals(returns.length, 3);
+        for (int i = 0; i < 3; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test multiplication with LHS operand zero")
+    public void testZeroMultiplication() {
+        BValue[] returns = BRunUtil.invoke(result, "testZeroMultiplication", new BValue[]{});
+        Assert.assertEquals(returns.length, 3);
+        for (int i = 0; i < 3; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+            BDecimal value = (BDecimal) returns[i];
+            Assert.assertTrue(value.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        }
+    }
+
+    @Test(description = "Test division with LHS operand zero")
+    public void testZeroDivision() {
+        BValue[] returns = BRunUtil.invoke(result, "testZeroDivision", new BValue[]{});
+        Assert.assertEquals(returns.length, 4);
+        for (int i = 0; i < 4; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.ZERO, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.ZERO, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test modulo with LHS operand zero")
+    public void testZeroModulo() {
+        BValue[] returns = BRunUtil.invoke(result, "testZeroModulo", new BValue[]{});
+        Assert.assertEquals(returns.length, 4);
+        for (int i = 0; i < 4; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.ZERO, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.ZERO, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test addition with LHS operand positive infinity")
+    public void testPositiveInfinityAddition() {
+        BValue[] returns = BRunUtil.invoke(result, "testPositiveInfinityAddition", new BValue[]{});
+        Assert.assertEquals(returns.length, 4);
+        for (int i = 0; i < 4; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test subtraction with LHS operand positive infinity")
+    public void testPositiveInfinitySubtraction() {
+        BValue[] returns = BRunUtil.invoke(result, "testPositiveInfinitySubtraction", new BValue[]{});
+        Assert.assertEquals(returns.length, 4);
+        for (int i = 0; i < 4; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test multiplication with LHS operand positive infinity")
+    public void testPositiveInfinityMultiplication() {
+        BValue[] returns = BRunUtil.invoke(result, "testPositiveInfinityMultiplication", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        BDecimal value5 = (BDecimal) returns[4];
+        BDecimal value6 = (BDecimal) returns[5];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value5.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value6.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test division with LHS operand positive infinity")
+    public void testPositiveInfinityDivision() {
+        BValue[] returns = BRunUtil.invoke(result, "testPositiveInfinityDivision", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        BDecimal value5 = (BDecimal) returns[4];
+        BDecimal value6 = (BDecimal) returns[5];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value5.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value6.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test modulo with LHS operand positive infinity")
+    public void testPositiveInfinityModulo() {
+        BValue[] returns = BRunUtil.invoke(result, "testPositiveInfinityModulo", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+            BDecimal value = (BDecimal) returns[i];
+            Assert.assertTrue(value.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        }
+    }
+
+    @Test(description = "Test addition with LHS operand negative infinity")
+    public void testNegativeInfinityAddition() {
+        BValue[] returns = BRunUtil.invoke(result, "testNegativeInfinityAddition", new BValue[]{});
+        Assert.assertEquals(returns.length, 4);
+        for (int i = 0; i < 4; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test subtraction with LHS operand negative infinity")
+    public void testNegativeInfinitySubtraction() {
+        BValue[] returns = BRunUtil.invoke(result, "testNegativeInfinitySubtraction", new BValue[]{});
+        Assert.assertEquals(returns.length, 4);
+        for (int i = 0; i < 4; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test multiplication with LHS operand negative infinity")
+    public void testNegativeInfinityMultiplication() {
+        BValue[] returns = BRunUtil.invoke(result, "testNegativeInfinityMultiplication", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        BDecimal value5 = (BDecimal) returns[4];
+        BDecimal value6 = (BDecimal) returns[5];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value5.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value6.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test division with LHS operand negative infinity")
+    public void testNegativeInfinityDivision() {
+        BValue[] returns = BRunUtil.invoke(result, "testNegativeInfinityDivision", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+        }
+        BDecimal value1 = (BDecimal) returns[0];
+        BDecimal value2 = (BDecimal) returns[1];
+        BDecimal value3 = (BDecimal) returns[2];
+        BDecimal value4 = (BDecimal) returns[3];
+        BDecimal value5 = (BDecimal) returns[4];
+        BDecimal value6 = (BDecimal) returns[5];
+        Assert.assertTrue(value1.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value2.valueKind == DecimalValueKind.POSITIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value3.valueKind == DecimalValueKind.NEGATIVE_INFINITY, "Invalid decimal value returned.");
+        Assert.assertTrue(value4.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value5.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        Assert.assertTrue(value6.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+    }
+
+    @Test(description = "Test modulo with LHS operand negative infinity")
+    public void testNegativeInfinityModulo() {
+        BValue[] returns = BRunUtil.invoke(result, "testNegativeInfinityModulo", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+            BDecimal value = (BDecimal) returns[i];
+            Assert.assertTrue(value.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        }
+    }
+
+    @Test(description = "Test mathematical operations with a NaN operand")
+    public void testNaNOperations() {
+        BValue[] returns = BRunUtil.invoke(result, "testNaNOperations", new BValue[]{});
+        Assert.assertEquals(returns.length, 5);
+        for (int i = 0; i < 5; i++) {
+            Assert.assertSame(returns[i].getClass(), BDecimal.class);
+            BDecimal value = (BDecimal) returns[i];
+            Assert.assertTrue(value.valueKind == DecimalValueKind.NOT_A_NUMBER, "Invalid decimal value returned.");
+        }
+    }
+
+    @Test(description = "Test isNaN builtin function")
+    public void testIsNaN() {
+        BValue[] returns = BRunUtil.invoke(result, "testIsNaN", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BBoolean.class);
+            BBoolean value = (BBoolean) returns[i];
+            if(i < 2) {
+                Assert.assertTrue(value.booleanValue(), "Invalid boolean value returned.");
+            } else {
+                Assert.assertFalse(value.booleanValue(), "Invalid boolean value returned.");
+            }
+        }
+    }
+
+    @Test(description = "Test isInfinite function")
+    public void testIsInfinite() {
+        BValue[] returns = BRunUtil.invoke(result, "testIsInfinite", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BBoolean.class);
+            BBoolean value = (BBoolean) returns[i];
+            if(i < 3) {
+                Assert.assertFalse(value.booleanValue(), "Invalid boolean value returned.");
+            } else {
+                Assert.assertTrue(value.booleanValue(), "Invalid boolean value returned.");
+            }
+        }
+    }
+
+    @Test(description = "Test isFinite function")
+    public void testIsFinite() {
+        BValue[] returns = BRunUtil.invoke(result, "testIsFinite", new BValue[]{});
+        Assert.assertEquals(returns.length, 6);
+        for (int i = 0; i < 6; i++) {
+            Assert.assertSame(returns[i].getClass(), BBoolean.class);
+            BBoolean value = (BBoolean) returns[i];
+            if(i < 3) {
+                Assert.assertFalse(value.booleanValue(), "Invalid boolean value returned.");
+            } else {
+                Assert.assertTrue(value.booleanValue(), "Invalid boolean value returned.");
+            }
+        }
+    }
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_nan_infinity.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_nan_infinity.bal
@@ -1,0 +1,244 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+final decimal ZERO = 0.0;
+final decimal NaN = <decimal>0.0 / 0.0;
+final decimal POSITIVE_INF = <decimal>2.1 / 0.0;
+final decimal NEGATIVE_INF = <decimal>(-2.1) / 0.0;
+
+
+// Test decimal zero divided by zero
+function testZeroDividedByZero() returns decimal {
+    decimal d1 = 0;
+    decimal d2 = <decimal>0/0;
+    return d2;
+}
+
+// Test positive decimal number divided by zero
+function testPositiveNumberDividedByZero() returns decimal {
+    decimal d1 = 23.2;
+    decimal d2 = 0;
+    decimal d3 = d1/d2;
+    return d3;
+}
+
+// Test negative decimal number divided by zero
+function testNegativeNumberDividedByZero() returns decimal {
+    decimal d1 = -23.2;
+    decimal d2 = 0;
+    decimal d3 = d1/d2;
+    return d3;
+}
+
+
+// Test addition with LHS operand zero
+function testZeroAddition() returns (decimal, decimal, decimal) {
+    decimal d1 = ZERO + POSITIVE_INF;
+    decimal d2 = ZERO + NEGATIVE_INF;
+    decimal d3 = ZERO + NaN;
+    return (d1, d2, d3);
+}
+
+// Test subtraction with LHS operand zero
+function testZeroSubtraction() returns (decimal, decimal, decimal) {
+    decimal d1 = ZERO - POSITIVE_INF;
+    decimal d2 = ZERO - NEGATIVE_INF;
+    decimal d3 = ZERO - NaN;
+    return (d1, d2, d3);
+}
+
+// Test multiplication with LHS operand zero
+function testZeroMultiplication() returns (decimal, decimal, decimal) {
+    decimal d1 = ZERO * POSITIVE_INF;
+    decimal d2 = ZERO * NEGATIVE_INF;
+    decimal d3 = ZERO * NaN;
+    return (d1, d2, d3);
+}
+
+// Test division with LHS operand zero
+function testZeroDivision() returns (decimal, decimal, decimal, decimal) {
+    decimal d1 = ZERO / POSITIVE_INF;
+    decimal d2 = ZERO / NEGATIVE_INF;
+    decimal d3 = ZERO / NaN;
+    decimal d4 = ZERO / ZERO;
+    return (d1, d2, d3, d4);
+}
+
+// Test modulo with LHS operand zero
+function testZeroModulo() returns (decimal, decimal, decimal, decimal) {
+    decimal d1 = ZERO % POSITIVE_INF;
+    decimal d2 = ZERO % NEGATIVE_INF;
+    decimal d3 = ZERO % NaN;
+    decimal d4 = ZERO % ZERO;
+    return (d1, d2, d3, d4);
+}
+
+
+// Test addition with LHS operand positive infinity
+function testPositiveInfinityAddition() returns (decimal, decimal, decimal, decimal) {
+    decimal d1 = POSITIVE_INF + <decimal> (-45.4);
+    decimal d2 = POSITIVE_INF + POSITIVE_INF;
+    decimal d3 = POSITIVE_INF + NEGATIVE_INF;
+    decimal d4 = POSITIVE_INF + NaN;
+    return (d1, d2, d3, d4);
+}
+
+// Test subtraction with LHS operand positive infinity
+function testPositiveInfinitySubtraction() returns (decimal, decimal, decimal, decimal) {
+    decimal d1 = POSITIVE_INF - <decimal> 45.4;
+    decimal d2 = POSITIVE_INF - POSITIVE_INF;
+    decimal d3 = POSITIVE_INF - NEGATIVE_INF;
+    decimal d4 = POSITIVE_INF - NaN;
+    return (d1, d2, d3, d4);
+}
+
+// Test multiplication with LHS operand positive infinity
+function testPositiveInfinityMultiplication() returns (decimal, decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = POSITIVE_INF * <decimal> 45.4;
+    decimal d2 = POSITIVE_INF * <decimal> (-45.4);
+    decimal d3 = POSITIVE_INF * <decimal> 0.0;
+    decimal d4 = POSITIVE_INF * POSITIVE_INF;
+    decimal d5 = POSITIVE_INF * NEGATIVE_INF;
+    decimal d6 = POSITIVE_INF * NaN;
+    return (d1, d2, d3, d4, d5, d6);
+}
+
+// Test division with LHS operand positive infinity
+function testPositiveInfinityDivision() returns (decimal, decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = POSITIVE_INF / <decimal> 45.4;
+    decimal d2 = POSITIVE_INF / <decimal> (-45.4);
+    decimal d3 = POSITIVE_INF / <decimal> 0.0;
+    decimal d4 = POSITIVE_INF / POSITIVE_INF;
+    decimal d5 = POSITIVE_INF / NEGATIVE_INF;
+    decimal d6 = POSITIVE_INF / NaN;
+    return (d1, d2, d3, d4, d5, d6);
+}
+
+// Test modulo with LHS operand positive infinity
+function testPositiveInfinityModulo() returns (decimal, decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = POSITIVE_INF % <decimal> 45.4;
+    decimal d2 = POSITIVE_INF % <decimal> (-45.4);
+    decimal d3 = POSITIVE_INF % <decimal> 0.0;
+    decimal d4 = POSITIVE_INF % POSITIVE_INF;
+    decimal d5 = POSITIVE_INF % NEGATIVE_INF;
+    decimal d6 = POSITIVE_INF % NaN;
+    return (d1, d2, d3, d4, d5, d6);
+}
+
+
+// Test addition with LHS operand negative infinity
+function testNegativeInfinityAddition() returns (decimal, decimal, decimal, decimal) {
+    decimal d1 = NEGATIVE_INF + <decimal> 45.4;
+    decimal d2 = NEGATIVE_INF + POSITIVE_INF;
+    decimal d3 = NEGATIVE_INF + NEGATIVE_INF;
+    decimal d4 = NEGATIVE_INF + NaN;
+    return (d1, d2, d3, d4);
+}
+
+// Test subtraction with LHS operand negative infinity
+function testNegativeInfinitySubtraction() returns (decimal, decimal, decimal, decimal) {
+    decimal d1 = NEGATIVE_INF - <decimal> 45.4;
+    decimal d2 = NEGATIVE_INF - POSITIVE_INF;
+    decimal d3 = NEGATIVE_INF - NEGATIVE_INF;
+    decimal d4 = NEGATIVE_INF - NaN;
+    return (d1, d2, d3, d4);
+}
+
+// Test multiplication with LHS operand negative infinity
+function testNegativeInfinityMultiplication() returns (decimal, decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = NEGATIVE_INF * <decimal> 45.4;
+    decimal d2 = NEGATIVE_INF * <decimal> (-45.4);
+    decimal d3 = NEGATIVE_INF * <decimal> 0.0;
+    decimal d4 = NEGATIVE_INF * POSITIVE_INF;
+    decimal d5 = NEGATIVE_INF * NEGATIVE_INF;
+    decimal d6 = NEGATIVE_INF * NaN;
+    return (d1, d2, d3, d4, d5, d6);
+}
+
+// Test division with LHS operand negative infinity
+function testNegativeInfinityDivision() returns (decimal, decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = NEGATIVE_INF / <decimal> 45.4;
+    decimal d2 = NEGATIVE_INF / <decimal> (-45.4);
+    decimal d3 = NEGATIVE_INF / <decimal> 0.0;
+    decimal d4 = NEGATIVE_INF / POSITIVE_INF;
+    decimal d5 = NEGATIVE_INF / NEGATIVE_INF;
+    decimal d6 = NEGATIVE_INF / NaN;
+    return (d1, d2, d3, d4, d5, d6);
+}
+
+// Test modulo with LHS operand negative infinity
+function testNegativeInfinityModulo() returns (decimal, decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = NEGATIVE_INF % <decimal> 45.4;
+    decimal d2 = NEGATIVE_INF % <decimal> (-45.4);
+    decimal d3 = NEGATIVE_INF % <decimal> 0.0;
+    decimal d4 = NEGATIVE_INF % POSITIVE_INF;
+    decimal d5 = NEGATIVE_INF % NEGATIVE_INF;
+    decimal d6 = NEGATIVE_INF % NaN;
+    return (d1, d2, d3, d4, d5, d6);
+}
+
+
+// Test mathematical operations with a NaN operand
+function testNaNOperations() returns (decimal, decimal, decimal, decimal, decimal) {
+    decimal d1 = NaN + NEGATIVE_INF;
+    decimal d2 = NaN - POSITIVE_INF;
+    decimal d3 = NaN * ZERO;
+    decimal d4 = NaN / NaN;
+    decimal d5 = NaN % <decimal> 23.2;
+    return (d1, d2, d3, d4, d5);
+}
+
+
+// ======================== Test builtin functions ================================
+
+// Test isNaN function
+function testIsNaN() returns (boolean, boolean, boolean, boolean, boolean, boolean) {
+    decimal d1 = -23.4;
+    decimal d2 = POSITIVE_INF + NEGATIVE_INF;
+    boolean b1 = NaN.isNaN();
+    boolean b2 = d2.isNaN();
+    boolean b3 = POSITIVE_INF.isNaN();
+    boolean b4 = NEGATIVE_INF.isNaN();
+    boolean b5 = ZERO.isNaN();
+    boolean b6 = d1.isNaN();
+    return(b1, b2, b3, b4, b5, b6);
+}
+
+// Test isInfinite function
+function testIsInfinite() returns (boolean, boolean, boolean, boolean, boolean, boolean) {
+    decimal d1 = -23.4;
+    decimal d2 = POSITIVE_INF * NEGATIVE_INF;
+    boolean b1 = NaN.isInfinite();
+    boolean b2 = ZERO.isInfinite();
+    boolean b3 = d1.isInfinite();
+    boolean b4 = POSITIVE_INF.isInfinite();
+    boolean b5 = NEGATIVE_INF.isInfinite();
+    boolean b6 = d2.isInfinite();
+    return(b1, b2, b3, b4, b5, b6);
+}
+
+// Test isFinite function
+function testIsFinite() returns (boolean, boolean, boolean, boolean, boolean, boolean) {
+    decimal d1 = -23.4;
+    decimal d2 = d1 / <decimal> 0.00001;
+    boolean b1 = NaN.isFinite();
+    boolean b2 = POSITIVE_INF.isFinite();
+    boolean b3 = NEGATIVE_INF.isFinite();
+    boolean b4 = ZERO.isFinite();
+    boolean b5 = d1.isFinite();
+    boolean b6 = d2.isFinite();
+    return(b1, b2, b3, b4, b5, b6);
+}


### PR DESCRIPTION
## Purpose
This PR introduces `NaN`, `Infinity` concepts in Ballerina decimal type. It also adds three new builtin functions `isNaN`, `isFinite` and `isInfinite` for decimal type. This PR resolves the following issues,

- Closes  https://github.com/ballerina-platform/ballerina-lang/issues/11385
- Closes https://github.com/ballerina-platform/ballerina-lang/issues/13198
- Closes https://github.com/ballerina-platform/ballerina-lang/issues/13199
- Closes https://github.com/ballerina-platform/ballerina-lang/issues/13201

GSheet [1] summarizes the results of all the supported mathematical operations between two decimal literals with the special case values `0`, `+infinity`, `-infinity` and `NaN`.

[1] https://docs.google.com/spreadsheets/d/1H580zDSK3JqKIfHC05wIQQWZ93JEhZ3kPvvrgSoe9Og/edit?usp=sharing