### PR TITLE
Time order window impls

### DIFF
--- a/stdlib/streams/src/main/ballerina/streams/windows.bal
+++ b/stdlib/streams/src/main/ballerina/streams/windows.bal
@@ -1949,3 +1949,175 @@ public function hopping(any[] windowParameters, function (StreamEvent[])? nextPr
     HoppingWindow hoppingWindow = new(nextProcessPointer, windowParameters);
     return hoppingWindow;
 }
+
+public type TimeOrderWindow object {
+
+    public int timeInMillis;
+    public any[] windowParameters;
+    public LinkedList expiredEventQueue;
+    public function (StreamEvent[])? nextProcessPointer;
+    public string timestamp;
+    public boolean dropOlderEvents;
+    public MergeSort mergeSort;
+
+    public function __init(function (StreamEvent[])? nextProcessPointer, any[] windowParameters) {
+        self.nextProcessPointer = nextProcessPointer;
+        self.windowParameters = windowParameters;
+        self.timeInMillis = 0;
+        self.timestamp = "";
+        self.dropOlderEvents = false;
+        self.expiredEventQueue = new;
+        self.mergeSort = new([], []);
+        self.initParameters(windowParameters);
+    }
+
+    public function initParameters(any[] parameters) {
+        if (parameters.length() == 3) {
+            any timestampParam = parameters[0];
+            if (timestampParam is string) {
+                self.timestamp = timestampParam;
+            } else {
+                error err = error("TimeOrder window's first parameter, timestamp should be of type string");
+                panic err;
+            }
+
+            any timeInMillisParam = parameters[1];
+            if (timeInMillisParam is int) {
+                self.timeInMillis = timeInMillisParam;
+            } else {
+                error err = error("TimeOrder window's second parameter, windowTime should be of type int");
+                panic err;
+            }
+
+            any dropOlderEventsParam = parameters[2];
+            if (dropOlderEventsParam is boolean) {
+                self.dropOlderEvents = dropOlderEventsParam;
+            } else {
+                error err = error("TimeOrder window's third parameter, dropOlderEvents should be of type boolean");
+                panic err;
+            }
+        } else {
+            error err = error("TimeOrder window should only have three parameters (<string> timestamp, <int> " +
+                "windowTime, <boolean> dropOlderEvents), but found " + parameters.length() + " input attributes");
+            panic err;
+        }
+
+        (function (map<anydata>) returns anydata)[] fieldFuncs = [function (map<anydata> x) returns anydata {
+            return x[self.timestamp];
+        }];
+        string[] sortTypes = [ASCENDING];
+        self.mergeSort = new(fieldFuncs, sortTypes);
+    }
+
+    public function process(StreamEvent[] streamEvents) {
+        LinkedList streamEventChunk = new;
+        lock {
+            foreach var event in streamEvents {
+                streamEventChunk.addLast(event);
+            }
+
+            streamEventChunk.resetToFront();
+
+            while (streamEventChunk.hasNext()) {
+                StreamEvent streamEvent = getStreamEvent(streamEventChunk.next());
+                int currentTime = time:currentTime().time;
+                self.expiredEventQueue.resetToFront();
+
+                while (self.expiredEventQueue.hasNext()) {
+                    StreamEvent expiredEvent = getStreamEvent(self.expiredEventQueue.next());
+                    int timeDiff = (self.getTimestamp(expiredEvent.data[self.timestamp]) - currentTime) +
+                        self.timeInMillis;
+                    if (timeDiff <= 0) {
+                        self.expiredEventQueue.removeCurrent();
+                        expiredEvent.timestamp = currentTime;
+                        streamEventChunk.insertBeforeCurrent(expiredEvent);
+                    } else {
+                        self.expiredEventQueue.resetToFront();
+                        break;
+                    }
+                }
+
+                if (streamEvent.eventType == CURRENT) {
+                    if (self.dropOlderEvents && (currentTime - self.getTimestamp(streamEvent.data[self.timestamp])) >
+                        self.timeInMillis) {
+                        streamEventChunk.removeCurrent();
+                    } else {
+                        StreamEvent clonedEvent = streamEvent.copy();
+                        clonedEvent.eventType = EXPIRED;
+                        self.expiredEventQueue.addLast(clonedEvent);
+                    }
+
+                    StreamEvent[] events = [];
+                    self.expiredEventQueue.resetToFront();
+
+                    while (self.expiredEventQueue.hasNext()) {
+                        StreamEvent streamEven = <StreamEvent>self.expiredEventQueue.next();
+                        events[events.length()] = streamEven;
+                    }
+
+                    self.mergeSort.topDownMergeSort(events);
+                    self.expiredEventQueue.clear();
+                    foreach var event in events {
+                        self.expiredEventQueue.addLast(event);
+                    }
+                }
+                self.expiredEventQueue.resetToFront();
+            }
+        }
+
+        any nextProcessFuncPointer = self.nextProcessPointer;
+        if (nextProcessFuncPointer is function (StreamEvent[])) {
+            if (streamEventChunk.getSize() != 0) {
+                StreamEvent[] events = [];
+                streamEventChunk.resetToFront();
+                while (streamEventChunk.hasNext()) {
+                    StreamEvent streamEvent = getStreamEvent(streamEventChunk.next());
+                    events[events.length()] = streamEvent;
+                }
+                nextProcessFuncPointer.call(events);
+            }
+        }
+    }
+
+    public function getCandidateEvents(
+                        StreamEvent originEvent,
+                        (function (map<anydata> e1Data, map<anydata> e2Data) returns boolean)? conditionFunc,
+                        boolean isLHSTrigger = true)
+                        returns (StreamEvent?, StreamEvent?)[] {
+        (StreamEvent?, StreamEvent?)[] events = [];
+        int i = 0;
+        foreach var e in self.expiredEventQueue.asArray() {
+            if (e is StreamEvent) {
+                StreamEvent lshEvent = (isLHSTrigger) ? originEvent : e;
+                StreamEvent rhsEvent = (isLHSTrigger) ? e : originEvent;
+
+                if (conditionFunc is function (map<anydata> e1Data, map<anydata> e2Data) returns boolean) {
+                    if (conditionFunc.call(lshEvent.data, rhsEvent.data)) {
+                        events[i] = (lshEvent, rhsEvent);
+                        i += 1;
+                    }
+                } else if (conditionFunc is ()) {
+                    events[i] = (lshEvent, rhsEvent);
+                    i += 1;
+                }
+            }
+        }
+        return events;
+    }
+
+    public function getTimestamp(any val) returns (int) {
+        if (val is int) {
+            return val;
+        } else {
+            error err = error("timestamp should be of type int");
+            panic err;
+        }
+    }
+};
+
+public function timeOrder(any[] windowParameters, function (StreamEvent[])? nextProcessPointer = ())
+                    returns Window {
+
+    TimeOrderWindow timeOrderWindow = new(nextProcessPointer, windowParameters);
+    return timeOrderWindow;
+}

--- a/stdlib/streams/src/test/java/org/ballerinalang/stdlib/streams/BallerinaStreamsV2TimeOrderWindowTest.java
+++ b/stdlib/streams/src/test/java/org/ballerinalang/stdlib/streams/BallerinaStreamsV2TimeOrderWindowTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.streams;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This contains methods to test TimeOrder window behaviour in Ballerina Streaming V2.
+ *
+ * @since 0.990.2
+ */
+public class BallerinaStreamsV2TimeOrderWindowTest {
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/streamingv2-time-order-window-test.bal");
+    }
+
+    @Test(description = "Test timeOrder window query")
+    public void testExternalTimeQuery() {
+                BValue[] outputEmployeeEvents = BRunUtil.invoke(result, "startTimeOrderWindowTest");
+        Assert.assertNotNull(outputEmployeeEvents);
+
+        Assert.assertEquals(outputEmployeeEvents.length, 4, "Expected events are not received");
+
+        BMap<String, BValue> employee0 = (BMap<String, BValue>) outputEmployeeEvents[0];
+        BMap<String, BValue> employee1 = (BMap<String, BValue>) outputEmployeeEvents[1];
+        BMap<String, BValue> employee2 = (BMap<String, BValue>) outputEmployeeEvents[2];
+        BMap<String, BValue> employee3 = (BMap<String, BValue>) outputEmployeeEvents[3];
+
+        Assert.assertEquals(employee0.get("name").stringValue(), "Mohan");
+        Assert.assertEquals(((BInteger) employee0.get("sumAge")).intValue(), 30);
+
+        Assert.assertEquals(employee1.get("name").stringValue(), "Raja");
+        Assert.assertEquals(((BInteger) employee1.get("sumAge")).intValue(), 75);
+
+        Assert.assertEquals(employee2.get("name").stringValue(), "Naveen");
+        Assert.assertEquals(((BInteger) employee2.get("sumAge")).intValue(), 110);
+
+        Assert.assertEquals(employee3.get("name").stringValue(), "Amal");
+        Assert.assertEquals(((BInteger) employee3.get("sumAge")).intValue(), 125);
+    }
+}

--- a/stdlib/streams/src/test/java/org/ballerinalang/stdlib/streams/BallerinaStreamsV2TimeOrderWindowTest.java
+++ b/stdlib/streams/src/test/java/org/ballerinalang/stdlib/streams/BallerinaStreamsV2TimeOrderWindowTest.java
@@ -34,11 +34,12 @@ import org.testng.annotations.Test;
  * @since 0.990.2
  */
 public class BallerinaStreamsV2TimeOrderWindowTest {
-    private CompileResult result;
+    private CompileResult result, result2;
 
     @BeforeClass
     public void setup() {
         result = BCompileUtil.compile("test-src/streamingv2-time-order-window-test.bal");
+        result2 = BCompileUtil.compile("test-src/streamingv2-time-order-window-test2.bal");
     }
 
     @Test(description = "Test timeOrder window query")
@@ -64,5 +65,26 @@ public class BallerinaStreamsV2TimeOrderWindowTest {
 
         Assert.assertEquals(employee3.get("name").stringValue(), "Amal");
         Assert.assertEquals(((BInteger) employee3.get("sumAge")).intValue(), 125);
+    }
+
+    @Test(description = "Test timeOrder window query with dropOlderEvents enabled")
+    public void testExternalTimeQuery2() {
+        BValue[] outputEmployeeEvents = BRunUtil.invoke(result2, "startTimeOrderWindowTest2");
+        Assert.assertNotNull(outputEmployeeEvents);
+
+        Assert.assertEquals(outputEmployeeEvents.length, 3, "Expected events are not received");
+
+        BMap<String, BValue> employee0 = (BMap<String, BValue>) outputEmployeeEvents[0];
+        BMap<String, BValue> employee1 = (BMap<String, BValue>) outputEmployeeEvents[1];
+        BMap<String, BValue> employee2 = (BMap<String, BValue>) outputEmployeeEvents[2];
+
+        Assert.assertEquals(employee0.get("name").stringValue(), "Mohan");
+        Assert.assertEquals(((BInteger) employee0.get("sumAge")).intValue(), 30);
+
+        Assert.assertEquals(employee1.get("name").stringValue(), "Raja");
+        Assert.assertEquals(((BInteger) employee1.get("sumAge")).intValue(), 75);
+
+        Assert.assertEquals(employee2.get("name").stringValue(), "Amal");
+        Assert.assertEquals(((BInteger) employee2.get("sumAge")).intValue(), 125);
     }
 }

--- a/stdlib/streams/src/test/resources/test-src/streamingv2-time-order-window-test.bal
+++ b/stdlib/streams/src/test/resources/test-src/streamingv2-time-order-window-test.bal
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/runtime;
+import ballerina/time;
+
+type Teacher record {
+    int timestamp;
+    string name;
+    int age;
+    string school;
+};
+
+type TeacherOutput record{
+    string name;
+    int sumAge;
+};
+
+int index = 0;
+stream<Teacher> inputStreamTimeOrderTest = new;
+stream<TeacherOutput > outputStreamTimeOrderTest = new;
+TeacherOutput[] globalEmployeeArray = [];
+
+function startTimeOrderWindowTest() returns (TeacherOutput[]) {
+
+    Teacher[] teachers = [];
+    Teacher t1 = { timestamp: time:currentTime().time, name: "Mohan", age: 30, school: "Hindu College" };
+    Teacher t2 = { timestamp: time:currentTime().time, name: "Raja", age: 45, school: "Hindu College" };
+    Teacher t3 = { timestamp: time:currentTime().time - 1500, name: "Naveen", age: 35, school: "Hindu College" };
+    Teacher t4 = { timestamp: time:currentTime().time, name: "Amal", age: 50, school: "Hindu College" };
+
+    teachers[0] = t1;
+    teachers[1] = t2;
+    teachers[2] = t3;
+    teachers[3] = t4;
+
+    testTimeOrderWindow();
+
+    outputStreamTimeOrderTest.subscribe(function(TeacherOutput e) {printTeachers(e);});
+    foreach var t in teachers {
+        inputStreamTimeOrderTest.publish(t);
+    }
+
+    int count = 0;
+    while(true) {
+        runtime:sleep(500);
+        count += 1;
+        if((globalEmployeeArray.length()) == 4 || count == 10) {
+            break;
+        }
+    }
+    return globalEmployeeArray;
+}
+
+function testTimeOrderWindow() {
+    forever {
+        from inputStreamTimeOrderTest window timeOrder(inputStreamTimeOrderTest.timestamp, 1000, false)
+        select inputStreamTimeOrderTest.name, sum(inputStreamTimeOrderTest.age) as sumAge
+        => (TeacherOutput [] teachers) {
+            foreach var t in teachers {
+                outputStreamTimeOrderTest.publish(t);
+            }
+        }
+    }
+}
+
+function printTeachers(TeacherOutput e) {
+    addToGlobalEmployeeArray(e);
+}
+
+function addToGlobalEmployeeArray(TeacherOutput e) {
+    globalEmployeeArray[index] = e;
+    index = index + 1;
+}

--- a/stdlib/streams/src/test/resources/test-src/streamingv2-time-order-window-test2.bal
+++ b/stdlib/streams/src/test/resources/test-src/streamingv2-time-order-window-test2.bal
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/runtime;
+import ballerina/time;
+
+type Teacher record {
+    int timestamp;
+    string name;
+    int age;
+    string school;
+};
+
+type TeacherOutput record{
+    string name;
+    int sumAge;
+};
+
+int index = 0;
+stream<Teacher> inputStreamTimeOrderTest = new;
+stream<TeacherOutput > outputStreamTimeOrderTest = new;
+TeacherOutput[] globalEmployeeArray = [];
+
+function startTimeOrderWindowTest2() returns (TeacherOutput[]) {
+
+    Teacher[] teachers = [];
+    Teacher t1 = { timestamp: time:currentTime().time, name: "Mohan", age: 30, school: "Hindu College" };
+    Teacher t2 = { timestamp: time:currentTime().time, name: "Raja", age: 45, school: "Hindu College" };
+    Teacher t3 = { timestamp: time:currentTime().time - 1500, name: "Naveen", age: 35, school: "Hindu College" };
+    Teacher t4 = { timestamp: time:currentTime().time, name: "Amal", age: 50, school: "Hindu College" };
+
+    teachers[0] = t1;
+    teachers[1] = t2;
+    teachers[2] = t3;
+    teachers[3] = t4;
+
+    testTimeOrderWindow();
+
+    outputStreamTimeOrderTest.subscribe(function(TeacherOutput e) {printTeachers(e);});
+    foreach var t in teachers {
+        inputStreamTimeOrderTest.publish(t);
+    }
+
+    int count = 0;
+    while(true) {
+        runtime:sleep(500);
+        count += 1;
+        if((globalEmployeeArray.length()) == 3 || count == 10) {
+            break;
+        }
+    }
+    return globalEmployeeArray;
+}
+
+function testTimeOrderWindow() {
+    forever {
+        from inputStreamTimeOrderTest window timeOrder(inputStreamTimeOrderTest.timestamp, 1000, true)
+        select inputStreamTimeOrderTest.name, sum(inputStreamTimeOrderTest.age) as sumAge
+        => (TeacherOutput [] teachers) {
+            foreach var t in teachers {
+                outputStreamTimeOrderTest.publish(t);
+            }
+        }
+    }
+}
+
+function printTeachers(TeacherOutput e) {
+    addToGlobalEmployeeArray(e);
+}
+
+function addToGlobalEmployeeArray(TeacherOutput e) {
+    globalEmployeeArray[index] = e;
+    index = index + 1;
+}

--- a/stdlib/streams/src/test/resources/test-src/streamingv2-time-order-window-test2.bal
+++ b/stdlib/streams/src/test/resources/test-src/streamingv2-time-order-window-test2.bal
@@ -30,8 +30,8 @@ type TeacherOutput record{
 };
 
 int index = 0;
-stream<Teacher> inputStreamTimeOrderTest = new;
-stream<TeacherOutput > outputStreamTimeOrderTest = new;
+stream<Teacher> inputStreamTimeOrderTest2 = new;
+stream<TeacherOutput > outputStreamTimeOrderTest2 = new;
 TeacherOutput[] globalEmployeeArray = [];
 
 function startTimeOrderWindowTest2() returns (TeacherOutput[]) {
@@ -49,9 +49,9 @@ function startTimeOrderWindowTest2() returns (TeacherOutput[]) {
 
     testTimeOrderWindow();
 
-    outputStreamTimeOrderTest.subscribe(function(TeacherOutput e) {printTeachers(e);});
+    outputStreamTimeOrderTest2.subscribe(function(TeacherOutput e) {printTeachers(e);});
     foreach var t in teachers {
-        inputStreamTimeOrderTest.publish(t);
+        inputStreamTimeOrderTest2.publish(t);
     }
 
     int count = 0;
@@ -67,11 +67,11 @@ function startTimeOrderWindowTest2() returns (TeacherOutput[]) {
 
 function testTimeOrderWindow() {
     forever {
-        from inputStreamTimeOrderTest window timeOrder(inputStreamTimeOrderTest.timestamp, 1000, true)
-        select inputStreamTimeOrderTest.name, sum(inputStreamTimeOrderTest.age) as sumAge
+        from inputStreamTimeOrderTest2 window timeOrder(inputStreamTimeOrderTest2.timestamp, 1000, true)
+        select inputStreamTimeOrderTest2.name, sum(inputStreamTimeOrderTest2.age) as sumAge
         => (TeacherOutput [] teachers) {
             foreach var t in teachers {
-                outputStreamTimeOrderTest.publish(t);
+                outputStreamTimeOrderTest2.publish(t);
             }
         }
     }


### PR DESCRIPTION
## Purpose
> Purpose of this PR is to add time order window to ballerina native streaming implementation.

>This window orders events that arrive out-of-order, using external timestamp-values provided in the event, and by comparing that timestamp value to system time.

**example query**
```
forever {
        from inputStreamt window timeOrder(inputStream.timestamp, 1000, false)
        select inputStream.name, sum(inputStream.age) as sumAge
        => (TeacherOutput [] teachers) {
            foreach var t in teachers {
                outputStream.publish(t);
            }
        }
    }
```
 
## Assignees
@mohanvive , @gimantha , @grainier 