### PR TITLE
Remove `apache-rat-plugin` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2137,11 +2137,6 @@
                     <!-- keep maven-failsafe-plugin in sync -->
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.rat</groupId>
-                    <artifactId>apache-rat-plugin</artifactId>
-                    <version>${apache.rat.plugin.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>${maven.buildnumber.plugin.version}</version>
@@ -2364,7 +2359,6 @@
         <maven.replacer.plugin.version>1.5.3</maven.replacer.plugin.version>
         <maven.jacoco.plugin.version>0.8.3</maven.jacoco.plugin.version>
 
-        <apache.rat.plugin.version>0.11</apache.rat.plugin.version>
         <apache.source.release.assembly.descriptor.version>1.0.5</apache.source.release.assembly.descriptor.version>
         <awaitility.version>3.1.6</awaitility.version>
 


### PR DESCRIPTION
## Purpose
This PR removes `apache-rat-plugin` dependency.

Related PR: https://github.com/ballerina-platform/ballerina-lang/pull/14097