### PR TITLE
Fix the Bad, Sad error on "ballerina test" when the non-zeroth module has compilation errors

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
@@ -285,13 +285,16 @@ public class BCompileUtil {
      * Compile with tests and return the semantic errors.
      *
      * @param context       Compiler Context
+     * @param listener      the diagnostic log common to a project
      * @param packageName   name of the module to compile
      * @param compilerPhase Compiler phase
      * @return Semantic errors
      */
-    public static CompileResult compileWithTests(CompilerContext context, String packageName,
+    public static CompileResult compileWithTests(CompilerContext context,
+                                                 CompileResult.CompileResultDiagnosticListener listener,
+                                                 String packageName,
                                                  CompilerPhase compilerPhase) {
-        return compile(context, packageName, compilerPhase, true);
+        return compile(context, listener, packageName, compilerPhase, true);
     }
 
     /**
@@ -328,11 +331,9 @@ public class BCompileUtil {
         options.put(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED, Boolean.TRUE.toString());
         context.put(SourceDirectory.class, sourceDirectory);
 
-        CompileResult comResult = new CompileResult();
-
-        // catch errors
-        DiagnosticListener listener = comResult::addDiagnostic;
+        CompileResult.CompileResultDiagnosticListener listener = new CompileResult.CompileResultDiagnosticListener();
         context.put(DiagnosticListener.class, listener);
+        CompileResult comResult = new CompileResult(listener);
 
         // compile
         Compiler compiler = Compiler.getInstance(context);
@@ -348,10 +349,17 @@ public class BCompileUtil {
 
     private static CompileResult compile(CompilerContext context, String packageName,
                                          CompilerPhase compilerPhase, boolean withTests) {
-        CompileResult comResult = new CompileResult();
-        // catch errors
-        DiagnosticListener listener = comResult::addDiagnostic;
+        CompileResult.CompileResultDiagnosticListener listener = new CompileResult.CompileResultDiagnosticListener();
         context.put(DiagnosticListener.class, listener);
+        return compile(context, listener, packageName, compilerPhase, withTests);
+    }
+
+    private static CompileResult compile(CompilerContext context,
+                                         CompileResult.CompileResultDiagnosticListener listener,
+                                         String packageName,
+                                         CompilerPhase compilerPhase,
+                                         boolean withTests) {
+        CompileResult comResult = new CompileResult(listener);
 
         // compile
         Compiler compiler = Compiler.getInstance(context);
@@ -397,10 +405,7 @@ public class BCompileUtil {
         options.put(PRESERVE_WHITESPACE, "false");
         options.put(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED, Boolean.TRUE.toString());
 
-        CompileResult comResult = new CompileResult();
-
-        // catch errors
-        DiagnosticListener listener = comResult::addDiagnostic;
+        CompileResult.CompileResultDiagnosticListener listener = new CompileResult.CompileResultDiagnosticListener();
         context.put(DiagnosticListener.class, listener);
 
         // compile
@@ -494,11 +499,9 @@ public class BCompileUtil {
         options.put(PRESERVE_WHITESPACE, "false");
         options.put(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED, Boolean.TRUE.toString());
 
-        CompileResult comResult = new CompileResult();
-
-        // catch errors
-        DiagnosticListener listener = comResult::addDiagnostic;
+        CompileResult.CompileResultDiagnosticListener listener = new CompileResult.CompileResultDiagnosticListener();
         context.put(DiagnosticListener.class, listener);
+        CompileResult comResult = new CompileResult(listener);
 
         // compile
         Compiler compiler = Compiler.getInstance(context);

--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/CompileResult.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/CompileResult.java
@@ -20,6 +20,7 @@ import org.ballerinalang.bre.old.WorkerExecutionContext;
 import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.diagnostic.Diagnostic;
+import org.ballerinalang.util.diagnostic.DiagnosticListener;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -32,44 +33,29 @@ import java.util.List;
  */
 public class CompileResult {
 
-    private List<Diagnostic> diagnostics;
     private PackageNode pkgNode;
     private ProgramFile progFile;
     //Used for stateful function invocation.
     private WorkerExecutionContext context;
-    private int errorCount = 0;
-    private int warnCount = 0;
+    private CompileResultDiagnosticListener diagnosticListener;
 
-    public CompileResult() {
-        diagnostics = new ArrayList<Diagnostic>();
-    }
-
-    public void addDiagnostic(Diagnostic diag) {
-        this.diagnostics.add(diag);
-        switch (diag.getKind()) {
-            case ERROR:
-                errorCount++;
-                break;
-            case WARNING:
-                warnCount++;
-                break;
-            default:
-                break;
-        }
+    public CompileResult(CompileResultDiagnosticListener diagnosticListener) {
+        this.diagnosticListener = diagnosticListener;
     }
 
     public Diagnostic[] getDiagnostics() {
+        List<Diagnostic> diagnostics = this.diagnosticListener.getDiagnostics();
         diagnostics.sort(Comparator.comparing((Diagnostic d) -> d.getSource().getCompilationUnitName()).
                 thenComparingInt(d -> d.getPosition().getStartLine()));
         return diagnostics.toArray(new Diagnostic[diagnostics.size()]);
     }
 
     public int getErrorCount() {
-        return errorCount;
+        return this.diagnosticListener.errorCount;
     }
 
     public int getWarnCount() {
-        return warnCount;
+        return this.diagnosticListener.warnCount;
     }
 
     public ProgramFile getProgFile() {
@@ -99,7 +85,7 @@ public class CompileResult {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        if (this.errorCount == 0) {
+        if (this.diagnosticListener.errorCount == 0) {
             builder.append("Compilation Successful");
         } else {
             builder.append("Compilation Failed:\n");
@@ -109,5 +95,46 @@ public class CompileResult {
         }
         return builder.toString();
     }
-    
+
+    /**
+     * Diagnostic listener implementation for module compilation.
+     *
+     * @since 0.990.4
+     */
+    public static class CompileResultDiagnosticListener implements DiagnosticListener {
+        private List<Diagnostic> diagnostics;
+        private int errorCount = 0;
+        private int warnCount = 0;
+
+        public CompileResultDiagnosticListener() {
+            this.diagnostics = new ArrayList<>();
+        }
+
+        @Override
+        public void received(Diagnostic diagnostic) {
+            this.diagnostics.add(diagnostic);
+            switch (diagnostic.getKind()) {
+                case ERROR:
+                    errorCount++;
+                    break;
+                case WARNING:
+                    warnCount++;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public int getErrorCount() {
+            return errorCount;
+        }
+
+        public int getWarnCount() {
+            return warnCount;
+        }
+
+        public List<Diagnostic> getDiagnostics() {
+            return diagnostics;
+        }
+    }
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -35,6 +35,7 @@ import org.ballerinalang.testerina.util.TesterinaUtils;
 import org.ballerinalang.util.codegen.ProgramFile;
 import org.ballerinalang.util.debugger.Debugger;
 import org.ballerinalang.util.diagnostic.Diagnostic;
+import org.ballerinalang.util.diagnostic.DiagnosticListener;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -186,10 +187,13 @@ public class BTestRunner {
         // compiled again.
         CompilerContext compilerContext =
                 BCompileUtil.createCompilerContext(sourceRoot, CompilerPhase.CODE_GEN, enableExpFeatures);
+        CompileResult.CompileResultDiagnosticListener listener = new CompileResult.CompileResultDiagnosticListener();
+        compilerContext.put(DiagnosticListener.class, listener);
         Arrays.stream(sourceFilePaths).forEach(sourcePackage -> {
             // compile
-            CompileResult compileResult = BCompileUtil.compileWithTests(compilerContext, sourcePackage.toString(),
-                CompilerPhase.CODE_GEN);
+            CompileResult compileResult = BCompileUtil.compileWithTests(compilerContext, listener,
+                                                                        sourcePackage.toString(),
+                                                                        CompilerPhase.CODE_GEN);
             // print errors
             for (Diagnostic diagnostic : compileResult.getDiagnostics()) {
                 errStream.println(diagnostic.getKind().toString().toLowerCase(Locale.ENGLISH) + ":"

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/TesterinaCompilationNegativeTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/TesterinaCompilationNegativeTest.java
@@ -21,27 +21,60 @@ package org.ballerinalang.testerina.test;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.testerina.core.BTestRunner;
 import org.ballerinalang.testerina.core.TesterinaRegistry;
+import org.ballerinalang.testerina.util.BTestUtil;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Testcase for validate behavior of source compilation failures.
  */
 public class TesterinaCompilationNegativeTest {
 
-    private String sourceRoot = "src/test/resources/compilationnegative";
-    private Path[] filePaths = { Paths.get("unreachable_code.bal") };
+    private ByteArrayOutputStream tempErrStream = new ByteArrayOutputStream();
+    private PrintStream defaultErr;
 
     @Test(expectedExceptions = BLangCompilerException.class,
             expectedExceptionsMessageRegExp = "compilation contains errors")
-    public void disableFunctionsTest() {
+    public void testSingleFileCompilationError() {
         BTestRunner testRunner = new BTestRunner();
-        testRunner.runTest(sourceRoot, filePaths, new ArrayList<>());
+        testRunner.runTest("src/test/resources/compilationnegative",
+                           new Path[]{Paths.get("unreachable_code.bal")}, new ArrayList<>());
+    }
+
+    @Test(description = "test proper compilation failure with ballerina test when the non-zeroth module of a project " +
+            "contains errors")
+    public void testMultiModuleProjectCompilationError() throws IOException {
+        boolean expectedExceptionThrown = false;
+        String sourceRoot = "src/test/resources/compilationnegative/multi-module-project";
+        try {
+            defaultErr = System.err;
+            System.setErr(new PrintStream(tempErrStream));
+            BTestUtil.runTestsInProject(sourceRoot, false);
+        } catch (BLangCompilerException e) {
+            expectedExceptionThrown = true;
+            assertEquals(e.getMessage(), "compilation contains errors",
+                         "excepted exception due to compilation failure");
+            assertTrue(tempErrStream.toString().contains(
+                         "error:testerina_test/foo:0.0.1::hello_world_negative.bal:20:1: mismatched input " +
+                                 "'}'. expecting {'is', ';', '?', '+', '-', '*', '/', '%', '==', '!=', '>', '<', '>" +
+                                 "=', '<=', '&&', '||', '===', '!==', '&', '^', '...', '|', '?:', '->>', '..<'}"),
+                         "invalid error message");
+        } finally {
+            tempErrStream.close();
+            System.setErr(defaultErr);
+            assertTrue(expectedExceptionThrown, "expected an exception to be thrown due to compilation error");
+        }
     }
 
     @AfterMethod

--- a/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/Ballerina.toml
@@ -1,0 +1,4 @@
+[project]
+org-name = "testerina_test"
+version = "0.0.1"
+

--- a/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/bar/hello_world.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/bar/hello_world.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+public function main() {
+    string s = "Hello, World!";
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/foo/hello_world_negative.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/foo/hello_world_negative.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+public function main() {
+    string s = "Hello, World!"
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/testng.xml
+++ b/misc/testerina/modules/testerina-core/src/test/resources/testng.xml
@@ -29,6 +29,7 @@ under the License.
         </run>
         </groups>
         <classes>
+            <class name="org.ballerinalang.testerina.test.TesterinaCompilationNegativeTest"/>
             <class name="org.ballerinalang.testerina.test.AssertTest"/>
             <class name="org.ballerinalang.testerina.test.ConfigAnnotationTest"/>
             <class name="org.ballerinalang.testerina.test.DataProviderTest"/>

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/spec/SpecConformanceTests.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/spec/SpecConformanceTests.java
@@ -32,6 +32,6 @@ public class SpecConformanceTests {
 
     @Test
     public void testSpecConformance() {
-        assertFalse(BTestUtil.runTestsInPackage("", true).isFailure());
+        assertFalse(BTestUtil.runTestsInProject("", true).isFailure());
     }
 }


### PR DESCRIPTION
Fix the NPE thrown on `ballerina test` when the non-zeroth module of a multi module project has a compilation error.

Fixes #13599