### PR TITLE
Allow returning errors from object __init() 

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -4892,7 +4892,6 @@ public class BVM {
             case TypeTags.BYTE_TAG:
             case TypeTags.NULL_TAG:
             case TypeTags.XML_TAG:
-            case TypeTags.SERVICE_TAG:
                 if (sourceType.getTag() == TypeTags.FINITE_TYPE_TAG) {
                     return ((BFiniteType) sourceType).valueSpace.stream()
                             .allMatch(bValue -> checkIsType(bValue, targetType));

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -36,6 +36,7 @@ import org.ballerinalang.model.types.BJSONType;
 import org.ballerinalang.model.types.BMapType;
 import org.ballerinalang.model.types.BObjectType;
 import org.ballerinalang.model.types.BRecordType;
+import org.ballerinalang.model.types.BServiceType;
 import org.ballerinalang.model.types.BStreamType;
 import org.ballerinalang.model.types.BStructureType;
 import org.ballerinalang.model.types.BTableType;
@@ -4392,7 +4393,6 @@ public class BVM {
                 insertToMap(ctx, bMap, fieldName, value);
                 break;
             case TypeTags.OBJECT_TYPE_TAG:
-            case TypeTags.SERVICE_TAG:
                 BObjectType objType = (BObjectType) mapType;
                 BField objField = objType.getFields().get(fieldName);
                 BType objFieldType = objField.getFieldType();
@@ -4918,7 +4918,8 @@ public class BVM {
                 return checkIsAnyType(sourceType);
             case TypeTags.ANYDATA_TAG:
             case TypeTags.OBJECT_TYPE_TAG:
-                return isAssignable(sourceType, targetType, unresolvedTypes);
+                return targetType instanceof BServiceType ? sourceType.getTag() == targetType.getTag() :
+                        isAssignable(sourceType, targetType, unresolvedTypes);
             case TypeTags.FINITE_TYPE_TAG:
                 return checkIsFiniteType(sourceType, (BFiniteType) targetType, unresolvedTypes);
             case TypeTags.FUTURE_TAG:

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/TypeTags.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/TypeTags.java
@@ -41,8 +41,7 @@ public class TypeTags {
     public static final int INVOKABLE_TAG = MAP_TAG + 1;
     public static final int ANY_TAG = INVOKABLE_TAG + 1;
     public static final int ENDPOINT_TAG = ANY_TAG + 1;
-    public static final int SERVICE_TAG = ENDPOINT_TAG + 1;
-    public static final int ARRAY_TAG = SERVICE_TAG + 1;
+    public static final int ARRAY_TAG = ENDPOINT_TAG + 1;
     public static final int UNION_TAG = ARRAY_TAG + 1;
     public static final int PACKAGE_TAG = UNION_TAG + 1;
     public static final int NONE_TAG = PACKAGE_TAG + 1;
@@ -61,4 +60,6 @@ public class TypeTags {
     public static final int BYTE_ARRAY_TAG = OBJECT_TYPE_TAG + 1;
     public static final int FUNCTION_POINTER_TAG = BYTE_ARRAY_TAG + 1;
     public static final int CHANNEL_TAG = FUNCTION_POINTER_TAG + 1;
+
+    public static final int SERVICE_TAG = OBJECT_TYPE_TAG;
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -71,6 +71,7 @@ public enum DiagnosticCode {
     EXTERN_FUNC_ABSTRACT_OBJECT("extern.function.abstract.object"),
     OBJECT_INIT_FUNCTION_CANNOT_BE_EXTERN("object.init.function.cannot.be.extern"),
     GLOBAL_VARIABLE_CYCLIC_DEFINITION("global.variable.cyclic.reference"),
+    INVALID_OBJECT_CONSTRUCTOR_INVOCATION("invalid.object.constructor.invocation"),
 
     INCOMPATIBLE_TYPES("incompatible.types"),
     INCOMPATIBLE_TYPES_EXP_TUPLE("incompatible.types.exp.tuple"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -71,7 +71,6 @@ public enum DiagnosticCode {
     EXTERN_FUNC_ABSTRACT_OBJECT("extern.function.abstract.object"),
     OBJECT_INIT_FUNCTION_CANNOT_BE_EXTERN("object.init.function.cannot.be.extern"),
     GLOBAL_VARIABLE_CYCLIC_DEFINITION("global.variable.cyclic.reference"),
-    INVALID_OBJECT_CONSTRUCTOR_INVOCATION("invalid.object.constructor.invocation"),
 
     INCOMPATIBLE_TYPES("incompatible.types"),
     INCOMPATIBLE_TYPES_EXP_TUPLE("incompatible.types.exp.tuple"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompiledPackageSymbolEnter.java
@@ -350,6 +350,7 @@ public class CompiledPackageSymbolEnter {
         BInvokableType funcType = createInvokableType(funcSig);
         BInvokableSymbol invokableSymbol = Symbols.createFunctionSymbol(flags, names.fromString(funcName),
                 this.env.pkgSymbol.pkgID, funcType, this.env.pkgSymbol, Symbols.isFlagOn(flags, Flags.NATIVE));
+        invokableSymbol.retType = funcType.retType;
         Scope scopeToDefine = this.env.pkgSymbol.scope;
 
         if (Symbols.isFlagOn(flags, Flags.ATTACHED)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -63,6 +63,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangStatementExpression
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTableLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeInit;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeTestExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangVariableReference;
@@ -232,6 +233,14 @@ public class ASTBuilderUtil {
         ifNode.body = thenBody;
         ifNode.elseStmt = elseStmt;
         return ifNode;
+    }
+
+    static BLangTypeTestExpr createTypeTestExpr(DiagnosticPos pos, BLangExpression expr, BLangType type) {
+        final BLangTypeTestExpr typeTestExpr = (BLangTypeTestExpr) TreeBuilder.createTypeTestExpressionNode();
+        typeTestExpr.pos = pos;
+        typeTestExpr.expr = expr;
+        typeTestExpr.typeNode = type;
+        return typeTestExpr;
     }
 
     static BLangForeach createForeach(DiagnosticPos pos,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -195,6 +195,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangTupleVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangXMLNSStatement;
+import org.wso2.ballerinalang.compiler.tree.types.BLangErrorType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangRecordTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangType;
@@ -2279,9 +2280,87 @@ public class Desugar extends BLangNodeVisitor {
                     typeInitExpr.initInvocation.symbol =
                             ((BObjectTypeSymbol) typeInitExpr.type.tsymbol).initializerFunc.symbol;
                 }
-                typeInitExpr.initInvocation = rewriteExpr(typeInitExpr.initInvocation);
-                result = typeInitExpr;
+                result = rewrite(desugarObjectTypeInit(typeInitExpr), env);
         }
+    }
+
+    private BLangStatementExpression desugarObjectTypeInit(BLangTypeInit typeInitExpr) {
+        typeInitExpr.desugared = true;
+
+        // Person|error $result$;
+        BLangSimpleVariableDef resultVarDef = createVarDef("$result$", typeInitExpr.type, null, typeInitExpr.pos);
+        BLangSimpleVarRef resultVarRef = ASTBuilderUtil.createVariableRef(typeInitExpr.pos, resultVarDef.var.symbol);
+
+        // Person $obj$ = new;
+        BType objType = getObjectType(typeInitExpr.type);
+        BLangSimpleVariableDef objVarDef = createVarDef("$obj$", objType, typeInitExpr, typeInitExpr.pos);
+        BLangSimpleVarRef objVarRef = ASTBuilderUtil.createVariableRef(typeInitExpr.pos, objVarDef.var.symbol);
+
+        // var $temp$ = $obj$.__init();
+        typeInitExpr.initInvocation.exprSymbol = objVarDef.var.symbol;
+        BLangSimpleVariableDef initInvRetValVarDef = createVarDef("$temp$", typeInitExpr.initInvocation.type,
+                                                                  typeInitExpr.initInvocation, typeInitExpr.pos);
+        BLangSimpleVarRef initRetValVarRef = ASTBuilderUtil.createVariableRef(typeInitExpr.pos,
+                                                                              initInvRetValVarDef.var.symbol);
+
+        // if ($temp$ is error) {
+        //      $result$ = $temp$;
+        // } else {
+        //      $result$ = $obj$;
+        // }
+        BLangBlockStmt thenStmt = ASTBuilderUtil.createBlockStmt(typeInitExpr.pos);
+        BLangTypeTestExpr isErrorTest = ASTBuilderUtil.createTypeTestExpr(typeInitExpr.pos, initRetValVarRef,
+                                                                          getErrorTypeNode());
+        isErrorTest.type = symTable.booleanType;
+
+        BLangAssignment errAssignment = ASTBuilderUtil.createAssignmentStmt(typeInitExpr.pos, resultVarRef,
+                                                                            initRetValVarRef);
+        thenStmt.addStatement(errAssignment);
+
+        BLangBlockStmt elseStmt = ASTBuilderUtil.createBlockStmt(typeInitExpr.pos);
+        BLangAssignment objAssignment = ASTBuilderUtil.createAssignmentStmt(typeInitExpr.pos, resultVarRef, objVarRef);
+        elseStmt.addStatement(objAssignment);
+
+        BLangIf ifelse = ASTBuilderUtil.createIfElseStmt(typeInitExpr.pos, isErrorTest, thenStmt, elseStmt);
+
+        // Add it all to an expression statement
+        BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(typeInitExpr.pos);
+        blockStmt.addStatement(resultVarDef);
+        blockStmt.addStatement(objVarDef);
+        blockStmt.addStatement(initInvRetValVarDef);
+        blockStmt.addStatement(ifelse);
+
+        BLangStatementExpression stmtExpr = ASTBuilderUtil.createStatementExpression(blockStmt, resultVarRef);
+        stmtExpr.type = resultVarRef.symbol.type;
+        return stmtExpr;
+    }
+
+    private BLangSimpleVariableDef createVarDef(String name, BType type, BLangExpression expr, DiagnosticPos pos) {
+        BVarSymbol objSym = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
+                                           type, this.env.scope.owner);
+        BLangSimpleVariable objVar = ASTBuilderUtil.createVariable(pos, "", type, expr, objSym);
+        BLangSimpleVariableDef objVarDef = ASTBuilderUtil.createVariableDef(pos);
+        objVarDef.var = objVar;
+        return objVarDef;
+    }
+
+    private BType getObjectType(BType type) {
+        if (type.tag == TypeTags.OBJECT) {
+            return type;
+        } else if (type.tag == TypeTags.UNION) {
+            return ((BUnionType) type).getMemberTypes().stream()
+                    .filter(t -> t.tag == TypeTags.OBJECT)
+                    .findFirst()
+                    .orElse(symTable.noType);
+        }
+
+        throw new IllegalStateException("None object type '" + type.toString() + "' found in object init conext");
+    }
+
+    private BLangErrorType getErrorTypeNode() {
+        BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
+        errorTypeNode.type = symTable.errorType;
+        return errorTypeNode;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -173,10 +173,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;
 import static org.wso2.ballerinalang.compiler.util.Constants.MAIN_FUNCTION_NAME;
@@ -1027,7 +1029,12 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         if (objectTypeNode.isFieldAnalyseRequired) {
             objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
         }
-        objectTypeNode.functions.forEach(e -> this.analyzeNode(e, objectEnv));
+
+        // To ensure the order of the compile errors
+        Stream.concat(objectTypeNode.functions.stream(),
+                      Optional.ofNullable(objectTypeNode.initFunction).map(Stream::of).orElseGet(Stream::empty))
+                .sorted(Comparator.comparingInt(fn -> fn.pos.sLine))
+                .forEachOrdered(fn -> this.analyzeNode(fn, objectEnv));
     }
 
     private void analyseType(BType type, DiagnosticPos pos) {
@@ -1892,7 +1899,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
 
         if (!enclInvokableHasErrorReturn) {
-            dlog.error(checkedExpr.expr.pos, DiagnosticCode.CHECKED_EXPR_NO_ERROR_RETURN_IN_ENCL_INVOKABLE);
+            dlog.error(checkedExpr.pos, DiagnosticCode.CHECKED_EXPR_NO_ERROR_RETURN_IN_ENCL_INVOKABLE);
         }
 
         returnTypes.peek().add(exprType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1443,9 +1443,8 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        // TODO: 2/8/19 IMPROVE THIS ERROR MESSAGE!!!
-        dlog.error(objectInitFn.pos, DiagnosticCode.INVALID_OBJECT_CONSTRUCTOR_INVOCATION, objectInitFn.name.value,
-                   objectInitFn.receiver.type.toString());
+        dlog.error(objectInitFn.pos, DiagnosticCode.INVALID_OBJECT_CONSTRUCTOR, objectInitFn.receiver.type.toString(),
+                   objectInitFn.returnTypeNode.type.toString());
     }
 
     private void validateRemoteFunctionAttachedToObject(BLangFunction funcNode, BObjectTypeSymbol objectSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1433,13 +1433,15 @@ public class SymbolEnter extends BLangNodeVisitor {
     private void validateObjectInitFnReturnSignature(BLangFunction objectInitFn) {
         BType returnType = objectInitFn.returnTypeNode.type;
 
-        if (returnType.tag == TypeTags.UNION &&
-                ((BUnionType) returnType).getMemberTypes().stream()
-                        .noneMatch(type -> type.tag != TypeTags.NIL && type.tag != TypeTags.ERROR)) {
-            return;
+        if (returnType.tag == TypeTags.UNION) {
+            Set<BType> memberTypes = ((BUnionType) returnType).getMemberTypes();
+            if (memberTypes.stream().noneMatch(type -> type.tag != TypeTags.NIL && type.tag != TypeTags.ERROR)
+                    && memberTypes.contains(symTable.nilType)) {
+                return;
+            }
         }
 
-        if (returnType.tag == TypeTags.NIL || returnType.tag == TypeTags.ERROR) {
+        if (returnType.tag == TypeTags.NIL) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1156,17 +1156,6 @@ public class TypeChecker extends BLangNodeVisitor {
             return unionType;
         } else if (initRetType.tag == TypeTags.NIL) {
             return objType;
-        } else if (initRetType.tag == TypeTags.ERROR) {
-            LinkedHashSet<BType> retTypeMembers = new LinkedHashSet<>();
-            retTypeMembers.add(objType);
-            retTypeMembers.add(initRetType);
-
-            BUnionType unionType = BUnionType.create(null, retTypeMembers);
-            unionType.tsymbol = Symbols.createTypeSymbol(SymTag.UNION_TYPE, 0,
-                                                         Names.EMPTY, env.enclPkg.symbol.pkgID, unionType,
-                                                         env.scope.owner);
-
-            return unionType;
         }
         return symTable.semanticError;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2308,6 +2308,14 @@ public class Types {
         }
     }
 
+    public boolean includesErrorType(BType type) {
+        if (type.tag == TypeTags.UNION) {
+            return ((BUnionType) type).getMemberTypes().stream().anyMatch(t -> t.tag == TypeTags.ERROR);
+        }
+
+        return type.tag == TypeTags.ERROR;
+    }
+
     private boolean analyzeUnionType(BUnionType type) {
         // NIL is a member.
         if (type.isNullable()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangUnionTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangUnionTypeNode.java
@@ -53,7 +53,7 @@ public class BLangUnionTypeNode extends BLangType implements UnionTypeNode {
 
     @Override
     public String toString() {
-        StringJoiner stringJoiner = new StringJoiner(" | ");
+        StringJoiner stringJoiner = new StringJoiner("|");
         memberTypeNodes.forEach(memberTypeNode -> stringJoiner.add(memberTypeNode.toString()));
         return stringJoiner.toString();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
@@ -42,8 +42,7 @@ public class TypeTags {
     // All the above types are branded types
     public static final int ANY = INVOKABLE + 1;
     public static final int ENDPOINT = ANY + 1;
-    public static final int SERVICE = ENDPOINT + 1;
-    public static final int ARRAY = SERVICE + 1;
+    public static final int ARRAY = ENDPOINT + 1;
     public static final int UNION = ARRAY + 1;
     public static final int PACKAGE = UNION + 1;
     public static final int NONE = PACKAGE + 1;
@@ -62,6 +61,8 @@ public class TypeTags {
     public static final int BYTE_ARRAY = OBJECT + 1;
     public static final int FUNCTION_POINTER = BYTE_ARRAY + 1;
     public static final int CHANNEL = BYTE_ARRAY + 1;
+
+    public static final int SERVICE = OBJECT;
 
     private TypeTags() {
     }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -392,6 +392,9 @@ error.object.field.and.func.with.same.name=\
 error.invalid.object.constructor=\
   invalid object constructor: input/output parameters are not allowed
 
+error.invalid.object.constructor.invocation=\
+  ''{0}'' object constructor returns ''{1}''
+
 error.explicit.invocation.of.record.init.is.not.allowed=\
   explicit invocation of ''{0}'' record initializer is not allowed
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -390,10 +390,7 @@ error.object.field.and.func.with.same.name=\
   function and field named ''{0}'' in object ''{1}''
 
 error.invalid.object.constructor=\
-  invalid object constructor: input/output parameters are not allowed
-
-error.invalid.object.constructor.invocation=\
-  ''{0}'' object constructor returns ''{1}''
+  invalid object constructor for ''{0}'': expected sub-type of ''error?'', but found ''{1}''
 
 error.explicit.invocation.of.record.init.is.not.allowed=\
   explicit invocation of ''{0}'' record initializer is not allowed

--- a/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
+++ b/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
@@ -106,7 +106,7 @@ public class HtmlDocTest {
         Assert.assertTrue(page.constructs.get(0) instanceof FunctionDoc, "Invalid documentable type");
         FunctionDoc functionDoc = (FunctionDoc) page.constructs.get(0);
         Assert.assertEquals(functionDoc.parameters.get(0).toString(), "string name", "Invalid parameter string value");
-        Assert.assertEquals(functionDoc.returnParams.get(0).toString(), "(string[],int) | error<>", "Invalid return " +
+        Assert.assertEquals(functionDoc.returnParams.get(0).toString(), "(string[],int)|error<>", "Invalid return " +
                 "type");
         Assert.assertEquals(functionDoc.returnParams.get(0).href, "primitive-types.html#string,primitive-types" + "" +
                 ".html#int,builtin.html#error", "Invalid link to return type");
@@ -345,7 +345,7 @@ public class HtmlDocTest {
         Assert.assertEquals(functionDoc2.name, "test2", "Invalid function name test2");
         Assert.assertEquals(functionDoc2.parameters.size(), 0);
         Assert.assertEquals(functionDoc2.icon, "fw-function", "test2 function is not detected as a function");
-        Assert.assertEquals(functionDoc2.returnParams.get(0).dataType, "string | error<>", "Invalid return type");
+        Assert.assertEquals(functionDoc2.returnParams.get(0).dataType, "string|error<>", "Invalid return type");
         Assert.assertEquals(functionDoc2.returnParams.get(0).description, "<p>returns the string or an error</p>\n");
     }
 

--- a/stdlib/bir/src/main/ballerina/bir/type_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/type_parser.bal
@@ -39,8 +39,7 @@ public type TypeParser object {
     // All the above types are branded types
     public int TYPE_TAG_ANY = TYPE_TAG_INVOKABLE + 1;
     public int TYPE_TAG_ENDPOINT = TYPE_TAG_ANY + 1;
-    public int TYPE_TAG_SERVICE = TYPE_TAG_ENDPOINT + 1;
-    public int TYPE_TAG_ARRAY = TYPE_TAG_SERVICE + 1;
+    public int TYPE_TAG_ARRAY = TYPE_TAG_ENDPOINT + 1;
     public int TYPE_TAG_UNION = TYPE_TAG_ARRAY + 1;
     public int TYPE_TAG_PACKAGE = TYPE_TAG_UNION + 1;
     public int TYPE_TAG_NONE = TYPE_TAG_PACKAGE + 1;
@@ -59,6 +58,8 @@ public type TypeParser object {
     public int TYPE_TAG_BYTE_ARRAY = TYPE_TAG_OBJECT + 1;
     public int TYPE_TAG_FUNCTION_POINTER = TYPE_TAG_BYTE_ARRAY + 1;
     public int TYPE_TAG_CHANNEL = TYPE_TAG_BYTE_ARRAY + 1;
+
+    public int TYPE_TAG_SERVICE = TYPE_TAG_OBJECT;
 
     public function __init(BirChannelReader reader) {
         self.reader = reader;

--- a/stdlib/http/src/test/resources/test-src/resiliency/circuit-breaker-test.bal
+++ b/stdlib/http/src/test/resources/test-src/resiliency/circuit-breaker-test.bal
@@ -293,9 +293,9 @@ public type MockClient client object {
     public http:Client httpClient;
 
     public function __init(string url, http:ClientEndpointConfig? config = ()) {
+        http:Client simpleClient = new(url);
         self.url = url;
         self.config = config ?: {};
-        http:Client simpleClient = new(url);
         self.httpClient = simpleClient;
     }
 

--- a/stdlib/http/src/test/resources/test-src/resiliency/failover-connector-test.bal
+++ b/stdlib/http/src/test/resources/test-src/resiliency/failover-connector-test.bal
@@ -81,9 +81,9 @@ public type MockClient client object {
     public http:Client httpClient;
 
     public function __init(string url, http:ClientEndpointConfig? config = ()) {
+        http:Client simpleClient = new(url);
         self.url = url;
         self.config = config ?: {};
-        http:Client simpleClient = new(url);
         self.httpClient = simpleClient;
     }
 

--- a/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/message.bal
+++ b/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/message.bal
@@ -44,7 +44,7 @@ public type Message client object {
             self.createMessage(session, string.convert(data), self.configuration);
         } else if (data is json) {
             self.createMessage(session, data.toString(), self.configuration);
-        } else if (data is byte[]) {
+        } else {
             self.messageType = BYTES;
             self.createMessage(session, data, self.configuration);
         }

--- a/stdlib/streams/src/main/ballerina/streams/collections.bal
+++ b/stdlib/streams/src/main/ballerina/streams/collections.bal
@@ -22,7 +22,7 @@ public type Node object {
     public Node? next;
     public Node? prev;
 
-    function __init(Node? prev, any? data, Node? next) {
+    public function __init(Node? prev, any? data, Node? next) {
         self.prev = prev;
         self.data = data;
         self.next = next;
@@ -37,7 +37,7 @@ public type LinkedList object {
     public int size = 0;
     public boolean ascend = true;
 
-    function __init() {
+    public function __init() {
         self.first = ();
         self.last = ();
         self.curr = ();

--- a/stdlib/streams/src/main/ballerina/streams/stream-event.bal
+++ b/stdlib/streams/src/main/ballerina/streams/stream-event.bal
@@ -34,8 +34,7 @@ public type StreamEvent object {
             foreach var (k, v) in eventData[1] {
                 self.data[eventData[0] + DELIMITER + k] = v;
             }
-        }
-        else if (eventData is map<anydata>) {
+        } else {
             self.data = eventData;
         }
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/debugger/VMDebuggerTest.java
@@ -358,6 +358,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 31, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 32, STEP_OVER, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 7, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 8, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 37, STEP_OVER, 1));
@@ -365,6 +366,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 26, STEP_OVER, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 30, STEP_OUT, 1));
+        debugPoints.add(Util.createDebugPoint(".", file, 9, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 10, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 35, STEP_IN, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 39, STEP_OVER, 1));
@@ -388,7 +390,7 @@ public class VMDebuggerTest {
         debugPoints.add(Util.createDebugPoint(".", file, 16, STEP_OUT, 1));
         debugPoints.add(Util.createDebugPoint(".", file, 4, RESUME, 1));
 
-        ExpectedResults expRes = new ExpectedResults(debugPoints, 35, 0, new ArrayList<>(), false);
+        ExpectedResults expRes = new ExpectedResults(debugPoints, 37, 0, new ArrayList<>(), false);
 
         VMDebuggerUtil.startDebug("test-src/debugger/test_object_and_match.bal", breakPoints, expRes);
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExprNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExprNegativeTest.java
@@ -42,7 +42,7 @@ public class CheckedExprNegativeTest {
         BAssertUtil.validateError(compile, 3, "incompatible types: expected 'string|error'" +
                                               ", found 'string|int'", 39, 25);
         BAssertUtil.validateError(compile, 4, "invalid usage of the checked expression " +
-                "operator: no error type return in enclosing invokable", 49, 25);
+                "operator: no error type return in enclosing invokable", 49, 19);
     }
 
     @Test
@@ -51,6 +51,6 @@ public class CheckedExprNegativeTest {
                 "test-src/expressions/checkedexpr/checked_expr_within_resource_negative.bal");
         Assert.assertEquals(compile.getErrorCount(), 1);
         BAssertUtil.validateError(compile, 0, "invalid usage of the checked expression " +
-                "operator: no error type return in enclosing invokable", 28, 28);
+                "operator: no error type return in enclosing invokable", 28, 22);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -77,7 +77,7 @@ public class ObjectInitializerTest {
     @Test(description = "Test negative object initializers scenarios")
     public void testObjectInitializerNegatives() {
         CompileResult result = BCompileUtil.compile("test-src/object/object_initializer_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 5);
+        Assert.assertEquals(result.getErrorCount(), 7);
         validateError(result, 0, "redeclared symbol 'Foo.__init'", 23, 14);
         validateError(result, 1,
                       "object initializer function can not be declared as private", 27, 4);
@@ -86,6 +86,13 @@ public class ObjectInitializerTest {
         validateError(result, 4,
                       "invalid object constructor for 'Person2': expected sub-type of 'error?', but found 'string?'",
                       54, 5);
+        validateError(result, 5,
+                      "invalid object constructor for 'Person3': expected sub-type of 'error?', but found 'error'",
+                      63, 5);
+        validateError(result, 6,
+                      "invalid object constructor for 'Person4': expected sub-type of 'error?', but found " +
+                              "'error|error'",
+                      85, 5);
     }
 
     @Test(description = "Test object initializer invocation")
@@ -159,13 +166,5 @@ public class ObjectInitializerTest {
         Assert.assertEquals(returns[0].getType().getTag(), TypeTags.ERROR);
         Assert.assertEquals(((BError) returns[0]).reason, "failed to create Person object");
         Assert.assertEquals(((BError) returns[0]).details.stringValue(), "{\"f\":\"foo\"}");
-    }
-
-    @Test(description = "Test returning only errors in initializer")
-    public void testErrorOnlyReturnInInit() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "testErrorOnlyReturnInInit");
-
-        Assert.assertEquals(returns[0].getType().getTag(), TypeTags.ERROR);
-        Assert.assertEquals(((BError) returns[0]).reason, "failed to create Person5 object");
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -185,7 +185,7 @@ public class ArrayTest {
     @Test(description = "Test arrays of types without implicit initial values")
     public void testArrayImplicitInitialValues() {
         String errMsgFormat = "array element type '%s' does not have an implicit initial value, use '%s'";
-        Assert.assertEquals(arrayImplicitInitialValueNegative.getErrorCount(), 17);
+        Assert.assertEquals(arrayImplicitInitialValueNegative.getErrorCount(), 18);
         BAssertUtil.validateError(arrayImplicitInitialValueNegative, 0,
                                   format(errMsgFormat, "ObjInitWithParam", "ObjInitWithParam?"), 53, 41);
         BAssertUtil.validateError(arrayImplicitInitialValueNegative, 1, format(errMsgFormat, "1|2|3", "1|2|3?"),
@@ -223,10 +223,9 @@ public class ArrayTest {
                                   format(errMsgFormat, "1|2|3", "1|2|3?"), 171, 11);
         BAssertUtil.validateError(arrayImplicitInitialValueNegative, 15,
                                   format(errMsgFormat, "1|2|3", "1|2|3?"), 179, 25);
-        // TODO: 3/14/19 Uncomment after PR #14220 is merged
-//        BAssertUtil.validateError(arrayImplicitInitialValueNegative, 16,
-//                                  format(errMsgFormat, "1|2|3", "1|2|3?"), 186, 21);
         BAssertUtil.validateError(arrayImplicitInitialValueNegative, 16,
+                                  format(errMsgFormat, "1|2|3", "1|2|3?"), 186, 21);
+        BAssertUtil.validateError(arrayImplicitInitialValueNegative, 17,
                                   format(errMsgFormat, "1|2|3", "1|2|3?"), 196, 29);
     }
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -71,7 +71,7 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 19, msg4 , 27, 15);
         BAssertUtil.validateError(result, 20, msg4 , 30, 15);
         BAssertUtil.validateError(result, 22, msg5, 35, 60);
-        BAssertUtil.validateError(result, 25, msg6, 45, 22);
+        BAssertUtil.validateError(result, 25, msg6, 45, 16);
     }
 
     @Test(description = "Test byte shift operators negative")

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/init/object-initializer.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/init/object-initializer.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import initializers as inp;
 
 public type person object {
@@ -53,4 +69,131 @@ function testObjectInitializerUsedAsAFunction() returns (int, string, int, strin
 
     p.__init(a = 20, n = "James");
     return (p.age, p.name, age1, name1);
+}
+
+type Person object {
+    string name;
+    int age;
+
+    function __init() returns error? {
+        self.name = check getError();
+        self.age = 25;
+    }
+};
+
+function getError() returns string|error {
+    map<string> m = {f: "foo"};
+    error e = error("failed to create Person object", m);
+    return e;
+}
+
+function testErrorReturningInitializer() returns Person|error {
+    Person|error p = new();
+    return p;
+}
+
+function testReturnedValWithTypeGuard() returns string {
+    Person|error p = new Person();
+
+    if (p is error) {
+        return "error";
+    } else {
+        return "Person";
+    }
+}
+
+function testAssigningToVar() returns error? {
+    var v = new Person();
+    if (v is error) {
+        return v;
+    }
+    return ();
+}
+
+function testTypeInitInReturn() returns Person|error {
+    return new();
+}
+
+type Person2 object {
+    string name;
+    int age = 27;
+    string profession;
+    anydata[] misc;
+
+    function __init(string name, string profession = "", anydata... misc) {
+        self.name = name;
+        self.profession = profession;
+        self.misc = misc;
+    }
+};
+
+function testInitializerWithRestArgs() returns Person2 {
+    json adr = {city: "Colombo", country: "Sri Lanka"};
+    Person2 p = new("Pubudu", profession = "Software Engineer", adr);
+    return p;
+}
+
+type Person3 object {
+    string name;
+    int age;
+
+    function __init(string name, int age) returns Err? {
+        self.name = check getError2(100);
+        self.age = 25;
+    }
+};
+
+type ErrorDetails record {
+    int id;
+};
+
+type Err error<string, ErrorDetails>;
+
+function getError2(int errId) returns string|Err {
+    Err e = error("Failed to create object", {id: errId});
+    return e;
+}
+
+function testCustomErrorReturn() returns (Person3|Err, Person3|error) {
+    Person3|Err p1 = new("Pubudu", 27);
+    Person3|error p2 = new("Pubudu", 27);
+    return (p1, p2);
+}
+
+type Person4 object {
+    string name;
+    int age;
+
+    function __init(boolean isFoo) returns FooErr|BarErr|() {
+        self.name = check getMultipleErrors(isFoo);
+        self.age = 25;
+    }
+};
+
+type FooErrData record {
+    string f;
+};
+
+type FooErr error<string, FooErrData>;
+
+type BarErrData record {
+    string b;
+};
+
+type BarErr error<string, BarErrData>;
+
+function getMultipleErrors(boolean isFoo) returns string|FooErr|BarErr {
+    if (isFoo) {
+        FooErr e = error("Foo Error", {f:"foo"});
+        return e;
+    } else {
+        BarErr e = error("Bar Error", {b:"bar"});
+        return e;
+    }
+}
+
+function testMultipleErrorReturn() returns (Person4|FooErr|BarErr, Person4|FooErr|BarErr) {
+    Person4|FooErr|BarErr p1 = new(true);
+    Person4|FooErr|BarErr p2 = new(false);
+    return (p1, p2);
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/init/object-initializer.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/init/object-initializer.bal
@@ -197,3 +197,18 @@ function testMultipleErrorReturn() returns (Person4|FooErr|BarErr, Person4|FooEr
     Person4|FooErr|BarErr p2 = new(false);
     return (p1, p2);
 }
+
+type Person5 object {
+    string name;
+
+    function __init() returns error {
+        self.name = "foo";
+        error e = error("failed to create Person5 object");
+        return e;
+    }
+};
+
+function testErrorOnlyReturnInInit() returns Person5|error {
+    Person5|error p = new Person5();
+    return p;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/init/object-initializer.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/init/object-initializer.bal
@@ -197,18 +197,3 @@ function testMultipleErrorReturn() returns (Person4|FooErr|BarErr, Person4|FooEr
     Person4|FooErr|BarErr p2 = new(false);
     return (p1, p2);
 }
-
-type Person5 object {
-    string name;
-
-    function __init() returns error {
-        self.name = "foo";
-        error e = error("failed to create Person5 object");
-        return e;
-    }
-};
-
-function testErrorOnlyReturnInInit() returns Person5|error {
-    Person5|error p = new Person5();
-    return p;
-}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/initializers/init.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/initializers/init.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 public type employee object {
 
     public int age = 0;
@@ -17,11 +33,14 @@ public function employee.getAge() {
     self.age = 12;
 }
 
-// Struct with private initializer
+// object with non-public initializer
 public type student object {
     public int age = 20;
     public string name = "";
     public string address = "";
+
+    function __init() {
+    }
 
     public function getAge();
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 type Foo object {
     public int age = 0;
     public string name = "";
@@ -9,4 +25,34 @@ type Foo object {
 
 type Bar object {
    private function __init() {}
+};
+
+type Person object {
+    string name;
+    int age;
+
+    function __init() returns error? {
+        self.name = check getError();
+        self.age = 25;
+    }
+};
+
+function getError() returns string|error {
+    map<string> m = {f: "foo"};
+    error e = error("failed to create Person object", m);
+    return e;
+}
+
+function testInit() {
+    Person p1 = new;
+    Person p2 = new Person();
+}
+
+type Person2 object {
+    string name;
+
+    function __init() returns string? {
+        self.name = "";
+        return "foo";
+    }
 };

--- a/tests/ballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
@@ -56,3 +56,35 @@ type Person2 object {
         return "foo";
     }
 };
+
+type Person3 object {
+    string name;
+
+    function __init() returns error {
+        self.name = "";
+        error e = error("failed to create Person3");
+        return e;
+    }
+};
+
+type FooErrData record {
+    string f;
+};
+
+type FooErr error<string, FooErrData>;
+
+type BarErrData record {
+    string b;
+};
+
+type BarErr error<string, BarErrData>;
+
+type Person4 object {
+    string name;
+
+    function __init() returns FooErr|BarErr {
+        self.name = "";
+        FooErr e = error("Foo Error", {f:"foo"});
+        return e;
+    }
+};


### PR DESCRIPTION
## Purpose
> This PR is to change the return type signature of the object initializer to allow error types as well. Fix #13342 

## Approach
> Previously, the new was modeled as `BLangTypeInit`. Two instructions were generated for this:
> - `NEWSTRUCT` to create a new empty object.
> - Call the `__init()` function of the created object to initialize it. 
> To support error types in the return, `BLangTypeInit` expression is now desugared to the following expression statement:
```ballerina
Person|error p = new Person();
----------------------------------------------
// new Person() is desugared to
{
    Person|error $result$; // The expr of the expression statement
    Person $obj$ = new Person();
    error? $temp$ = $obj$.__init();

    if ($temp$ is error) {
        $result$ = $temp$;
    } else {
        $result$ = $obj$;
    }
}
```
> With this change, only the `NEWSTRUCT` instruction is emitted for the `BLangTypeInit`. The invocation of the `__init()` is handled in the normal flow.
> For `__init()` functions which do not return errors, the type test mentioned above is not done. It's desugared to the following:
```ballerina
{
    Person $obj$ = new Person(); // $obj$ is the expr of the expression stmt in this case
    $obj$.__init();
}
```

## Samples
```ballerina
import ballerina/io;

public function main() {
    Person|error p = new Person();

    if (p is Person) {
        io:println("Person created");
    } else {
        io:println("Failed to create a Person: ", p);
    }
}

type Person object {
    string name = "";

    function __init() returns error? {
        self.name = check test();
    }

    function foo() returns string {
        return "foo";
    }
};

function test() returns string|error {
    error e = error("test");
    return e;
}
```

