### PR TITLE
Ask & fill-up empty files with a service upon API editor open

### DIFF
--- a/tool-plugins/vscode/resources/templates/http-service.bal
+++ b/tool-plugins/vscode/resources/templates/http-service.bal
@@ -1,0 +1,6 @@
+import ballerina/http;
+
+service serviceName on new http:Listener(8080) {
+    resource function newResource(http:Caller caller, http:Request request) {
+    }
+}

--- a/tool-plugins/vscode/src/api-editor/activator.ts
+++ b/tool-plugins/vscode/src/api-editor/activator.ts
@@ -16,7 +16,7 @@
  * under the License.
  *
  */
-import { workspace, commands, window, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent, Uri } from 'vscode';
+import { workspace, commands, window, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent, Uri, Position } from 'vscode';
 import { ExtendedLangClient } from '../core/extended-language-client';
 import * as _ from 'lodash';
 import { apiEditorRender } from './renderer';
@@ -24,8 +24,10 @@ import { BallerinaExtension } from '../core';
 import { API_DESIGNER_NO_SERVICE } from '../core/messages';
 import { WebViewRPCHandler, WebViewMethod } from '../utils';
 import { join } from "path";
+import { readFileSync } from "fs";
 
 const DEBOUNCE_WAIT = 500;
+const CMD_SHOW_API_EDITOR = "ballerina.showAPIEditor";
 
 let oasEditorPanel: WebviewPanel | undefined;
 let activeEditor: TextEditor | undefined;
@@ -118,7 +120,29 @@ function showAPIEditorPanel(context: ExtensionContext, langClient: ExtendedLangC
     } else {
         langClient.getServiceListForActiveFile(activeEditor.document.uri).then(resp => {
             if (resp.services.length === 0) {
-                window.showInformationMessage(API_DESIGNER_NO_SERVICE);
+                const actions:string[] = [];
+                // Provide an action to fill up empty bal files with a default service
+                const actionAddService = "Add HTTP Service";
+                if (activeEditor && activeEditor.document.getText().trim().length === 0) {
+                    actions.push(actionAddService);
+                }
+                window.showInformationMessage(API_DESIGNER_NO_SERVICE, ...actions)
+                    .then((selection) => {
+                        if (selection === actionAddService) {
+                            const svcTemplatePath = join(context.extensionPath, "resources", 
+                                            "templates", "http-service.bal");
+                            const svcTemplate = readFileSync(svcTemplatePath).toString();
+                            if (activeEditor) {
+                                activeEditor.edit((editBuilder) => {
+                                    editBuilder.insert(new Position(0, 0), svcTemplate);
+                                }).then((insertSuccess) => {
+                                    if (insertSuccess) {
+                                        commands.executeCommand(CMD_SHOW_API_EDITOR);
+                                    }
+                                });
+                            }
+                        }
+                    });
             } else if (resp.services && resp.services.length > 1) {
                 window.showQuickPick(resp.services).then(service => {
                     if (service && activeEditor) {
@@ -187,7 +211,7 @@ function createAPIEditorPanel(selectedService: string, renderHtml: string,
 export function activate(ballerinaExtInstance: BallerinaExtension) {
     let context = <ExtensionContext> ballerinaExtInstance.context;
     let langClient = <ExtendedLangClient> ballerinaExtInstance.langClient;
-    const showAPIRenderer = commands.registerCommand('ballerina.showAPIEditor', serviceNameArg => {
+    const showAPIRenderer = commands.registerCommand(CMD_SHOW_API_EDITOR, serviceNameArg => {
         ballerinaExtInstance.onReady()
         .then(() => {
             const { experimental } = langClient.initializeResult!.capabilities;

--- a/tool-plugins/vscode/src/core/messages.ts
+++ b/tool-plugins/vscode/src/core/messages.ts
@@ -26,4 +26,4 @@ export const OLD_PLUGIN_VERSION: string ="Your Ballerina vscode plugin version d
 export const MISSING_SERVER_CAPABILITY: string = "Your version of Ballerina platform distribution does not support this feature. Please update to the latest Ballerina platform";
 export const INVALID_FILE: string = "The current file is not a valid ballerina file. Please open a ballerina file and try again.";
 export const UNKNOWN_ERROR: string ="Unknown Error : Failed to start Ballerina Plugin.";
-export const API_DESIGNER_NO_SERVICE: string = "There are no services available in the source. Please add a service and try again.";
+export const API_DESIGNER_NO_SERVICE: string = "There are no services available in current file. Please add a service and try again.";


### PR DESCRIPTION
Provide a way to fill an empty file with a service template when opening the API designer for it.
![screenrecording20190213at3](https://user-images.githubusercontent.com/1505855/52702299-dfa6c700-2fa1-11e9-8ade-2dc75711903c.gif)
