### PR TITLE
Remove `apache-mime4j-core` dependency

### DIFF
--- a/distribution/zip/ballerina/src/assembly/bin.xml
+++ b/distribution/zip/ballerina/src/assembly/bin.xml
@@ -149,7 +149,6 @@
                 <include>jaxen:jaxen</include>
                 <include>org.apache.geronimo.specs:geronimo-activation_1.1_spec</include>
                 <include>org.apache.geronimo.specs:geronimo-stax-api_1.0_spec</include>
-                <include>org.apache.james:apache-mime4j-core</include>
                 <include>info.picocli:picocli</include>
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.slf4j:slf4j-jdk14</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1099,11 +1099,6 @@
                 <version>${staxon.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j-core</artifactId>
-                <version>${mime4j.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.orbit.net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
                 <version>${saxon.wso2.version}</version>


### PR DESCRIPTION
## Purpose
This PR removes `apache-mime4j-core` dependency.

Related PR - https://github.com/ballerina-platform/ballerina-lang/pull/14019