### PR TITLE
Add import module declarations to BIR

### DIFF
--- a/compiler/ballerina-backend-llvm/src/main/ballerina/compiler_backend_llvm/sample.bal
+++ b/compiler/ballerina-backend-llvm/src/main/ballerina/compiler_backend_llvm/sample.bal
@@ -3,6 +3,7 @@ import ballerina/bir;
 function writeSample(string path) {
 
     bir:Package ifSample = {
+        importModules:[],
         functions: [
             {
                 argsCount: 0,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIREmitter.java
@@ -51,7 +51,16 @@ public class BIREmitter extends BIRVisitor {
 
     public void visit(BIRNode.BIRPackage birPackage) {
         sb.append("module ").append(birPackage.name).append(";").append("\n\n");
+        birPackage.importModules.forEach(birImpModule -> birImpModule.accept(this));
+        sb.append("\n");
         birPackage.functions.forEach(birFunction -> birFunction.accept(this));
+    }
+
+    public void visit(BIRNode.BIRImportModule birImpModule) {
+        sb.append("import ").append(birImpModule.org).append("/");
+        sb.append(birImpModule.name).append(":").append(birImpModule.version).append(";");
+        writePosition(birImpModule.pos);
+        sb.append("\n");
     }
 
     public void visit(BIRNode.BIRVariableDcl birVariableDcl) {
@@ -64,8 +73,9 @@ public class BIREmitter extends BIRVisitor {
         StringJoiner sj = new StringJoiner(",");
         birFunction.type.paramTypes.forEach(paramType -> sj.add(paramType.toString()));
         sb.append(sj.toString()).append(")").append(" -> ").append(birFunction.type.retType);
+        sb.append(" {");
         writePosition(birFunction.pos);
-        sb.append(" {\n");
+        sb.append("\n");
 
         birFunction.localVars.forEach(birVariableDcl -> birVariableDcl.accept(this));
         sb.append("\n");
@@ -162,7 +172,7 @@ public class BIREmitter extends BIRVisitor {
 
 
     private void writePosition(DiagnosticPos pos) {
-        sb.append("\t\t\\\\ pos:[").append(pos.sLine).append(":").append(pos.sCol).append("-");
+        sb.append("\t\t// pos:[").append(pos.sLine).append(":").append(pos.sCol).append("-");
         sb.append(pos.eLine).append(":").append(pos.eCol).append("]");
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -48,6 +48,7 @@ public abstract class BIRNode {
         public Name org;
         public Name name;
         public Name version;
+        public List<BIRImportModule> importModules;
         public List<BIRTypeDefinition> typeDefs;
         public List<BIRFunction> functions;
 
@@ -56,8 +57,32 @@ public abstract class BIRNode {
             this.org = org;
             this.name = name;
             this.version = version;
+            this.importModules = new ArrayList<>();
             this.typeDefs = new ArrayList<>();
             this.functions = new ArrayList<>();
+        }
+
+        @Override
+        public void accept(BIRVisitor visitor) {
+            visitor.visit(this);
+        }
+    }
+
+    /**
+     * An import package definition.
+     *
+     * @since 0.990.0
+     */
+    public static class BIRImportModule extends BIRNode {
+        public Name org;
+        public Name name;
+        public Name version;
+
+        public BIRImportModule(DiagnosticPos pos, Name org, Name name, Name version) {
+            super(pos);
+            this.org = org;
+            this.name = name;
+            this.version = version;
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRVisitor.java
@@ -40,6 +40,10 @@ public abstract class BIRVisitor {
         throw new AssertionError();
     }
 
+    public void visit(BIRNode.BIRImportModule birImportModule) {
+        throw new AssertionError();
+    }
+
     public void visit(BIRVariableDcl birVariableDcl) {
         throw new AssertionError();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -58,6 +58,8 @@ public class BIRBinaryWriter {
         int pkgIndex = cp.addCPEntry(new PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
         birbuf.writeInt(pkgIndex);
 
+        //Write import module declarations
+        writeImportModuleDecls(birbuf, birPackage.importModules);
         // Write type defs
         writeTypeDefs(birbuf, typeWriter, birPackage.typeDefs);
         // Write functions
@@ -79,6 +81,15 @@ public class BIRBinaryWriter {
     }
 
     // private methods
+
+    private void writeImportModuleDecls(ByteBuf buf, List<BIRNode.BIRImportModule> birImpModList) {
+        buf.writeInt(birImpModList.size());
+        birImpModList.forEach(impMod -> {
+            buf.writeInt(addStringCPEntry(impMod.org.value));
+            buf.writeInt(addStringCPEntry(impMod.name.value));
+            buf.writeInt(addStringCPEntry(impMod.version.value));
+        });
+    }
 
     private void writeTypeDefs(ByteBuf buf, BIRTypeWriter typeWriter, List<BIRTypeDefinition> birTypeDefList) {
         buf.writeInt(birTypeDefList.size());

--- a/stdlib/bir/src/main/ballerina/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_model.bal
@@ -5,12 +5,19 @@ public type PackageId record {
 };
 
 public type Package record {
+    ImportModule[] importModules;
     TypeDef[] typeDefs;
     Function[] functions = [];
     Name name = {};
     Name org = {};
     BType[] types = [];
     Name versionValue = {};
+};
+
+public type ImportModule record {
+    Name modOrg;
+    Name modName;
+    Name modVersion;
 };
 
 public type TypeDef record {

--- a/stdlib/bir/src/main/ballerina/bir/bir_pkg_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_pkg_parser.bal
@@ -64,6 +64,7 @@ public type PackageParser object {
 
     public function parsePackage() returns Package {
         var pkgIdCp = self.reader.readInt32();
+        ImportModule[] importModules = self.parseImportMods();
         TypeDef[] typeDefs = self.parseTypeDefs();
         var numFuncs = self.reader.readInt32();
         Function[] funcs = [];
@@ -74,7 +75,20 @@ public type PackageParser object {
         }
         //BirEmitter emitter = new({ typeDefs: typeDefs, functions: funcs });
         //emitter.emitPackage();
-        return { typeDefs: typeDefs, functions: funcs };
+        return { importModules: importModules, typeDefs: typeDefs, functions: funcs };
+    }
+
+    function parseImportMods() returns ImportModule[] {
+        int numImportMods = self.reader.readInt32();
+        ImportModule[] importModules = [];
+        foreach var i in 0..<numImportMods {
+            string modOrg = self.reader.readStringCpRef();
+            string modName = self.reader.readStringCpRef();
+            string modVersion = self.reader.readStringCpRef();
+            importModules[i] = { modOrg: { value: modOrg }, modName: { value: modName },
+                modVersion: { value: modVersion } };
+        }
+        return importModules;
     }
 
     function parseTypeDefs() returns TypeDef[] {


### PR DESCRIPTION
This PR adds import package declarations to the BIR model. Here is a sample BIR.

```ballerina
module bazz;

import sameera/foo:0.0.1;		// pos:[1:1-1:12]
import sameera/bar:0.0.1;		// pos:[2:1-2:12]

function main() -> () {		// pos:[5:1-7:2]
	int %0;		// local
	int %1;		// temp

	bb0 {
		%1 = const_load 5;
		%0 = %1;
		goto bb1;
	}

	bb1 {
		return;
	}
}
```
