### PR TITLE
Remove mina-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1365,12 +1365,6 @@
                 <version>${quartz.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.mina</groupId>
-                <artifactId>mina-core</artifactId>
-                <version>${apache.mina.core}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson-core.version}</version>
@@ -2351,7 +2345,6 @@
         <quartz.version>2.3.0</quartz.version>
         <commons-net.version>3.6</commons-net.version>
         <jackson-core.version>2.9.8</jackson-core.version>
-        <apache.mina.core>2.0.19</apache.mina.core>
         <mimepull.version>1.9.7</mimepull.version>
         <broker.version>0.970.5</broker.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>

--- a/tests/ballerina-integration-test-utils/pom.xml
+++ b/tests/ballerina-integration-test-utils/pom.xml
@@ -34,11 +34,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.mina</groupId>
-            <artifactId>mina-core</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -18,7 +18,6 @@
 package org.ballerinalang.test.context;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.mina.util.ConcurrentHashSet;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.slf4j.Logger;
@@ -31,6 +30,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import static org.ballerinalang.test.context.Constant.BALLERINA_AGENT_PATH;
@@ -52,8 +53,8 @@ public class BServerInstance implements BServer {
     private Process process;
     private ServerLogReader serverInfoLogReader;
     private ServerLogReader serverErrorLogReader;
-    private ConcurrentHashSet<LogLeecher> tmpInfoLeechers = new ConcurrentHashSet<>();
-    private ConcurrentHashSet<LogLeecher> tmpErrorLeechers = new ConcurrentHashSet<>();
+    private Set<LogLeecher> tmpInfoLeechers = ConcurrentHashMap.newKeySet();
+    private Set<LogLeecher> tmpErrorLeechers = ConcurrentHashMap.newKeySet();
     private int[] requiredPorts;
 
     public BServerInstance(BalServer balServer) throws BallerinaTestException {

--- a/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/ServerLogReader.java
+++ b/tests/ballerina-integration-test-utils/src/main/java/org/ballerinalang/test/context/ServerLogReader.java
@@ -17,7 +17,6 @@
 */
 package org.ballerinalang.test.context;
 
-import org.apache.mina.util.ConcurrentHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -39,7 +40,7 @@ public class ServerLogReader implements Runnable {
     private InputStream inputStream;
     private volatile boolean running = true;
 
-    private ConcurrentHashSet<LogLeecher> leechers = new ConcurrentHashSet<>();
+    private Set<LogLeecher> leechers = ConcurrentHashMap.newKeySet();
 
     /**
      * Initialize the reader with reader name and stream to read.


### PR DESCRIPTION
## Purpose
This PR removes `mina-core` dependency.

**Note** - `ConcurrentHashSet` is missing in the `java.util.concurrent` package because we can get/create a `ConcurrentHashSet` using a `ConcurrentHashMap`.

The way to do this in `Java 8+` is -

```java
Set<String> concurrentSet = ConcurrentHashMap.newKeySet();
```
