### PR TITLE
Fix rendering source with syntax issues when annotation merging in API Designer

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -519,9 +519,18 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
                                                 tree, firstTokenIndex);
                                         targetResourceInfoOperation.add(sourceKeyValue);
                                     } else {
+                                        // Add new key value pair to the annotation record.
                                         FormattingSourceGen.reconcileWS(sourceKeyValue, targetResourceInfoOperation,
                                                 tree, -1);
                                         targetResourceInfoOperation.add(sourceKeyValue);
+
+                                        if (targetResourceInfoOperation.size() > 1) {
+                                            // Add a new comma to separate the new key value pair.
+                                            int startIndex = FormattingSourceGen.extractWS(sourceKeyValue).get(0)
+                                                    .getAsJsonObject().get("i").getAsInt();
+                                            FormattingSourceGen.addNewWS(matchedTargetResourceInfo
+                                                    .getAsJsonObject("value"), tree, "", ",", true, startIndex);
+                                        }
                                     }
                                 }
 
@@ -565,9 +574,17 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
                                         .getAsJsonArray("keyValuePairs"), tree, firstTokenIndex);
                                 matchedTargetRecord.getAsJsonArray("keyValuePairs").add(sourceKeyValue);
                             } else {
+                                // Add the new record key value pair.
                                 FormattingSourceGen.reconcileWS(sourceKeyValue, matchedTargetRecord
                                         .getAsJsonArray("keyValuePairs"), tree, -1);
                                 matchedTargetRecord.getAsJsonArray("keyValuePairs").add(sourceKeyValue);
+
+                                if (matchedTargetRecord.getAsJsonArray("keyValuePairs").size() > 1) {
+                                    // Add a new comma to separate the new key value pair.
+                                    int startIndex = FormattingSourceGen.extractWS(sourceKeyValue).get(0)
+                                            .getAsJsonObject().get("i").getAsInt();
+                                    FormattingSourceGen.addNewWS(matchedTargetRecord, tree, "", ",", true, startIndex);
+                                }
                             }
                         }
                     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingSourceGen.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingSourceGen.java
@@ -129,6 +129,42 @@ public class FormattingSourceGen {
     }
 
     /**
+     * Add new whitespace object to given target node on given start index
+     * and then update the rest of the tree accordingly.
+     *
+     * @param targetNode target node where new WS to be added
+     * @param tree       AST for the whole source file
+     * @param ws         Whitespace
+     * @param text       text in the whitespace
+     * @param isStatic   set the Static state of the ws
+     * @param startIndex start index for the whitespace
+     */
+    public static void addNewWS(JsonObject targetNode, JsonObject tree, String ws, String text, boolean isStatic,
+                                int startIndex) {
+        JsonObject newWS = new JsonObject();
+        List<JsonObject> astWS = getSortedWSList(tree);
+        List<JsonObject> nodeWS = extractWS(targetNode);
+
+        if (startIndex == -1) {
+            startIndex = nodeWS.get(nodeWS.size() - 1)
+                    .getAsJsonObject().get("i").getAsInt();
+        }
+
+        newWS.addProperty("i", startIndex);
+        newWS.addProperty("static", isStatic);
+        newWS.addProperty(FormattingConstants.WS, ws);
+        newWS.addProperty(FormattingConstants.TEXT, text);
+
+        targetNode.getAsJsonArray(FormattingConstants.WS).add(newWS);
+
+        for (JsonObject wsItem : astWS) {
+            if (wsItem.get("i").getAsInt() >= startIndex) {
+                wsItem.addProperty("i", wsItem.get("i").getAsInt() + 1);
+            }
+        }
+    }
+
+    /**
      * Get the start position suitable in the given attach point where new node to be added.
      *
      * @param node         Parent of the attach point


### PR DESCRIPTION
## Purpose
This commit will fix the issue with API designer AST merge introduce syntax issue as missing a comma when merging annotation attachments in resources.