### PR TITLE
 Decouple connection pool with gRPC client

### DIFF
--- a/examples/grpc-bidirectional-streaming/grpc_bidirectional_streaming_pb.bal
+++ b/examples/grpc-bidirectional-streaming/grpc_bidirectional_streaming_pb.bal
@@ -3,16 +3,11 @@ import ballerina/io;
 
 // Generated non-blocking client endpoint based on the service definition.
 public type ChatClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {

--- a/examples/grpc-client-streaming/grpc_client_streaming_pb.bal
+++ b/examples/grpc-client-streaming/grpc_client_streaming_pb.bal
@@ -3,16 +3,11 @@ import ballerina/io;
 
 // Generated non-blocking client endpoint based on the service definition.
 public type HelloWorldClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {

--- a/examples/grpc-secured-unary/grpc_secured_unary_pb.bal
+++ b/examples/grpc-secured-unary/grpc_secured_unary_pb.bal
@@ -3,16 +3,11 @@ import ballerina/io;
 
 // Generated blocking client endpoint based on the service definition.
 public type HelloWorldBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {
@@ -37,16 +32,11 @@ public type HelloWorldBlockingClient client object {
 
 // Generated non-blocking client endpoint based on the service definition.
 public type HelloWorldClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {

--- a/examples/grpc-server-streaming/grpc_server_streaming_pb.bal
+++ b/examples/grpc-server-streaming/grpc_server_streaming_pb.bal
@@ -3,16 +3,11 @@ import ballerina/io;
 
 // Generated non-blocking client endpoint based on the service definition.
 public type HelloWorldClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {

--- a/examples/grpc-unary-blocking/grpc_unary_blocking_pb.bal
+++ b/examples/grpc-unary-blocking/grpc_unary_blocking_pb.bal
@@ -3,16 +3,11 @@ import ballerina/io;
 
 // Generated blocking client endpoint based on the service definition.
 public type HelloWorldBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {
@@ -37,16 +32,11 @@ public type HelloWorldBlockingClient client object {
 
 // Generated non-blocking client endpoint based on the service definition.
 public type HelloWorldClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {

--- a/examples/grpc-unary-non-blocking/grpc_unary_non_blocking_pb.bal
+++ b/examples/grpc-unary-non-blocking/grpc_unary_non_blocking_pb.bal
@@ -3,16 +3,11 @@ import ballerina/io;
 
 // Generated blocking client endpoint based on the service definition.
 public type HelloWorldBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {
@@ -38,16 +33,11 @@ public type HelloWorldBlockingClient client object {
 
 // Generated non-blocking client endpoint based on the service definition.
 public type HelloWorldClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // Initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR,
                                                             getDescriptorMap());
         if (result is error) {

--- a/stdlib/grpc/pom.xml
+++ b/stdlib/grpc/pom.xml
@@ -97,6 +97,21 @@
             <classifier>ballerina-binary-repo</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-system</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-config-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/stdlib/grpc/src/main/ballerina/grpc/client_connection_pool.bal
+++ b/stdlib/grpc/src/main/ballerina/grpc/client_connection_pool.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/config;
+
+# Configurations for managing HTTP client connection pool.
+#
+# + maxActiveConnections - Max active connections per route(host:port). Default value is -1 which indicates unlimited.
+# + maxIdleConnections - Maximum number of idle connections allowed per pool.
+# + waitTimeinMillis - Maximum amount of time, the client should wait for an idle connection before it sends an error when the pool is exhausted
+# + maxActiveStreamsPerConnection - Maximum active streams per connection. This only applies to HTTP/2.
+public type PoolConfiguration record {
+    int maxActiveConnections = config:getAsInt("b7a.http.pool.maxActiveConnections", default = -1);
+    int maxIdleConnections = config:getAsInt("b7a.http.pool.maxIdleConnections", default = 1000);
+    int waitTimeinMillis = config:getAsInt("b7a.http.pool.waitTimeinMillis", default = 60000);
+    int maxActiveStreamsPerConnection = config:getAsInt("b7a.http.pool.maxActiveStreamsPerConnection", default = 50);
+};
+
+//This is a hack to get the global map initialized, without involving locking.
+type ConnectionManager object {
+    public PoolConfiguration poolConfig = {};
+    public function __init() {
+        self.initGlobalPool(self.poolConfig);
+    }
+    extern function initGlobalPool(PoolConfiguration poolConfig);
+};
+
+ConnectionManager connectionManager = new;
+PoolConfiguration globalHttpClientConnPool = connectionManager.poolConfig;

--- a/stdlib/grpc/src/main/ballerina/grpc/client_connection_pool.bal
+++ b/stdlib/grpc/src/main/ballerina/grpc/client_connection_pool.bal
@@ -16,7 +16,7 @@
 
 import ballerina/config;
 
-# Configurations for managing HTTP client connection pool.
+# Configurations for managing gRPC client connection pool.
 #
 # + maxActiveConnections - Max active connections per route(host:port). Default value is -1 which indicates unlimited.
 # + maxIdleConnections - Maximum number of idle connections allowed per pool.
@@ -27,16 +27,22 @@ public type PoolConfiguration record {
     int maxIdleConnections = config:getAsInt("b7a.http.pool.maxIdleConnections", default = 1000);
     int waitTimeinMillis = config:getAsInt("b7a.http.pool.waitTimeinMillis", default = 60000);
     int maxActiveStreamsPerConnection = config:getAsInt("b7a.http.pool.maxActiveStreamsPerConnection", default = 50);
+    !...;
 };
 
 //This is a hack to get the global map initialized, without involving locking.
 type ConnectionManager object {
-    public PoolConfiguration poolConfig = {};
+    private PoolConfiguration poolConfig = {};
+
     public function __init() {
         self.initGlobalPool(self.poolConfig);
     }
     extern function initGlobalPool(PoolConfiguration poolConfig);
+
+    public function getPoolConfiguration() returns PoolConfiguration {
+        return self.poolConfig;
+    }
 };
 
 ConnectionManager connectionManager = new;
-PoolConfiguration globalHttpClientConnPool = connectionManager.poolConfig;
+PoolConfiguration globalGrpcClientConnPool = connectionManager.getPoolConfiguration();

--- a/stdlib/grpc/src/main/ballerina/grpc/client_endpoint.bal
+++ b/stdlib/grpc/src/main/ballerina/grpc/client_endpoint.bal
@@ -29,7 +29,7 @@ public type Client client object {
     public function __init(string url, ClientEndpointConfig? config = ()) {
         self.config = config ?: {};
         self.url = url;
-        self.init(self.url, self.config, globalHttpClientConnPool);
+        self.init(self.url, self.config, globalGrpcClientConnPool);
     }
 
     extern function init(string url, ClientEndpointConfig config, PoolConfiguration globalPoolConfig);

--- a/stdlib/grpc/src/main/ballerina/grpc/client_endpoint.bal
+++ b/stdlib/grpc/src/main/ballerina/grpc/client_endpoint.bal
@@ -23,7 +23,11 @@ public type Client client object {
     #
     # + url - The server url.
     # + config - - The ClientEndpointConfig of the endpoint.
-    public extern function init(string url, ClientEndpointConfig config);
+    public function __init(string url, ClientEndpointConfig config) {
+        self.init(url, config, globalHttpClientConnPool);
+    }
+
+    extern function init(string url, ClientEndpointConfig config, PoolConfiguration globalPoolConfig);
 
     # Calls when initializing client endpoint with service descriptor data extracted from proto file.
     #
@@ -82,7 +86,7 @@ public type ClientEndpointConfig record {
     Chunking chunking = CHUNKING_NEVER;
     string forwarded = "disable";
     ProxyConfig? proxy = ();
-    ConnectionThrottling? connectionThrottling = {};
+    PoolConfiguration? poolConfig = ();
     SecureSocket? secureSocket = ();
     Compression compression = COMPRESSION_AUTO;
     !...;
@@ -99,20 +103,6 @@ public type ProxyConfig record {
     int port = 0;
     string userName = "";
     string password = "";
-    !...;
-};
-
-# Provides configurations for throttling connections of the endpoint.
-#
-# + maxActiveConnections - Maximum number of active connections allowed for the endpoint. The default value, -1,
-#                          indicates that the number of connections are not restricted.
-# + waitTime - Maximum waiting time for a request to grab an idle connection from the client
-# + maxActiveStreamsPerConnection - Maximum number of active streams allowed per an HTTP/2 connection
-public type ConnectionThrottling record {
-    int maxActiveConnections = -1;
-    int waitTime = 60000;
-    // In order to distribute the workload among multiple connections in HTTP/2 scenario.
-    int maxActiveStreamsPerConnection = 20000;
     !...;
 };
 

--- a/stdlib/grpc/src/main/ballerina/grpc/client_endpoint.bal
+++ b/stdlib/grpc/src/main/ballerina/grpc/client_endpoint.bal
@@ -18,13 +18,18 @@
 # provides includes functions to send request/error messages.
 public type Client client object {
 
+    private ClientEndpointConfig config = {};
+    private string url;
+
     # Gets invoked to initialize the endpoint. During initialization, configurations provided through the `config`
     # record is used for endpoint initialization.
     #
     # + url - The server url.
     # + config - - The ClientEndpointConfig of the endpoint.
-    public function __init(string url, ClientEndpointConfig config) {
-        self.init(url, config, globalHttpClientConnPool);
+    public function __init(string url, ClientEndpointConfig? config = ()) {
+        self.config = config ?: {};
+        self.url = url;
+        self.init(self.url, self.config, globalHttpClientConnPool);
     }
 
     extern function init(string url, ClientEndpointConfig config, PoolConfiguration globalPoolConfig);
@@ -76,7 +81,7 @@ public type Client client object {
 # + chunking - The chunking behaviour of the request
 # + forwarded - The choice of setting `forwarded`/`x-forwarded` header
 # + proxy - Proxy server related options
-# + connectionThrottling - Configurations for connection throttling
+# + poolConfig - Connection pool configuration
 # + secureSocket - SSL/TLS related options
 # + compression - Specifies the way of handling compression (`accept-encoding`) header
 public type ClientEndpointConfig record {

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
@@ -67,6 +67,8 @@ import static org.ballerinalang.net.http.HttpUtil.populateSenderConfigurations;
 )
 public class Init extends BlockingNativeCallableUnit {
 
+    private static final int CLIENT_ENDPOINT_CONFIG_INDEX = 1;
+    private static final int CLIENT_GLOBAL_POOL_INDEX = 2;
     private HttpWsConnectorFactory httpConnectorFactory = HttpUtil.createHttpWsConnectionFactory();
 
     @Override
@@ -74,9 +76,9 @@ public class Init extends BlockingNativeCallableUnit {
         Struct clientEndpoint = BLangConnectorSPIUtil.getConnectorEndpointStruct(context);
         // Creating client endpoint with channel as native data.
         BMap<String, BValue> endpointConfigStruct =
-                (BMap<String, BValue>) context.getRefArgument(1);
+                (BMap<String, BValue>) context.getRefArgument(CLIENT_ENDPOINT_CONFIG_INDEX);
         BMap<String, BValue> globalPoolConfig = (BMap<String, BValue>) context
-                .getRefArgument(2);
+                .getRefArgument(CLIENT_GLOBAL_POOL_INDEX);
         Struct endpointConfig = BLangConnectorSPIUtil.toStruct(endpointConfigStruct);
         String urlString = context.getStringArgument(0);
         HttpConnectionManager connectionManager = HttpConnectionManager.getInstance();

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
@@ -101,15 +101,10 @@ public class Init extends BlockingNativeCallableUnit {
         senderConfiguration.setTLSStoreType(HttpConstants.PKCS_STORE_TYPE);
 
         populateSenderConfigurations(senderConfiguration, endpointConfig);
-        ConnectionManager poolManager;
         BMap<String, BValue> userDefinedPoolConfig = (BMap<String, BValue>) endpointConfigStruct.get(
                 HttpConstants.USER_DEFINED_POOL_CONFIG);
-
-        if (userDefinedPoolConfig == null) {
-            poolManager = getConnectionManager(globalPoolConfig);
-        } else {
-            poolManager = getConnectionManager(userDefinedPoolConfig);
-        }
+        ConnectionManager poolManager = userDefinedPoolConfig == null ? getConnectionManager(globalPoolConfig) :
+                getConnectionManager(userDefinedPoolConfig);
         senderConfiguration.setHttpVersion(String.valueOf(Constants.HTTP_2_0));
         senderConfiguration.setForceHttp2(true);
         HttpClientConnector clientConnector = httpConnectorFactory.createHttpClientConnector(properties,

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
@@ -35,7 +35,6 @@ import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.ConnectionManager;
-import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.PoolConfiguration;
 import org.wso2.transport.http.netty.message.HttpConnectorUtil;
 
 import java.net.MalformedURLException;
@@ -48,9 +47,7 @@ import static org.ballerinalang.net.grpc.GrpcConstants.ENDPOINT_URL;
 import static org.ballerinalang.net.grpc.GrpcConstants.ORG_NAME;
 import static org.ballerinalang.net.grpc.GrpcConstants.PROTOCOL_PACKAGE_GRPC;
 import static org.ballerinalang.net.grpc.GrpcConstants.PROTOCOL_STRUCT_PACKAGE_GRPC;
-import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
 import static org.ballerinalang.net.http.HttpUtil.getConnectionManager;
-import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
 import static org.ballerinalang.net.http.HttpUtil.populateSenderConfigurations;
 
 /**

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
@@ -74,9 +74,9 @@ public class Init extends BlockingNativeCallableUnit {
         Struct clientEndpoint = BLangConnectorSPIUtil.getConnectorEndpointStruct(context);
         // Creating client endpoint with channel as native data.
         BMap<String, BValue> endpointConfigStruct =
-                (BMap<String, BValue>) context.getRefArgument(HttpConstants.CLIENT_ENDPOINT_CONFIG_INDEX);
+                (BMap<String, BValue>) context.getRefArgument(1);
         BMap<String, BValue> globalPoolConfig = (BMap<String, BValue>) context
-                .getRefArgument(HttpConstants.CLIENT_GLOBAL_POOL_INDEX);
+                .getRefArgument(2);
         Struct endpointConfig = BLangConnectorSPIUtil.toStruct(endpointConfigStruct);
         String urlString = context.getStringArgument(0);
         HttpConnectionManager connectionManager = HttpConnectionManager.getInstance();

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/Init.java
@@ -49,6 +49,7 @@ import static org.ballerinalang.net.grpc.GrpcConstants.ORG_NAME;
 import static org.ballerinalang.net.grpc.GrpcConstants.PROTOCOL_PACKAGE_GRPC;
 import static org.ballerinalang.net.grpc.GrpcConstants.PROTOCOL_STRUCT_PACKAGE_GRPC;
 import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
+import static org.ballerinalang.net.http.HttpUtil.getConnectionManager;
 import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
 import static org.ballerinalang.net.http.HttpUtil.populateSenderConfigurations;
 
@@ -113,20 +114,5 @@ public class Init extends BlockingNativeCallableUnit {
         clientEndpoint.addNativeData(CLIENT_CONNECTOR, clientConnector);
         clientEndpoint.addNativeData(ENDPOINT_URL, urlString);
 
-    }
-
-    private ConnectionManager getConnectionManager(BMap<String, BValue> poolStruct) {
-        ConnectionManager poolManager = (ConnectionManager) poolStruct.getNativeData(CONNECTION_MANAGER);
-        if (poolManager == null) {
-            synchronized (poolStruct) {
-                if (poolStruct.getNativeData(CONNECTION_MANAGER) == null) {
-                    PoolConfiguration userDefinedPool = new PoolConfiguration();
-                    populatePoolingConfig(poolStruct, userDefinedPool);
-                    poolManager = new ConnectionManager(userDefinedPool);
-                    poolStruct.addNativeData(CONNECTION_MANAGER, poolManager);
-                }
-            }
-        }
-        return poolManager;
     }
 }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/InitGlobalPool.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/InitGlobalPool.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.grpc.nativeimpl.clientendpoint;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.net.http.HttpConstants;
+import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.ConnectionManager;
+import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.PoolConfiguration;
+
+import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
+import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
+
+/**
+ * Initializes the global pool.
+ *
+ * @since 0.995.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "grpc",
+        functionName = "initGlobalPool",
+        isPublic = true
+)
+public class InitGlobalPool extends BlockingNativeCallableUnit {
+
+    @Override
+    public void execute(Context context) {
+        BMap<String, BValue> globalPoolConfig = (BMap<String, BValue>) context
+                .getRefArgument(HttpConstants.POOL_CONFIG_INDEX);
+        PoolConfiguration globalPool = new PoolConfiguration();
+        populatePoolingConfig(globalPoolConfig, globalPool);
+        ConnectionManager connectionManager = new ConnectionManager(globalPool);
+        globalPoolConfig.addNativeData(CONNECTION_MANAGER, connectionManager);
+    }
+}

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/InitGlobalPool.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/nativeimpl/clientendpoint/InitGlobalPool.java
@@ -20,13 +20,16 @@ package org.ballerinalang.net.grpc.nativeimpl.clientendpoint;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.HttpConstants;
 import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.ConnectionManager;
 import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.PoolConfiguration;
 
+import static org.ballerinalang.net.grpc.GrpcConstants.PROTOCOL_STRUCT_PACKAGE_GRPC;
 import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
 import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
 
@@ -38,6 +41,8 @@ import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
 @BallerinaFunction(
         orgName = "ballerina", packageName = "grpc",
         functionName = "initGlobalPool",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = "ConnectionManager", structPackage =
+                PROTOCOL_STRUCT_PACKAGE_GRPC),
         isPublic = true
 )
 public class InitGlobalPool extends BlockingNativeCallableUnit {

--- a/stdlib/grpc/src/main/resources/templates/skeleton/clientStub.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/clientStub.mustache
@@ -2,16 +2,11 @@
 import ballerina/io;
 {{/if}}{{#stubList}}
 public type {{serviceName}}{{#equals stubType "blocking"}}Blocking{{/equals}}Client client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("{{stubType}}", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/stdlib/grpc/src/test/java/org/ballerinalang/net/grpc/ConnectionPoolTestCase.java
+++ b/stdlib/grpc/src/test/java/org/ballerinalang/net/grpc/ConnectionPoolTestCase.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.net.grpc;
+
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.connector.api.Struct;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.http.HttpConstants;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.ConnectionManager;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.ballerinalang.net.http.HttpConstants.CLIENT_ENDPOINT_CONFIG;
+import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
+
+/**
+ * Test connection pool configurations.
+ *
+ * @since 0.995.0
+ */
+public class ConnectionPoolTestCase {
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        Path sourceFilePath = Paths.get("src", "test", "resources", "test-src",
+                "client_connection_pool.bal");
+        compileResult = BCompileUtil.compileAndSetup(sourceFilePath.toAbsolutePath().toString());
+    }
+
+    @Test
+    public void testGlobalPoolConfig() {
+        BValue[] returns = BRunUtil.invokeStateful(compileResult, "testGlobalPoolConfig");
+        Assert.assertEquals(returns.length, 3);
+        verifyResults((BMap<String, BValue>) returns[0]);
+        verifyResults((BMap<String, BValue>) returns[1]);
+        verifyResults((BMap<String, BValue>) returns[2]);
+    }
+
+    @Test
+    public void testSharedConfig() {
+        BValue[] returns = BRunUtil.invokeStateful(compileResult, "testSharedConfig");
+        Assert.assertEquals(returns.length, 2);
+        ConnectionManager connectionManager1 = verifyPoolConfig(returns[0]);
+        ConnectionManager connectionManager2 = verifyPoolConfig(returns[1]);
+        Assert.assertEquals(connectionManager1, connectionManager2,
+                "Both the clients should have same connection manager");
+    }
+
+    @Test
+    public void testPoolPerClient() {
+        BValue[] returns = BRunUtil.invokeStateful(compileResult, "testPoolPerClient");
+        Assert.assertEquals(returns.length, 2);
+        ConnectionManager connectionManager1 = verifyPoolConfig(returns[0]);
+        ConnectionManager connectionManager2 = verifyPoolConfig(returns[1]);
+        Assert.assertNotEquals(connectionManager1, connectionManager2,
+                "Both the clients should have their own connection manager");
+    }
+
+    private void verifyResults(BMap<String, BValue> client) {
+        Struct httpClient = BLangConnectorSPIUtil.toStruct(client);
+        Struct userDefinedPoolConfig = httpClient.getStructField(HttpConstants.USER_DEFINED_POOL_CONFIG);
+        Assert.assertNull(userDefinedPoolConfig, "Client shouldn't have pool config defined by the user");
+    }
+
+    private ConnectionManager verifyPoolConfig(BValue aReturn) {
+        Struct httpClient = BLangConnectorSPIUtil.toStruct((BMap<String, BValue>) aReturn);
+        Struct clientConfig = httpClient.getStructField(CLIENT_ENDPOINT_CONFIG);
+        Struct userDefinedPoolConfig = clientConfig.getStructField(HttpConstants.USER_DEFINED_POOL_CONFIG);
+        Assert.assertNotNull(userDefinedPoolConfig, "Client should have a pool config defined by the user");
+        return (ConnectionManager) userDefinedPoolConfig.getNativeData(CONNECTION_MANAGER);
+    }
+}

--- a/stdlib/grpc/src/test/java/org/ballerinalang/net/grpc/ConnectionPoolTestCase.java
+++ b/stdlib/grpc/src/test/java/org/ballerinalang/net/grpc/ConnectionPoolTestCase.java
@@ -61,8 +61,8 @@ public class ConnectionPoolTestCase {
     }
 
     @Test
-    public void testSharedConfig() {
-        BValue[] returns = BRunUtil.invokeStateful(compileResult, "testSharedConfig");
+    public void testSharedPoolConfig() {
+        BValue[] returns = BRunUtil.invokeStateful(compileResult, "testSharedPoolConfig");
         Assert.assertEquals(returns.length, 2);
         ConnectionManager connectionManager1 = verifyPoolConfig(returns[0]);
         ConnectionManager connectionManager2 = verifyPoolConfig(returns[1]);

--- a/stdlib/grpc/src/test/resources/test-src/client_connection_pool.bal
+++ b/stdlib/grpc/src/test/resources/test-src/client_connection_pool.bal
@@ -26,7 +26,7 @@ function testGlobalPoolConfig() returns grpc:Client?[] {
     return clients;
 }
 
-function testSharedConfig() returns grpc:Client?[] {
+function testSharedPoolConfig() returns grpc:Client?[] {
     grpc:Client client1 = new("http://localhost:8080", config = { poolConfig: sharedPoolConfig });
     grpc:Client client2 = new("http://localhost:8080", config = { poolConfig: sharedPoolConfig });
     grpc:Client?[] clients = [client1, client2];

--- a/stdlib/grpc/src/test/resources/test-src/client_connection_pool.bal
+++ b/stdlib/grpc/src/test/resources/test-src/client_connection_pool.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/grpc;
+
+grpc:PoolConfiguration sharedPoolConfig = {};
+
+function testGlobalPoolConfig() returns grpc:Client?[] {
+    grpc:Client client1 = new("http://localhost:8080");
+    grpc:Client client2 = new("http://localhost:8080");
+    grpc:Client client3 = new("http://localhost:8081");
+    grpc:Client?[] clients = [client1, client2, client3];
+    return clients;
+}
+
+function testSharedConfig() returns grpc:Client?[] {
+    grpc:Client client1 = new("http://localhost:8080", config = { poolConfig: sharedPoolConfig });
+    grpc:Client client2 = new("http://localhost:8080", config = { poolConfig: sharedPoolConfig });
+    grpc:Client?[] clients = [client1, client2];
+    return clients;
+}
+
+function testPoolPerClient() returns grpc:Client?[] {
+    grpc:Client client1 = new("http://localhost:8080", config = { poolConfig: { maxActiveConnections: 50 } });
+    grpc:Client client2 = new("http://localhost:8080", config = { poolConfig: { maxActiveConnections: 25 } });
+    grpc:Client?[] clients = [client1, client2];
+    return clients;
+}

--- a/stdlib/grpc/src/test/resources/testng.xml
+++ b/stdlib/grpc/src/test/resources/testng.xml
@@ -26,6 +26,7 @@ under the License.
             <class name="org.ballerinalang.net.grpc.ProtoBuilderDefinitionTest"/>
             <class name="org.ballerinalang.net.grpc.ResourceReturnTypeTest"/>
             <class name="org.ballerinalang.net.grpc.UnsupportedFieldTypesTest"/>
+            <class name="org.ballerinalang.net.grpc.ConnectionPoolTestCase"/>
         </classes>
     </test>
 </suite>

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -1229,89 +1229,6 @@ public class HttpUtil {
         return responseStruct;
     }
 
-    /**
-     * Populates Sender configuration instance with client endpoint configuration.
-     *
-     * @param senderConfiguration  sender configuration instance.
-     * @param clientEndpointConfig client endpoint configuration.
-     */
-    @Deprecated
-    public static void populateSenderConfigurationOptions(SenderConfiguration senderConfiguration, Struct
-            clientEndpointConfig) {
-        ProxyServerConfiguration proxyServerConfiguration;
-        Struct secureSocket = clientEndpointConfig.getStructField(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
-
-        if (secureSocket != null) {
-            HttpUtil.populateSSLConfiguration(senderConfiguration, secureSocket);
-        } else {
-            HttpUtil.setDefaultTrustStore(senderConfiguration);
-        }
-        Struct proxy = clientEndpointConfig.getStructField(HttpConstants.PROXY_STRUCT_REFERENCE);
-        if (proxy != null) {
-            String proxyHost = proxy.getStringField(HttpConstants.PROXY_HOST);
-            int proxyPort = (int) proxy.getIntField(HttpConstants.PROXY_PORT);
-            String proxyUserName = proxy.getStringField(HttpConstants.PROXY_USERNAME);
-            String proxyPassword = proxy.getStringField(HttpConstants.PROXY_PASSWORD);
-            try {
-                proxyServerConfiguration = new ProxyServerConfiguration(proxyHost, proxyPort);
-            } catch (UnknownHostException e) {
-                throw new BallerinaConnectorException("Failed to resolve host" + proxyHost, e);
-            }
-            if (!proxyUserName.isEmpty()) {
-                proxyServerConfiguration.setProxyUsername(proxyUserName);
-            }
-            if (!proxyPassword.isEmpty()) {
-                proxyServerConfiguration.setProxyPassword(proxyPassword);
-            }
-            senderConfiguration.setProxyServerConfiguration(proxyServerConfiguration);
-        }
-
-        String chunking = clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_CHUNKING).getStringValue();
-        senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
-
-        long timeoutMillis = clientEndpointConfig.getIntField(HttpConstants.CLIENT_EP_ENDPOINT_TIMEOUT);
-        if (timeoutMillis < 0 || !isInteger(timeoutMillis)) {
-            throw new BallerinaConnectorException("invalid idle timeout: " + timeoutMillis);
-        }
-        senderConfiguration.setSocketIdleTimeout((int) timeoutMillis);
-
-        String keepAliveConfig = clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_IS_KEEP_ALIVE)
-                .getStringValue();
-        senderConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAliveConfig));
-
-        String httpVersion = clientEndpointConfig.getStringField(HttpConstants.CLIENT_EP_HTTP_VERSION);
-        if (httpVersion != null) {
-            senderConfiguration.setHttpVersion(httpVersion);
-        }
-        String forwardedExtension = clientEndpointConfig.getStringField(HttpConstants.CLIENT_EP_FORWARDED);
-        senderConfiguration.setForwardedExtensionConfig(HttpUtil.getForwardedExtensionConfig(forwardedExtension));
-
-        Struct connectionThrottling = clientEndpointConfig.getStructField(HttpConstants.
-                CONNECTION_THROTTLING_STRUCT_REFERENCE);
-        if (connectionThrottling != null) {
-            long maxActiveConnections = connectionThrottling
-                    .getIntField(HttpConstants.CONNECTION_THROTTLING_MAX_ACTIVE_CONNECTIONS);
-            if (!isInteger(maxActiveConnections)) {
-                throw new BallerinaConnectorException("invalid maxActiveConnections value: "
-                        + maxActiveConnections);
-            }
-            senderConfiguration.getPoolConfiguration().setMaxActivePerPool((int) maxActiveConnections);
-
-            long waitTime = connectionThrottling
-                    .getIntField(HttpConstants.CONNECTION_THROTTLING_WAIT_TIME);
-            senderConfiguration.getPoolConfiguration().setMaxWaitTime(waitTime);
-
-            long maxActiveStreamsPerConnection = connectionThrottling.
-                    getIntField(HttpConstants.CONNECTION_THROTTLING_MAX_ACTIVE_STREAMS_PER_CONNECTION);
-            if (!isInteger(maxActiveStreamsPerConnection)) {
-                throw new BallerinaConnectorException("invalid maxActiveStreamsPerConnection value: "
-                        + maxActiveStreamsPerConnection);
-            }
-            senderConfiguration.getPoolConfiguration().setHttp2MaxActiveStreamsPerConnection(
-                    maxActiveStreamsPerConnection == -1 ? Integer.MAX_VALUE : (int) maxActiveStreamsPerConnection);
-        }
-    }
-
     public static void populateSenderConfigurations(SenderConfiguration senderConfiguration, Struct
             clientEndpointConfig) {
         ProxyServerConfiguration proxyServerConfiguration;
@@ -1383,10 +1300,6 @@ public class HttpUtil {
         poolConfiguration.setHttp2MaxActiveStreamsPerConnection(
                 maxActiveStreamsPerConnection == -1 ? Integer.MAX_VALUE : validateConfig(maxActiveStreamsPerConnection,
                                                                 CONNECTION_POOLING_MAX_ACTIVE_STREAMS_PER_CONNECTION));
-    }
-
-    private static boolean isInteger(long val) {
-        return (int) val == val;
     }
 
     private static int validateConfig(long value, String configName) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_CLIENT;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
+import static org.ballerinalang.net.http.HttpUtil.getConnectionManager;
 import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
 import static org.ballerinalang.net.http.HttpUtil.populateSenderConfigurations;
 
@@ -113,20 +114,5 @@ public class CreateSimpleHttpClient extends BlockingNativeCallableUnit {
         httpClient.addNativeData(HttpConstants.CLIENT_ENDPOINT_CONFIG, clientEndpointConfig);
         configBStruct.addNativeData(HttpConstants.HTTP_CLIENT, httpClientConnector);
         context.setReturnValues((httpClient));
-    }
-
-    private ConnectionManager getConnectionManager(BMap<String, BValue> poolStruct) {
-        ConnectionManager poolManager = (ConnectionManager) poolStruct.getNativeData(CONNECTION_MANAGER);
-        if (poolManager == null) {
-            synchronized (this) {
-                if (poolStruct.getNativeData(CONNECTION_MANAGER) == null) {
-                    PoolConfiguration userDefinedPool = new PoolConfiguration();
-                    populatePoolingConfig(poolStruct, userDefinedPool);
-                    poolManager = new ConnectionManager(userDefinedPool);
-                    poolStruct.addNativeData(CONNECTION_MANAGER, poolManager);
-                }
-            }
-        }
-        return poolManager;
     }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -35,18 +35,15 @@ import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.ConnectionManager;
-import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.PoolConfiguration;
 import org.wso2.transport.http.netty.message.HttpConnectorUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_CLIENT;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
 import static org.ballerinalang.net.http.HttpUtil.getConnectionManager;
-import static org.ballerinalang.net.http.HttpUtil.populatePoolingConfig;
 import static org.ballerinalang.net.http.HttpUtil.populateSenderConfigurations;
 
 /**

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/advanced_type_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/advanced_type_client.bal
@@ -113,16 +113,11 @@ function testInputStructNoOutput(StockQuote quote) returns (string) {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -204,16 +199,11 @@ public type HelloWorldBlockingClient client object {
 
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config;
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
         // initialize client endpoint.
-        self.config = config ?: {};
-        self.url = url;
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/array_field_type_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/array_field_type_client.bal
@@ -176,16 +176,11 @@ function testStructArrayOutput() returns (TestStruct|string) {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -322,16 +317,11 @@ public type HelloWorldBlockingClient client object {
 
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/bidirectional_streaming_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/bidirectional_streaming_client.bal
@@ -95,16 +95,11 @@ service ChatMessageListener = service {
 // Non-blocking client endpoint
 public type ChatClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/client_streaming_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/client_streaming_client.bal
@@ -79,16 +79,11 @@ service HelloWorldMessageListener = service {
 // Non-blocking client endpoint
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_byte_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_byte_client.bal
@@ -62,16 +62,11 @@ function testLargeByteArray(string filePath) returns (string) {
 }
 
 public type byteServiceBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -95,16 +90,11 @@ public type byteServiceBlockingClient client object {
 };
 
 public type byteServiceClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_client_socket_timeout.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_client_socket_timeout.bal
@@ -36,16 +36,11 @@ public function testClientSocketTimeout() returns string {
 }
 
 public type HelloWorld14BlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -66,16 +61,11 @@ public type HelloWorld14BlockingClient client object {
 };
 
 public type HelloWorld14Client client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_enum_test_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_enum_test_client.bal
@@ -31,16 +31,11 @@ function testEnum() returns (string) {
 }
 
 public type testEnumServiceBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -59,16 +54,11 @@ public type testEnumServiceBlockingClient client object {
 };
 
 public type testEnumServiceClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_oneof_field_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_oneof_field_client.bal
@@ -225,16 +225,11 @@ public function testBytesFieldValue() returns string {
 }
 
 public type OneofFieldServiceBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -276,16 +271,11 @@ public type OneofFieldServiceBlockingClient client object {
 };
 
 public type OneofFieldServiceClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_secured_unary_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_secured_unary_client.bal
@@ -53,16 +53,11 @@ function testUnarySecuredBlocking() returns (string) {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -82,16 +77,11 @@ public type HelloWorldBlockingClient client object {
 
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_ssl_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/grpc_ssl_client.bal
@@ -40,16 +40,11 @@ function testUnarySecuredBlockingWithCerts() returns (string) {
 }
 
 public type grpcMutualSslServiceBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -70,16 +65,11 @@ public type grpcMutualSslServiceBlockingClient client object {
 
 public type grpcMutualSslServiceClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/invalid_resource_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/invalid_resource_client.bal
@@ -80,16 +80,11 @@ function testNonExistenceRemoteMethod(boolean isAvailable) returns (boolean|stri
 }
 
 public type HelloWorldBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/server_streaming_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/server_streaming_client.bal
@@ -70,16 +70,11 @@ service HelloWorldMessageListener = service {
 // Non-blocking client endpoint
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_blocking_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_blocking_client.bal
@@ -112,16 +112,11 @@ function testUnaryBlockingStructClient(Request req) returns (Response) {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -208,16 +203,11 @@ public type HelloWorldBlockingClient client object {
 
 public type helloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_client_with_error_return.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_client_with_error_return.bal
@@ -34,16 +34,11 @@ public function testErrorResponse(string name) returns string {
 }
 
 public type HelloWorldBlockingClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -63,16 +58,11 @@ public type HelloWorldBlockingClient client object {
 };
 
 public type HelloWorldClient client object {
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_client_with_headers.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_client_with_headers.bal
@@ -64,16 +64,11 @@ function testBlockingHeader(string name) returns (string) {
 // Blocking endpoint.
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -94,16 +89,11 @@ public type HelloWorldBlockingClient client object {
 //Non-blocking endpoint
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_nonblocking_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/unary_nonblocking_client.bal
@@ -71,16 +71,11 @@ service HelloWorldMessageListener = service {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -152,16 +147,11 @@ public type HelloWorldBlockingClient client object {
 
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-integration-test/src/test/resources/grpc/clients/unavailable_service_client.bal
+++ b/tests/ballerina-integration-test/src/test/resources/grpc/clients/unavailable_service_client.bal
@@ -33,16 +33,11 @@ function testUnaryBlockingClient(string name) returns (string) {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -62,16 +57,11 @@ public type HelloWorldBlockingClient client object {
 
 public type helloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-tools-integration-test/src/test/resources/grpc/nested_type_client.bal
+++ b/tests/ballerina-tools-integration-test/src/test/resources/grpc/nested_type_client.bal
@@ -58,15 +58,10 @@ function testOutputNestedStruct(string name) returns Person|string {
 public type HelloWorldBlockingClient client object {
 
     private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;
@@ -100,15 +95,10 @@ public type HelloWorldBlockingClient client object {
 public type HelloWorldClient client object {
 
     private grpc:Client grpcClient = new;
-    private grpc:ClientEndpointConfig config = {};
-    private string url;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
-        self.config = config ?: {};
-        self.url = url;
         // initialize client endpoint.
-        grpc:Client c = new;
-        c.init(self.url, self.config);
+        grpc:Client c = new(url, config = config);
         error? result = c.initStub("non-blocking", ROOT_DESCRIPTOR, getDescriptorMap());
         if (result is error) {
             panic result;

--- a/tests/ballerina-tools-integration-test/src/test/resources/grpc/nested_type_client.bal
+++ b/tests/ballerina-tools-integration-test/src/test/resources/grpc/nested_type_client.bal
@@ -57,7 +57,7 @@ function testOutputNestedStruct(string name) returns Person|string {
 
 public type HelloWorldBlockingClient client object {
 
-    private grpc:Client grpcClient = new;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
         // initialize client endpoint.
@@ -94,7 +94,7 @@ public type HelloWorldBlockingClient client object {
 
 public type HelloWorldClient client object {
 
-    private grpc:Client grpcClient = new;
+    private grpc:Client grpcClient;
 
     function __init(string url, grpc:ClientEndpointConfig? config = ()) {
         // initialize client endpoint.


### PR DESCRIPTION
## Purpose
This is to decouple the connection pool from gRPC client.
Resolves #13884

## Goals
By default gRPC clients will share a global pool but they also has a way to configure their own pool

## Automation tests
 - Unit tests 
   > Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes