### PR TITLE
Remove `commons-cli` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1280,11 +1280,6 @@
                 <version>${guice.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-cli</groupId>
-                <artifactId>commons-cli</artifactId>
-                <version>${commons-cli.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-core</artifactId>
                 <version>${io.swagger.version}</version>
@@ -2295,7 +2290,6 @@
         <swagger.codegen.version>2.4.2</swagger.codegen.version>
         <airline.version>0.7</airline.version>
         <guice.version>4.1.0</guice.version>
-        <commons-cli.version>1.3.1</commons-cli.version>
         <io.swagger.version>1.5.18</io.swagger.version>
         <com.fasterxml.jackson.datatype.version>2.4.1</com.fasterxml.jackson.datatype.version>
         <swagger.parser.version>1.0.34</swagger.parser.version>


### PR DESCRIPTION
## Purpose
This PR removes `commons-cli` dependency

Closes https://github.com/ballerina-platform/ballerina-lang/pull/14046.