### PR TITLE
Always log ballerina distribution and plugin details to Ballerina channel

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -33,7 +33,7 @@ import { exec, execSync } from 'child_process';
 import { LanguageClientOptions, State as LS_STATE, RevealOutputChannelOn, DidChangeConfigurationParams } from "vscode-languageclient";
 import { getServerOptions } from '../server/server';
 import { ExtendedLangClient } from './extended-language-client';
-import { log, getOutputChannel } from '../utils/index';
+import { info, getOutputChannel } from '../utils/index';
 import { AssertionError } from "assert";
 export class BallerinaExtension {
 
@@ -65,32 +65,33 @@ export class BallerinaExtension {
 
             // Check if ballerina home is set.
             if (this.hasBallerinaHomeSetting()) {
-                log("Ballerina home is configured in settings.");
+                info("Ballerina home is configured in settings.");
                 this.ballerinaHome = this.getBallerinaHome();
                 // Lets check if ballerina home is valid.
                 if (!this.isValidBallerinaHome(this.ballerinaHome)) {
-                    log("Configured Ballerina home is not valid.");
+                    info("Configured Ballerina home is not valid.");
                     // Ballerina home in setting is invalid show message and quit.
                     // Prompt to correct the home. // TODO add auto ditection.
                     this.showMessageInvalidBallerinaHome();
                     return Promise.resolve();
                 }
             } else {
-                log("Auto detecting Ballerina home.");
+                info("Auto detecting Ballerina home.");
                 // If ballerina home is not set try to auto ditect ballerina home.
                 // TODO If possible try to update the setting page.
                 this.ballerinaHome = this.autoDitectBallerinaHome();
                 if (!this.ballerinaHome) {
                     this.showMessageInstallBallerina();
-                    log("Unable to auto detect Ballerina home.");
+                    info("Unable to auto detect Ballerina home.");
                     return Promise.resolve();
                 }
             }
-            log("Using " + this.ballerinaHome + " as the Ballerina home.");
+            info("Using " + this.ballerinaHome + " as the Ballerina home.");
             // Validate the ballerina version.
             const pluginVersion = this.extention.packageJSON.version.split('-')[0];
             return this.getBallerinaVersion(this.ballerinaHome).then(ballerinaVersion => {
                 ballerinaVersion = ballerinaVersion.split('-')[0];
+                info(`Plugin version: ${pluginVersion}\nBallerina version: ${ballerinaVersion}`);
                 this.checkCompatibleVersion(pluginVersion, ballerinaVersion);
                 // if Home is found load Language Server.
                 this.langClient = new ExtendedLangClient('ballerina-vscode', 'Ballerina LS Client',
@@ -104,7 +105,7 @@ export class BallerinaExtension {
                 // Following was put in to handle server startup failiers.
                 const disposeDidChange = this.langClient.onDidChangeState(stateChangeEvent => {
                     if (stateChangeEvent.newState === LS_STATE.Stopped) {
-                        log("Couldn't establish language server connection.");
+                        info("Couldn't establish language server connection.");
                         this.showPluginActivationError();
                     }
                 });
@@ -116,11 +117,11 @@ export class BallerinaExtension {
                     this.context!.subscriptions.push(disposable);
                 });
             }).catch(e => {
-                log(`Error when checking ballerina version. Got ${e}`);
+                info(`Error when checking ballerina version. Got ${e}`);
             });
 
         } catch (ex) {
-            log("Error while activating plugin: " + (ex.message ? ex.message : ex));
+            info("Error while activating plugin: " + (ex.message ? ex.message : ex));
             // If any failure occurs while intializing show an error messege
             this.showPluginActivationError();
             return Promise.resolve();

--- a/tool-plugins/vscode/src/utils/logger.ts
+++ b/tool-plugins/vscode/src/utils/logger.ts
@@ -19,23 +19,34 @@
  */
 import * as vscode from 'vscode';
 
-let outputChannel: vscode.OutputChannel | undefined;
+const outputChannel = vscode.window.createOutputChannel("Ballerina");
 const logLevelDebug: boolean = vscode.workspace.getConfiguration('ballerina').get('debugLog') === true;
 
-if (logLevelDebug) {
-    outputChannel = vscode.window.createOutputChannel("Ballerina");
+function withNewLine(value: string) {
+    if (!value.endsWith('\n')) {
+        return value+='\n';
+    }
+    return value;
 }
 
+// This function will log the value to the Ballerina output channel only if debug log is enabled
 export function log(value: string) : void {
-    if (!value.endsWith('\n')) {
-        value+='\n';
+    const output = withNewLine(value);
+    console.log(output);
+    if (logLevelDebug) {
+        outputChannel.append(output);
     }
-    console.log(value);
-    if (outputChannel) {
-        outputChannel.append(value);
-    }
+}
+
+// This function will log the value to the Ballerina output channel
+export function info(value: string) : void {
+    const output = withNewLine(value);
+    console.log(output);
+    outputChannel.append(output);
 }
 
 export function getOutputChannel() {
-    return outputChannel;
+    if (logLevelDebug) {
+        return outputChannel;
+    }
 }


### PR DESCRIPTION
## Purpose
Following details will always be logged to the Ballerina channel. (even without setting debugLog: true)
 * if ballerina home is auto detected or explicitly set
 * path to the ballerina distro
 * ballerina version
 * plugin version

## Approach
Add a new method to logger module named `info` which will always log.