### PR TITLE
Fix PkgRunFunctionPositiveTestCase

### DIFF
--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/run/PkgRunFunctionPositiveTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/run/PkgRunFunctionPositiveTestCase.java
@@ -19,43 +19,35 @@ package org.ballerinalang.test.run;
 
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.ballerinalang.test.context.LogLeecher;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
 
 /**
- * This class tests invoking an entry function in a package via the Ballerina Run Command and the data binding 
+ * This class tests invoking a main function in a package via the Ballerina Run Command and the data binding
  * functionality.
- *
- * e.g., ballerina run abc:nomoremain 1 "Hello World" data binding main
- *  where nomoremain is the following function
- *      public function nomoremain(int i, string s, string... args) {
- *          ...
- *      }
  */
 public class PkgRunFunctionPositiveTestCase extends BaseTest {
 
-    private static final int LOG_LEECHER_TIMEOUT = 10000;
-
     @Test
     public void testNoArg() throws BallerinaTestException {
-        LogLeecher outLogLeecher = new LogLeecher("1");
-        balClient.runMain((new File("src/test/resources/run/package/")).getAbsolutePath(), "no_params",
-                          new String[]{}, new String[0], new LogLeecher[]{outLogLeecher});
-        outLogLeecher.waitForText(LOG_LEECHER_TIMEOUT);
+        String output = balClient.runMainAndReadStdOut("run", new String[]{ "no_params" },
+                                                       (new File("src/test/resources/run/package/")).getAbsolutePath());
+        Assert.assertEquals(output, "1");
     }
 
     @Test
     public void testMultipleParam() throws BallerinaTestException {
-        LogLeecher outLogLeecher = new LogLeecher("integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, "
-                                                          + "boolean: true, JSON Name Field: Maryam, XML Element Name: "
-                                                          + "book, Employee Name Field: Em, string rest args: just the"
-                                                          + " rest ");
-        balClient.runMain((new File("src/test/resources/run/package/")).getAbsolutePath(), "multiple_params",
-                          new String[]{}, new String[]{"1000", "1.0", "Hello Ballerina", "255", "true",
-                        "{ \"name\": \"Maryam\" }", "<book>Harry Potter</book>", "{ \"name\": \"Em\" }", "just", "the",
-                        "rest"}, new LogLeecher[]{outLogLeecher});
-        outLogLeecher.waitForText(LOG_LEECHER_TIMEOUT);
+        String output = balClient.runMainAndReadStdOut("run",
+                                                       new String[]{ "multiple_params", "1000", "1.0",
+                                                               "Hello Ballerina", "255", "true",
+                                                               "{ \"name\": \"Maryam\" }", "<book>Harry Potter</book>",
+                                                               "{ \"name\": \"Em\" }", "just", "the", "rest"},
+                                                       (new File("src/test/resources/run/package/")).getAbsolutePath());
+        Assert.assertEquals(output,
+                            "integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, boolean: true, " +
+                                    "JSON Name Field: Maryam, XML Element Name: book, Employee Name Field: Em, " +
+                                    "string rest args: just the rest ");
     }
 }


### PR DESCRIPTION
## Purpose
The tests in PkgRunFunctionPositiveTestCase fail intermittently due to the following:

> Force exit is called for the log leechers, when main function execution completes. At times this happens before the log leecher's log found boolean variable is set. Thus the test fails even though the log is available.

This PR fixes the tests to use the new `runMainAndReadStdOut` method available with `BMainInstance` to directly check the output written to std out.

Fixes #13975
Fixes #14125 