### PR TITLE
Flatten the union type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -1219,8 +1219,7 @@ public class CompiledPackageSymbolEnter {
                 case 'O':
                     BTypeSymbol unionTypeSymbol = Symbols.createTypeSymbol(SymTag.UNION_TYPE, Flags.asMask(EnumSet
                             .of(Flag.PUBLIC)), Names.EMPTY, env.pkgSymbol.pkgID, null, env.pkgSymbol.owner);
-                    return new BUnionType(unionTypeSymbol, new LinkedHashSet<>(memberTypes),
-                            memberTypes.contains(symTable.nilType));
+                    return BUnionType.create(unionTypeSymbol, new LinkedHashSet<>(memberTypes));
                 case 'P':
                     BTypeSymbol tupleTypeSymbol = Symbols.createTypeSymbol(SymTag.TUPLE_TYPE, Flags.asMask(EnumSet
                             .of(Flag.PUBLIC)), Names.EMPTY, env.pkgSymbol.pkgID, null, env.pkgSymbol.owner);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1331,7 +1331,7 @@ public class CodeGenerator extends BLangNodeVisitor {
                 list.add(new Operand(1)); // Todo - Cleanup counts
                 list.add(iExpr.regIndex);
 
-                BType resultType = ((BUnionType) iExpr.type).memberTypes.iterator().next();
+                BType resultType = ((BUnionType) iExpr.type).iterator().next();
                 list.add(getTypeCPIndex(resultType));
 
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3435,7 +3435,7 @@ public class Desugar extends BLangNodeVisitor {
         // Owner of the variable symbol must be an invokable symbol
         BType enclosingFuncReturnType = ((BInvokableType) invokableSymbol.type).retType;
         Set<BType> returnTypeSet = enclosingFuncReturnType.tag == TypeTags.UNION ?
-                ((BUnionType) enclosingFuncReturnType).memberTypes :
+                ((BUnionType) enclosingFuncReturnType).getMemberTypes() :
                 new LinkedHashSet<BType>() {{
                     add(enclosingFuncReturnType);
                 }};
@@ -3716,7 +3716,7 @@ public class Desugar extends BLangNodeVisitor {
         BType[] memberTypes;
         if (patternType.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) patternType;
-            memberTypes = unionType.memberTypes.toArray(new BType[0]);
+            memberTypes = unionType.getMemberTypes().toArray(new BType[0]);
         } else {
             memberTypes = new BType[1];
             memberTypes[0] = patternType;
@@ -3901,7 +3901,7 @@ public class Desugar extends BLangNodeVisitor {
 
         if (bLangMatchExpression.expr.type.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) bLangMatchExpression.expr.type;
-            exprTypes = new ArrayList<>(unionType.memberTypes);
+            exprTypes = new ArrayList<>(unionType.getMemberTypes());
         } else {
             exprTypes = Lists.of(bLangMatchExpression.type);
         }
@@ -3987,7 +3987,8 @@ public class Desugar extends BLangNodeVisitor {
             return false;
         }
 
-        return ((BUnionType) type).memberTypes.contains(symTable.nilType);
+        // TODO: 2/26/19 Should be able to use type.isNullable() here
+        return ((BUnionType) type).getMemberTypes().contains(symTable.nilType);
     }
 
     private BLangExpression rewriteSafeNavigationExpr(BLangAccessExpression accessExpr) {
@@ -4082,7 +4083,7 @@ public class Desugar extends BLangNodeVisitor {
         if (iExpr.builtInMethod == BLangBuiltInMethod.FREEZE) {
             if (iExpr.expr.type.tag == TypeTags.UNION && iExpr.expr.type.isNullable()) {
                 BUnionType unionType = (BUnionType) iExpr.expr.type;
-                return unionType.memberTypes.size() == 2 && unionType.memberTypes.stream()
+                return unionType.getMemberTypes().size() == 2 && unionType.getMemberTypes().stream()
                         .noneMatch(type -> type.tag != TypeTags.NIL && types.isValueType(type));
             }
         } else if (iExpr.builtInMethod == BLangBuiltInMethod.IS_FROZEN) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -363,7 +363,7 @@ public class Desugar extends BLangNodeVisitor {
         LinkedHashSet<BType> members = new LinkedHashSet<>();
         members.add(symTable.errorType);
         members.add(symTable.nilType);
-        final BUnionType returnType = new BUnionType(null, members, true);
+        final BUnionType returnType = BUnionType.create(null, members);
         BInvokableType invokableType = new BInvokableType(new ArrayList<>(), returnType, null);
 
         BInvokableSymbol functionSymbol = Symbols.createFunctionSymbol(Flags.asMask(bLangFunction.flagSet),
@@ -3929,7 +3929,7 @@ public class Desugar extends BLangNodeVisitor {
         if (unmatchedTypes.size() == 1) {
             defaultPatternType = unmatchedTypes.get(0);
         } else {
-            defaultPatternType = new BUnionType(null, new LinkedHashSet<>(unmatchedTypes), false);
+            defaultPatternType = BUnionType.create(null, new LinkedHashSet<>(unmatchedTypes));
         }
 
         String patternCaseVarName = GEN_VAR_PREFIX.value + "t_match_default";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
@@ -59,7 +59,6 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.programfile.InstructionCodes;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 import static org.wso2.ballerinalang.compiler.util.Names.GEN_VAR_PREFIX;
@@ -352,9 +351,7 @@ public class HttpFiltersDesugar {
         foreach.varType = filterType;
         BMapType mapType = new BMapType(TypeTags.RECORD, filterType, symTable.mapType.tsymbol);
         foreach.resultType = mapType;
-        LinkedHashSet<BType> memberTypes = new LinkedHashSet<>();
-        memberTypes.add(mapType);
-        foreach.nillableResultType = new BUnionType(null, memberTypes, true);
+        foreach.nillableResultType = BUnionType.create(null, mapType, symTable.nilType);
 
         foreach.variableDefinitionNode = variableDefinition;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/IterableCodeDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/IterableCodeDesugar.java
@@ -72,7 +72,6 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -266,9 +265,7 @@ public class IterableCodeDesugar {
         foreachStmt.varType = paramType;
         BMapType mapType = new BMapType(TypeTags.RECORD, paramType, symTable.mapType.tsymbol);
         foreachStmt.resultType = mapType;
-        LinkedHashSet<BType> memberTypes = new LinkedHashSet<>();
-        memberTypes.add(mapType);
-        foreachStmt.nillableResultType = new BUnionType(null, memberTypes, true);
+        foreachStmt.nillableResultType = BUnionType.create(null, mapType, symTable.nilType);
 
         // foreach variable are the result variables.
         if (isReturningIteratorFunction(ctx)) {
@@ -321,9 +318,7 @@ public class IterableCodeDesugar {
         foreachStmt.varType = paramType;
         BMapType mapType = new BMapType(TypeTags.RECORD, paramType, symTable.mapType.tsymbol);
         foreachStmt.resultType = mapType;
-        LinkedHashSet<BType> memberTypes = new LinkedHashSet<>();
-        memberTypes.add(mapType);
-        foreachStmt.nillableResultType = new BUnionType(null, memberTypes, true);
+        foreachStmt.nillableResultType = BUnionType.create(null, mapType, symTable.nilType);
 
         if (foreachVariables.size() > 1) {
             // Create tuple, for lambda invocation.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -186,7 +186,7 @@ public class ServiceDesugar {
         BLangExpression rhsExpr = methodInvocation;
         // Add optional check.
         if (((BInvokableType) methodInvocationSymbol.type).retType.tag == TypeTags.UNION
-                && ((BUnionType) ((BInvokableType) methodInvocationSymbol.type).retType).memberTypes.stream()
+                && ((BUnionType) ((BInvokableType) methodInvocationSymbol.type).retType).getMemberTypes().stream()
                 .anyMatch(type -> type.tag == TypeTags.ERROR)) {
             final BLangCheckedExpr checkExpr = ASTBuilderUtil.createCheckExpr(pos, methodInvocation, symTable.anyType);
             checkExpr.equivalentErrorTypeList.add(symTable.errorType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/StreamingCodeDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/StreamingCodeDesugar.java
@@ -586,9 +586,7 @@ public class StreamingCodeDesugar extends BLangNodeVisitor {
         foreach.isDeclaredWithVar = true;
         foreach.varType = foreachVariable.type;
         foreach.resultType = indexAccessExpr.type;
-        LinkedHashSet<BType> memberTypes = new LinkedHashSet<>();
-        memberTypes.add(indexAccessExpr.type);
-        foreach.nillableResultType = new BUnionType(null, memberTypes, true);
+        foreach.nillableResultType = BUnionType.create(null, indexAccessExpr.type, symTable.nilType);
         return foreach;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -803,7 +803,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 return true;
             case TypeTags.UNION:
                 BUnionType unionMatchType = (BUnionType) matchType;
-                return unionMatchType.memberTypes
+                return unionMatchType.getMemberTypes()
                         .stream()
                         .anyMatch(memberMatchType -> isValidStaticMatchPattern(memberMatchType, literal));
             case TypeTags.TUPLE:
@@ -1803,7 +1803,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         if (bLangMatchExpression.expr.type.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) bLangMatchExpression.expr.type;
-            exprTypes = new ArrayList<>(unionType.memberTypes);
+            exprTypes = new ArrayList<>(unionType.getMemberTypes());
         } else {
             exprTypes = Lists.of(bLangMatchExpression.expr.type);
         }
@@ -1869,7 +1869,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         BType exprType = env.enclInvokable.getReturnTypeNode().type;
         if (exprType.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) env.enclInvokable.getReturnTypeNode().type;
-            enclInvokableHasErrorReturn = unionType.memberTypes.stream()
+            enclInvokableHasErrorReturn = unionType.getMemberTypes().stream()
                     .anyMatch(memberType -> types.isAssignable(memberType, symTable.errorType));
         } else if (types.isAssignable(exprType, symTable.errorType)) {
             enclInvokableHasErrorReturn = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1249,7 +1249,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
         returnTypeAndSendType.add(workerSendNode.expr.type);
         if (returnTypeAndSendType.size() > 1) {
-            return new BUnionType(null, returnTypeAndSendType, false);
+            return BUnionType.create(null, returnTypeAndSendType);
         } else {
             return workerSendNode.expr.type;
         }
@@ -1319,7 +1319,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
         returnTypeAndSendType.add(symTable.nilType);
         if (returnTypeAndSendType.size() > 1) {
-            return new BUnionType(null, returnTypeAndSendType, true);
+            return BUnionType.create(null, returnTypeAndSendType);
         } else {
             return symTable.nilType;
         }
@@ -2103,9 +2103,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
 
         if (!types.isAssignable(funcNode.returnTypeNode.type,
-                                new BUnionType(null, new LinkedHashSet<BType>() {
-                                    { add(symTable.nilType); add(symTable.errorType); }
-                                }, true))) {
+                                BUnionType.create(null, symTable.nilType, symTable.errorType))) {
             this.dlog.error(funcNode.returnTypeNode.pos, DiagnosticCode.MAIN_RETURN_SHOULD_BE_ERROR_OR_NIL,
                             funcNode.returnTypeNode.type);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
@@ -43,7 +43,6 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.util.Lists;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -361,10 +360,7 @@ public class IterableAnalyzer {
                 logNotEnoughVariablesError(op, 1);
                 return Lists.of(symTable.semanticError);
             } else if (op.arity == 1) {
-                LinkedHashSet<BType> types = new LinkedHashSet<>();
-                types.add(symTable.xmlType);
-                types.add(symTable.stringType);
-                return Lists.of(new BUnionType(null, types, false));
+                return Lists.of(BUnionType.create(null, symTable.xmlType, symTable.stringType));
             }
             logTooManyVariablesError(op);
             return Lists.of(symTable.semanticError);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1373,7 +1373,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         BType exprType = typeChecker.checkExpr(matchNode.expr, env, symTable.noType);
         if (exprType.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) exprType;
-            exprTypes = new ArrayList<>(unionType.memberTypes);
+            exprTypes = new ArrayList<>(unionType.getMemberTypes());
         } else {
             exprTypes = Lists.of(exprType);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -719,7 +719,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                                     memberTupleTypes.add(varNode.type);
                                 }
                             }
-                            memberTupleTypes.add(new BUnionType(null, memberTypes, false));
+                            memberTupleTypes.add(BUnionType.create(null, memberTypes));
                         }
                         tupleTypeNode = new BTupleType(memberTupleTypes);
                         break;
@@ -833,7 +833,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                                 })
                                 .collect(Collectors.toCollection(LinkedHashSet::new));
                         recordVarType.restFieldType = memberTypes.size() > 1 ?
-                                new BUnionType(null, memberTypes, false) :
+                                BUnionType.create(null, memberTypes) :
                                 memberTypes.iterator().next();
                     }
                     recordVarType.tsymbol = recordSymbol;
@@ -917,10 +917,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                             recordVarType.restFieldType.tag == TypeTags.ANY) {
                         restType = recordVarType.restFieldType;
                     } else {
-                        LinkedHashSet<BType> typesForRestField = new LinkedHashSet<>();
-                        typesForRestField.add(recordVarType.restFieldType);
-                        typesForRestField.add(symTable.nilType);
-                        restType = new BUnionType(null, typesForRestField, true);
+                        restType = BUnionType.create(null, recordVarType.restFieldType, symTable.nilType);
                     }
                     value.type = restType;
                     value.accept(this);
@@ -990,8 +987,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             }
 
             BType fieldType = memberTypes.size() > 1 ?
-                    new BUnionType(null, memberTypes, memberTypes.contains(symTable.nilType)) :
-                    memberTypes.iterator().next();
+                    BUnionType.create(null, memberTypes) : memberTypes.iterator().next();
             fields.add(new BField(names.fromString(fieldName),
                     new BVarSymbol(0, names.fromString(fieldName), env.enclPkg.symbol.pkgID,
                             fieldType, recordSymbol)));
@@ -1004,10 +1000,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         if (fieldTypes.tag == TypeTags.ANYDATA || fieldTypes.tag == TypeTags.ANY) {
             fieldType = fieldTypes;
         } else {
-            LinkedHashSet<BType> typesForField = new LinkedHashSet<>();
-            typesForField.add(fieldTypes);
-            typesForField.add(symTable.nilType);
-            fieldType = new BUnionType(null, typesForField, true);
+            fieldType = BUnionType.create(null, fieldTypes, symTable.nilType);
         }
 
         BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(0, names.fromString(ANONYMOUS_RECORD_NAME),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -542,7 +542,7 @@ public class SymbolResolver extends BLangNodeVisitor {
     BSymbol getNumericConversionOrCastSymbol(BLangTypeConversionExpr conversionExpr, BType sourceType,
                                              BType targetType) {
         if (targetType.tag == TypeTags.UNION &&
-                ((BUnionType) targetType).memberTypes.stream()
+                ((BUnionType) targetType).getMemberTypes().stream()
                         .filter(memType -> types.isBasicNumericType(memType)).count() > 1) {
             return symTable.notFoundSymbol;
         }
@@ -565,7 +565,7 @@ public class SymbolResolver extends BLangNodeVisitor {
                 case TypeTags.JSON:
                     return createTypeCastSymbol(sourceType, targetType);
                 case TypeTags.UNION:
-                    if (((BUnionType) sourceType).memberTypes.stream()
+                    if (((BUnionType) sourceType).getMemberTypes().stream()
                             .anyMatch(memType -> types.isBasicNumericType(memType))) {
                         return createTypeCastSymbol(sourceType, targetType);
                     }
@@ -644,7 +644,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         // if it is not already a union type, JSON type, or any type
         if (typeNode.nullable && this.resultType.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) this.resultType;
-            unionType.memberTypes.add(symTable.nilType);
+            unionType.getMemberTypes().add(symTable.nilType);
             unionType.setNullable(true);
         } else if (typeNode.nullable && resultType.tag != TypeTags.JSON && resultType.tag != TypeTags.ANY) {
             this.resultType = BUnionType.create(null, resultType, symTable.nilType);
@@ -841,7 +841,7 @@ public class SymbolResolver extends BLangNodeVisitor {
                 .map(memTypeNode -> resolveTypeNode(memTypeNode, env))
                 .flatMap(memBType ->
                         memBType.tag == TypeTags.UNION ?
-                                ((BUnionType) memBType).memberTypes.stream() :
+                                ((BUnionType) memBType).getMemberTypes().stream() :
                                 Stream.of(memBType))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -644,8 +644,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         // if it is not already a union type, JSON type, or any type
         if (typeNode.nullable && this.resultType.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) this.resultType;
-            unionType.getMemberTypes().add(symTable.nilType);
-            unionType.setNullable(true);
+            unionType.add(symTable.nilType);
         } else if (typeNode.nullable && resultType.tag != TypeTags.JSON && resultType.tag != TypeTags.ANY) {
             this.resultType = BUnionType.create(null, resultType, symTable.nilType);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -474,14 +474,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return symTable.createOperator(name, paramTypes, targetType, InstructionCodes.STAMP);
         }
         if (types.isStampingAllowed(variableSourceType, targetType)) {
-            List<BType> unionReturnTypes = new ArrayList<>();
-            unionReturnTypes.add(targetType);
-            unionReturnTypes.add(symTable.errorType);
-            BType returnType = new BUnionType(null, new LinkedHashSet<BType>() {
-                {
-                    addAll(unionReturnTypes);
-                }
-            }, false);
+            BType returnType = BUnionType.create(null, targetType, symTable.errorType);
             List<BType> paramTypes = new ArrayList<>();
             paramTypes.add(variableSourceType);
             return symTable.createOperator(name, paramTypes, returnType, InstructionCodes.STAMP);
@@ -654,11 +647,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             unionType.memberTypes.add(symTable.nilType);
             unionType.setNullable(true);
         } else if (typeNode.nullable && resultType.tag != TypeTags.JSON && resultType.tag != TypeTags.ANY) {
-            LinkedHashSet<BType> memberTypes = new LinkedHashSet<BType>() {{
-                add(resultType);
-                add(symTable.nilType);
-            }};
-            this.resultType = new BUnionType(null, memberTypes, true);
+            this.resultType = BUnionType.create(null, resultType, symTable.nilType);
         }
 
         typeNode.type = resultType;
@@ -864,8 +853,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return;
         }
 
-        BUnionType unionType = new BUnionType(unionTypeSymbol, memberTypes,
-                memberTypes.contains(symTable.nilType));
+        BUnionType unionType = BUnionType.create(unionTypeSymbol, memberTypes);
         unionTypeSymbol.type = unionType;
 
         resultType = unionType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1138,7 +1138,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
     private List<BType> findMembersWithMatchingInitFunc(BLangTypeInit cIExpr, BUnionType lhsUnionType) {
         List<BType> matchingLhsMemberTypes = new ArrayList<>();
-        for (BType memberType : lhsUnionType.memberTypes) {
+        for (BType memberType : lhsUnionType.getMemberTypes()) {
             if (memberType.tag != TypeTags.OBJECT) {
                 // member is not an object.
                 continue;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2572,10 +2572,7 @@ public class TypeChecker extends BLangNodeVisitor {
             return actualType;
         }
 
-        BUnionType type = BUnionType.create(null, actualType);
-        type.getMemberTypes().add(symTable.nilType);
-        type.setNullable(true);
-        return type;
+        return BUnionType.create(null, actualType, symTable.nilType);
     }
 
     private BType checkStructFieldAccess(BLangVariableReference varReferExpr, Name fieldName, BType structType) {
@@ -2749,22 +2746,20 @@ public class TypeChecker extends BLangNodeVisitor {
         BUnionType unionType = BUnionType.create(null, actualType);
 
         if (returnsNull(accessExpr)) {
-            unionType.getMemberTypes().add(symTable.nilType);
-            unionType.setNullable(true);
+            unionType.add(symTable.nilType);
         }
 
         BType parentType = accessExpr.expr.type;
         if (accessExpr.safeNavigate && (parentType.tag == TypeTags.SEMANTIC_ERROR || (parentType.tag == TypeTags.UNION
                 && ((BUnionType) parentType).getMemberTypes().contains(symTable.errorType)))) {
-            unionType.getMemberTypes().add(symTable.errorType);
+            unionType.add(symTable.errorType);
         }
 
         // If there's only one member, and the one an only member is:
         //    a) nilType OR
         //    b) not-nullable 
         // then return that only member, as the return type.
-        if (unionType.getMemberTypes().size() == 1 &&
-                (!unionType.isNullable() || unionType.getMemberTypes().contains(symTable.nilType))) {
+        if (unionType.getMemberTypes().size() == 1) {
             return unionType.getMemberTypes().toArray(new BType[0])[0];
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
@@ -239,22 +239,21 @@ public class TypeNarrower extends BLangNodeVisitor {
 
     private BType getTypeIntersection(BType currentType, BType targetType) {
         List<BType> narrowingTypes = types.getAllTypes(targetType);
-        List<BType> intersection = narrowingTypes.stream().map(type -> {
+        LinkedHashSet<BType> intersection = narrowingTypes.stream().map(type -> {
             if (types.isAssignable(type, currentType)) {
                 return type;
             } else if (types.isAssignable(currentType, type)) {
                 return currentType;
             }
             return null;
-        }).filter(type -> type != null).collect(Collectors.toList());
+        }).filter(type -> type != null).collect(Collectors.toCollection(LinkedHashSet::new));
 
         if (intersection.isEmpty() || intersection.contains(symTable.semanticError)) {
             return symTable.semanticError;
         } else if (intersection.size() == 1) {
-            return intersection.get(0);
+            return intersection.toArray(new BType[0])[0];
         } else {
-            LinkedHashSet<BType> memberTypes = new LinkedHashSet<>(intersection);
-            return new BUnionType(null, memberTypes, memberTypes.contains(symTable.nilType));
+            return BUnionType.create(null, intersection);
         }
     }
 
@@ -269,7 +268,7 @@ public class TypeNarrower extends BLangNodeVisitor {
         } else if (union.size() == 1) {
             return union.toArray(new BType[1])[0];
         }
-        return new BUnionType(null, union, union.contains(symTable.nilType));
+        return BUnionType.create(null, union);
     }
 
     private BVarSymbol getOriginalVarSymbol(BVarSymbol varSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1965,10 +1965,9 @@ public class Types {
         BUnionType errorLiftedType = BUnionType.create(null, (LinkedHashSet<BType>) unionType.getMemberTypes());
 
         // Lift nil always. Lift error only if safe navigation is used.
-        errorLiftedType.getMemberTypes().remove(symTable.nilType);
-        errorLiftedType.setNullable(false);
+        errorLiftedType.remove(symTable.nilType);
         if (liftError) {
-            errorLiftedType.getMemberTypes().remove(symTable.errorType);
+            errorLiftedType.remove(symTable.errorType);
         }
 
         if (errorLiftedType.getMemberTypes().size() == 1) {
@@ -2033,7 +2032,7 @@ public class Types {
         }
 
         // All members are of same type and has the implicit initial value as a member.
-        Iterator<BType> iterator = type.getMemberTypes().iterator();
+        Iterator<BType> iterator = type.iterator();
         BType firstMember;
         for (firstMember = iterator.next(); iterator.hasNext(); ) {
             if (!isSameType(firstMember, iterator.next())) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1962,7 +1962,8 @@ public class Types {
         }
 
         BUnionType unionType = (BUnionType) type;
-        BUnionType errorLiftedType = BUnionType.create(null, (LinkedHashSet<BType>) unionType.getMemberTypes());
+        LinkedHashSet<BType> memTypes = new LinkedHashSet<>(unionType.getMemberTypes());
+        BUnionType errorLiftedType = BUnionType.create(null, memTypes);
 
         // Lift nil always. Lift error only if safe navigation is used.
         errorLiftedType.remove(symTable.nilType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -619,7 +619,7 @@ public class SymbolTable {
         } else {
             if (targetType.tag == TypeTags.UNION) {
                 BUnionType unionType = (BUnionType) targetType;
-                unionType.getMemberTypes().add(this.errorType);
+                unionType.add(this.errorType);
                 retType = targetType;
             } else {
                 retType = BUnionType.create(null, targetType, errorType);
@@ -645,7 +645,7 @@ public class SymbolTable {
         } else {
             if (targetType.tag == TypeTags.UNION) {
                 BUnionType unionType = (BUnionType) targetType;
-                unionType.getMemberTypes().add(this.errorType);
+                unionType.add(this.errorType);
                 retType = targetType;
             } else {
                 retType = BUnionType.create(null, targetType, errorType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -63,7 +63,6 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -623,12 +622,7 @@ public class SymbolTable {
                 unionType.memberTypes.add(this.errorType);
                 retType = targetType;
             } else {
-                BUnionType unionType = new BUnionType(null,
-                                                      new LinkedHashSet<BType>() {{
-                                                          add(targetType);
-                                                          add(errorType);
-                                                      }}, false);
-                retType = unionType;
+                retType = BUnionType.create(null, targetType, errorType);
             }
         }
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);
@@ -654,12 +648,7 @@ public class SymbolTable {
                 unionType.memberTypes.add(this.errorType);
                 retType = targetType;
             } else {
-                BUnionType unionType = new BUnionType(null,
-                        new LinkedHashSet<BType>() {{
-                            add(targetType);
-                            add(errorType);
-                        }}, false);
-                retType = unionType;
+                retType = BUnionType.create(null, targetType, errorType);
             }
         }
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -619,7 +619,7 @@ public class SymbolTable {
         } else {
             if (targetType.tag == TypeTags.UNION) {
                 BUnionType unionType = (BUnionType) targetType;
-                unionType.memberTypes.add(this.errorType);
+                unionType.getMemberTypes().add(this.errorType);
                 retType = targetType;
             } else {
                 retType = BUnionType.create(null, targetType, errorType);
@@ -645,7 +645,7 @@ public class SymbolTable {
         } else {
             if (targetType.tag == TypeTags.UNION) {
                 BUnionType unionType = (BUnionType) targetType;
-                unionType.memberTypes.add(this.errorType);
+                unionType.getMemberTypes().add(this.errorType);
                 retType = targetType;
             } else {
                 retType = BUnionType.create(null, targetType, errorType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -31,7 +31,6 @@ import org.wso2.ballerinalang.programfile.InstructionCodes;
 import org.wso2.ballerinalang.util.Flags;
 import org.wso2.ballerinalang.util.Lists;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -169,10 +168,7 @@ public class Symbols {
             unionType.memberTypes.add(errorType);
             retType = unionType;
         } else {
-            LinkedHashSet<BType> memberTypes = new LinkedHashSet<>();
-            memberTypes.add(targetType);
-            memberTypes.add(errorType);
-            retType = new BUnionType(null, memberTypes, false);
+            retType = BUnionType.create(null, targetType, errorType);
         }
 
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -165,7 +165,7 @@ public class Symbols {
             retType = targetType;
         } else if (targetType.tag == TypeTags.UNION && targetType instanceof BUnionType) {
             BUnionType unionType = (BUnionType) targetType;
-            unionType.memberTypes.add(errorType);
+            unionType.add(errorType);
             retType = unionType;
         } else {
             retType = BUnionType.create(null, targetType, errorType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.TypeDescriptor;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -50,7 +51,7 @@ public class BUnionType extends BType implements UnionType {
 
     @Override
     public Set<BType> getMemberTypes() {
-        return memberTypes;
+        return Collections.unmodifiableSet(this.memberTypes);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -141,6 +141,18 @@ public class BUnionType extends BType implements UnionType {
         types.forEach(this::add);
     }
 
+    public void remove(BType type) {
+        if (type.tag == TypeTags.UNION) {
+            this.memberTypes.removeAll(((BUnionType) type).getMemberTypes());
+        } else {
+            this.memberTypes.remove(type);
+        }
+
+        if (type.isNullable()) {
+            this.nullable = false;
+        }
+    }
+
     /**
      * Returns an iterator to iterate over the member types of the union.
      *

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.TypeDescriptor;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -39,7 +40,7 @@ import java.util.stream.Stream;
 public class BUnionType extends BType implements UnionType {
     private boolean nullable;
 
-    public LinkedHashSet<BType> memberTypes;
+    private LinkedHashSet<BType> memberTypes;
 
     private BUnionType(BTypeSymbol tsymbol, LinkedHashSet<BType> memberTypes, boolean nullable) {
         super(TypeTags.UNION, tsymbol);
@@ -88,16 +89,71 @@ public class BUnionType extends BType implements UnionType {
         this.nullable = nullable;
     }
 
+    /**
+     * Creates a union type using the types specified in the `types` set. The created union will not have union types in
+     * its member types set. If the set contains the nil type, calling isNullable() will return true.
+     *
+     * @param tsymbol Type symbol for the union.
+     * @param types   The types to be used to define the union.
+     * @return The created union type.
+     */
     public static BUnionType create(BTypeSymbol tsymbol, LinkedHashSet<BType> types) {
-        LinkedHashSet<BType> memberTypes = types.stream()
-                .flatMap(type -> type.tag == TypeTags.UNION ?
-                        ((BUnionType) type).memberTypes.stream() : Stream.of(type))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        LinkedHashSet<BType> memberTypes = toFlatTypeSet(types);
         return new BUnionType(tsymbol, memberTypes, memberTypes.stream().anyMatch(type -> type.tag == TypeTags.NIL));
     }
 
+    /**
+     * Creates a union type using the provided types. If the set contains the nil type, calling isNullable() will return
+     * true.
+     *
+     * @param tsymbol Type symbol for the union.
+     * @param types   The types to be used to define the union.
+     * @return The created union type.
+     */
     public static BUnionType create(BTypeSymbol tsymbol, BType... types) {
         LinkedHashSet<BType> memberTypes = Arrays.stream(types).collect(Collectors.toCollection(LinkedHashSet::new));
         return create(tsymbol, memberTypes);
+    }
+
+    /**
+     * Adds the specified type as a member of the union. If the specified type is also a union, all the member types of
+     * it are added to the union. If the newly added type is nil or is a nil-able type, the union type will also be a
+     * nil-able type.
+     *
+     * @param type Type to be added to the union.
+     */
+    public void add(BType type) {
+        if (type.tag == TypeTags.UNION) {
+            this.memberTypes.addAll(toFlatTypeSet(((BUnionType) type).memberTypes));
+        } else {
+            this.memberTypes.add(type);
+        }
+
+        this.nullable = this.nullable || type.isNullable();
+    }
+
+    /**
+     * Adds all the types in the specified set as members of the union.
+     *
+     * @param types Types to be added to the union.
+     */
+    public void addAll(LinkedHashSet<BType> types) {
+        types.forEach(this::add);
+    }
+
+    /**
+     * Returns an iterator to iterate over the member types of the union.
+     *
+     * @return  An iterator over the member set.
+     */
+    public Iterator<BType> iterator() {
+        return this.memberTypes.iterator();
+    }
+
+    private static LinkedHashSet<BType> toFlatTypeSet(LinkedHashSet<BType> types) {
+        return types.stream()
+                .flatMap(type -> type.tag == TypeTags.UNION ?
+                        ((BUnionType) type).memberTypes.stream() : Stream.of(type))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -124,6 +124,7 @@ public class BUnionType extends BType implements UnionType {
      */
     public void add(BType type) {
         if (type.tag == TypeTags.UNION) {
+            assert type instanceof BUnionType;
             this.memberTypes.addAll(toFlatTypeSet(((BUnionType) type).memberTypes));
         } else {
             this.memberTypes.add(type);
@@ -143,6 +144,7 @@ public class BUnionType extends BType implements UnionType {
 
     public void remove(BType type) {
         if (type.tag == TypeTags.UNION) {
+            assert type instanceof BUnionType;
             this.memberTypes.removeAll(((BUnionType) type).getMemberTypes());
         } else {
             this.memberTypes.remove(type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/AbstractTransportCompilerPlugin.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/AbstractTransportCompilerPlugin.java
@@ -51,6 +51,6 @@ public abstract class AbstractTransportCompilerPlugin extends AbstractCompilerPl
         LinkedHashSet<BType> memberTypes = new LinkedHashSet<>();
         memberTypes.add(symbolTable.errorType);
         memberTypes.add(symbolTable.nilType);
-        this.errorOrNil = new BUnionType(null, memberTypes, true);
+        this.errorOrNil = BUnionType.create(null, memberTypes);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
@@ -153,7 +153,7 @@ public class ValueSpaceGenerator {
         } else if (bType instanceof BUnionType) {
             // Check for union assignment int|string
             BUnionType bUnionType = (BUnionType) bType;
-            Set<BType> memberTypes = bUnionType.memberTypes;
+            Set<BType> memberTypes = bUnionType.getMemberTypes();
             if (!memberTypes.isEmpty()) {
                 return getValueSpaceByType(importsAcceptor, currentPkgId, memberTypes.stream().findFirst().get(),
                                            template);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
@@ -182,7 +182,7 @@ public class PositionTreeVisitor extends LSNodeVisitor {
                     HoverUtil.isMatchingPosition(userDefinedType.getPosition(), this.position)) {
                 try {
                     BUnionType bUnionType = (BUnionType) userDefinedType.type;
-                    for (BType type : bUnionType.memberTypes) {
+                    for (BType type : bUnionType.getMemberTypes()) {
                         if (type.tsymbol != null && type.tsymbol.getName().getValue().equals(userDefinedType
                                                                                                      .typeName
                                                                                                      .getValue())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -636,7 +636,7 @@ public class CommonUtil {
                 }
                 break;
             case UNION:
-                List<BType> memberTypes = new ArrayList<>(((BUnionType) bType).memberTypes);
+                List<BType> memberTypes = new ArrayList<>(((BUnionType) bType).getMemberTypes());
                 typeString = getDefaultValueForType(memberTypes.get(0));
                 break;
             case STREAM:
@@ -1302,7 +1302,7 @@ public class CommonUtil {
                 return template.replace("{%1}", mapDef);
             } else if (bType instanceof BUnionType) {
                 BUnionType bUnionType = (BUnionType) bType;
-                Set<BType> memberTypes = bUnionType.memberTypes;
+                Set<BType> memberTypes = bUnionType.getMemberTypes();
                 if (memberTypes.size() == 2 && memberTypes.stream().anyMatch(bType1 -> bType1 instanceof BNilType)) {
                     Optional<BType> type = memberTypes.stream()
                             .filter(bType1 -> !(bType1 instanceof BNilType)).findFirst();
@@ -1435,7 +1435,7 @@ public class CommonUtil {
             } else if (bType instanceof BUnionType) {
                 // Check for union type assignment eg. int | string
                 List<String> list = new ArrayList<>();
-                Set<BType> memberTypes = ((BUnionType) bType).memberTypes;
+                Set<BType> memberTypes = ((BUnionType) bType).getMemberTypes();
                 if (memberTypes.size() == 2 && memberTypes.stream().anyMatch(bType1 -> bType1 instanceof BNilType)) {
                     Optional<BType> type = memberTypes.stream()
                             .filter(bType1 -> !(bType1 instanceof BNilType)).findFirst();
@@ -1602,7 +1602,7 @@ public class CommonUtil {
                     .map(Object::toString)
                     .collect(Collectors.joining("|"));
         } else if (bType instanceof BUnionType) {
-            List<BType> memberTypes = new ArrayList<>(((BUnionType) bType).memberTypes);
+            List<BType> memberTypes = new ArrayList<>(((BUnionType) bType).getMemberTypes());
             return " // Values allowed: " + memberTypes.stream()
                     .map(BType::toString)
                     .collect(Collectors.joining("|"));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
@@ -86,7 +86,7 @@ public class StatementContextResolver extends AbstractItemResolver {
                 .filter(symbolInfo -> symbolInfo.getScopeEntry().symbol.type instanceof BUnionType)
                 .map(symbolInfo -> {
                     List<BType> members =
-                            new ArrayList<>(((BUnionType) symbolInfo.getScopeEntry().symbol.type).memberTypes);
+                            new ArrayList<>(((BUnionType) symbolInfo.getScopeEntry().symbol.type).getMemberTypes());
                     String symbolName = symbolInfo.getScopeEntry().symbol.name.getValue();
                     String label = symbolName + " - typeguard " + symbolName;
                     String detail = "Destructure the variable " + symbolName + " with typeguard";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesTreeVisitor.java
@@ -406,7 +406,7 @@ public class ReferencesTreeVisitor extends LSNodeVisitor {
             } else if (udType instanceof BUnionType) {
                 try {
                     BUnionType bUnionType = (BUnionType) udType;
-                    for (BType type : bUnionType.memberTypes) {
+                    for (BType type : bUnionType.getMemberTypes()) {
                         if (type.tsymbol != null && isReferencedRegardlessPkgs(type.tsymbol.name.getValue(),
                                                                                type.tsymbol.owner)) {
                             addLocation(userDefinedType, type.tsymbol.owner.pkgID.name.getValue(),

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -324,7 +324,7 @@ public class Generator {
         switch (bType.tag) {
             case TypeTags.UNION:
                 BUnionType union = (BUnionType) bType;
-                return extractLink(union.memberTypes);
+                return extractLink(union.getMemberTypes());
             case TypeTags.TUPLE:
                 BTupleType tuple = (BTupleType) bType;
                 return extractLink(tuple.tupleTypes);


### PR DESCRIPTION
## Purpose
> This PR is to flatten the union type to avoid having to special case union type in the compiler and recursively check each of the member types. Fix #13902 