### PR TITLE
Update ballerina script to take in an external environment variable for classpath extension

### DIFF
--- a/distribution/zip/ballerina/bin/ballerina
+++ b/distribution/zip/ballerina/bin/ballerina
@@ -196,6 +196,10 @@ fi
 
 #   cd "$BALLERINA_HOME"
 
+# BALLERINA_CLASSPATH_EXT is for outsiders to additionally add
+# classpath locations, e.g. AWS Lambda function libraries.
+BALLERINA_CLASSPATH=$BALLERINA_CLASSPATH:$BALLERINA_CLASSPATH_EXT
+
 $JAVACMD \
 	-Xbootclasspath/a:"$BALLERINA_XBOOTCLASSPATH" \
 	-Xms256m -Xmx1024m \

--- a/distribution/zip/ballerina/bin/ballerina.bat
+++ b/distribution/zip/ballerina/bin/ballerina.bat
@@ -121,6 +121,10 @@ rem ---------- Add jars to classpath ----------------
 
 set BALLERINA_CLASSPATH=.\bre\lib\bootstrap;%BALLERINA_CLASSPATH%
 
+rem BALLERINA_CLASSPATH_EXT is for outsiders to additionally add
+rem classpath locations, e.g. AWS Lambda function libraries.
+set BALLERINA_CLASSPATH=%BALLERINA_CLASSPATH%;%BALLERINA_CLASSPATH_EXT%
+
 set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%BALLERINA_HOME%\heap-dump.hprof"  -Dcom.sun.management.jmxremote -classpath %BALLERINA_CLASSPATH% %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%"  -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version} -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager"
 
 


### PR DESCRIPTION
This is required in order to pass in an environment variable from outside the ballerina script to be added to the runtime Java classpath. For example, this is required for AWS Lambda integration. 