### PR TITLE
Update apacheds-all version from 1.5.5 to 2.0.0-M24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2427,7 +2427,7 @@
         <chewiebug.gcviewer.version>1.35</chewiebug.gcviewer.version>
 
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
-        <apache.directory.server.version>1.5.5</apache.directory.server.version>
+        <apache.directory.server.version>2.0.0-M24</apache.directory.server.version>
         <bouncycastle.version>1.61</bouncycastle.version>
     </properties>
 


### PR DESCRIPTION
## Purpose
To update apacheds-all version to a later version which used in LDAP integration tests.
Fix: https://github.com/ballerina-platform/ballerina-lang/issues/13880

## Goals
Make sure LDAP authstore work with latest apache DS.

## Approach
Update apacheds dependancy used in integration test to a newer version.

## Automation tests
 - Integration tests
   > yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes