### PR TITLE
Fix pull module code action fails when VSCode configured to an old ballerina.home

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -203,7 +203,7 @@ public class BallerinaLanguageServer implements ExtendedLanguageServer, Extended
     // Private Methods
 
     private LSIndexImpl initLSIndex() {
-        String indexDumpPath = Paths.get(CommonUtil.BALLERINA_HOME + "/lib/tools/lang-server/resources/" +
+        String indexDumpPath = Paths.get(CommonUtil.getBallerinaHome() + "/lib/tools/lang-server/resources/" +
                 "lang-server-index.sql").toString();
         return new LSIndexImpl(indexDumpPath);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -78,8 +78,8 @@ public class PullModuleExecutor implements LSCommandExecutor {
                 return;
             }
             // Execute `ballerina pull` command
-            String ballerinaHome = Paths.get(CommonUtil.BALLERINA_HOME).resolve("bin").resolve("ballerina").toString();
-            ProcessBuilder processBuilder = new ProcessBuilder(ballerinaHome, "pull", moduleName);
+            String ballerina = Paths.get(CommonUtil.getBallerinaHome()).resolve("bin").resolve("ballerina").toString();
+            ProcessBuilder processBuilder = new ProcessBuilder(ballerina, "pull", moduleName);
             LanguageClient client = context.get(ExecuteCommandKeys.LANGUAGE_SERVER_KEY).getClient();
             LSCompiler lsCompiler = context.get(ExecuteCommandKeys.LS_COMPILER_KEY);
             DiagnosticsHelper diagnosticsHelper = context.get(ExecuteCommandKeys.DIAGNOSTICS_HELPER_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -20,6 +20,7 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.LSGlobalContextKeys;
 import org.ballerinalang.langserver.SnippetBlock;
+import org.ballerinalang.langserver.client.config.BallerinaClientConfigHolder;
 import org.ballerinalang.langserver.command.testgen.TestGenerator.TestFunctionGenerator;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
@@ -142,7 +143,7 @@ public class CommonUtil {
 
     public static final boolean LS_DEBUG_ENABLED;
 
-    public static final String BALLERINA_HOME;
+    private static String ballerinaHome;
 
     public static final String PLAIN_TEXT_MARKUP_KIND = "plaintext";
 
@@ -151,10 +152,24 @@ public class CommonUtil {
     static {
         String debugLogStr = System.getProperty("ballerina.debugLog");
         LS_DEBUG_ENABLED = debugLogStr != null && Boolean.parseBoolean(debugLogStr);
-        BALLERINA_HOME = System.getProperty("ballerina.home");
+        ballerinaHome = System.getProperty("ballerina.home");
+        BallerinaClientConfigHolder.getInstance().register((oldConfig, newConfig) -> {
+            String configHome = newConfig.getHome();
+            ballerinaHome = (configHome != null && !configHome.isEmpty()) ? newConfig.getHome()
+                    : System.getProperty("ballerina.home");
+        });
     }
 
     private CommonUtil() {
+    }
+
+    /**
+     * Returns ballerina home.
+     *
+     * @return {@link String} ballerina home
+     */
+    public static String getBallerinaHome() {
+        return ballerinaHome;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/example/BallerinaExampleServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/example/BallerinaExampleServiceImpl.java
@@ -60,7 +60,7 @@ public class BallerinaExampleServiceImpl implements BallerinaExampleService {
         return CompletableFuture.supplyAsync(() -> {
             BallerinaExampleListResponse response = new BallerinaExampleListResponse();
             Gson gson = new Gson();
-            Path bbeJSONPath = Paths.get(CommonUtil.BALLERINA_HOME).resolve(EXAMPLES_DIR).resolve(BBE_DEF_JSON);
+            Path bbeJSONPath = Paths.get(CommonUtil.getBallerinaHome()).resolve(EXAMPLES_DIR).resolve(BBE_DEF_JSON);
             try {
                 InputStreamReader fileReader = new InputStreamReader(
                         new FileInputStream(bbeJSONPath.toFile()), StandardCharsets.UTF_8);


### PR DESCRIPTION
## Purpose
> Pull module code action fails sometimes whenever `ballerina.home` is set to an old version of ballerina and a latest version is already installed through the installers.

> Tooling Pull Module code action, BBE page and LS indexer now uses `ballerina/home` received  through LSP didConfig change notifications.

> This PR resolves https://github.com/ballerina-platform/ballerina-lang/issues/13788