### PR TITLE
Fix annotation auto completion and signature help Issues

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
@@ -207,6 +207,6 @@ public class LSAnnotationCache {
     private boolean isPackageProcessed(PackageID packageID) {
         return processedPackages
                 .stream()
-                .noneMatch(processedPkgId -> processedPkgId.toString().equals(packageID.toString()));
+                .anyMatch(processedPkgId -> processedPkgId.toString().equals(packageID.toString()));
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -455,8 +455,13 @@ public class CommonUtil {
         BLangPackage srcOwnerPkg = CommonUtil.getSourceOwnerBLangPackage(relativePath, pkg);
         List<BLangImportPackage> imports = CommonUtil.getCurrentFileImports(srcOwnerPkg, ctx);
         Optional currentPkgImport = imports.stream()
-                .filter(bLangImportPackage -> bLangImportPackage.symbol != null
-                        && bLangImportPackage.symbol.pkgID.equals(packageID))
+                .filter(bLangImportPackage -> {
+                    String pkgName = bLangImportPackage.orgName + "/"
+                            + CommonUtil.getPackageNameComponentsCombined(bLangImportPackage);
+                    String evalPkgName = packageID.orgName + "/" + packageID.nameComps.stream()
+                            .map(Name::getValue).collect(Collectors.joining("."));
+                    return pkgName.equals(evalPkgName);
+                })
                 .findAny();
         // if the particular import statement not available we add the additional text edit to auto import
         if (!currentPkgImport.isPresent()) {
@@ -731,7 +736,8 @@ public class CommonUtil {
             String defaultFieldEntry = bStructField.getName().getValue()
                     + UtilSymbolKeys.PKG_DELIMITER_KEYWORD + " " + getDefaultValueForType(bStructField.getType());
             if (bStructField.getType() instanceof BFiniteType || bStructField.getType() instanceof BUnionType) {
-                defaultFieldEntry += (i < fields.size() -1 ? "," : "") + getFiniteAndUnionTypesComment(bStructField.type);
+                defaultFieldEntry += (i < fields.size() - 1 ? "," : "") +
+                        getFiniteAndUnionTypesComment(bStructField.type);
             }
             fieldEntries.add(defaultFieldEntry);
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -726,14 +726,15 @@ public class CommonUtil {
     public static CompletionItem getFillAllStructFieldsItem(List<BField> fields) {
         List<String> fieldEntries = new ArrayList<>();
 
-        fields.forEach(bStructField -> {
+        for (int i = 0; i < fields.size(); i++) {
+            BField bStructField = fields.get(i);
             String defaultFieldEntry = bStructField.getName().getValue()
                     + UtilSymbolKeys.PKG_DELIMITER_KEYWORD + " " + getDefaultValueForType(bStructField.getType());
             if (bStructField.getType() instanceof BFiniteType || bStructField.getType() instanceof BUnionType) {
-                defaultFieldEntry += "," + getFiniteAndUnionTypesComment(bStructField.type);
+                defaultFieldEntry += (i < fields.size() -1 ? "," : "") + getFiniteAndUnionTypesComment(bStructField.type);
             }
             fieldEntries.add(defaultFieldEntry);
-        });
+        }
 
         String insertText = String.join(("," + LINE_SEPARATOR), fieldEntries);
         String label = "Add All Attributes";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -43,7 +43,6 @@ import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.TopLevelNode;
-import org.ballerinalang.model.types.FiniteType;
 import org.ballerinalang.util.BLangConstants;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
@@ -370,8 +369,7 @@ public class CommonUtil {
      */
     public static String topLevelNodeInLine(TextDocumentIdentifier identifier, int cursorLine,
                                             WorkspaceDocumentManager docManager) {
-        List<String> topLevelKeywords = Arrays.asList("function", "service", "resource", "endpoint", "object",
-                                                      "record");
+        List<String> topLevelKeywords = Arrays.asList("function", "service", "resource", "endpoint");
         LSDocument document = new LSDocument(identifier.getUri());
 
         try {
@@ -384,13 +382,23 @@ public class CommonUtil {
                 List<String> alphaNumericTokens = new ArrayList<>(Arrays.asList(lineContent.split("[^\\w']+")));
 
                 ListIterator<String> iterator = alphaNumericTokens.listIterator();
+                int tokenCounter = 0;
                 while (iterator.hasNext()) {
                     String topLevelKeyword = iterator.next();
-                    if (topLevelKeywords.contains(topLevelKeyword) &&
-                            (!iterator.hasNext() || !CONSTRUCTOR_FUNCTION_SUFFIX.equals(iterator.next()))) {
+
+                    boolean validTypeDef = (topLevelKeyword.equals(UtilSymbolKeys.RECORD_KEYWORD_KEY)
+                            || topLevelKeyword.equals(UtilSymbolKeys.OBJECT_KEYWORD_KEY))
+                            && tokenCounter > 1
+                            && alphaNumericTokens.get(tokenCounter - 2).equals("type");
+
+                    if (validTypeDef || (topLevelKeywords.contains(topLevelKeyword) &&
+                            (!iterator.hasNext() || !CONSTRUCTOR_FUNCTION_SUFFIX.equals(iterator.next())))) {
                         return topLevelKeyword;
                     }
+                    tokenCounter++;
                 }
+
+
             }
             return null;
         } catch (WorkspaceDocumentException e) {
@@ -602,17 +610,21 @@ public class CommonUtil {
                 typeString = "[]";
                 break;
             case RECORD:
+            case MAP:
                 typeString = "{}";
                 break;
             case FINITE:
-                List<String> types = new ArrayList<>();
-                ((FiniteType) bType).getValueSpace().forEach(typeEntry -> types.add(typeEntry.toString()));
-                types.sort(Comparator.naturalOrder());
-                typeString = String.join("|", types);
+                List<BLangExpression> valueSpace = new ArrayList<>(((BFiniteType) bType).valueSpace);
+                String value = valueSpace.get(0).toString();
+                BType type = valueSpace.get(0).type;
+                typeString = value;
+                if (type.toString().equals("string")) {
+                    typeString = "\"" + typeString + "\"";
+                }
                 break;
             case UNION:
-                String[] typeNameComps = bType.toString().split(UtilSymbolKeys.PKG_DELIMITER_KEYWORD);
-                typeString = typeNameComps[typeNameComps.length - 1];
+                List<BType> memberTypes = new ArrayList<>(((BUnionType) bType).memberTypes);
+                typeString = getDefaultValueForType(memberTypes.get(0));
                 break;
             case STREAM:
             default:
@@ -688,6 +700,9 @@ public class CommonUtil {
                 insertText.append("{").append(LINE_SEPARATOR).append("\t${1}").append(LINE_SEPARATOR).append("}");
             } else {
                 insertText.append("${1:").append(getDefaultValueForType(bStructField.getType())).append("}");
+                if (bStructField.getType() instanceof BFiniteType || bStructField.getType() instanceof BUnionType) {
+                    insertText.append(getFiniteAndUnionTypesComment(bStructField.getType()));
+                }
             }
             CompletionItem fieldItem = new CompletionItem();
             fieldItem.setInsertText(insertText.toString());
@@ -714,6 +729,9 @@ public class CommonUtil {
         fields.forEach(bStructField -> {
             String defaultFieldEntry = bStructField.getName().getValue()
                     + UtilSymbolKeys.PKG_DELIMITER_KEYWORD + " " + getDefaultValueForType(bStructField.getType());
+            if (bStructField.getType() instanceof BFiniteType || bStructField.getType() instanceof BUnionType) {
+                defaultFieldEntry += "," + getFiniteAndUnionTypesComment(bStructField.type);
+            }
             fieldEntries.add(defaultFieldEntry);
         });
 
@@ -1560,6 +1578,22 @@ public class CommonUtil {
             }
         }
         return pkgPrefix;
+    }
+
+    private static String getFiniteAndUnionTypesComment(BType bType) {
+        if (bType instanceof BFiniteType) {
+            List<BLangExpression> valueSpace = new ArrayList<>(((BFiniteType) bType).valueSpace);
+            return " // Values allowed: " + valueSpace.stream()
+                    .map(Object::toString)
+                    .collect(Collectors.joining("|"));
+        } else if (bType instanceof BUnionType) {
+            List<BType> memberTypes = new ArrayList<>(((BUnionType) bType).memberTypes);
+            return " // Values allowed: " + memberTypes.stream()
+                    .map(BType::toString)
+                    .collect(Collectors.joining("|"));
+        }
+
+        return "";
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangMatchExpressionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangMatchExpressionContextResolver.java
@@ -74,11 +74,11 @@ public class BLangMatchExpressionContextResolver extends AbstractItemResolver {
             String allFieldFiller = String.join("," + CommonUtil.LINE_SEPARATOR, memberTypesSnippets.values());
             String anyFieldFiller = UtilSymbolKeys.ANY_KEYWORD_KEY + " => ${1:" + defaultType + "}";
             
-            memberTypesSnippets.entrySet().forEach(entry -> {
+            memberTypesSnippets.forEach((key, value) -> {
                 CompletionItem memberItem = new CompletionItem();
-                memberItem.setLabel(matchSnippet + entry.getKey());
+                memberItem.setLabel(matchSnippet + key);
                 memberItem.setDetail(ItemResolverConstants.SNIPPET_TYPE);
-                memberItem.setInsertText(entry.getValue());
+                memberItem.setInsertText(value);
                 memberItem.setKind(CompletionItemKind.Snippet);
                 memberItem.setInsertTextFormat(InsertTextFormat.Snippet);
                 memberItem.setSortText(Priority.PRIORITY130.toString());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleVariableDefinitionStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleVariableDefinitionStatementContextResolver.java
@@ -51,6 +51,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangStatement;
 import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangType;
+import org.wso2.ballerinalang.compiler.tree.types.BLangUnionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 
@@ -277,7 +278,7 @@ public class ParserRuleVariableDefinitionStatementContextResolver extends Abstra
     }
 
     private String getTypeName(BLangType bLangType) throws LSCompletionException {
-        if (bLangType instanceof BLangValueType) {
+        if (bLangType instanceof BLangValueType || bLangType instanceof BLangUnionTypeNode) {
             return bLangType.toString();
         } else if (bLangType instanceof BLangUserDefinedType) {
             BLangUserDefinedType userDefinedType = (BLangUserDefinedType) bLangType;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -186,8 +186,10 @@ public class SignatureHelpUtil {
         SignatureInfoModel signatureInfoModel = new SignatureInfoModel();
         List<ParameterInfoModel> paramModels = new ArrayList<>();
         MarkdownDocAttachment docAttachment = bInvokableSymbol.getMarkdownDocAttachment();
-        
-        signatureInfoModel.setSignatureDescription(docAttachment.description.trim(), signatureCtx);
+
+        if (docAttachment.description != null) {
+            signatureInfoModel.setSignatureDescription(docAttachment.description.trim(), signatureCtx);
+        }
         docAttachment.parameters.forEach(attribute ->
                 paramDescMap.put(attribute.getName(), attribute.getDescription()));
 
@@ -195,7 +197,9 @@ public class SignatureHelpUtil {
             ParameterInfoModel parameterInfoModel = new ParameterInfoModel();
             parameterInfoModel.setParamType(bVarSymbol.getType().toString());
             parameterInfoModel.setParamValue(bVarSymbol.getName().getValue());
-            parameterInfoModel.setDescription(paramDescMap.get(bVarSymbol.getName().getValue()));
+            if (paramDescMap.containsKey(bVarSymbol.getName().getValue())) {
+                parameterInfoModel.setDescription(paramDescMap.get(bVarSymbol.getName().getValue()));
+            }
             paramModels.add(parameterInfoModel);
         });
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpTest.java
@@ -77,6 +77,7 @@ public class SignatureHelpTest {
         log.info("Test textDocument/signatureHelp");
         return new Object[][] {
                 {"functionInSameFile.json", "functionInSameFile.bal"},
+                {"functionInSameFileWithoutDocumentation.json", "functionInSameFileWithoutDocumentation.bal"},
                 {"typeAttachedFunctions.json", "typeAttachedFunctions.bal"},
                 {"functionInBuiltinPackage.json", "functionInBuiltinPackage.bal"},
                 {"endpointActions.json", "endpointActions.bal"},

--- a/language-server/modules/langserver-core/src/test/resources/signature/functionInSameFileWithoutDocumentation.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/functionInSameFileWithoutDocumentation.json
@@ -1,0 +1,36 @@
+{
+  "position": {
+    "line": 1,
+    "character": 16
+  },
+  "expected": {
+    "result": {
+      "signatures": [
+        {
+          "label": "getGreeting(int year, string message)",
+          "parameters": [
+            {
+              "label": "year",
+              "documentation": {
+                "right": {
+                  "kind": "markdown"
+                }
+              }
+            },
+            {
+              "label": "message",
+              "documentation": {
+                "right": {
+                  "kind": "markdown"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "activeSignature": 0,
+      "activeParameter": 0
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/signature/source/functionInSameFileWithoutDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/signature/source/functionInSameFileWithoutDocumentation.bal
@@ -1,0 +1,7 @@
+function testSignatureHelp () {
+    getGreeting(
+}
+
+function getGreeting (int year, string message) returns string {
+    return message + year;
+}


### PR DESCRIPTION
## Purpose
> With this, fix the following issues,
- Annotation add all attributes issue of not providing the default values for finite and union types
- Signature Help not provided for the functions without documentation
- Record and object code actions are provided for anonymous records
- Resolves #13399 and #13388
- When adding an annotation with the particular package has been imported already, annotation selection will add another import statement