### PR TITLE
Fix version infering for ballerina versions like 0.990-r3.1

### DIFF
--- a/tool-plugins/vscode/scripts/update-version.js
+++ b/tool-plugins/vscode/scripts/update-version.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 const path = require("path");
 const packageJson = require("../package.json");
-packageJson.version = process.argv[2].match(/\d+/g).join(".");
+packageJson.version = process.argv[2].match(/\d+/g).slice(0,3).join(".");
 
-fs.writeFileSync(path.join(__dirname, "../package.json"), JSON.stringify(packageJson, null, 4)+'\n');
+fs.writeFileSync(
+    path.join(__dirname, "../package.json"),
+    JSON.stringify(packageJson, null, 4)+"\n");


### PR DESCRIPTION
## Purpose

L1 fixing releases have 4 numbers on there version texts (0.990-r3.1). But probably won't require a separate plugin release. So the plugin version on this case would be 0.990.3
