### PR TITLE
Refactor to use same symbol for type casting and conversion for unsafe numeric types

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -2460,11 +2460,15 @@ public class BVM {
             case InstructionCodes.I2BI:
                 i = operands[0];
                 j = operands[1];
-                if (isByteLiteral(sf.longRegs[i])) {
-                    sf.refRegs[j] = new BByte((byte) sf.longRegs[i]);
-                } else {
-                    handleTypeConversionError(ctx, sf, j, TypeConstants.INT_TNAME, TypeConstants.BYTE_TNAME);
+                if (!isByteLiteral(sf.longRegs[i])) {
+                    ctx.setError(BLangVMErrors.createError(ctx, BallerinaErrorReasons.NUMBER_CONVERSION_ERROR,
+                                                           "'" + TypeConstants.INT_TNAME + "' value '" +
+                                                                   sf.longRegs[i] + "' cannot be converted to '" +
+                                                                   TypeConstants.BYTE_TNAME + "'"));
+                    handleError(ctx);
+                    break;
                 }
+                sf.intRegs[j] = new BByte((byte) sf.longRegs[i]).byteValue();
                 break;
             case InstructionCodes.BI2I:
                 i = operands[0];

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/StreamingCodeDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/StreamingCodeDesugar.java
@@ -93,6 +93,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.util.Lists;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1576,7 +1576,7 @@ public class TypeChecker extends BLangNodeVisitor {
             } else {
                 BOperatorSymbol conversionSym = (BOperatorSymbol) symbol;
                 conversionExpr.conversionSymbol = conversionSym;
-                actualType = conversionSym.type.getReturnType();
+                actualType = targetType;
             }
         }
         resultType = types.checkType(conversionExpr, actualType, this.expType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -504,7 +504,7 @@ public class SymbolTable {
         defineConversionOperator(intType, stringType, true, InstructionCodes.I2S);
         defineConversionOperator(intType, byteType, false, InstructionCodes.I2BI);
         defineConversionOperator(byteType, intType, true, InstructionCodes.BI2I);
-        defineConversionOperator(floatType, intType, true, InstructionCodes.F2I);
+        defineConversionOperator(floatType, intType, false, InstructionCodes.F2I);
         defineConversionOperator(floatType, decimalType, true, InstructionCodes.F2D);
         defineConversionOperator(floatType, booleanType, true, InstructionCodes.F2B);
         defineConversionOperator(floatType, stringType, true, InstructionCodes.F2S);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -508,7 +508,7 @@ public class SymbolTable {
         defineConversionOperator(floatType, decimalType, true, InstructionCodes.F2D);
         defineConversionOperator(floatType, booleanType, true, InstructionCodes.F2B);
         defineConversionOperator(floatType, stringType, true, InstructionCodes.F2S);
-        defineConversionOperator(decimalType, intType, true, InstructionCodes.D2I);
+        defineConversionOperator(decimalType, intType, false, InstructionCodes.D2I);
         defineConversionOperator(decimalType, floatType, true, InstructionCodes.D2F);
         defineConversionOperator(decimalType, booleanType, true, InstructionCodes.D2B);
         defineConversionOperator(decimalType, stringType, true, InstructionCodes.D2S);

--- a/examples/type-conversion/type_conversion.bal
+++ b/examples/type-conversion/type_conversion.bal
@@ -62,12 +62,12 @@ function convertSimpleBasicTypes() {
     }
 
     // A `float` to `int` conversion can result in some of the information getting lost.
-    // However, this conversion is always safe since there is a corresponding `int` representation
-    // for all `float` values except for `NaN` or `infinite` float values, in which case the
-    // the conversion attempt will result in a panic.
-    int intVal = int.convert(f);
-    io:println("int value: ", intVal);
-
+    // However, this conversion is unsafe due to `NaN` or `infinite` float values where the conversion attempt will 
+    // result in a error.
+    int|error intVal = int.convert(f);
+    if (intVal is int) {
+        io:println("int value: ", intVal);
+    }
     // A `string` to `boolean` conversion is always safe. The `string` value `true` (ignoring case)
     // evaluates to the `boolean` value `true`, while any other `string` is converted to the
     // `boolean` value `false`.

--- a/stdlib/utils/pom.xml
+++ b/stdlib/utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ballerina-parent</artifactId>
         <groupId>org.ballerinalang</groupId>
-        <version>0.990.3-SNAPSHOT</version>
+        <version>0.990.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/ballerina-spec-conformance-tests/S05_simple_values/tests/int.bal
+++ b/tests/ballerina-spec-conformance-tests/S05_simple_values/tests/int.bal
@@ -42,8 +42,8 @@ function testInt(int i1, int i2, int i3, int i4) {
     dataProvider: "decimalDataProvider"
 }
 function testOutOfRangeValueAsInt(decimal d) {
-    utils:assertPanic(function() returns int { return int.convert(d); },
-        "{ballerina}NumberConversionError", "invalid reason on out of range int value");
+    utils:assertPanic(function() returns int|error { return int.convert(d); },
+        "{ballerina}ConversionError", "invalid reason on out of range int value");
 }
 
 function intDataProvider() returns int[][] {

--- a/tests/ballerina-spec-conformance-tests/S05_structured_values/tests/mappings/maps/map_field_shape.bal
+++ b/tests/ballerina-spec-conformance-tests/S05_structured_values/tests/mappings/maps/map_field_shape.bal
@@ -30,7 +30,7 @@ function testMapFieldShape() {
     m1.bazFieldTwo = 1.0;
     conversionResult = BazRecordTen.convert(m1);
     if (conversionResult is error) {
-        test:assertEquals(conversionResult.reason(), "{ballerina}StampError",
+        test:assertEquals(conversionResult.reason(), "{ballerina}ConversionError",
             msg = "invalid reason on conversion failure due to shape mismatch");
     } else {
         test:assertFail(msg = "expected conversion to fail");
@@ -42,7 +42,7 @@ function testMapFieldShape() {
     m1.bazFieldThree = "test string 3";
     conversionResult = BazRecordTen.convert(m1);
     if (conversionResult is error) {
-        test:assertEquals(conversionResult.reason(), "{ballerina}StampError",
+        test:assertEquals(conversionResult.reason(), "{ballerina}ConversionError",
             msg = "invalid reason on conversion failure due to shape mismatch");
     } else {
         test:assertFail(msg = "expected conversion to fail");

--- a/tests/ballerina-spec-conformance-tests/S05_structured_values/tests/mappings/records/record_field_shape.bal
+++ b/tests/ballerina-spec-conformance-tests/S05_structured_values/tests/mappings/records/record_field_shape.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 import utils;
 
-const STAMP_ERROR_REASON = "{ballerina}StampError";
+const CONVERSION_ERROR_REASON = "{ballerina}ConversionError";
 
 // The shape of a mapping value is an unordered collection of field shapes one for each field.
 // The field shape for a field f has a name, which is the same as the name of f, and a shape,
@@ -32,7 +32,7 @@ function testRecordFieldShape() {
     r1.bazFieldTwo = 1.0;
     conversionResult = BazRecordEleven.convert(r1);
     if (conversionResult is error) {
-        test:assertEquals(conversionResult.reason(), STAMP_ERROR_REASON,
+        test:assertEquals(conversionResult.reason(), CONVERSION_ERROR_REASON,
             msg = "invalid reason on conversion failure due to shape mismatch");
     } else {
         test:assertFail(msg = "expected conversion to fail");
@@ -43,7 +43,7 @@ function testRecordFieldShape() {
     DefaultOpenRecord r2 = { bazFieldThree: "test string 3", bazFieldOne: 1.0 };
     conversionResult = BazRecordEleven.convert(r2);
     if (conversionResult is error) {
-        test:assertEquals(conversionResult.reason(), STAMP_ERROR_REASON,
+        test:assertEquals(conversionResult.reason(), CONVERSION_ERROR_REASON,
             msg = "invalid reason on conversion failure due to shape mismatch");
     } else {
         test:assertFail(msg = "expected conversion to fail");

--- a/tests/ballerina-spec-conformance-tests/S05_structured_values/tests/mappings/records/record_field_types.bal
+++ b/tests/ballerina-spec-conformance-tests/S05_structured_values/tests/mappings/records/record_field_types.bal
@@ -79,7 +79,7 @@ function testRequiredFields() {
     map<anydata> b2 = { fieldOne: "test string 1" };
     result = FooRecord.convert(b2);
     if (result is error) {
-        test:assertEquals(result.reason(), "{ballerina}StampError",
+        test:assertEquals(result.reason(), "{ballerina}ConversionError",
             msg = "expected conversion to fail due to missing fields");
     } else {
         test:assertFail(msg = "expected conversion to fail since all required fields are not present");

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -94,8 +94,8 @@ public class BByteValueNegativeTest {
         BValue[] returnValue = BRunUtil.invoke(result, "invalidByteLiteral1", new BValue[]{});
         Assert.assertEquals(returnValue.length, 1);
         Assert.assertTrue(returnValue[0] instanceof BError);
-        Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}ConversionError {\"message\":\"'int' cannot be" +
-                " converted to 'byte'\"}");
+        Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}NumberConversionError {\"message\":\"'int' " 
+                + "value '-12' cannot be converted to 'byte'\"}");
     }
 
     @Test(description = "Test int to byte conversion negative")
@@ -103,8 +103,8 @@ public class BByteValueNegativeTest {
         BValue[] returnValue = BRunUtil.invoke(result, "invalidByteLiteral2", new BValue[]{});
         Assert.assertEquals(returnValue.length, 1);
         Assert.assertTrue(returnValue[0] instanceof BError);
-        Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}ConversionError {\"message\":\"'int' cannot be" +
-                " converted to 'byte'\"}");
+        Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}NumberConversionError {\"message\":\"'int' " 
+                + "value '-257' cannot be converted to 'byte'\"}");
     }
 
     @Test(description = "Test int to byte conversion negative")
@@ -112,7 +112,7 @@ public class BByteValueNegativeTest {
         BValue[] returnValue = BRunUtil.invoke(result, "invalidByteLiteral3", new BValue[]{});
         Assert.assertEquals(returnValue.length, 1);
         Assert.assertTrue(returnValue[0] instanceof BError);
-        Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}ConversionError {\"message\":\"'int' cannot be" +
-                " converted to 'byte'\"}");
+        Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}NumberConversionError {\"message\":\"'int' " 
+                + "value '12345' cannot be converted to 'byte'\"}");
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/closures/closure.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/closures/closure.bal
@@ -523,7 +523,7 @@ function testByteAndBoolean() returns (function (int, byte) returns
     return function (int a, byte b) returns (function (byte, int, boolean) returns byte[][]) {
         boolean boo2 = false;
         return function (byte c, int f, boolean booF) returns (byte[][]) {
-            var value = <byte> f;
+            var value = trap <byte> f;
             if (value is byte) {
                 byte i = value;
                 byte[][] bArr = [];

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-taint-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-taint-negative.bal
@@ -22,8 +22,8 @@ function testSensitiveArg(@sensitive int intArg) {
     int c = intArg;
 }
 
-public function convertTaintedValue() {
+public function convertTaintedValue() returns error? {
     float x = returnTaintedValue();
-    int y = int.convert(x);
+    int y = check int.convert(x);
     testSensitiveArg(y);
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
@@ -446,9 +446,9 @@ function testJsonIntToString () returns string|error {
     return  string.convert(value);
 }
 
-function testFloatToInt() returns (int) {
+function testFloatToInt() returns int|error {
     float f = 10.05344;
-    int i = int.convert(f);
+    int|error i = int.convert(f);
     return i;
 }
 
@@ -682,9 +682,9 @@ function testEmptyJSONtoStructWithOptionals () returns (StructWithOptionals | er
     return testStruct;
 }
 
-function testSameTypeConversion() returns (int) {
+function testSameTypeConversion() returns int|error {
     float f = 10.05;
-    var i =  int.convert(f);
+    var i =  check int.convert(f);
     i =  int.convert(i);
     return i;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value-negative.bal
@@ -21,13 +21,13 @@ function invalidByteLiteral() {
     byte s = r;
 
     int x1 = -123;
-    byte x2 = <byte> x1;
+    byte x2 = trap <byte> x1;
 
     int x3 = 256;
-    byte x4 = <byte> x3;
+    byte x4 = trap <byte> x3;
 
     int x5 = 12345;
-    byte x6 = <byte> x5;
+    byte x6 = trap <byte> x5;
 }
 
 function testUnreachableByteMatchStmt3() {
@@ -42,7 +42,7 @@ function testUnreachableByteMatchStmt4() {
 
 function foo (int a) returns (byte|int|string[]) {
     if (a == 1) {
-        return check <byte>12;
+        return check trap <byte>12;
     } else if (a == 3) {
         return 267;
     }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value-runtime-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value-runtime-negative.bal
@@ -1,19 +1,19 @@
 function invalidByteLiteral1() returns error? {
     int a = -12;
-    byte b = check <byte>a;
+    byte b = check trap <byte>a;
     return;
 }
 
 
 function invalidByteLiteral2() returns error? {
     int c = -257;
-    byte d = check <byte>c;
+    byte d = check trap <byte>c;
     return;
 }
 
 
 function invalidByteLiteral3() returns error? {
     int e = 12345;
-    byte f = check <byte>e;
+    byte f = check trap <byte>e;
     return;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -29,7 +29,7 @@ function testGlobalByte(byte b) returns byte {
 }
 
 function testIntToByteCast(int b) returns byte|error {
-    byte a = check <byte> b;
+    byte a = check trap <byte> b;
     return a;
 }
 
@@ -39,12 +39,12 @@ function testByteToIntCast(byte a) returns int {
 }
 
 function testIntToByteExplicitCast(int b) returns byte|error {
-    byte a = check <byte> b;
+    byte a = check trap <byte> b;
     return a;
 }
 
 function testIntToByteConversion(int b) returns byte|error {
-    var c = check <byte> b;
+    var c = check trap <byte> b;
     return c;
 }
 
@@ -160,7 +160,7 @@ function testByteOrIntMatch4() returns int {
 
 function byteOrInt(int a) returns byte|int|string[]|Foo|error {
     if (a == 1) {
-        return check <byte>12;
+        return check trap <byte>12;
     } else if (a == 2) {
         return 266;
     } else if (a == 3) {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/var/top-level-var-declaration.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/var/top-level-var-declaration.bal
@@ -7,7 +7,7 @@ var decimalValue = <decimal>100;
 
 var booleanValue = true;
 
-var byteValue = <byte>2;
+var byteValue = trap <byte>2;
 
 var floatValue = 2.0;
 


### PR DESCRIPTION
## Purpose

According to spec, Convert method will return an error for failed conversion and type casting will be panic. When we use same symbol for both cases, type casting compilation will fail since we check for error as well.

This fix will provide to use same conversion symbol for type casting and conversion.
We need to remove error type from conversion symbol for type casting since type casting will be panic in unsafe conversion. 

This pr will also make float to int and decimal to int conversions unsafe as per spec.

This will fix the tests accordingly.


