### PR TITLE
Fix type checking for the error reason specified in the error constructor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2706,6 +2706,7 @@ public class Desugar extends BLangNodeVisitor {
     }
     @Override
     public void visit(BLangErrorConstructorExpr errConstExpr) {
+        errConstExpr.reasonExpr = addConversionExprIfRequired(errConstExpr.reasonExpr, symTable.stringType);
         errConstExpr.reasonExpr = rewriteExpr(errConstExpr.reasonExpr);
         errConstExpr.detailsExpr = rewriteExpr(Optional.ofNullable(errConstExpr.detailsExpr)
                 .orElseGet(() -> ASTBuilderUtil.createEmptyRecordLiteral(errConstExpr.pos, symTable.mapType)));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2706,6 +2706,12 @@ public class Desugar extends BLangNodeVisitor {
     }
     @Override
     public void visit(BLangErrorConstructorExpr errConstExpr) {
+        if (errConstExpr.reasonExpr.impConversionExpr != null &&
+                errConstExpr.reasonExpr.impConversionExpr.targetType.tag != TypeTags.STRING) {
+            // Override casts to constants/finite types.
+            // For reason expressions of any form, the cast has to be to string.
+            errConstExpr.reasonExpr.impConversionExpr = null;
+        }
         errConstExpr.reasonExpr = addConversionExprIfRequired(errConstExpr.reasonExpr, symTable.stringType);
         errConstExpr.reasonExpr = rewriteExpr(errConstExpr.reasonExpr);
         errConstExpr.detailsExpr = rewriteExpr(Optional.ofNullable(errConstExpr.detailsExpr)

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1992,9 +1992,10 @@ public class TypeChecker extends BLangNodeVisitor {
             return;
         }
 
-        // No matter what, message expression has to exist and it's type should be string type.
+        // No matter what, message expression has to exist and its type should be string for the built-in error type
+        // or the type specified when defining the error, for user defined error types.
         Optional.ofNullable(errorConstructorExpr.reasonExpr)
-                .map(expr -> checkExpr(expr, env, symTable.stringType))
+                .map(expr -> checkExpr(expr, env, ((BErrorType) expType).reasonType))
                 .orElseThrow(AssertionError::new);
 
         Optional.ofNullable(errorConstructorExpr.detailsExpr)

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BValueArray;
 import org.testng.Assert;
@@ -42,6 +43,7 @@ public class ErrorTest {
     private static final String ERROR2 = "error2";
     private static final String ERROR3 = "error3";
     private static final String EMPTY_CURLY_BRACE = "{}";
+    private static final String CONST_ERROR_REASON = "reason one";
 
     @BeforeClass
     public void setup() {
@@ -167,5 +169,21 @@ public class ErrorTest {
         Assert.assertEquals(array.getString(3), "Error3");
         Assert.assertEquals(array.getString(4), "Something Went Wrong");
         Assert.assertEquals(array.getString(5), "1");
+    }
+
+    @Test
+    public void testErrorWithUserDefinedReasonType() {
+        BValue[] returns = BRunUtil.invoke(basicErrorTest, "testErrorWithUserDefinedReasonType");
+        Assert.assertTrue(returns[0] instanceof BError);
+        Assert.assertEquals(((BError) returns[0]).reason, CONST_ERROR_REASON);
+    }
+
+    @Test
+    public void testErrorWithConstantAsReason() {
+        BValue[] returns = BRunUtil.invoke(basicErrorTest, "testErrorWithConstantAsReason");
+        Assert.assertTrue(returns[0] instanceof BError);
+        Assert.assertEquals(((BError) returns[0]).reason, CONST_ERROR_REASON);
+        Assert.assertEquals(((BMap) ((BError) returns[0]).details).get("message").stringValue(),
+                            "error detail message");
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/error/basicErrorTest.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/error/basicErrorTest.bal
@@ -132,3 +132,21 @@ function panicWithReasonAndDetailRecord() {
     DetailRec detail = { message: "Something Went Wrong", statusCode: 1 };
     panic error("Error3", detail);
 }
+
+type ErrorReasons "reason one"|"reason two";
+
+const ERROR_REASON_ONE = "reason one";
+const ERROR_REASON_TWO = "reason two";
+
+type UserDefErrorOne error<ErrorReasons>;
+type UserDefErrorTwo error<ERROR_REASON_ONE, map<string>>;
+
+function testErrorWithUserDefinedReasonType() returns error {
+    UserDefErrorOne e = error(ERROR_REASON_ONE);
+    return e;
+}
+
+function testErrorWithConstantAsReason() returns error {
+    UserDefErrorTwo e = error(ERROR_REASON_ONE, { message: "error detail message" });
+    return e;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -141,12 +141,23 @@ const ERROR_REASON_TWO = "reason two";
 type UserDefErrorOne error<ErrorReasons>;
 type UserDefErrorTwo error<ERROR_REASON_ONE, map<string>>;
 
-function testErrorWithUserDefinedReasonType() returns error {
+function testErrorConstrWithConstForUserDefinedReasonType() returns error {
     UserDefErrorOne e = error(ERROR_REASON_ONE);
     return e;
 }
 
-function testErrorWithConstantAsReason() returns error {
+function testErrorConstrWithLiteralForUserDefinedReasonType() returns error {
+    UserDefErrorOne e = error("reason one");
+    return e;
+}
+
+function testErrorConstrWithConstForConstReason() returns error {
     UserDefErrorTwo e = error(ERROR_REASON_ONE, { message: "error detail message" });
+    return e;
+}
+
+
+function testErrorConstrWithConstLiteralForConstReason() returns error {
+    UserDefErrorTwo e = error("reason one", { message: "error detail message" });
     return e;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type ErrorReasons "reason one"|"reason two";
+
+const ERROR_REASON_ONE = "reason one";
+const ERROR_REASON_TWO = "reason two";
+
+type UserDefErrorOne error<ErrorReasons>;
+type UserDefErrorTwo error<ERROR_REASON_ONE, map<string>>;
+
+function testInvalidErrorReasonWithUserDefinedReasonType() returns error {
+    UserDefErrorOne e = error("");
+    return e;
+}
+
+function testInvalidErrorReasonWithConstantAsReason() returns error {
+    UserDefErrorTwo e = error(ERROR_REASON_TWO, { message: "error detail message" });
+    return e;
+}


### PR DESCRIPTION
## Purpose
 Fix type checking for the error reason specified in the error constructor.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/13654

## Automation tests
 - Unit tests 
Added.