### PR TITLE
Avoid re-defining package when orgname is used in import

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -297,11 +297,12 @@ public class SymbolEnter extends BLangNodeVisitor {
         } else if (importPkgNode.orgName.value.equals(enclPackageID.orgName.value)) {
             // means it's in 'import <org-name>/<pkg-name>' style and <org-name> is used to import within same project
             orgName = names.fromIdNode(importPkgNode.orgName);
-            // Here we set the version as empty due to the following cases:
-            // 1) Suppose the import is from the same package, then the project version will be set later
+            // Here we set the version to enclosing package version. Following cases will be handled properly:
+            // 1) Suppose the import is from the same project, then the enclosing package version set here will be used
+            //    to lookup package symbol cache, avoiding re-defining package symbol.
             // 2) Suppose the import is from Ballerina Central or another project which has the same org, then the
-            //    version is set when loading the import module
-            version = new Name("");
+            //    version is set when loading the import module.
+            version = (Names.DEFAULT_VERSION.equals(enclPackageID.version)) ? new Name("") : enclPackageID.version;
         } else {
             // means it's in 'import <org-name>/<pkg-name>' style
             orgName = names.fromIdNode(importPkgNode.orgName);


### PR DESCRIPTION
## Purpose
$subject. Resolves #13460

This is bringing back the original fix we did at PR #11049. Please check the said PR #11049 and issue  #13460 for further details.