### PR TITLE
Fixes reagarding adding workers

### DIFF
--- a/composer/packages/ast-model/src/model-utils.ts
+++ b/composer/packages/ast-model/src/model-utils.ts
@@ -88,6 +88,30 @@ export function isWorker(node: ASTNode) {
     return false;
 }
 
+export function isWorkerFuture(node: ASTNode) {
+    if (ASTKindChecker.isVariableDef(node)) {
+        if (ASTKindChecker.isVariable((node as VariableDef).variable)) {
+            const initialExp = ((node as VariableDef).variable as Variable).initialExpression;
+
+            if (initialExp === undefined) {
+                return false;
+            }
+
+            if (ASTKindChecker.isInvocation(initialExp)) {
+                const exp = (initialExp as Invocation).expression;
+                if (exp === undefined) {
+                    return false;
+                }
+                if (ASTKindChecker.isSimpleVariableRef(exp)) {
+                    const simpleVarName: string = (exp as SimpleVariableRef).variableName.value;
+                    return /^0.*/.test(simpleVarName);
+                }
+            }
+        }
+    }
+    return false;
+}
+
 export function isValidObjectType(node: ASTNode): boolean {
     if (ASTKindChecker.isTypeDefinition(node)) {
         const typeDefinition = node as TypeDefinition;

--- a/composer/packages/ast-model/src/source-gen/index.ts
+++ b/composer/packages/ast-model/src/source-gen/index.ts
@@ -4,7 +4,7 @@ import { Visitor } from "../base-visitor";
 import { ASTKindChecker } from "../check-kind-util";
 import * as defaults from "../default-nodes";
 import { emitTreeModified } from "../events";
-import { traversNode } from "../model-utils";
+import { isWorkerFuture, traversNode } from "../model-utils";
 
 class SourceGenVisitor implements Visitor {
     private ws: any;
@@ -62,6 +62,10 @@ function getStartIndex(attachingNode: ASTNode, attachPointNodes: ASTNode[], inse
             if (previousNodeVar.service) {
                 previousNode = attachPointNodes[insertAt - 3];
             }
+        }
+
+        if (isWorkerFuture(previousNode)) {
+            previousNode = attachPointNodes[insertAt - 2];
         }
 
         const attachPointWS = getWS(previousNode);

--- a/composer/packages/diagram/src/views/components/function.tsx
+++ b/composer/packages/diagram/src/views/components/function.tsx
@@ -100,9 +100,16 @@ export const Function = (props: { model: FunctionNode }, context: IDiagramContex
                             }
                         }}
                         onAddWorker={() => {
-                            if (model.body && ast) {
-                                ASTUtil.addWorkerToBlock(model.body, ast);
+                            if (!(model.body && ast)) {
+                                return;
                             }
+                            let nextWorkerIndex: number = model.body.statements.length;
+                            model.body.statements.forEach((statement, i) => {
+                                if (ASTUtil.isWorkerFuture(statement)) {
+                                    nextWorkerIndex = i + 1;
+                                }
+                            });
+                            ASTUtil.addWorkerToBlock(model.body, ast, nextWorkerIndex);
                         }}
                     />
                 )}

--- a/composer/packages/diagram/src/visitors/action-view.ts
+++ b/composer/packages/diagram/src/visitors/action-view.ts
@@ -11,6 +11,7 @@ function isOrdinaryStatement(node: ASTNode): boolean {
         && !ASTKindChecker.isWorkerSend(node)
         && !ASTKindChecker.isWorkerSyncSend(node)
         && !ASTUtil.isWorker(node)
+        && !ASTUtil.isWorkerFuture(node)
         && !ASTUtil.isWorkerReceive(node)
         && !ASTUtil.isActionInvocation(node);
 }

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -141,7 +141,10 @@ export const visitor: Visitor = {
         const viewState: BlockViewState = node.viewState;
         let height = 0;
         node.statements.forEach((element) => {
-            if (ASTUtil.isWorker(element)) { return; }
+            if (ASTUtil.isWorker(element)) {
+                height += config.statement.height;
+                return;
+            }
             element.viewState.bBox.x = viewState.bBox.x;
             element.viewState.bBox.y = viewState.bBox.y + element.viewState.bBox.paddingTop + height;
             height += element.viewState.bBox.h + element.viewState.bBox.paddingTop;


### PR DESCRIPTION
## Purpose
* Workers are now added under the last added worker. Fixes breaking the ballerina symtax by adding it always to the end of the function.
* Fix the arrow head showing start of a worker getting overlapped with existing statements