### PR TITLE
Remove constraint placed on the position of client object declaration.

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -142,7 +142,6 @@ public enum DiagnosticCode {
     REMOTE_IN_NON_OBJECT_FUNCTION("remote.in.non.object.function"),
     REMOTE_ON_NON_REMOTE_FUNCTION("remote.on.non.remote.function"),
     REMOTE_REQUIRED_ON_REMOTE_FUNCTION("remote.required.on.remote.function"),
-    INVALID_ENDPOINT_DECLARATION("invalid.endpoint.declaration"),
     INVALID_LISTENER_VARIABLE("invalid.listener.var"),
     INVALID_LISTENER_ATTACHMENT("invalid.listener.attachment"),
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1124,8 +1124,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     public void visit(BLangSimpleVariableDef varDefNode) {
         this.checkStatementExecutionValidity(varDefNode);
         analyzeNode(varDefNode.var, env);
-        // validate for endpoints here.
-        validateEndpointDeclaration(varDefNode);
     }
 
     public void visit(BLangCompoundAssignment compoundAssignment) {
@@ -1478,39 +1476,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         if (invocationExpr.actionInvocation) {
             validateActionInvocation(invocationExpr.pos, invocationExpr);
-        }
-    }
-
-    private void validateEndpointDeclaration(BLangSimpleVariableDef varDefNode) {
-        if (Objects.isNull(varDefNode.var.symbol) || varDefNode.var.symbol.tag != SymTag.ENDPOINT ||
-                Objects.isNull(varDefNode.parent) || Objects
-                .isNull(varDefNode.parent.parent)) {
-            return;
-        }
-        // Check for valid parents nodes. (immediate parent is block node)
-        switch (varDefNode.parent.parent.getKind()) {
-            case RESOURCE:
-            case FUNCTION:
-                break;
-            default:
-                dlog.error(varDefNode.pos, DiagnosticCode.INVALID_ENDPOINT_DECLARATION);
-                return;
-        }
-        // Check with siblings now.
-        BLangBlockStmt blockStmt = (BLangBlockStmt) varDefNode.parent;
-        for (BLangStatement statement : blockStmt.stmts) {
-            if (statement == varDefNode) {
-                break;
-            }
-            if (statement.getKind() != NodeKind.VARIABLE_DEF) {
-                dlog.error(varDefNode.pos, DiagnosticCode.INVALID_ENDPOINT_DECLARATION);
-                break;
-            }
-            BLangSimpleVariableDef def = (BLangSimpleVariableDef) statement;
-            if (def.var.symbol.tag != SymTag.ENDPOINT) {
-                dlog.error(varDefNode.pos, DiagnosticCode.INVALID_ENDPOINT_DECLARATION);
-                break;
-            }
         }
     }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -518,9 +518,6 @@ error.remote.on.non.remote.function=\
 error.remote.required.on.remote.function=\
   remote modifier required here
 
-error.invalid.endpoint.declaration=\
-  client object declaration not allowed here, declare at the top of a function or at module level
-
 error.invalid.listener.var=\
   listener variable incompatible types: ''{0}'' is not an AbstractListener object
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
@@ -61,6 +61,24 @@ public class ClientObjectTest {
     }
 
     @Test
+    public void testEndPointDeclInALoop() {
+        BValue[] result = BRunUtil.invoke(remoteBasic, "clientObjectDeclaredInLoop");
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 10);
+    }
+
+    @Test
+    public void testEndPointDeclInAIfStmtIfBlock() {
+        BValue[] result = BRunUtil.invoke(remoteBasic, "clientObjectDeclaredInIfStatement");
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 10);
+    }
+
+    @Test
+    public void testEndPointDeclInAIfStmtElseBlock() {
+        BValue[] result = BRunUtil.invoke(remoteBasic, "clientObjectDeclaredInIfStatementElseBlock");
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 10);
+    }
+
+    @Test
     public void testReferringEndpointInDifferentPkg() {
         CompileResult compileResult = BCompileUtil.compile(this, "test-src/endpoint", "pkg.bc");
 
@@ -102,30 +120,17 @@ public class ClientObjectTest {
         BAssertUtil
                 .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
                         75, 9);
-        BAssertUtil.validateError(compileResult, errIdx++,
-                "client object declaration not allowed here, declare at the top of a function or at module level", 89,
-                9);
-        BAssertUtil.validateError(compileResult, errIdx++,
-                "client object declaration not allowed here, declare at the top of a function or at module level", 97,
-                9);
-
         BAssertUtil
                 .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                        112, 13);
+                        91, 13);
         BAssertUtil
                 .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                        120, 13);
-        BAssertUtil.validateError(compileResult, errIdx++,
-                "client object declaration not allowed here, declare at the top of a function or at module level", 126,
-                5);
-        BAssertUtil.validateError(compileResult, errIdx++,
-                "client object declaration not allowed here, declare at the top of a function or at module level", 134,
-                5);
-        BAssertUtil.validateError(compileResult, errIdx++, "variable 'ep' is not initialized", 142, 12);
-        BAssertUtil.validateError(compileResult, errIdx++, "variable 'ep' is not initialized", 149, 13);
+                        99, 13);
+        BAssertUtil.validateError(compileResult, errIdx++, "variable 'ep' is not initialized", 106, 12);
+        BAssertUtil.validateError(compileResult, errIdx++, "variable 'ep' is not initialized", 113, 13);
 
-        BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 154, 5);
-        BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 163, 5);
+        BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 118, 5);
+        BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 127, 5);
         Assert.assertEquals(compileResult.getErrorCount(), errIdx);
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 type TestEP client object {
     remote function action1(string s, int i) returns boolean {
         if (i > 5) {
@@ -31,7 +32,6 @@ type TestEP client object {
         return 5;
     }
 };
-
 
 remote function TestEP.action2(string s, boolean b) returns int {
     return 10;
@@ -67,4 +67,34 @@ type TestObject object {
 function test3() returns boolean {
     TestObject x = new;
     return x.test();
+}
+
+function clientObjectDeclaredInLoop() returns int {
+    foreach var index in 1...3 {
+        TestEP x = new;
+        if (4 - 2 == 2) {
+            return x->action2("0", false);
+        }
+    }
+    return 0;
+}
+
+function clientObjectDeclaredInIfStatement() returns int {
+    if (4 - 2 == 2) {
+        TestEP x = new;
+        return x->action2("0", false);
+    }
+    return 0;
+}
+
+function clientObjectDeclaredInIfStatementElseBlock() returns int {
+    if (4 - 2 == 0) {
+        return 0;
+    } else {
+        int i = 0;
+        int j = 100;
+        int k = i + j;
+        TestEP x = new;
+        return x->action2("0", false);
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic_negative.bal
@@ -81,27 +81,6 @@ type Bar object {
    }
 };
 
-function testFunc3() {
-    Bar b = new;
-    int i = 10;
-    if(i > 5) {
-        // endpoint declaration not allowed here, declare at the top of a function or at module level
-        Foo x = new;
-        var y = x->pqr("test");
-    }
-}
-
-function testFunc4() {
-    worker w1{
-        // endpoint declaration not allowed here, declare at the top of a function or at module level
-        Foo x = new;
-        var y = x->pqr("test");
-    }
-    worker w2 {
-        int i = 10;
-    }
-}
-
 // valid.
 Foo gep = new;
 
@@ -118,21 +97,6 @@ function testFunc6(Foo ep, string b) {
 
     // invalid remote function invocation syntax, use '->' operator
     var z = ep.pqr("test");
-}
-
-function testFunc7 (string s) {
-    string a = "abc";
-    // endpoint declaration not allowed here, declare at the top of a function or at module level
-    Foo ep = new;
-    var y = ep->pqr("test");
-}
-
-function testFunc8 (string s) {
-    Foo ep;
-    string a = "abc";
-    // endpoint declaration not allowed here, declare at the top of a function or at module level
-    Foo ep2 = new;
-    var y = ep2->pqr("test");
 }
 
 function testFunc9 (string s) returns boolean{


### PR DESCRIPTION
## Purpose
There is a constraint on Ballerina to only allow client object declarations to go on module level or as the first statement(s) (if there are multiple such declarations) of a function. This PR remove that constraint.

Following is valid now.
```ballerina
import ballerina/http;
import ballerina/io;

public function main() {
    io:println("GET request:");
    foreach var item in 1...3 {
        http:Client clientEndpoint = new("https://postman-echo.com");
        var response = clientEndpoint->get("/get?test=123");
        io:println(response);
    }
}
```
output
```
GET request:
{statusCode:200, reasonPhrase:"OK", server:"nginx", resolvedRequestedURI:"", cacheControl:()}
{statusCode:200, reasonPhrase:"OK", server:"nginx", resolvedRequestedURI:"", cacheControl:()}
{statusCode:200, reasonPhrase:"OK", server:"nginx", resolvedRequestedURI:"", cacheControl:()}
```


This PR fixes https://github.com/ballerina-platform/ballerina-lang/issues/14299