### PR TITLE
Fix SO error when calling same function inside mocking function

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -271,9 +271,9 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
             }
 
             for (PackageInfo packageInfo : programFile.getPackageInfoEntries()) {
-                int instrEndLimit = getInstructionsEndLimit(packageInfo);
+                int limit = getTestInstructionsPosition(packageInfo);
                 Instruction[] instructions = packageInfo.getInstructions();
-                for (int i = 0; i < instrEndLimit; i++) {
+                for (int i = 0; i < limit; i++) {
                     Instruction ins = instructions[i];
                     if (ins instanceof Instruction.InstructionCALL) {
                         // replace the function pointer of the instruction with the mock function pointer
@@ -544,7 +544,7 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
         return bLangPackage.packageID.toString();
     }
 
-    private static int getInstructionsEndLimit(PackageInfo packageInfo) {
+    private static int getTestInstructionsPosition(PackageInfo packageInfo) {
         FunctionInfo testInitFunctionInfo = packageInfo.getTestInitFunctionInfo();
         if (testInitFunctionInfo != null) {
             return testInitFunctionInfo.getDefaultWorkerInfo().getCodeAttributeInfo().getCodeAddrs();

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -271,7 +271,10 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
             }
 
             for (PackageInfo packageInfo : programFile.getPackageInfoEntries()) {
-                for (Instruction ins : packageInfo.getInstructions()) {
+                int instrEndLimit = getInstructionsEndLimit(packageInfo);
+                Instruction[] instructions = packageInfo.getInstructions();
+                for (int i = 0; i < instrEndLimit; i++) {
+                    Instruction ins = instructions[i];
                     if (ins instanceof Instruction.InstructionCALL) {
                         // replace the function pointer of the instruction with the mock function pointer
                         Instruction.InstructionCALL call = (Instruction.InstructionCALL) ins;
@@ -539,5 +542,13 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
     private String getPackageName(PackageNode packageNode) {
         BLangPackage bLangPackage = ((BLangPackage) packageNode);
         return bLangPackage.packageID.toString();
+    }
+
+    private static int getInstructionsEndLimit(PackageInfo packageInfo) {
+        FunctionInfo testInitFunctionInfo = packageInfo.getTestInitFunctionInfo();
+        if (testInitFunctionInfo != null) {
+            return testInitFunctionInfo.getDefaultWorkerInfo().getCodeAttributeInfo().getCodeAddrs();
+        }
+        return packageInfo.getInstructions().length;
     }
 }

--- a/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest2.pkg/test-sub-program.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest2.pkg/test-sub-program.bal
@@ -1,4 +1,3 @@
-
 import ballerina/test;
 import ballerina/io;
 

--- a/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/sub-program.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/sub-program.bal
@@ -1,0 +1,6 @@
+import ballerina/io;
+
+// this function should not get called as mocked
+public function printSomething() {
+    io:println("something");
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/sub-program.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/sub-program.bal
@@ -1,6 +1,6 @@
 import ballerina/io;
 
-// this function should not get called as mocked
+// This function should not get called as it is being mocked.
 public function printSomething() {
     io:println("something");
 }

--- a/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/tests/test-sub-program.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/tests/test-sub-program.bal
@@ -16,5 +16,5 @@ public function mockPrint(any... s) {
 @test:Config{}
 function testAssertIntEquals () {
     printSomething();
-    test:assertTrue(success, msg = "using same function inside mocking function failed");
+    test:assertTrue(success, msg = "using the same function inside the mocking function failed");
 }

--- a/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/tests/test-sub-program.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/tests/test-sub-program.bal
@@ -1,0 +1,20 @@
+
+import ballerina/test;
+import ballerina/io;
+
+boolean success = false;
+
+@test:Mock {
+    moduleName: "ballerina/io",
+    functionName: "println"
+}
+public function mockPrint(any... s) {
+    io:println("io:println: Mocked");
+    success = true;
+}
+
+@test:Config{}
+function testAssertIntEquals () {
+    printSomething();
+    test:assertTrue(success, msg = "using same function inside mocking function failed");
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/tests/test-sub-program.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/functionmocktest4.pkg/tests/test-sub-program.bal
@@ -9,7 +9,7 @@ boolean success = false;
     functionName: "println"
 }
 public function mockPrint(any... s) {
-    io:println("io:println: Mocked");
+    io:println("The function 'io:println' was mocked");
     success = true;
 }
 


### PR DESCRIPTION
## Purpose
> Fix SO error when calling the same function inside mocking function
> ```ballerina
> @test:Mock {
>     moduleName: "ballerina/io",
>     functionName: "println"
> }
> public function mockPrint(any... s) {
>     io:println("hello");
> }
> ```
## Approach
> Skip replacement of function calls with mocking functions **inside** the test contents.
## Issues
> This PR solves https://github.com/ballerina-platform/ballerina-lang/issues/12853