### PR TITLE
Add additional details to client generation example

### DIFF
--- a/examples/client-generation/client_generation.description
+++ b/examples/client-generation/client_generation.description
@@ -1,3 +1,4 @@
 // In this example, you generate a client for a Ballerina service.
 // Add the `@swagger:ClientEndpoint` annotation to mark the endpoint(s) that are used for client generation.
 // Add the `@swagger:ClientConfig {generate: true}` annotation to the service to enable client generation.
+// The generated client can be found in `<project.home>/target/client/` directory.


### PR DESCRIPTION
## Purpose
This will add additional details to the `.description` file in client-generation example about where they can find the generated `.bal`