### PR TITLE
Correct decode-private-key parameter type

### DIFF
--- a/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/DecodePrivateKey.java
+++ b/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/DecodePrivateKey.java
@@ -54,7 +54,7 @@ import java.security.cert.CertificateException;
         args = {
                 @Argument(name = "keyStore", type = TypeKind.RECORD, structType = Constants.KEY_STORE_RECORD),
                 @Argument(name = "keyAlias", type = TypeKind.STRING),
-                @Argument(name = "keyPassword", type = TypeKind.ARRAY, elementType = TypeKind.BYTE),
+                @Argument(name = "keyPassword", type = TypeKind.STRING),
         },
         returnType = {
                 @ReturnType(type = TypeKind.RECORD, structType = Constants.PRIVATE_KEY_RECORD,


### PR DESCRIPTION
## Purpose
`DecodePrivateKey` function takes string argument with key password. This is mentioned as byte array in the native function implementation incorrectly. PR corrects this error. 