### PR TITLE
Add a top padding for If, While and Foreach

### DIFF
--- a/composer/packages/diagram/src/config/default.ts
+++ b/composer/packages/diagram/src/config/default.ts
@@ -116,6 +116,7 @@ export class DiagramConfig {
         },
         leftMargin: STATEMENT_HEIGHT,
         leftMarginDefault: 60,
+        paddingTop: STATEMENT_HEIGHT / 4,
         rightMargin: STATEMENT_HEIGHT,
         whileGap: STATEMENT_HEIGHT,
     };

--- a/composer/packages/diagram/src/visitors/sizing-visitor.ts
+++ b/composer/packages/diagram/src/visitors/sizing-visitor.ts
@@ -218,6 +218,18 @@ export const visitor: Visitor = {
         }
     },
 
+    beginVisitIf(node: If) {
+        node.viewState.bBox.paddingTop = config.flowCtrl.paddingTop;
+    },
+
+    beginVisitWhile(node: While) {
+        node.viewState.bBox.paddingTop = config.flowCtrl.paddingTop;
+    },
+
+    beginVisitForeach(node: Foreach) {
+        node.viewState.bBox.paddingTop = config.flowCtrl.paddingTop;
+    },
+
     // tslint:disable-next-line:ban-types
     endVisitFunction(node: Function) {
         if (node.lambda || !node.body) { return; }


### PR DESCRIPTION
## Purpose
This avoids worker start arrows touching those node components

Before: 
![screenshot from 2019-01-25 11-31-50](https://user-images.githubusercontent.com/3872221/51728871-c217c900-2097-11e9-914b-1d1fb058317f.png)

After:

![screenshot from 2019-01-25 11-31-07](https://user-images.githubusercontent.com/3872221/51728870-c217c900-2097-11e9-9c8a-c15e90163d64.png)
