### PR TITLE
Allow the ballerina central access token to be specified as an environment variable when pushing modules

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -65,7 +65,7 @@ public class PushUtils {
     private static final String BALLERINA_CENTRAL_CLI_TOKEN = "https://central.ballerina.io/cli-token";
     private static final Path BALLERINA_HOME_PATH = RepoUtils.createAndGetHomeReposPath();
     private static final Path SETTINGS_TOML_FILE_PATH = BALLERINA_HOME_PATH.resolve(
-                                                                        ProjectDirConstants.SETTINGS_FILE_NAME);
+            ProjectDirConstants.SETTINGS_FILE_NAME);
 
     private static EmbeddedExecutor executor = EmbeddedExecutorProvider.getInstance().getExecutor();
     private static Settings settings;

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -20,7 +20,6 @@ package org.ballerinalang.packerina;
 import org.ballerinalang.launcher.LauncherUtils;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.spi.EmbeddedExecutor;
-import org.ballerinalang.toml.model.Central;
 import org.ballerinalang.toml.model.Manifest;
 import org.ballerinalang.toml.model.Proxy;
 import org.ballerinalang.toml.model.Settings;
@@ -141,24 +140,8 @@ public class PushUtils {
         }
         
         if (installToRepo == null) {
-            // The access token can be specified as an environment variable or in 'Settings.toml'. First we would
-            // check if the access token was specified as an environment variable. If not we would read it from
-            // 'Settings.toml'.
-
-            // Check if the access token is specified as an environment variable
-            String accessToken = System.getenv("BALLERINA_CENTRAL_ACCESS_TOKEN");
-            if (accessToken != null) {
-                // Read 'Settings.toml' to get values of other properties specified
-                settings = TomlParserUtils.readSettings();
-                // Add the access token to the settings object
-                Central b7aCentral = new Central();
-                b7aCentral.setAccessToken(accessToken);
-                settings.setCentral(b7aCentral);
-            } else {
-                // If the access token is not given as an environment variable, read the access token from
-                // 'Settings.toml'
-                accessToken = checkAccessToken();
-            }
+            // Get access token
+            String accessToken = checkAccessToken();
 
             // Read the Module.md file content from the artifact
             String mdFileContent = getModuleMDFileContent(pkgPathFromPrjtDir.toString(), packageName);
@@ -316,6 +299,12 @@ public class PushUtils {
      */
     private static String getAccessTokenOfCLI() {
         settings = TomlParserUtils.readSettings();
+        // The access token can be specified as an environment variable or in 'Settings.toml'. First we would check if
+        // the access token was specified as an environment variable. If not we would read it from 'Settings.toml'
+        String tokenAsEnvVar = System.getenv(ProjectDirConstants.BALLERINA_CENTRAL_ACCESS_TOKEN);
+        if (tokenAsEnvVar != null) {
+            return tokenAsEnvVar;
+        }
         if (settings.getCentral() != null) {
             return settings.getCentral().getAccessToken();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -57,4 +57,8 @@ public class ProjectDirConstants {
     public static final String BALLERINA_SOURCE_ROOT = "ballerina.source.root";
 
     public static final String NIGHTLY_BUILD = "nightly.build";
+
+    public static final String BALLERINA_CENTRAL_ACCESS_TOKEN = "BALLERINA_CENTRAL_ACCESS_TOKEN";
+
+
 }

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModulePushTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModulePushTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.packaging;
+
+import org.ballerinalang.test.BaseTest;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.test.utils.PackagingTestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Testing pushing a module from central by specifying the access token as an environment variable.
+ *
+ * @since 0.990.5
+ */
+public class ModulePushTestCase extends BaseTest {
+    private Path tempProjectDirectory;
+    private String moduleName = "test";
+    private Map<String, String> envVariables;
+
+    @BeforeClass()
+    public void setUp() throws IOException {
+        tempProjectDirectory = Files.createTempDirectory("bal-test-integration-packaging-project-");
+        moduleName = moduleName + PackagingTestUtils.randomModuleName(8);
+        envVariables = addEnvVariables(PackagingTestUtils.getEnvVariables());
+    }
+
+    @Test(description = "Test pushing a package to central by specifying the access token as an environment variable")
+    public void testPush() throws Exception {
+        // Org-name
+        String orgName = "integrationtests";
+
+        // Initialize a ballerina project and create a module to be pushed
+        Path projectPath = tempProjectDirectory.resolve("initPushProject");
+        Files.createDirectories(projectPath);
+        String[] options = {"\n", orgName + "\n", "\n", "m\n", moduleName + "\n", "f\n"};
+        balClient.runMain("init", new String[]{"-i"}, envVariables, options, new LogLeecher[]{},
+                projectPath.toString());
+
+        // Push the module to Ballerina Central
+        String msg = orgName + "/" + moduleName + ":0.0.1 [project repo -> central]";
+        LogLeecher logLeecher = new LogLeecher(msg);
+        balClient.runMain("push", new String[]{moduleName}, envVariables, new String[]{},
+                new LogLeecher[]{logLeecher}, projectPath.toString());
+        logLeecher.waitForText(5000);
+    }
+
+
+    /**
+     * Get environment variables.
+     *
+     * @return env directory variable array
+     */
+    private Map<String, String> addEnvVariables(Map<String, String> envVariables) {
+        envVariables.put("BALLERINA_DEV_STAGE_CENTRAL", "true");
+        envVariables.put("BALLERINA_CENTRAL_ACCESS_TOKEN", "0f647e67-857d-32e8-a679-bd3c1c3a7eb2");
+        return envVariables;
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        PackagingTestUtils.deleteFiles(tempProjectDirectory);
+    }
+}

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModulePushTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModulePushTestCase.java
@@ -66,7 +66,6 @@ public class ModulePushTestCase extends BaseTest {
         logLeecher.waitForText(5000);
     }
 
-
     /**
      * Get environment variables.
      *

--- a/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/testng.xml
@@ -33,6 +33,7 @@
             <class name="org.ballerinalang.test.packaging.ModuleBuildTestCase"/>
             <class name="org.ballerinalang.test.packaging.ModuleRunTestCase"/>
             <class name="org.ballerinalang.test.packaging.ModuleInitTestCase"/>
+            <class name="org.ballerinalang.test.packaging.ModulePushTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingNegativeTestCase"/>
             <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>
             <class name="org.ballerinalang.test.packaging.RunTopLevelBalInProjectTestCase"/>


### PR DESCRIPTION
## Purpose
> $subject

Following environment variable should be specified with the access token.
```bash
BALLERINA_CENTRAL_ACCESS_TOKEN="xxxx-xxxx-xxxx-xxxx"
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/14241

## Automation tests
 - Integration tests
   > Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes