### PR TITLE
Re-log trx info log at warn level

### DIFF
--- a/examples/transactions-distributed/tests/transactions_distributed_test.bal
+++ b/examples/transactions-distributed/tests/transactions_distributed_test.bal
@@ -12,6 +12,7 @@ public function mockLogInfo(string | (function() returns (string)) msg) {
     if (msg is string) {
         outputs[count] = msg;
         count += 1;
+        log:printWarn(msg);
     }
 }
 


### PR DESCRIPTION
## Purpose
This PR reprints INFO logs intercepted in BBE test, 'transactions_distributed_test' back at WARN level. This is because we need to see the logs to identify the cause of reported intermittent failure in that test case.
