### PR TITLE
Fix comparing versions to work with versions like x.x-r1

### DIFF
--- a/tool-plugins/vscode/package-lock.json
+++ b/tool-plugins/vscode/package-lock.json
@@ -22,9 +22,9 @@
             "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
-                "@types/minimatch": "*",
-                "@types/node": "*"
+                "@types/events": "1.2.0",
+                "@types/minimatch": "3.0.3",
+                "@types/node": "8.10.38"
             }
         },
         "@types/lodash": {
@@ -57,8 +57,8 @@
             "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
-                "@types/node": "*"
+                "@types/events": "1.2.0",
+                "@types/node": "8.10.38"
             }
         },
         "abbrev": {
@@ -72,10 +72,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
             "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
             }
         },
         "amdefine": {
@@ -122,7 +122,7 @@
             "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "requires": {
-                "buffer-equal": "^1.0.0"
+                "buffer-equal": "1.0.0"
             }
         },
         "argparse": {
@@ -131,7 +131,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -139,8 +139,8 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "requires": {
-                "arr-flatten": "^1.0.1",
-                "array-slice": "^0.2.3"
+                "arr-flatten": "1.1.0",
+                "array-slice": "0.2.3"
             }
         },
         "arr-flatten": {
@@ -168,7 +168,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -191,7 +191,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "assert-plus": {
@@ -236,9 +236,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -247,11 +247,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "supports-color": {
@@ -272,7 +272,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "block-stream": {
@@ -280,7 +280,7 @@
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "boolbase": {
@@ -294,7 +294,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -303,9 +303,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.3"
             }
         },
         "browser-stdout": {
@@ -351,12 +351,12 @@
             "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
             "dev": true,
             "requires": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.1.0",
-                "type-detect": "^4.0.5"
+                "assertion-error": "1.1.0",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.8"
             }
         },
         "chalk": {
@@ -365,9 +365,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -376,7 +376,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 },
                 "has-flag": {
@@ -391,7 +391,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -408,12 +408,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "~1.2.0",
-                "dom-serializer": "~0.1.0",
-                "entities": "~1.1.1",
-                "htmlparser2": "^3.9.1",
-                "lodash": "^4.15.0",
-                "parse5": "^3.0.1"
+                "css-select": "1.2.0",
+                "dom-serializer": "0.1.0",
+                "entities": "1.1.2",
+                "htmlparser2": "3.10.0",
+                "lodash": "4.17.11",
+                "parse5": "3.0.3"
             }
         },
         "clone": {
@@ -436,9 +436,9 @@
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "color-convert": {
@@ -461,18 +461,13 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-        },
-        "compare-versions": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-            "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -489,7 +484,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "core-util-is": {
@@ -502,8 +497,8 @@
             "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
             "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
             "requires": {
-                "cross-spawn": "^6.0.5",
-                "is-windows": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "is-windows": "1.0.2"
             }
         },
         "cross-spawn": {
@@ -511,11 +506,11 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.5",
+                "path-key": "2.0.1",
+                "semver": "5.6.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "css-select": {
@@ -524,10 +519,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0",
-                "css-what": "2.1",
+                "boolbase": "1.0.0",
+                "css-what": "2.1.2",
                 "domutils": "1.5.1",
-                "nth-check": "~1.0.1"
+                "nth-check": "1.0.2"
             }
         },
         "css-what": {
@@ -541,10 +536,10 @@
             "resolved": "http://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
             "integrity": "sha1-jbrn3f26rmLB6ph8Pg+Kmsc3tz0=",
             "requires": {
-                "csv-generate": "^0.0.6",
-                "csv-parse": "^1.0.0",
-                "csv-stringify": "^0.0.8",
-                "stream-transform": "^0.1.0"
+                "csv-generate": "0.0.6",
+                "csv-parse": "1.3.3",
+                "csv-stringify": "0.0.8",
+                "stream-transform": "0.1.2"
             }
         },
         "csv-generate": {
@@ -567,7 +562,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "debug": {
@@ -584,7 +579,7 @@
             "integrity": "sha512-XLFg1feTf4cZ5MBxJWEkvQTo7m5PiYF7oNkCGT/ibytYOUGucLBr+WZB+cbyK+6Z4wpazFbrmoUAU0+/6DC/2w==",
             "dev": true,
             "requires": {
-                "callsite": "^1.0.0"
+                "callsite": "1.0.0"
             }
         },
         "deep-assign": {
@@ -592,7 +587,7 @@
             "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "deep-eql": {
@@ -601,7 +596,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "^4.0.0"
+                "type-detect": "4.0.8"
             }
         },
         "deep-is": {
@@ -615,7 +610,7 @@
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.0.12"
             }
         },
         "delayed-stream": {
@@ -640,8 +635,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
+                "domelementtype": "1.1.3",
+                "entities": "1.1.2"
             },
             "dependencies": {
                 "domelementtype": {
@@ -664,7 +659,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1"
+                "domelementtype": "1.2.1"
             }
         },
         "domutils": {
@@ -673,8 +668,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.2.1"
             }
         },
         "duplexer": {
@@ -687,10 +682,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
             "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -698,8 +693,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "end-of-stream": {
@@ -707,7 +702,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "entities": {
@@ -727,11 +722,11 @@
             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
             "dev": true,
             "requires": {
-                "esprima": "^2.7.1",
-                "estraverse": "^1.9.1",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.2.0"
+                "esprima": "2.7.3",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.2.0"
             },
             "dependencies": {
                 "source-map": {
@@ -741,7 +736,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -769,13 +764,13 @@
             "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
             }
         },
         "expand-brackets": {
@@ -783,7 +778,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
             }
         },
         "expand-range": {
@@ -791,7 +786,7 @@
             "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             }
         },
         "extend": {
@@ -804,7 +799,7 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "requires": {
-                "kind-of": "^1.1.0"
+                "kind-of": "1.1.0"
             }
         },
         "extglob": {
@@ -812,7 +807,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -848,7 +843,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "filename-regex": {
@@ -861,11 +856,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "3.1.1",
+                "repeat-element": "1.1.3",
+                "repeat-string": "1.6.1"
             }
         },
         "first-chunk-stream": {
@@ -878,8 +873,8 @@
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "for-in": {
@@ -892,7 +887,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -905,9 +900,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.21"
             }
         },
         "from": {
@@ -920,8 +915,8 @@
             "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "through2": "^2.0.3"
+                "graceful-fs": "4.1.15",
+                "through2": "2.0.5"
             }
         },
         "fs.realpath": {
@@ -934,10 +929,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.15",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "function-bind": {
@@ -956,7 +951,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -964,12 +959,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -977,8 +972,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "glob-parent": {
@@ -986,7 +981,7 @@
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -999,7 +994,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -1009,8 +1004,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             }
         },
         "glob-stream": {
@@ -1018,14 +1013,14 @@
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "requires": {
-                "extend": "^3.0.0",
-                "glob": "^5.0.3",
-                "glob-parent": "^3.0.0",
-                "micromatch": "^2.3.7",
-                "ordered-read-streams": "^0.3.0",
-                "through2": "^0.6.0",
-                "to-absolute-glob": "^0.1.1",
-                "unique-stream": "^2.0.2"
+                "extend": "3.0.2",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
             },
             "dependencies": {
                 "glob": {
@@ -1033,11 +1028,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -1050,10 +1045,10 @@
                     "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -1066,8 +1061,8 @@
                     "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -1087,9 +1082,9 @@
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.5"
             }
         },
         "gulp-filter": {
@@ -1097,9 +1092,9 @@
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
             }
         },
         "gulp-gunzip": {
@@ -1107,8 +1102,8 @@
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -1121,10 +1116,10 @@
                     "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -1137,8 +1132,8 @@
                     "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -1149,10 +1144,10 @@
             "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
             "requires": {
                 "event-stream": "3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
+                "node.extend": "1.1.8",
+                "request": "2.88.0",
+                "through2": "2.0.5",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1170,12 +1165,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -1185,11 +1180,11 @@
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
+                "convert-source-map": "1.6.0",
+                "graceful-fs": "4.1.15",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.5",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1207,8 +1202,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1220,9 +1215,9 @@
             "integrity": "sha512-UHd3MokfIN7SrFdsbV5uZTwzBpL0ZSTu7iq98fuDqBGZ0dlHxgbQBJwfd6qjCW83snkQ3Hz9IY4sMRMz2iTq7w==",
             "requires": {
                 "event-stream": "3.3.4",
-                "mkdirp": "^0.5.1",
-                "queue": "^3.1.0",
-                "vinyl-fs": "^2.4.3"
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
             }
         },
         "gulp-untar": {
@@ -1230,11 +1225,11 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "requires": {
-                "event-stream": "~3.3.4",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3",
-                "vinyl": "^1.2.0"
+                "event-stream": "3.3.4",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.5",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1252,8 +1247,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1265,12 +1260,12 @@
             "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
             "requires": {
                 "event-stream": "3.3.4",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^3.0.3",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
+                "queue": "4.5.0",
+                "through2": "2.0.5",
+                "vinyl": "2.2.0",
+                "vinyl-fs": "3.0.3",
+                "yauzl": "2.10.0",
+                "yazl": "2.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -1288,16 +1283,16 @@
                     "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
                     "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "requires": {
-                        "extend": "^3.0.0",
-                        "glob": "^7.1.1",
-                        "glob-parent": "^3.1.0",
-                        "is-negated-glob": "^1.0.0",
-                        "ordered-read-streams": "^1.0.0",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.1.5",
-                        "remove-trailing-separator": "^1.0.1",
-                        "to-absolute-glob": "^2.0.0",
-                        "unique-stream": "^2.0.2"
+                        "extend": "3.0.2",
+                        "glob": "7.1.3",
+                        "glob-parent": "3.1.0",
+                        "is-negated-glob": "1.0.0",
+                        "ordered-read-streams": "1.0.1",
+                        "pumpify": "1.5.1",
+                        "readable-stream": "2.3.6",
+                        "remove-trailing-separator": "1.1.0",
+                        "to-absolute-glob": "2.0.2",
+                        "unique-stream": "2.2.1"
                     }
                 },
                 "is-valid-glob": {
@@ -1310,7 +1305,7 @@
                     "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
                     "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "requires": {
-                        "readable-stream": "^2.0.1"
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "queue": {
@@ -1318,7 +1313,7 @@
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.0.tgz",
                     "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
                     "requires": {
-                        "inherits": "~2.0.0"
+                        "inherits": "2.0.3"
                     }
                 },
                 "to-absolute-glob": {
@@ -1326,8 +1321,8 @@
                     "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
                     "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
                     "requires": {
-                        "is-absolute": "^1.0.0",
-                        "is-negated-glob": "^1.0.0"
+                        "is-absolute": "1.0.0",
+                        "is-negated-glob": "1.0.0"
                     }
                 },
                 "vinyl": {
@@ -1335,12 +1330,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 },
                 "vinyl-fs": {
@@ -1348,23 +1343,23 @@
                     "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
                     "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
                     "requires": {
-                        "fs-mkdirp-stream": "^1.0.0",
-                        "glob-stream": "^6.1.0",
-                        "graceful-fs": "^4.0.0",
-                        "is-valid-glob": "^1.0.0",
-                        "lazystream": "^1.0.0",
-                        "lead": "^1.0.0",
-                        "object.assign": "^4.0.4",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.3.3",
-                        "remove-bom-buffer": "^3.0.0",
-                        "remove-bom-stream": "^1.2.0",
-                        "resolve-options": "^1.1.0",
-                        "through2": "^2.0.0",
-                        "to-through": "^2.0.0",
-                        "value-or-function": "^3.0.0",
-                        "vinyl": "^2.0.0",
-                        "vinyl-sourcemap": "^1.1.0"
+                        "fs-mkdirp-stream": "1.0.0",
+                        "glob-stream": "6.1.0",
+                        "graceful-fs": "4.1.15",
+                        "is-valid-glob": "1.0.0",
+                        "lazystream": "1.0.0",
+                        "lead": "1.0.0",
+                        "object.assign": "4.1.0",
+                        "pumpify": "1.5.1",
+                        "readable-stream": "2.3.6",
+                        "remove-bom-buffer": "3.0.0",
+                        "remove-bom-stream": "1.2.0",
+                        "resolve-options": "1.1.0",
+                        "through2": "2.0.5",
+                        "to-through": "2.0.0",
+                        "value-or-function": "3.0.0",
+                        "vinyl": "2.2.0",
+                        "vinyl-sourcemap": "1.1.0"
                     }
                 }
             }
@@ -1375,10 +1370,10 @@
             "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "async": "2.6.1",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.4.9"
             },
             "dependencies": {
                 "async": {
@@ -1387,7 +1382,7 @@
                     "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.10"
+                        "lodash": "4.17.11"
                     }
                 }
             }
@@ -1402,8 +1397,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.5.5",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -1411,7 +1406,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -1420,7 +1415,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -1444,12 +1439,12 @@
             "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
             "dev": true,
             "requires": {
-                "domelementtype": "^1.3.0",
-                "domhandler": "^2.3.0",
-                "domutils": "^1.5.1",
-                "entities": "^1.1.1",
-                "inherits": "^2.0.1",
-                "readable-stream": "^3.0.6"
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.2",
+                "domutils": "1.5.1",
+                "entities": "1.1.2",
+                "inherits": "2.0.3",
+                "readable-stream": "3.0.6"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1464,9 +1459,9 @@
                     "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
                     "dev": true,
                     "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
+                        "inherits": "2.0.3",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 }
             }
@@ -1476,9 +1471,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.15.2"
             }
         },
         "inflight": {
@@ -1486,8 +1481,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -1505,8 +1500,8 @@
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.2"
             }
         },
         "is-buffer": {
@@ -1524,7 +1519,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -1542,7 +1537,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
             }
         },
         "is-negated-glob": {
@@ -1555,7 +1550,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1563,7 +1558,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1588,7 +1583,7 @@
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "requires": {
-                "is-unc-path": "^1.0.0"
+                "is-unc-path": "1.0.0"
             }
         },
         "is-stream": {
@@ -1606,7 +1601,7 @@
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "requires": {
-                "unc-path-regex": "^0.1.2"
+                "unc-path-regex": "0.1.2"
             }
         },
         "is-utf8": {
@@ -1653,20 +1648,20 @@
             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.x",
-                "async": "1.x",
-                "escodegen": "1.8.x",
-                "esprima": "2.7.x",
-                "glob": "^5.0.15",
-                "handlebars": "^4.0.1",
-                "js-yaml": "3.x",
-                "mkdirp": "0.5.x",
-                "nopt": "3.x",
-                "once": "1.x",
-                "resolve": "1.1.x",
-                "supports-color": "^3.1.0",
-                "which": "^1.1.1",
-                "wordwrap": "^1.0.0"
+                "abbrev": "1.0.9",
+                "async": "1.2.1",
+                "escodegen": "1.8.1",
+                "esprima": "2.7.3",
+                "glob": "5.0.15",
+                "handlebars": "4.0.12",
+                "js-yaml": "3.12.0",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "once": "1.4.0",
+                "resolve": "1.1.7",
+                "supports-color": "3.2.3",
+                "which": "1.3.1",
+                "wordwrap": "1.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -1675,11 +1670,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-flag": {
@@ -1694,7 +1689,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "1.0.0"
                     }
                 }
             }
@@ -1711,8 +1706,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             },
             "dependencies": {
                 "esprima": {
@@ -1743,7 +1738,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1777,7 +1772,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.3.6"
             }
         },
         "lead": {
@@ -1785,7 +1780,7 @@
             "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "requires": {
-                "flush-write-stream": "^1.0.2"
+                "flush-write-stream": "1.0.3"
             }
         },
         "levn": {
@@ -1794,8 +1789,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "linkify-it": {
@@ -1804,7 +1799,7 @@
             "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
             "dev": true,
             "requires": {
-                "uc.micro": "^1.0.1"
+                "uc.micro": "1.0.5"
             }
         },
         "lodash": {
@@ -1834,11 +1829,11 @@
             "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "entities": "~1.1.1",
-                "linkify-it": "^2.0.0",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
+                "argparse": "1.0.10",
+                "entities": "1.1.2",
+                "linkify-it": "2.0.3",
+                "mdurl": "1.0.1",
+                "uc.micro": "1.0.5"
             }
         },
         "math-random": {
@@ -1857,7 +1852,7 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "micromatch": {
@@ -1865,19 +1860,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1885,7 +1880,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "is-extglob": {
@@ -1898,7 +1893,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1906,7 +1901,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1927,7 +1922,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.37.0"
             }
         },
         "minimatch": {
@@ -1935,7 +1930,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -1994,12 +1989,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "growl": {
@@ -2020,7 +2015,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -2040,9 +2035,9 @@
             "resolved": "https://registry.npmjs.org/ms-wmic/-/ms-wmic-1.0.4.tgz",
             "integrity": "sha1-FE28YDCH8Jv9mUDgVPGtBLYiP6g=",
             "requires": {
-                "async": "~1.2.1",
-                "csv": "~0.4.0",
-                "lodash": "~3.9.3"
+                "async": "1.2.1",
+                "csv": "0.4.6",
+                "lodash": "3.9.3"
             },
             "dependencies": {
                 "lodash": {
@@ -2057,10 +2052,10 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
             }
         },
         "mute-stream": {
@@ -2079,8 +2074,8 @@
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
             "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "requires": {
-                "has": "^1.0.3",
-                "is": "^3.2.1"
+                "has": "1.0.3",
+                "is": "3.2.1"
             }
         },
         "nopt": {
@@ -2089,7 +2084,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1"
+                "abbrev": "1.0.9"
             }
         },
         "normalize-path": {
@@ -2097,7 +2092,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "now-and-later": {
@@ -2105,7 +2100,7 @@
             "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "requires": {
-                "once": "^1.3.2"
+                "once": "1.4.0"
             }
         },
         "nth-check": {
@@ -2114,7 +2109,7 @@
             "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0"
+                "boolbase": "1.0.0"
             }
         },
         "oauth-sign": {
@@ -2137,10 +2132,10 @@
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.12"
             }
         },
         "object.omit": {
@@ -2148,8 +2143,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "once": {
@@ -2157,7 +2152,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "openport": {
@@ -2171,8 +2166,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
             },
             "dependencies": {
                 "wordwrap": {
@@ -2189,12 +2184,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "ordered-read-streams": {
@@ -2202,8 +2197,8 @@
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "requires": {
-                "is-stream": "^1.0.1",
-                "readable-stream": "^2.0.1"
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.6"
             }
         },
         "os-homedir": {
@@ -2224,8 +2219,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "parse-glob": {
@@ -2233,10 +2228,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2249,7 +2244,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -2260,7 +2255,7 @@
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
-                "semver": "^5.1.0"
+                "semver": "5.6.0"
             }
         },
         "parse5": {
@@ -2269,7 +2264,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "8.10.38"
             }
         },
         "path-dirname": {
@@ -2304,7 +2299,7 @@
             "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
-                "through": "~2.3"
+                "through": "2.3.8"
             }
         },
         "pend": {
@@ -2322,11 +2317,11 @@
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
             }
         },
         "prelude-ls": {
@@ -2350,7 +2345,7 @@
             "resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
             "integrity": "sha1-mvZ6mdex0BMuUaUDCZ04qNKs4sM=",
             "requires": {
-                "table-parser": "^0.1.3"
+                "table-parser": "0.1.3"
             }
         },
         "psl": {
@@ -2363,8 +2358,8 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -2372,9 +2367,9 @@
             "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.6.1",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -2403,7 +2398,7 @@
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "randomatic": {
@@ -2411,9 +2406,9 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
             "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -2434,7 +2429,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "~0.0.4"
+                "mute-stream": "0.0.7"
             }
         },
         "readable-stream": {
@@ -2442,13 +2437,13 @@
             "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "regex-cache": {
@@ -2456,7 +2451,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "remap-istanbul": {
@@ -2465,11 +2460,11 @@
             "integrity": "sha512-lpA+zkWfT7v81k76asd+w82+dnbBTmBEsyuBVQ28armnOqsZZO23uI4ZCBGd8TtIb9Tq4CauswB+A44cbkuiMA==",
             "dev": true,
             "requires": {
-                "amdefine": "^1.0.0",
+                "amdefine": "1.0.1",
                 "istanbul": "0.4.5",
-                "minimatch": "^3.0.3",
-                "plugin-error": "^0.1.2",
-                "source-map": "^0.6.1",
+                "minimatch": "3.0.4",
+                "plugin-error": "0.1.2",
+                "source-map": "0.6.1",
                 "through2": "2.0.1"
             },
             "dependencies": {
@@ -2485,12 +2480,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -2505,8 +2500,8 @@
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "~2.0.0",
-                        "xtend": "~4.0.0"
+                        "readable-stream": "2.0.6",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -2516,8 +2511,8 @@
             "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "requires": {
-                "is-buffer": "^1.1.5",
-                "is-utf8": "^0.2.1"
+                "is-buffer": "1.1.6",
+                "is-utf8": "0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -2525,9 +2520,9 @@
             "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "requires": {
-                "remove-bom-buffer": "^3.0.0",
-                "safe-buffer": "^5.1.0",
-                "through2": "^2.0.3"
+                "remove-bom-buffer": "3.0.0",
+                "safe-buffer": "5.1.2",
+                "through2": "2.0.5"
             }
         },
         "remove-trailing-separator": {
@@ -2555,26 +2550,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.21",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "requires-port": {
@@ -2593,7 +2588,7 @@
             "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "requires": {
-                "value-or-function": "^3.0.0"
+                "value-or-function": "3.0.0"
             }
         },
         "rimraf": {
@@ -2601,7 +2596,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.3"
             }
         },
         "safe-buffer": {
@@ -2624,7 +2619,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -2642,8 +2637,8 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
             "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
             }
         },
         "split": {
@@ -2651,7 +2646,7 @@
             "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "requires": {
-                "through": "2"
+                "through": "2.3.8"
             }
         },
         "sprintf-js": {
@@ -2665,15 +2660,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
             "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "stat-mode": {
@@ -2686,7 +2681,7 @@
             "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "requires": {
-                "duplexer": "~0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "stream-shift": {
@@ -2704,7 +2699,7 @@
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
             }
         },
         "streamifier": {
@@ -2717,7 +2712,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -2726,7 +2721,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -2734,7 +2729,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-bom-stream": {
@@ -2742,8 +2737,8 @@
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
             }
         },
         "supports-color": {
@@ -2751,7 +2746,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
             "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
             "requires": {
-                "has-flag": "^2.0.0"
+                "has-flag": "2.0.0"
             }
         },
         "table-parser": {
@@ -2759,7 +2754,7 @@
             "resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
             "integrity": "sha1-BEHPzhallIFoTCfRtaZ/8VpDx7A=",
             "requires": {
-                "connected-domain": "^1.0.0"
+                "connected-domain": "1.0.0"
             }
         },
         "tar": {
@@ -2767,9 +2762,9 @@
             "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "through": {
@@ -2782,8 +2777,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "through2-filter": {
@@ -2791,8 +2786,8 @@
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
+                "through2": "2.0.5",
+                "xtend": "4.0.1"
             }
         },
         "tmp": {
@@ -2801,7 +2796,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.1"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -2809,7 +2804,7 @@
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "requires": {
-                "extend-shallow": "^2.0.1"
+                "extend-shallow": "2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2817,7 +2812,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -2827,7 +2822,7 @@
             "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "requires": {
-                "through2": "^2.0.3"
+                "through2": "2.0.5"
             }
         },
         "toml": {
@@ -2840,8 +2835,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
+                "psl": "1.1.29",
+                "punycode": "1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -2857,14 +2852,14 @@
             "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.0",
-                "buffer-from": "^1.1.0",
-                "diff": "^3.1.0",
-                "make-error": "^1.1.1",
-                "minimist": "^1.2.0",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.5.6",
-                "yn": "^2.0.0"
+                "arrify": "1.0.1",
+                "buffer-from": "1.1.1",
+                "diff": "3.3.1",
+                "make-error": "1.3.5",
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.5.9",
+                "yn": "2.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -2887,18 +2882,18 @@
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.27.2"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.19.0",
+                "diff": "3.3.1",
+                "glob": "7.1.3",
+                "js-yaml": "3.12.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.8.1",
+                "semver": "5.6.0",
+                "tslib": "1.9.3",
+                "tsutils": "2.29.0"
             },
             "dependencies": {
                 "commander": {
@@ -2913,7 +2908,7 @@
                     "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.6"
                     }
                 }
             }
@@ -2924,7 +2919,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.3"
             }
         },
         "tunnel": {
@@ -2938,7 +2933,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -2952,7 +2947,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "type-detect": {
@@ -2998,8 +2993,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.17.1",
-                "source-map": "~0.6.1"
+                "commander": "2.17.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -3027,8 +3022,8 @@
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
             }
         },
         "uri-js": {
@@ -3036,7 +3031,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "url-join": {
@@ -3050,8 +3045,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
             "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.1.0",
+                "requires-port": "1.0.0"
             }
         },
         "util-deprecate": {
@@ -3079,9 +3074,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vinyl": {
@@ -3089,8 +3084,8 @@
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "requires": {
-                "clone": "^0.2.0",
-                "clone-stats": "^0.0.1"
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
             }
         },
         "vinyl-fs": {
@@ -3098,23 +3093,23 @@
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "requires": {
-                "duplexify": "^3.2.0",
-                "glob-stream": "^5.3.2",
-                "graceful-fs": "^4.0.0",
+                "duplexify": "3.6.1",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.15",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "^0.3.0",
-                "lazystream": "^1.0.0",
-                "lodash.isequal": "^4.0.0",
-                "merge-stream": "^1.0.0",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.0",
-                "readable-stream": "^2.0.4",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^1.0.0",
-                "through2": "^2.0.0",
-                "through2-filter": "^2.0.0",
-                "vali-date": "^1.0.0",
-                "vinyl": "^1.0.0"
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.6",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.5",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -3132,8 +3127,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -3144,8 +3139,8 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
+                "through2": "2.0.5",
+                "vinyl": "0.4.6"
             }
         },
         "vinyl-sourcemap": {
@@ -3153,13 +3148,13 @@
             "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "requires": {
-                "append-buffer": "^1.0.2",
-                "convert-source-map": "^1.5.0",
-                "graceful-fs": "^4.1.6",
-                "normalize-path": "^2.1.1",
-                "now-and-later": "^2.0.0",
-                "remove-bom-buffer": "^3.0.0",
-                "vinyl": "^2.0.0"
+                "append-buffer": "1.0.2",
+                "convert-source-map": "1.6.0",
+                "graceful-fs": "4.1.15",
+                "normalize-path": "2.1.1",
+                "now-and-later": "2.0.0",
+                "remove-bom-buffer": "3.0.0",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -3177,12 +3172,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -3193,23 +3188,23 @@
             "integrity": "sha512-okap3jGyz6JeUNJon09MJbjsyAq3zeEJj3YpbYGjslDNn+0g5HikK1VGykNcpVTy5imYdwBAuIDubsm3xPFTEA==",
             "dev": true,
             "requires": {
-                "cheerio": "^1.0.0-rc.1",
-                "commander": "^2.8.1",
-                "denodeify": "^1.2.1",
-                "glob": "^7.0.6",
-                "lodash": "^4.17.10",
-                "markdown-it": "^8.3.1",
-                "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
-                "osenv": "^0.1.3",
-                "parse-semver": "^1.1.1",
-                "read": "^1.0.7",
-                "semver": "^5.1.0",
+                "cheerio": "1.0.0-rc.2",
+                "commander": "2.11.0",
+                "denodeify": "1.2.1",
+                "glob": "7.1.3",
+                "lodash": "4.17.11",
+                "markdown-it": "8.4.2",
+                "mime": "1.6.0",
+                "minimatch": "3.0.4",
+                "osenv": "0.1.5",
+                "parse-semver": "1.1.1",
+                "read": "1.0.7",
+                "semver": "5.6.0",
                 "tmp": "0.0.29",
-                "url-join": "^1.1.0",
+                "url-join": "1.1.0",
                 "vso-node-api": "6.1.2-preview",
-                "yauzl": "^2.3.1",
-                "yazl": "^2.2.2"
+                "yauzl": "2.10.0",
+                "yazl": "2.5.0"
             }
         },
         "vscode": {
@@ -3217,20 +3212,20 @@
             "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.22.tgz",
             "integrity": "sha512-G/zu7PRAN1yF80wg+l6ebIexDflU3uXXeabacJuLearTIfObKw4JaI8aeHwDEmpnCkc3MkIr3Bclkju2gtEz6A==",
             "requires": {
-                "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
+                "glob": "7.1.3",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.1",
-                "gulp-symdest": "^1.1.1",
-                "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.2",
-                "mocha": "^4.0.1",
-                "request": "^2.83.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.3",
-                "vinyl-source-stream": "^1.1.0"
+                "gulp-remote-src-vscode": "0.5.1",
+                "gulp-symdest": "1.1.1",
+                "gulp-untar": "0.0.7",
+                "gulp-vinyl-zip": "2.1.2",
+                "mocha": "4.1.0",
+                "request": "2.88.0",
+                "semver": "5.6.0",
+                "source-map-support": "0.5.9",
+                "url-parse": "1.4.4",
+                "vinyl-source-stream": "1.1.2"
             },
             "dependencies": {
                 "mocha": {
@@ -3255,12 +3250,12 @@
                             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                             "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
                             }
                         }
                     }
@@ -3272,7 +3267,7 @@
             "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.32.1.tgz",
             "integrity": "sha512-D7hpwmh4mPNJXLavginjGYbeIpSJj7L/FhfB4EqEnJH2om8jTvnMq6NvOyuHONn6YzarS/L3oAye7RNro9iviw==",
             "requires": {
-                "mkdirp": "^0.5.1",
+                "mkdirp": "0.5.1",
                 "vscode-debugprotocol": "1.32.0"
             }
         },
@@ -3300,7 +3295,7 @@
             "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.1.tgz",
             "integrity": "sha512-jMxshi+BPRQFNG8GB00dJv7ldqMda0be26laYYll/udtJuHbog6RqK10GSxHWDN0PgY0b0m5fePyTk3bq8a0TA==",
             "requires": {
-                "semver": "^5.5.0",
+                "semver": "5.6.0",
                 "vscode-languageserver-protocol": "3.13.0"
             }
         },
@@ -3309,7 +3304,7 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
             "integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
             "requires": {
-                "vscode-jsonrpc": "^4.0.0",
+                "vscode-jsonrpc": "4.0.0",
                 "vscode-languageserver-types": "3.13.0"
             }
         },
@@ -3324,10 +3319,10 @@
             "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
             "dev": true,
             "requires": {
-                "q": "^1.0.1",
+                "q": "1.5.1",
                 "tunnel": "0.0.4",
-                "typed-rest-client": "^0.9.0",
-                "underscore": "^1.8.3"
+                "typed-rest-client": "0.9.0",
+                "underscore": "1.9.1"
             }
         },
         "which": {
@@ -3335,7 +3330,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "wordwrap": {
@@ -3354,8 +3349,8 @@
             "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
             "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0"
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.2"
             }
         },
         "xtend": {
@@ -3368,8 +3363,8 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.1.0"
             }
         },
         "yazl": {
@@ -3377,7 +3372,7 @@
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.0.tgz",
             "integrity": "sha512-rgptqKwX/f1/7bIRF1FHb4HGsP5k11QyxBpDl1etUDfNpTa7CNjDOYNPFnIaEzZ9dRq0c47IEJS+sy+T39JCLw==",
             "requires": {
-                "buffer-crc32": "~0.2.3"
+                "buffer-crc32": "0.2.13"
             }
         },
         "yn": {

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -253,7 +253,6 @@
         "package": "vsce package"
     },
     "dependencies": {
-        "compare-versions": "^3.4.0",
         "cross-env": "^5.2.0",
         "glob": "^7.1.3",
         "lodash": "^4.17.11",

--- a/tool-plugins/vscode/test/core/ballerina-extention.test.ts
+++ b/tool-plugins/vscode/test/core/ballerina-extention.test.ts
@@ -53,4 +53,16 @@ suite("Ballerina Extension Core Tests", function () {
         });
     });
 
+    test("Test compareVersions", function () {
+        assert(ballerinaExtInstance.compareVersions("0.100.5", "0.100.8") === 0);
+        assert(ballerinaExtInstance.compareVersions("0.101.0", "0.100.0") > 0);
+        assert(ballerinaExtInstance.compareVersions("1.100.0", "0.100.0") > 0);
+        assert(ballerinaExtInstance.compareVersions("0.100.0", "0.101.0") < 0);
+        assert(ballerinaExtInstance.compareVersions("0.100.0", "1.100.0") < 0);
+        assert(ballerinaExtInstance.compareVersions("0.100.5", "0.100-r8") === 0);
+        assert(ballerinaExtInstance.compareVersions("0.101.0", "0.100-r1") > 0);
+        assert(ballerinaExtInstance.compareVersions("1.100.0", "0.100-r1") > 0);
+        assert(ballerinaExtInstance.compareVersions("0.100.0", "0.101-r1") < 0);
+        assert(ballerinaExtInstance.compareVersions("0.100.0", "1.100-r1") < 0);
+    });
 });


### PR DESCRIPTION
## Purpose
vscode plugin will compare major and minor versions of ballerina and the plugin to warn user of unmatching versions. Also works with 0.990-r1 like version strings.