### PR TITLE
Fix class definition not found error

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/pom.xml
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/pom.xml
@@ -88,7 +88,7 @@
                                     <include>io.swagger.parser.v3:swagger-parser-v3</include>
                                     <include>javax.validation:validation-api</include>
                                     <include>com.google.code.gson:gson</include>
-                                    <include>org.ballerinalang:ballerina-to-openapi</include>
+                                    <include>org.ballerinalang:ballerina-to-openapi-generator</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/misc/openapi-ballerina/pom.xml
+++ b/misc/openapi-ballerina/pom.xml
@@ -37,8 +37,8 @@
     </properties>
 
     <modules>
-        <module>modules/openapi-to-ballerina-generator</module>
         <module>modules/ballerina-to-openapi-generator</module>
+        <module>modules/openapi-to-ballerina-generator</module>
         <module>modules/ballerina-client-generator</module>
     </modules>
 </project>


### PR DESCRIPTION
## Purpose
> This will fix no ClassDefFound error while exporting a OpenApi Specification