### PR TITLE
Modify the finite type assignability logic

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1734,6 +1734,7 @@ public class BLangPackageBuilder {
                     (BLangLiteral) TreeBuilder.createNumericLiteralExpression();
             literal.setValue(((BLangLiteral) constantNode.value).value);
             literal.type = ((BLangLiteral) constantNode.value).type;
+            literal.isConstant = true;
 
             // Create a new finite type node.
             BLangFiniteTypeNode finiteTypeNode = (BLangFiniteTypeNode) TreeBuilder.createFiniteTypeNode();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1750,15 +1750,15 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
 
         BLangLiteral value = (BLangLiteral) constant.value;
-
+        BType resultType;
         if (constant.typeNode != null) {
             // Check the type of the value.
-            typeChecker.checkExpr(value, env, constant.symbol.literalValueType);
+            resultType = typeChecker.checkExpr(value, env, constant.symbol.literalValueType);
             constant.symbol.literalValueTypeTag = constant.symbol.literalValueType.tag;
         } else {
             // We don't have any expected type in this case since the type node is not available. So we get the type
             // from the value.
-            typeChecker.checkExpr(value, env, symTable.getTypeFromTag(value.type.tag));
+            resultType = typeChecker.checkExpr(value, env, symTable.getTypeFromTag(value.type.tag));
             constant.symbol.literalValueTypeTag = value.type.tag;
         }
 
@@ -1770,8 +1770,10 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         // codegen when retrieving the default value.
         BLangFiniteTypeNode typeNode = (BLangFiniteTypeNode) constant.associatedTypeDefinition.typeNode;
         for (BLangExpression literal : typeNode.valueSpace) {
-            // If the expected type of the constant is decimal, check type for the literals in the value space.
-            if (literal.type.tag == TypeTags.FLOAT && constant.symbol.literalValueType.tag == TypeTags.DECIMAL) {
+            if (resultType.tag != TypeTags.SEMANTIC_ERROR) {
+                // Check type for the literals in the value space to update to the correct types. Otherwise, we won't
+                // be able to differentiate between decimal, float and int, byte as the type of the literals in the
+                // above cases would be float and int respectively.
                 typeChecker.checkExpr(literal, env, constant.symbol.literalValueType);
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -148,8 +148,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.xml.XMLConstants;
 
-import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MAX_VALUE;
-import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MIN_VALUE;
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;
 import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_PREFIX;
 
@@ -268,7 +266,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 literalType = symTable.decimalType;
                 literalExpr.value = String.valueOf(literalValue);
             } else if (expType.tag == TypeTags.BYTE) {
-                if (!isByteLiteralValue((Long) literalValue)) {
+                if (!types.isByteLiteralValue((Long) literalValue)) {
                     dlog.error(literalExpr.pos, DiagnosticCode.INCOMPATIBLE_TYPES, expType, literalType);
                     resultType = symTable.semanticError;
                     return;
@@ -314,10 +312,6 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         resultType = types.checkType(literalExpr, literalType, expType);
-    }
-
-    private static boolean isByteLiteralValue(Long longObject) {
-        return (longObject.intValue() >= BBYTE_MIN_VALUE && longObject.intValue() <= BBYTE_MAX_VALUE);
     }
 
     public void visit(BLangTableLiteral tableLiteral) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -68,6 +68,8 @@ import org.wso2.ballerinalang.programfile.InstructionCodes;
 import org.wso2.ballerinalang.util.Flags;
 import org.wso2.ballerinalang.util.Lists;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -80,6 +82,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
+
+import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MAX_VALUE;
+import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MIN_VALUE;
 
 /**
  * This class consists of utility methods which operate on types.
@@ -1622,10 +1627,9 @@ public class Types {
             if (((BLangLiteral) memberLiteral).value == null) {
                 return literalExpr.value == null;
             }
-            // Check whether the member literal and the literal that needs to be tested are of same kind and check
-            // the value equality between them.
-            return memberLiteral.getKind().equals(literalExpr.getKind()) &&
-                    ((BLangLiteral) memberLiteral).value.equals(literalExpr.value);
+            // Check whether the literal that needs to be tested is assignable to any of the member literal in the
+            // value space.
+            return checkLiteralAssignabilityBasedOnType((BLangLiteral) memberLiteral, literalExpr);
         }).count();
 
         // If more than one match means the value space contains ambiguous values.
@@ -1633,6 +1637,68 @@ public class Types {
             dlog.error(literalExpr.pos, DiagnosticCode.AMBIGUOUS_TYPES, type);
         }
         return matchCount == 1;
+    }
+
+    private boolean checkLiteralAssignabilityBasedOnType(BLangLiteral baseLiteral, BLangLiteral candidateLiteral) {
+        // Different literal kinds.
+        if (baseLiteral.getKind() != candidateLiteral.getKind()) {
+            return false;
+        }
+        Object baseValue = baseLiteral.value;
+        Object candidateValue = candidateLiteral.value;
+        int candidateTypeTag = candidateLiteral.type.tag;
+
+        // Numeric literal assignability is based on assignable type and numeric equivalency of values.
+        // If the base numeric literal is,
+        // (1) byte: we can assign byte or a int simple literal (Not an int constant) with the same value.
+        // (2) int: we can assign int literal or int constants with the same value.
+        // (3) float: we can assign int simple literal(Not an int constant) or a float literal/constant with same value.
+        // (4) decimal: we can assign int simple literal or float simple literal (Not int/float constants) or decimal
+        // with the same value.
+        switch (baseLiteral.type.tag) {
+            case TypeTags.BYTE:
+                if (candidateTypeTag == TypeTags.BYTE) {
+                    return (byte) baseValue == (byte) candidateValue;
+                } else if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant &&
+                        isByteLiteralValue((Long) candidateValue)) {
+                    return (byte) baseValue == ((Long) candidateValue).byteValue();
+                }
+            case TypeTags.INT:
+                if (candidateTypeTag == TypeTags.INT) {
+                    return (long) baseValue == (long) candidateValue;
+                }
+            case TypeTags.FLOAT:
+                double baseDoubleVal = Double.parseDouble(String.valueOf(baseValue));
+                double candidateDoubleVal;
+                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
+                    candidateDoubleVal = ((Long) candidateValue).doubleValue();
+                    return baseDoubleVal == candidateDoubleVal;
+                } else if (candidateTypeTag == TypeTags.FLOAT) {
+                    candidateDoubleVal = Double.parseDouble(String.valueOf(candidateValue));
+                    return baseDoubleVal == candidateDoubleVal;
+                }
+            case TypeTags.DECIMAL:
+                BigDecimal baseDecimalVal = new BigDecimal(String.valueOf(baseValue), MathContext.DECIMAL128);
+                BigDecimal candidateDecimalVal;
+                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
+                    candidateDecimalVal = new BigDecimal((long) candidateValue, MathContext.DECIMAL128);
+                    return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
+                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant) {
+                    candidateDecimalVal = new BigDecimal(Double.parseDouble(String.valueOf(candidateValue)),
+                            MathContext.DECIMAL128);
+                    return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
+                } else if (candidateTypeTag == TypeTags.DECIMAL) {
+                    candidateDecimalVal = new BigDecimal(String.valueOf(candidateValue), MathContext.DECIMAL128);
+                    return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
+                }
+            default:
+                // Non-numeric literal kind.
+                return baseValue.equals(candidateValue);
+        }
+    }
+
+    boolean isByteLiteralValue(Long longObject) {
+        return (longObject.intValue() >= BBYTE_MIN_VALUE && longObject.intValue() <= BBYTE_MAX_VALUE);
     }
 
     boolean validEqualityIntersectionExists(BType lhsType, BType rhsType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1663,10 +1663,12 @@ public class Types {
                         isByteLiteralValue((Long) candidateValue)) {
                     return (byte) baseValue == ((Long) candidateValue).byteValue();
                 }
+                break;
             case TypeTags.INT:
                 if (candidateTypeTag == TypeTags.INT) {
                     return (long) baseValue == (long) candidateValue;
                 }
+                break;
             case TypeTags.FLOAT:
                 double baseDoubleVal = Double.parseDouble(String.valueOf(baseValue));
                 double candidateDoubleVal;
@@ -1677,24 +1679,24 @@ public class Types {
                     candidateDoubleVal = Double.parseDouble(String.valueOf(candidateValue));
                     return baseDoubleVal == candidateDoubleVal;
                 }
+                break;
             case TypeTags.DECIMAL:
                 BigDecimal baseDecimalVal = new BigDecimal(String.valueOf(baseValue), MathContext.DECIMAL128);
                 BigDecimal candidateDecimalVal;
                 if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
                     candidateDecimalVal = new BigDecimal((long) candidateValue, MathContext.DECIMAL128);
                     return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
-                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant) {
-                    candidateDecimalVal = new BigDecimal(Double.parseDouble(String.valueOf(candidateValue)),
-                            MathContext.DECIMAL128);
-                    return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
-                } else if (candidateTypeTag == TypeTags.DECIMAL) {
+                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant ||
+                        candidateTypeTag == TypeTags.DECIMAL) {
                     candidateDecimalVal = new BigDecimal(String.valueOf(candidateValue), MathContext.DECIMAL128);
                     return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
                 }
+                break;
             default:
                 // Non-numeric literal kind.
                 return baseValue.equals(candidateValue);
         }
+        return false;
     }
 
     boolean isByteLiteralValue(Long longObject) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1633,6 +1633,16 @@ public class Types {
         });
     }
 
+    /**
+     * Method to check the literal assignability based on the types of the literals. For numeric literals the
+     * assignability depends on the equivalency of the literals. If the candidate literal could either be a simple
+     * literal or a constant. In case of a constant, it is assignable to the base literal if and only if both
+     * literals have same type and equivalent values.
+     *
+     * @param baseLiteral      Literal based on which we check the assignability.
+     * @param candidateLiteral Literal to be tested whether it is assignable to the base literal or not.
+     * @return true if assignable; false otherwise.
+     */
     private boolean checkLiteralAssignabilityBasedOnType(BLangLiteral baseLiteral, BLangLiteral candidateLiteral) {
         // Different literal kinds.
         if (baseLiteral.getKind() != candidateLiteral.getKind()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1623,20 +1623,14 @@ public class Types {
         }
 
         BFiniteType expType = (BFiniteType) type;
-        long matchCount = expType.valueSpace.stream().filter(memberLiteral -> {
+        return expType.valueSpace.stream().anyMatch(memberLiteral -> {
             if (((BLangLiteral) memberLiteral).value == null) {
                 return literalExpr.value == null;
             }
             // Check whether the literal that needs to be tested is assignable to any of the member literal in the
             // value space.
             return checkLiteralAssignabilityBasedOnType((BLangLiteral) memberLiteral, literalExpr);
-        }).count();
-
-        // If more than one match means the value space contains ambiguous values.
-        if (matchCount > 1) {
-            dlog.error(literalExpr.pos, DiagnosticCode.AMBIGUOUS_TYPES, type);
-        }
-        return matchCount == 1;
+        });
     }
 
     private boolean checkLiteralAssignabilityBasedOnType(BLangLiteral baseLiteral, BLangLiteral candidateLiteral) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangLiteral.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangLiteral.java
@@ -29,6 +29,7 @@ public class BLangLiteral extends BLangExpression implements LiteralNode {
     public Object value;
     public String originalValue;
     public boolean isJSONContext;
+    public boolean isConstant;
 
     @Override
     public Object getValue() {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/ConstantNegativeTests.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/ConstantNegativeTests.java
@@ -52,7 +52,11 @@ public class ConstantNegativeTests {
                 offset += 9, 25);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '20', found 'int'",
                 offset += 7, 28);
-        BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '240', found 'int'",
+        // TODO: We should revert the below validation change (240 -> -16) once git issue #13821 is fixed.
+        // For byte type, values greater than 127 would get the equivalent value between -128 to 127 based on
+        // round-robin algorithm. As a result, for negative test cases a different value might get printed than the
+        // expected.
+        BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '-16', found 'int'",
                 offset += 9, 26);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '4.0', found 'float'",
                 offset += 9, 27);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantNegativeTest.java
@@ -111,7 +111,11 @@ public class ConstantNegativeTest {
                 offset += 11, 25);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '20', found 'int'", offset += 9,
                 28);
-        BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '240', found 'int'",
+        // TODO: We should revert the below validation change (240 -> -16) once git issue #13821 is fixed.
+        // For byte type, values greater than 127 would get the equivalent value between -128 to 127 based on
+        // round-robin algorithm. As a result, for negative test cases a different value might get printed than the
+        // expected.
+        BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '-16', found 'int'",
                 offset += 11, 26);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '4.0', found 'float'",
                 offset += 11, 27);

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
@@ -47,10 +47,16 @@ public class FiniteTypeNegativeTest {
     @Test()
     public void testInvalidLiteralAssignment() {
         CompileResult result = BCompileUtil.compile("test-src/types/finite/finite_type_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 3, "Error count mismatch");
+        Assert.assertEquals(result.getErrorCount(), 9, "Error count mismatch");
 
-        validateError(result, 0, "incompatible types: expected '5|5|5', found 'float'", 32, 16);
-        validateError(result, 1, "incompatible types: expected '5|100', found 'string'", 37, 16);
-        validateError(result, 2, "incompatible types: expected '100.5|S', found 'float'", 42, 23);
+        validateError(result, 0, "incompatible types: expected '5|100', found 'string'", 33, 16);
+        validateError(result, 1, "incompatible types: expected '5', found 'int'", 40, 18);
+        validateError(result, 2, "incompatible types: expected '5', found 'byte'", 47, 17);
+        validateError(result, 3, "incompatible types: expected '5', found 'float'", 52, 17);
+        validateError(result, 4, "incompatible types: expected '5.0', found 'int'", 59, 19);
+        validateError(result, 5, "incompatible types: expected '5.0', found 'decimal'", 64, 19);
+        validateError(result, 6, "incompatible types: expected '5', found 'int'", 71, 21);
+        validateError(result, 7, "incompatible types: expected '5', found 'float'", 76, 21);
+        validateError(result, 8, "incompatible types: expected '5', found 'int'", 81, 17);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -21,6 +21,9 @@ package org.ballerinalang.test.types.finite;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BByte;
+import org.ballerinalang.model.values.BDecimal;
+import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
@@ -28,6 +31,8 @@ import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
 
 /**
  * Test finite type.
@@ -257,5 +262,70 @@ public class FiniteTypeTest {
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 5, "Value mismatch");
         Assert.assertTrue(returns[1] instanceof BString, "Type mismatch");
         Assert.assertEquals(returns[1].stringValue(), "s", "Value mismatch");
+    }
+
+    @Test
+    public void testFiniteTypeWithNumericConstants() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypeWithNumericConstants");
+        Assert.assertTrue(returns[0] instanceof BInteger, "Type mismatch");
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 5, "Value mismatch");
+        Assert.assertTrue(returns[1] instanceof BFloat, "Type mismatch");
+        Assert.assertEquals(((BFloat) returns[1]).floatValue(), 5.0, "Value mismatch");
+    }
+
+    @Test
+    public void testAssigningIntLiteralToByteFiniteType() {
+        BValue[] returns = BRunUtil.invoke(result, "testAssigningIntLiteralToByteFiniteType");
+        Assert.assertTrue(returns[0] instanceof BInteger, "Type mismatch");
+        Assert.assertEquals(((BInteger) returns[0]).byteValue(), 5, "Value mismatch");
+    }
+
+    @Test
+    public void testAssigningIntLiteralToFloatFiniteType() {
+        BValue[] returns = BRunUtil.invoke(result, "testAssigningIntLiteralToFloatFiniteType");
+        Assert.assertTrue(returns[0] instanceof BInteger, "Type mismatch");
+        Assert.assertEquals(((BInteger) returns[0]).floatValue(), 5.0, "Value mismatch");
+    }
+
+    @Test
+    public void testAssigningIntLiteralToDecimalFiniteType() {
+        BValue[] returns = BRunUtil.invoke(result, "testAssigningIntLiteralToDecimalFiniteType");
+        Assert.assertTrue(returns[0] instanceof BInteger, "Type mismatch");
+        Assert.assertTrue(((BInteger) returns[0]).decimalValue().compareTo(new BigDecimal("5")) == 0, "Value mismatch");
+    }
+
+    @Test
+    public void testAssigningFloatLiteralToDecimalFiniteType() {
+        BValue[] returns = BRunUtil.invoke(result, "testAssigningFloatLiteralToDecimalFiniteType");
+        Assert.assertTrue(returns[0] instanceof BFloat, "Type mismatch");
+        Assert.assertTrue(((BFloat) returns[0]).decimalValue().compareTo(new BigDecimal("5.0")) == 0, "Value mismatch");
+    }
+
+    @Test
+    public void testDifferentPrecisionFloatAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testDifferentPrecisionFloatAssignment");
+        Assert.assertTrue(returns[0] instanceof BFloat, "Type mismatch");
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 5.0, "Value mismatch");
+    }
+
+    @Test
+    public void testDifferentPrecisionFloatConstantAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testDifferentPrecisionFloatConstantAssignment");
+        Assert.assertTrue(returns[0] instanceof BFloat, "Type mismatch");
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 5.0, "Value mismatch");
+    }
+
+    @Test
+    public void testDifferentPrecisionDecimalAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testDifferentPrecisionDecimalAssignment");
+        Assert.assertTrue(returns[0] instanceof BFloat, "Type mismatch");
+        Assert.assertTrue(((BFloat) returns[0]).decimalValue().compareTo(new BigDecimal("5.0")) == 0, "Value mismatch");
+    }
+
+    @Test
+    public void testDifferentPrecisionDecimalConstantAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testDifferentPrecisionDecimalConstantAssignment");
+        Assert.assertTrue(returns[0] instanceof BDecimal, "Type mismatch");
+        Assert.assertTrue(((BDecimal) returns[0]).decimalValue().compareTo(new BigDecimal("5")) == 0, "Value mismatch");
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -21,7 +21,6 @@ package org.ballerinalang.test.types.finite;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BByte;
 import org.ballerinalang.model.values.BDecimal;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -249,3 +249,69 @@ function testFiniteTypeWithConstants() returns (FiniteType, FiniteType) {
 
     return (f,s);
 }
+
+const byte BCONST = 5;
+const int ICONST = 5;
+const float FCONST = 5;
+const decimal DCONST = 5;
+
+type Number DCONST|FCONST|ICONST|BCONST;
+
+function testFiniteTypeWithNumericConstants() returns (Number, Number) {
+    Number n1 = 5;
+    Number n2 = 5.0;
+    return (n1, n2);
+}
+
+type ByteType BCONST;
+
+function testAssigningIntLiteralToByteFiniteType() returns (ByteType) {
+    ByteType b = 5;
+    return b;
+}
+
+type FloatType FCONST;
+
+function testAssigningIntLiteralToFloatFiniteType() returns (FloatType) {
+    FloatType f = 5;
+    return f;
+}
+
+type DecimalType DCONST;
+
+function testAssigningIntLiteralToDecimalFiniteType() returns (DecimalType) {
+    DecimalType d = 5;
+    return d;
+}
+
+function testAssigningFloatLiteralToDecimalFiniteType() returns (DecimalType) {
+    DecimalType d = 5.0;
+    return d;
+}
+
+function testDifferentPrecisionFloatAssignment() returns (FloatType) {
+    // Though, the below value is mathematically different when comparing to 5.0, the double value(representation)
+    // is same. Hence, it is assignable to 5.0 float value.
+    FloatType f = 5.00000000000000000001;
+    return f;
+}
+
+const float FLOAT = 5.0000000000000;
+
+function testDifferentPrecisionFloatConstantAssignment() returns (FloatType) {
+    FloatType f = FLOAT;
+    return f;
+}
+
+function testDifferentPrecisionDecimalAssignment() returns (DecimalType) {
+    DecimalType d = 5.0000000000000;
+    return d;
+}
+
+const decimal DECIMAL = 5.0000000000000;
+
+
+function testDifferentPrecisionDecimalConstantAssignment() returns (DecimalType) {
+    DecimalType d = DECIMAL;
+    return d;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/finite_type_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/finite/finite_type_negative.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+const byte BCONST = 5;
 const int ICONST = 5;
 const float FCONST = 5;
 const decimal DCONST = 5;
@@ -27,17 +28,55 @@ type Finite ICONST|ICONST2;
 
 type FloatingPoint FCONST2|SCONST;
 
-// Test invalid literal assignment
-function testInvalidAssignment() {
-    Number n = 5.0;
-}
-
 // Test invalid string assignment
 function testDifferentLiteralKindsWithSameValue() {
     Finite f = "5";
 }
 
-// Test float with same value but different precision assignment
-function testDifferentPrecisionFloatAssignment() {
-    FloatingPoint f = 100.50000000;
+type ByteType BCONST;
+
+// Test assigning int constant to byte finite type
+function testAssigningIntConstantToByteFiniteType() {
+    ByteType b = ICONST;
+}
+
+type IntType ICONST;
+
+// Test assigning byte constant to int finite type
+function testAssigningByteConstantToIntFiniteType() {
+    IntType i = BCONST;
+}
+
+// Test assigning float literal to int finite type
+function testAssigningFloatLiteralToIntFiniteType() {
+    IntType i = 23.00;
+}
+
+type FloatType FCONST;
+
+// Test assigning int constant to float finite type
+function testAssigningIntConstantToFloatFiniteType() {
+    FloatType f = ICONST;
+}
+
+// Test assigning decimal constant to float finite type
+function testAssigningDecimalConstantToFloatFiniteType() {
+    FloatType f = DCONST;
+}
+
+type DecimalType DCONST;
+
+// Test assigning int constant to decimal finite type
+function testAssigningIntConstantToDecimalFiniteType() {
+    DecimalType d = ICONST;
+}
+
+// Test assigning float constant to decimal finite type
+function testAssigningFloatConstantToDecimalFiniteType() {
+    DecimalType d = FCONST;
+}
+
+// Test assigning an expression to a finite type
+function testAssigningExpressionToFiniteType() {
+    IntType i = 2 + 3;
 }


### PR DESCRIPTION
## Purpose
This PR modifies the finite type assignability logic to check the literal assignability based on types.

* Fixes https://github.com/ballerina-platform/ballerina-lang/issues/13317
* Fixes https://github.com/ballerina-platform/ballerina-lang/issues/13820
* Fixes https://github.com/ballerina-platform/ballerina-lang/issues/13587
* Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10923
