### PR TITLE
Fix swagger mock and client gen command in examples

### DIFF
--- a/examples/swagger-to-ballerina/swagger_to_ballerina.out
+++ b/examples/swagger-to-ballerina/swagger_to_ballerina.out
@@ -1,7 +1,7 @@
 #Run the following command in the Ballerina tools distribution for mock service generation.
-$ ballerina swagger mock swagger_to_ballerina.yaml -p pet_service
+$ ballerina swagger mock swagger_to_ballerina.yaml -m pet_service
 successfully generated ballerina mock service for input file - swagger_to_ballerina.yaml
 
 #Run the following command in the Ballerina tools distribution for client service generation.
-$ ballerina swagger client swagger_to_ballerina.yaml -p pet_client
+$ ballerina swagger client swagger_to_ballerina.yaml -m pet_client
 successfully generated ballerina client for input file - swagger_to_ballerina.yaml


### PR DESCRIPTION
## Purpose
In swagger-to-ballerina example's `.out` file swagger command for both mock service and client generation is outdated and this will fix it.