### PR TITLE
Add function invocation expanding to diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,5 @@ All notable changes to this project will be documented in this file. When sendin
 
 ### Tooling
 
--
+- Added feature of function invocation collapsing to the diagram editor
 -

--- a/composer/packages/diagram/src/config/default.ts
+++ b/composer/packages/diagram/src/config/default.ts
@@ -14,6 +14,10 @@ export class DiagramConfig {
 
     public statement = {
         actionHeight: STATEMENT_HEIGHT * 2,
+        expanded: {
+            header: 30,
+            offset: 20,
+        },
         height: STATEMENT_HEIGHT,
         margin: {
             bottom: 0,

--- a/composer/packages/diagram/src/config/default.ts
+++ b/composer/packages/diagram/src/config/default.ts
@@ -15,10 +15,11 @@ export class DiagramConfig {
     public statement = {
         actionHeight: STATEMENT_HEIGHT * 2,
         expanded: {
+            bottomMargin: 10,
             footer: 10,
             header: 40,
             margin: 20,
-            offset: 20,
+            offset: 45,
         },
         height: STATEMENT_HEIGHT,
         margin: {

--- a/composer/packages/diagram/src/config/default.ts
+++ b/composer/packages/diagram/src/config/default.ts
@@ -15,7 +15,9 @@ export class DiagramConfig {
     public statement = {
         actionHeight: STATEMENT_HEIGHT * 2,
         expanded: {
-            header: 30,
+            footer: 10,
+            header: 40,
+            margin: 20,
             offset: 20,
         },
         height: STATEMENT_HEIGHT,

--- a/composer/packages/diagram/src/config/default.ts
+++ b/composer/packages/diagram/src/config/default.ts
@@ -17,7 +17,7 @@ export class DiagramConfig {
         expanded: {
             bottomMargin: 10,
             footer: 10,
-            header: 30,
+            header: 40,
             margin: 20,
             offset: 45,
         },

--- a/composer/packages/diagram/src/config/default.ts
+++ b/composer/packages/diagram/src/config/default.ts
@@ -17,7 +17,7 @@ export class DiagramConfig {
         expanded: {
             bottomMargin: 10,
             footer: 10,
-            header: 40,
+            header: 30,
             margin: 20,
             offset: 45,
         },

--- a/composer/packages/diagram/src/diagram/diagram-context.ts
+++ b/composer/packages/diagram/src/diagram/diagram-context.ts
@@ -14,6 +14,7 @@ export interface IDiagramContext {
     toggleEditing: () => void;
     diagramHeight: number;
     diagramWidth: number;
+    update: () => void;
     zoomLevel: number;
     zoomIn: () => void;
     zoomOut: () => void;
@@ -35,6 +36,9 @@ const defaultDiagramContext: IDiagramContext = {
     hasSyntaxErrors: false,
     mode: DiagramMode.ACTION,
     toggleEditing: () => {
+        // do nothing
+    },
+    update: () => {
         // do nothing
     },
     zoomFit: () => {

--- a/composer/packages/diagram/src/diagram/diagram-utils.tsx
+++ b/composer/packages/diagram/src/diagram/diagram-utils.tsx
@@ -14,6 +14,7 @@ const textElement = document.createElementNS("http://www.w3.org/2000/svg", "text
 svg.appendChild(textElement);
 document.body.appendChild(svg);
 
+const ellipsesLength = getEllipsesLength();
 export class DiagramUtils {
 
     public static getComponents(nodeArray: any): React.ReactNode[] {
@@ -51,7 +52,8 @@ export class DiagramUtils {
         text = text.trim();
         textElement.innerHTML = _.escape(text);
 
-        let width = paddingLeft + textElement.getComputedTextLength() + paddingRight;
+        let labelWidth = textElement.getComputedTextLength();
+        let width = paddingLeft + labelWidth + paddingRight;
 
         // if the width is more then max width crop the text
         if (width <= minWidth) {
@@ -72,10 +74,12 @@ export class DiagramUtils {
             }
             // We need room for the ellipses as well, hence removing 'ellipses.length' no. of characters.
             text = text.substring(0, (possibleCharactersCount - ellipses.length)) + ellipses; // Appending ellipses.
-
+            labelWidth = textElement.getSubStringLength(
+                0, (possibleCharactersCount - ellipses.length)) + ellipsesLength;
             width = maxWidth;
         }
         return {
+            labelWidth,
             text,
             w: width,
         };
@@ -87,4 +91,9 @@ export class DiagramUtils {
     public static getConfig(): DiagramConfig {
         return DefaultConfig;
     }
+}
+
+function getEllipsesLength() {
+    textElement.textContent = "...";
+    return textElement.getComputedTextLength();
 }

--- a/composer/packages/diagram/src/diagram/diagram.tsx
+++ b/composer/packages/diagram/src/diagram/diagram.tsx
@@ -114,6 +114,9 @@ export class Diagram extends React.Component<DiagramProps, DiagramState> {
             diagramHeight: diagramSize.h,
             diagramWidth: diagramSize.w,
             mode: currentMode,
+            update: () => {
+                this.forceUpdate();
+            },
             zoomFit: () => {
                 this.setState({
                     currentZoom: 1

--- a/composer/packages/diagram/src/view-model/endpoint.ts
+++ b/composer/packages/diagram/src/view-model/endpoint.ts
@@ -3,6 +3,7 @@ import { ViewState } from "./view-state";
 export class EndpointViewState extends ViewState {
     public visible: boolean = false;
     public usedAsClient: boolean = false;
+    public actualEpName?: string;
 
     constructor() {
         super();

--- a/composer/packages/diagram/src/view-model/expand-context.ts
+++ b/composer/packages/diagram/src/view-model/expand-context.ts
@@ -1,8 +1,7 @@
-import { ASTNode, Invocation } from "@ballerina/ast-model";
+import { Function as BalFunction, Invocation } from "@ballerina/ast-model";
 
 export class ExpandContext {
-    public expandedSubTree: ASTNode | undefined;
-    public expanderX: number = 0; // TODO: Check if this is xpneeded
+    public expandedSubTree: BalFunction | undefined;
     public expandedSubTreeDocUri: string = ""; // The uri of the bal file where the definition is in
     public expandableNode: Invocation;
 

--- a/composer/packages/diagram/src/view-model/expand-context.ts
+++ b/composer/packages/diagram/src/view-model/expand-context.ts
@@ -1,0 +1,12 @@
+import { ASTNode, Invocation } from "@ballerina/ast-model";
+
+export class ExpandContext {
+    public expandedSubTree: ASTNode | undefined;
+    public expanderX: number = 0; // TODO: Check if this is xpneeded
+    public expandedSubTreeDocUri: string = ""; // The uri of the bal file where the definition is in
+    public expandableNode: Invocation;
+
+    constructor(expandableNode: Invocation) {
+        this.expandableNode = expandableNode;
+    }
+}

--- a/composer/packages/diagram/src/view-model/function.ts
+++ b/composer/packages/diagram/src/view-model/function.ts
@@ -1,3 +1,4 @@
+import { VisibleEndpoint } from "@ballerina/ast-model";
 import { ReturnViewState } from "./return";
 import { SimpleBBox } from "./simple-bbox";
 import { SimplePoint } from "./simple-point";
@@ -12,6 +13,9 @@ export class FunctionViewState extends ViewState {
     public menuTrigger: SimplePoint = new SimplePoint();
     public icon: string = "function";
     public implicitReturn: ReturnViewState = new ReturnViewState();
+    public isExpandedFunction: boolean = false;
+    public containingVisibleEndpoints: VisibleEndpoint[] = []; // The endpoints visible to
+    // functions expanded within this function
 
     constructor() {
         super();

--- a/composer/packages/diagram/src/view-model/simple-bbox.ts
+++ b/composer/packages/diagram/src/view-model/simple-bbox.ts
@@ -7,5 +7,6 @@ export class SimpleBBox {
     public opaque: boolean = false;
     public leftMargin: number = 0;
     public label: string = "";
+    public labelWidth: number = 0;
     public paddingTop: number = 0;
 }

--- a/composer/packages/diagram/src/view-model/statement.ts
+++ b/composer/packages/diagram/src/view-model/statement.ts
@@ -1,9 +1,13 @@
+import { ASTNode } from "@ballerina/ast-model";
 import { ViewState } from "./view-state";
 
 export class StmntViewState extends ViewState {
     public isAction: boolean = false;
     public isReturn: boolean = false;
     public endpoint: ViewState = new ViewState();
+    public expanded: boolean = false;
+    public expandedSubTree: ASTNode | undefined = undefined;
+    public expandedSubTreeDocUri: string = "";
 
     constructor() {
         super();

--- a/composer/packages/diagram/src/view-model/statement.ts
+++ b/composer/packages/diagram/src/view-model/statement.ts
@@ -1,13 +1,11 @@
-import { ASTNode } from "@ballerina/ast-model";
+import { ExpandContext } from "./expand-context";
 import { ViewState } from "./view-state";
 
 export class StmntViewState extends ViewState {
     public isAction: boolean = false;
     public isReturn: boolean = false;
     public endpoint: ViewState = new ViewState();
-    public expanded: boolean = false;
-    public expandedSubTree: ASTNode | undefined = undefined;
-    public expandedSubTreeDocUri: string = "";
+    public expandContext: ExpandContext | undefined;
 
     constructor() {
         super();

--- a/composer/packages/diagram/src/views/components/block.tsx
+++ b/composer/packages/diagram/src/views/components/block.tsx
@@ -35,8 +35,6 @@ export class Block extends React.Component<{ model: BlockNode }, { isHovered: bo
             const returnViewState: ViewState = ((model.parent as FunctionNode)
                     .viewState as FunctionViewState)
                     .implicitReturn;
-            returnViewState.bBox.x = triggerPosition.x;
-            returnViewState.bBox.y = triggerPosition.y;
             implicitReturn.viewState = returnViewState;
             if (!(implicitReturn.viewState as ReturnViewState).hidden) {
                 additionalComponents.push(<Return model={implicitReturn} />);

--- a/composer/packages/diagram/src/views/components/expanded-function.tsx
+++ b/composer/packages/diagram/src/views/components/expanded-function.tsx
@@ -56,36 +56,33 @@ export const ExpandedFunction: React.SFC<ExpandedFunctionProps> = ({ model, docU
                 }
 
                 return (
-                    <g>
-                        <rect className="expanded-func-frame"
+                    <g className="expanded-func">
+                        <rect className="frame"
                             x={bBox.x - config.statement.expanded.margin}
                             y={bBox.y + config.statement.height / 2}
                             width={bBox.w + config.statement.expanded.margin}
                             height={bBox.h - config.statement.expanded.footer - (config.statement.height / 2)}/>
-                        <rect className="expanded-func-name-background"
+                        <rect className="name-background"
                             x={bBox.statement.x - 2}
                             y={bBox.y}
                             width={bBox.statement.textWidth + 10}
                             height={config.statement.height}/>
-                        <text className="expanded-func-name"
+                        <text className="func-name"
                             x={bBox.statement.x}
                             y={bBox.statement.y + (config.statement.height / 2)}>
                             {bBox.statement.text}
                         </text>
-                        <text className="expanded-func-collapser"
+                        <text className="collapser"
                             x={bBox.statement.x + bBox.w - 30}
                             y={bBox.statement.y + config.statement.height + 5}
                             onClick={onClickClose}>
                             {getCodePoint("up")}
                         </text>
-
-                        <g className="life-line">
-                            <line x1={bBox.x}
-                                x2={expandedFnBbox.x}
-                                y1={expandedFnBbox.y}
-                                y2={expandedFnBbox.y} />
-                            <line { ...lifeLine } />
-                        </g>
+                        <line className="life-line" x1={bBox.x}
+                            x2={expandedFnBbox.x}
+                            y1={expandedFnBbox.y}
+                            y2={expandedFnBbox.y} />
+                        <line className="life-line" { ...lifeLine } />
                         { /* Override the docUri context value */ }
                         <DiagramContext.Provider value={{ ...context, docUri }}>
                             {workers.map((worker) => {

--- a/composer/packages/diagram/src/views/components/expanded-function.tsx
+++ b/composer/packages/diagram/src/views/components/expanded-function.tsx
@@ -1,0 +1,118 @@
+import { ASTNode, ASTUtil, Function as BallerinaFunction, NodePosition } from "@ballerina/ast-model";
+import { getCodePoint } from "@ballerina/font";
+import { BallerinaAST, IBallerinaLangClient } from "@ballerina/lang-service";
+import * as React from "react";
+import { DiagramContext } from "../../diagram/index";
+import { StmntViewState } from "../../view-model/index";
+import { visitor as initVisitor } from "../../visitors/init-visitor";
+import { Block } from "./block";
+
+interface ExpandedFunctionProps {
+    model: BallerinaFunction;
+    docUri: string;
+    bBox: any;
+}
+
+export const ExpandedFunction: React.SFC<ExpandedFunctionProps> = ({ model, docUri, bBox }) => {
+    return (
+        <DiagramContext.Consumer>
+            {(context) => {
+                if (!model.body) {
+                    return null;
+                }
+                return (
+                    // Override the docUri context value
+                    <g>
+                        <g className="life-line">
+                            <line x1={bBox.x} x2={bBox.x} y1={bBox.y} y2={bBox.y + bBox.h} />
+                        </g>
+                        <DiagramContext.Provider value={{ ...context, docUri }}>
+                            <Block model={model.body} />
+                        </DiagramContext.Provider>
+                    </g>
+                );
+            }}
+        </DiagramContext.Consumer>
+    );
+};
+
+interface FunctionExpanderProps {
+    x: number;
+    y: number;
+    position: NodePosition;
+    viewState: StmntViewState;
+}
+
+export const FunctionExpander: React.SFC<FunctionExpanderProps> = ({ x, y, position, viewState }) => {
+    return (
+        <DiagramContext.Consumer>
+            {({ langClient, docUri, update }) => (
+                <text x={x} y={y} onClick={getExpandFunctionHandler(langClient, docUri, position, viewState, update)}>
+                    {getCodePoint("down")}
+                </text>
+            )}
+        </DiagramContext.Consumer>
+    );
+};
+
+function getExpandFunctionHandler(
+    langClient: IBallerinaLangClient | undefined, docUri: string | undefined,
+    position: NodePosition, viewState: StmntViewState, update: () => void) {
+
+    return async (e: React.MouseEvent<SVGTextElement>) => {
+        if (!langClient || !docUri) {
+            return;
+        }
+
+        const res = await langClient.getDefinitionPosition({
+            position: {
+                character: position.startColumn,
+                line: position.startLine - 1,
+            },
+            textDocument: {
+                uri: docUri,
+            },
+        });
+
+        const astRes = await langClient.getAST({
+            documentIdentifier: {
+                uri: res.uri
+            }
+        });
+
+        const subTree = findDefinitionSubTree({
+            endColumn: res.range.end.character + 1,
+            endLine: res.range.end.line + 1,
+            startColumn: res.range.start.character + 1,
+            startLine: res.range.start.line + 1,
+        }, astRes.ast);
+
+        const defTree = subTree as BallerinaFunction;
+
+        ASTUtil.traversNode(defTree, initVisitor);
+
+        viewState.expanded = true;
+        viewState.expandedSubTree = defTree;
+        viewState.expandedSubTreeDocUri = res.uri;
+        update();
+    };
+}
+
+function findDefinitionSubTree(position: NodePosition, ast: BallerinaAST) {
+    return ast.topLevelNodes.find((balNode) => {
+        const node = balNode as ASTNode;
+        if (!node.position) {
+            return false;
+        }
+
+        if (node.position.startColumn === position.startColumn &&
+            node.position.endColumn === position.endColumn &&
+            node.position.startLine === position.startLine &&
+            node.position.endLine === position.endLine) {
+
+            return true;
+        }
+
+        return false;
+    });
+}

--- a/composer/packages/diagram/src/views/components/expanded-function.tsx
+++ b/composer/packages/diagram/src/views/components/expanded-function.tsx
@@ -1,31 +1,73 @@
 import { ASTNode, ASTUtil, Function as BallerinaFunction, NodePosition } from "@ballerina/ast-model";
-import { getCodePoint } from "@ballerina/font";
 import { BallerinaAST, IBallerinaLangClient } from "@ballerina/lang-service";
 import * as React from "react";
+import { DiagramConfig } from "../../config/default";
+import { DiagramUtils } from "../../diagram/diagram-utils";
 import { DiagramContext } from "../../diagram/index";
-import { StmntViewState } from "../../view-model/index";
+import { getCodePoint } from "../../utils";
+import { BlockViewState } from "../../view-model/block";
+import { ExpandContext } from "../../view-model/expand-context";
+import { FunctionViewState } from "../../view-model/index";
 import { visitor as initVisitor } from "../../visitors/init-visitor";
 import { Block } from "./block";
+
+const config: DiagramConfig = DiagramUtils.getConfig();
 
 interface ExpandedFunctionProps {
     model: BallerinaFunction;
     docUri: string;
     bBox: any;
+    onClose: () => void;
 }
 
-export const ExpandedFunction: React.SFC<ExpandedFunctionProps> = ({ model, docUri, bBox }) => {
+export const ExpandedFunction: React.SFC<ExpandedFunctionProps> = ({ model, docUri, bBox, onClose }) => {
+    if (!model.body) {
+        return null;
+    }
+
+    const expandedFnViewState = model.body.viewState as BlockViewState;
+    const expandedFnBbox = expandedFnViewState.bBox;
+
     return (
         <DiagramContext.Consumer>
             {(context) => {
                 if (!model.body) {
                     return null;
                 }
+
+                const onClickClose = () => {
+                    onClose();
+                    context.update();
+                };
+
                 return (
-                    // Override the docUri context value
                     <g>
+                        <rect className="expanded-func-frame"
+                            x={expandedFnBbox.x - expandedFnBbox.leftMargin - config.statement.expanded.margin}
+                            y={bBox.y}
+                            width={expandedFnBbox.w + expandedFnBbox.leftMargin + config.statement.expanded.margin}
+                            height={bBox.h}/>
+                        <text
+                            x={bBox.statement.x}
+                            y={bBox.statement.y + (config.statement.height / 2)}>
+                            {bBox.statement.text}
+                        </text>
+                        <text
+                            x={bBox.statement.x + bBox.statement.textWidth + 2}
+                            y={bBox.statement.y + (config.statement.height / 2)}
+                            onClick={onClickClose}>
+                            {getCodePoint("up")}
+                        </text>
                         <g className="life-line">
-                            <line x1={bBox.x} x2={bBox.x} y1={bBox.y} y2={bBox.y + bBox.h} />
+                            <line x1={bBox.x - config.statement.expanded.offset}
+                                x2={bBox.x}
+                                y1={bBox.y + config.statement.expanded.header}
+                                y2={bBox.y + config.statement.expanded.header} />
+                            <line x1={bBox.x} x2={bBox.x}
+                                y1={bBox.y + config.statement.expanded.header}
+                                y2={bBox.y + bBox.h - config.statement.expanded.footer} />
                         </g>
+                        { /* Override the docUri context value */ }
                         <DiagramContext.Provider value={{ ...context, docUri }}>
                             <Block model={model.body} />
                         </DiagramContext.Provider>
@@ -40,14 +82,15 @@ interface FunctionExpanderProps {
     x: number;
     y: number;
     position: NodePosition;
-    viewState: StmntViewState;
+    expandContext: ExpandContext;
 }
 
-export const FunctionExpander: React.SFC<FunctionExpanderProps> = ({ x, y, position, viewState }) => {
+export const FunctionExpander: React.SFC<FunctionExpanderProps> = ({ x, y, position, expandContext }) => {
     return (
         <DiagramContext.Consumer>
             {({ langClient, docUri, update }) => (
-                <text x={x} y={y} onClick={getExpandFunctionHandler(langClient, docUri, position, viewState, update)}>
+                <text x={x} y={y}
+                    onClick={getExpandFunctionHandler(langClient, docUri, position, expandContext, update)}>
                     {getCodePoint("down")}
                 </text>
             )}
@@ -57,7 +100,7 @@ export const FunctionExpander: React.SFC<FunctionExpanderProps> = ({ x, y, posit
 
 function getExpandFunctionHandler(
     langClient: IBallerinaLangClient | undefined, docUri: string | undefined,
-    position: NodePosition, viewState: StmntViewState, update: () => void) {
+    position: NodePosition, expandContext: ExpandContext, update: () => void) {
 
     return async (e: React.MouseEvent<SVGTextElement>) => {
         if (!langClient || !docUri) {
@@ -88,12 +131,13 @@ function getExpandFunctionHandler(
         }, astRes.ast);
 
         const defTree = subTree as BallerinaFunction;
-
         ASTUtil.traversNode(defTree, initVisitor);
 
-        viewState.expanded = true;
-        viewState.expandedSubTree = defTree;
-        viewState.expandedSubTreeDocUri = res.uri;
+        const viewState = defTree.viewState as FunctionViewState;
+        viewState.client.bBox.x = expandContext.expanderX - config.statement.expanded.offset;
+
+        expandContext.expandedSubTree = defTree;
+        expandContext.expandedSubTreeDocUri = res.uri;
         update();
     };
 }

--- a/composer/packages/diagram/src/views/components/function.tsx
+++ b/composer/packages/diagram/src/views/components/function.tsx
@@ -74,7 +74,7 @@ export const Function = (props: { model: FunctionNode }) => {
                 />
             }
             {model.body && <Block model={model.body} />}
-            {viewState.containingVisibleEndpoints
+            {model.VisibleEndpoints && model.VisibleEndpoints
                 .filter((element) => element.viewState.visible)
                 .map((element: VisibleEndpoint) => {
                     return <LifeLine title={element.name} icon="endpoint"

--- a/composer/packages/diagram/src/views/components/function.tsx
+++ b/composer/packages/diagram/src/views/components/function.tsx
@@ -1,23 +1,23 @@
 import {
     ASTUtil, Function as FunctionNode, Identifier,
-    Lambda, Literal, Variable, VariableDef, VisibleEndpoint
+    Literal, Variable, VariableDef, VisibleEndpoint
 } from "@ballerina/ast-model";
 import { BallerinaEndpoint } from "@ballerina/lang-service";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
-import { DiagramContext, IDiagramContext } from "../../diagram/index";
+import { DiagramContext } from "../../diagram/index";
 import { FunctionViewState } from "../../view-model/index";
-import { WorkerViewState } from "../../view-model/worker";
 import { AddWorkerOrEndpointMenu } from "./add-worker-or-endpoint-menu";
 import { Block } from "./block";
 import { LifeLine } from "./life-line";
 import { Panel } from "./panel";
 import { StartInvocation } from "./start-invocation";
+import { Worker } from "./worker";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
-export const Function = (props: { model: FunctionNode }, context: IDiagramContext) => {
+export const Function = (props: { model: FunctionNode }) => {
     const { model } = props;
     const viewState: FunctionViewState = model.viewState;
     if (model.lambda || model.body === undefined) { return <g />; }
@@ -29,19 +29,10 @@ export const Function = (props: { model: FunctionNode }, context: IDiagramContex
             <LifeLine title="Default" icon="worker" model={viewState.defaultWorker.lifeline.bBox}
                 astModel={model} />
             {model.body!.statements.filter((statement) => ASTUtil.isWorker(statement)).map((worker) => {
-                const workerViewState: WorkerViewState = worker.viewState;
-                const variable: Variable = ((worker as VariableDef).variable as Variable);
-                const lambda: Lambda = (variable.initialExpression as Lambda);
-                const functionNode = lambda.functionNode;
                 const startY = viewState.defaultWorker.initHeight + viewState.defaultWorker.bBox.y
-                + config.lifeLine.header.height - config.statement.height;
-                return <g>
-                    <StartInvocation client={viewState.defaultWorker.lifeline} worker={workerViewState.lifeline}
-                        y={startY} label="start" />
-                    <LifeLine title={workerViewState.name} icon="worker"
-                        model={workerViewState.lifeline.bBox} astModel={worker} />
-                    {functionNode.body && <Block model={functionNode.body} />}
-                </g>;
+                    + config.lifeLine.header.height - config.statement.height;
+                return <Worker
+                    model={worker as VariableDef} startY={startY} client={viewState.defaultWorker.lifeline} />;
             })}
             {model.resource ?
                 <StartInvocation
@@ -83,7 +74,7 @@ export const Function = (props: { model: FunctionNode }, context: IDiagramContex
                 />
             }
             {model.body && <Block model={model.body} />}
-            {model.VisibleEndpoints && model.VisibleEndpoints
+            {viewState.containingVisibleEndpoints
                 .filter((element) => element.viewState.visible)
                 .map((element: VisibleEndpoint) => {
                     return <LifeLine title={element.name} icon="endpoint"

--- a/composer/packages/diagram/src/views/components/return.tsx
+++ b/composer/packages/diagram/src/views/components/return.tsx
@@ -21,7 +21,6 @@ export const Return: React.StatelessComponent<{
         const returnLine = { x1: 1, y1: 0, x2: 0, y2: 0 };
         returnLine.x1 = model.viewState.bBox.x;
         returnLine.y1 = returnLine.y2 = model.viewState.bBox.y + config.statement.height;
-        // TODO: Following is a hack to fix object return need to revisit the logic.
         returnLine.x2 = model.viewState.client.bBox.x + (model.viewState.client.bBox.w / 2);
 
         if (viewState.isAction) {

--- a/composer/packages/diagram/src/views/components/return.tsx
+++ b/composer/packages/diagram/src/views/components/return.tsx
@@ -18,12 +18,11 @@ export const Return: React.StatelessComponent<{
         if (viewState.hidden) {
             return null;
         }
-
         const returnLine = { x1: 1, y1: 0, x2: 0, y2: 0 };
         returnLine.x1 = model.viewState.bBox.x;
         returnLine.y1 = returnLine.y2 = model.viewState.bBox.y + config.statement.height;
         // TODO: Following is a hack to fix object return need to revisit the logic.
-        returnLine.x2 = 90; // model.viewState.client.bBox.x + (model.viewState.client.bBox.w / 2);
+        returnLine.x2 = model.viewState.client.bBox.x + (model.viewState.client.bBox.w / 2);
 
         if (viewState.isAction) {
             returnLine.y2 = returnLine.y1 += (config.statement.height / 2);

--- a/composer/packages/diagram/src/views/components/source-linked-label.tsx
+++ b/composer/packages/diagram/src/views/components/source-linked-label.tsx
@@ -52,7 +52,8 @@ export const SourceLinkedLabel: React.StatelessComponent<{
                     }}
                 >
                     {text}
-                </text>)
+                </text>
+                )
             }
             </DiagramContext.Consumer>
         );

--- a/composer/packages/diagram/src/views/components/statement.tsx
+++ b/composer/packages/diagram/src/views/components/statement.tsx
@@ -40,8 +40,7 @@ export const Statement: React.StatelessComponent<{
             const expanderProps = {
                 expandContext: viewState.expandContext,
                 position: viewState.expandContext.expandableNode.position!,
-                x: viewState.bBox.x + viewState.bBox.labelWidth + 10,
-                y: viewState.bBox.y + (viewState.bBox.h / 2) + 2,
+                statementViewState: viewState,
             };
 
             expander = <FunctionExpander {...expanderProps}/>;
@@ -83,7 +82,10 @@ export const Statement: React.StatelessComponent<{
                     <HiddenBlock model={model} />
                 }
                 {!viewState.hiddenBlock &&
-                    <g className="statement">
+                    <g className="statement"
+                        onMouseEnter={() => {(viewState as any).hovered = true; console.log(viewState.hovered);}}
+                        onMouseLeave={() => {(viewState as any).hovered = false; console.log(viewState.hovered);}}
+                    >
                         {viewState.isAction && !viewState.isReturn
                             && <ActionInvocation
                                 model={viewState}

--- a/composer/packages/diagram/src/views/components/statement.tsx
+++ b/composer/packages/diagram/src/views/components/statement.tsx
@@ -1,10 +1,13 @@
-
-import { ASTNode, ASTUtil } from "@ballerina/ast-model";
+import {
+    Assignment, ASTKindChecker, ASTUtil, Break,
+    CompoundAssignment, ExpressionStatement, Function as BallerinaFunction, Panic, VariableDef
+} from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
 import { StmntViewState } from "../../view-model";
 import { ActionInvocation } from "./action-invocation";
+import { ExpandedFunction, FunctionExpander } from "./expanded-function";
 import { HiddenBlock } from "./hidden-block";
 import { ReturnActionInvocation } from "./return-action-invocation";
 import { SourceLinkedLabel } from "./source-linked-label";
@@ -12,7 +15,7 @@ import { SourceLinkedLabel } from "./source-linked-label";
 const config: DiagramConfig = DiagramUtils.getConfig();
 
 export const Statement: React.StatelessComponent<{
-    model: ASTNode
+    model: ExpressionStatement | VariableDef | Assignment | CompoundAssignment | Panic | Break
 }> = ({
     model
 }) => {
@@ -21,39 +24,70 @@ export const Statement: React.StatelessComponent<{
         let fullText = (model) ? ASTUtil.genSource(model) : label;
         fullText = fullText.replace(/\/\/.*$/gm, "");
 
+        let shouldDrawExpander = false;
+        let expandedPosition;
+
+        if (ASTKindChecker.isExpressionStatement(model) && ASTKindChecker.isInvocation(model.expression)) {
+            shouldDrawExpander = true;
+        }
+
+        const expanderProps = {
+            position: model.position,
+            viewState,
+            x: viewState.bBox.x + config.statement.padding.left,
+            y: viewState.bBox.y + (viewState.bBox.h / 2) + 3,
+        };
+
         const statementProps = {
             className: "statement",
             fullText,
             target: model,
             text: label,
-            x: viewState.bBox.x + config.statement.padding.left,
-            y: viewState.bBox.y + (viewState.bBox.h / 2)
+            x: expanderProps.x + 20,
+            y: viewState.bBox.y + (viewState.bBox.h / 2),
+        };
+
+        const expandedProps = {
+            bBox: {
+                h: viewState.bBox.h,
+                w: viewState.bBox.w,
+                x: viewState.bBox.x + config.statement.expanded.offset,
+                y: viewState.bBox.y,
+            }
         };
 
         return (
             <g>
-                { viewState.hiddenBlock &&
+                {viewState.hiddenBlock &&
                     <HiddenBlock model={model} />
                 }
-                { !viewState.hiddenBlock &&
-                <g className="statement">
-                    {viewState.isAction && !viewState.isReturn
-                        && <ActionInvocation
+                {!viewState.hiddenBlock &&
+                    <g className="statement">
+                        {viewState.isAction && !viewState.isReturn
+                            && <ActionInvocation
                                 model={viewState}
                                 action={viewState.bBox.label}
                                 astModel={model}
                             />}
-                    {viewState.isAction && viewState.isReturn
-                        && <ReturnActionInvocation
+                        {viewState.isAction && viewState.isReturn
+                            && <ReturnActionInvocation
                                 model={viewState}
                                 action={viewState.bBox.label}
                                 astModel={model}
                             />}
-                    {!viewState.isAction && !viewState.hiddenBlock  &&
-                        <SourceLinkedLabel {...statementProps}  />
-                    }
-                </g>
+                        {!viewState.isAction && !viewState.hiddenBlock && !viewState.expanded &&
+                            <SourceLinkedLabel {...statementProps} />
+                        }
+                        {!viewState.isAction && !viewState.hiddenBlock && !viewState.expanded &&
+                            <FunctionExpander {...expanderProps} />
+                        }
+                        {!viewState.isAction && !viewState.hiddenBlock &&
+                            viewState.expanded && viewState.expandedSubTree &&
+                            <ExpandedFunction model={viewState.expandedSubTree as BallerinaFunction}
+                                docUri={viewState.expandedSubTreeDocUri} bBox={expandedProps.bBox} />
+                        }
+                    </g>
                 }
             </g>
-            );
+        );
     };

--- a/composer/packages/diagram/src/views/components/statement.tsx
+++ b/composer/packages/diagram/src/views/components/statement.tsx
@@ -1,6 +1,6 @@
 import {
     Assignment, ASTUtil, Break,
-    CompoundAssignment, ExpressionStatement, Function as BallerinaFunction, Panic, VariableDef
+    CompoundAssignment, ExpressionStatement, Panic, VariableDef
 } from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
@@ -69,7 +69,7 @@ export const Statement: React.StatelessComponent<{
                 };
 
                 expandedFunction = <ExpandedFunction
-                    model={viewState.expandContext.expandedSubTree as BallerinaFunction}
+                    model={viewState.expandContext.expandedSubTree}
                     docUri={viewState.expandContext.expandedSubTreeDocUri}
                     bBox={expandedBBox}
                     onClose={onClose}

--- a/composer/packages/diagram/src/views/components/statement.tsx
+++ b/composer/packages/diagram/src/views/components/statement.tsx
@@ -51,14 +51,13 @@ export const Statement: React.StatelessComponent<{
                 const expandedBBox = {
                     h: viewState.bBox.h,
                     statement: {
-                        h: viewState.bBox.h,
                         text: label,
                         textWidth: viewState.bBox.labelWidth,
                         x: viewState.bBox.x + config.statement.padding.left,
                         y: viewState.bBox.y,
                     },
-                    w: viewState.bBox.w + viewState.bBox.leftMargin,
-                    x: viewState.bBox.x + config.statement.expanded.offset,
+                    w: viewState.bBox.w,
+                    x: viewState.bBox.x,
                     y: viewState.bBox.y,
                 };
 
@@ -83,8 +82,6 @@ export const Statement: React.StatelessComponent<{
                 }
                 {!viewState.hiddenBlock &&
                     <g className="statement"
-                        onMouseEnter={() => {(viewState as any).hovered = true; console.log(viewState.hovered);}}
-                        onMouseLeave={() => {(viewState as any).hovered = false; console.log(viewState.hovered);}}
                     >
                         {viewState.isAction && !viewState.isReturn
                             && <ActionInvocation

--- a/composer/packages/diagram/src/views/components/statement.tsx
+++ b/composer/packages/diagram/src/views/components/statement.tsx
@@ -40,6 +40,7 @@ export const Statement: React.StatelessComponent<{
             const expanderProps = {
                 expandContext: viewState.expandContext,
                 position: viewState.expandContext.expandableNode.position!,
+                statement: viewState.expandContext.expandableNode,
                 statementViewState: viewState,
             };
 

--- a/composer/packages/diagram/src/views/components/worker.tsx
+++ b/composer/packages/diagram/src/views/components/worker.tsx
@@ -1,0 +1,27 @@
+import { Lambda, VariableDef } from "@ballerina/ast-model";
+import * as React from "react";
+import { ViewState } from "../../view-model/index";
+import { WorkerViewState } from "../../view-model/worker";
+import { Block } from "./block";
+import { LifeLine } from "./life-line";
+import { StartInvocation } from "./start-invocation";
+
+interface WorkerProps {
+    model: VariableDef;
+    startY: number;
+    client: ViewState;
+}
+
+export const Worker: React.SFC<WorkerProps> = ({ model, startY, client }) => {
+    const workerViewState: WorkerViewState = model.viewState;
+    const variable = model.variable;
+    const lambda: Lambda = variable.initialExpression as Lambda;
+    const functionNode = lambda.functionNode;
+    return <g>
+        <StartInvocation client={client} worker={workerViewState.lifeline}
+            y={startY} label="start" />
+        <LifeLine title={workerViewState.name} icon="worker"
+            model={workerViewState.lifeline.bBox} astModel={model} />
+        {functionNode.body && <Block model={functionNode.body} />}
+    </g>;
+};

--- a/composer/packages/diagram/src/visitors/action-view.ts
+++ b/composer/packages/diagram/src/visitors/action-view.ts
@@ -1,4 +1,5 @@
 import { ASTKindChecker, ASTNode, ASTUtil, Block, Visitor } from "@ballerina/ast-model";
+import { StmntViewState } from "../view-model/index";
 
 let actionView = false;
 
@@ -31,6 +32,10 @@ export const visitor: Visitor = {
                 if (!ASTUtil.isWorker(element)) {
                     hiddenSet = false;
                 }
+            }
+            const viewState = element.viewState as StmntViewState;
+            if (viewState.expandContext && actionView) {
+                viewState.expandContext = undefined;
             }
         });
     }

--- a/composer/packages/diagram/src/visitors/init-visitor.ts
+++ b/composer/packages/diagram/src/visitors/init-visitor.ts
@@ -122,6 +122,11 @@ export const visitor: Visitor = {
 
     endVisitExpressionStatement(node: ExpressionStatement) {
         initStatement(node);
+
+        if (ASTUtil.isActionInvocation(node)) {
+            return;
+        }
+
         const viewState = node.viewState as StmntViewState;
         if (ASTKindChecker.isInvocation(node.expression) && !viewState.expandContext) {
             viewState.expandContext = new ExpandContext(node.expression);
@@ -130,6 +135,11 @@ export const visitor: Visitor = {
 
     endVisitVariableDef(node: VariableDef) {
         initStatement(node);
+
+        if (ASTUtil.isActionInvocation(node)) {
+            return;
+        }
+
         const viewState = node.viewState as StmntViewState;
         if (node.variable.initialExpression &&
             ASTKindChecker.isInvocation(node.variable.initialExpression) &&

--- a/composer/packages/diagram/src/visitors/init-visitor.ts
+++ b/composer/packages/diagram/src/visitors/init-visitor.ts
@@ -1,9 +1,10 @@
 import {
-    Assignment, ASTNode, ASTUtil, Block,
+    Assignment, ASTKindChecker, ASTNode, ASTUtil, Block,
     ExpressionStatement, Function, Return, VariableDef, VisibleEndpoint, Visitor, WorkerSend
 } from "@ballerina/ast-model";
 import { EndpointViewState, FunctionViewState, StmntViewState, ViewState } from "../view-model";
 import { BlockViewState } from "../view-model/block";
+import { ExpandContext } from "../view-model/expand-context";
 import { ReturnViewState } from "../view-model/return";
 import { WorkerViewState } from "../view-model/worker";
 import { WorkerSendViewState } from "../view-model/worker-send";
@@ -60,6 +61,10 @@ export const visitor: Visitor = {
 
     endVisitExpressionStatement(node: ExpressionStatement) {
         initStatement(node);
+        const viewState = node.viewState as StmntViewState;
+        if (ASTKindChecker.isInvocation(node.expression) && !viewState.expandContext) {
+            viewState.expandContext = new ExpandContext(node.expression);
+        }
     },
 
     endVisitVariableDef(node: VariableDef) {

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -6,7 +6,7 @@ import {
 import { DiagramConfig } from "../config/default";
 import { DiagramUtils } from "../diagram/diagram-utils";
 import { BlockViewState } from "../view-model/block";
-import { CompilationUnitViewState, FunctionViewState, ViewState } from "../view-model/index";
+import { CompilationUnitViewState, FunctionViewState, ViewState, StmntViewState } from "../view-model/index";
 import { WorkerViewState } from "../view-model/worker";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
@@ -145,9 +145,23 @@ export const visitor: Visitor = {
                 height += config.statement.height;
                 return;
             }
-            element.viewState.bBox.x = viewState.bBox.x;
-            element.viewState.bBox.y = viewState.bBox.y + element.viewState.bBox.paddingTop + height;
-            height += element.viewState.bBox.h + element.viewState.bBox.paddingTop;
+
+            const elViewStatement: StmntViewState = element.viewState;
+
+            elViewStatement.bBox.x = viewState.bBox.x;
+            elViewStatement.bBox.y = viewState.bBox.y + elViewStatement.bBox.paddingTop + height;
+            height += elViewStatement.bBox.h + elViewStatement.bBox.paddingTop;
+            if (elViewStatement.expanded) {
+                if (elViewStatement.expandedSubTree) {
+                    const expandedSubTree = elViewStatement.expandedSubTree as Function;
+                    if (expandedSubTree.body) {
+                        const bodyViewState = expandedSubTree.body.viewState as BlockViewState;
+                        bodyViewState.bBox.x = elViewStatement.bBox.x + config.statement.expanded.offset;
+                        bodyViewState.bBox.y = elViewStatement.bBox.y + config.statement.expanded.header;
+                        ASTUtil.traversNode(expandedSubTree.body, visitor);
+                    }
+                }
+            }
         });
         viewState.menuTrigger = {
             x: viewState.bBox.x,

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -1,12 +1,12 @@
 import {
     ASTKindChecker, ASTUtil, Block, CompilationUnit, Foreach,
-    Function, If, Lambda, Match, MatchStaticPatternClause, ObjectType, Service,
+    Function as BalFunction, If, Lambda, Match, MatchStaticPatternClause, ObjectType, Service,
     TypeDefinition, Variable, VariableDef, VisibleEndpoint, Visitor, While
 } from "@ballerina/ast-model";
 import { DiagramConfig } from "../config/default";
 import { DiagramUtils } from "../diagram/diagram-utils";
 import { BlockViewState } from "../view-model/block";
-import { CompilationUnitViewState, FunctionViewState, ViewState, StmntViewState } from "../view-model/index";
+import { CompilationUnitViewState, FunctionViewState, StmntViewState, ViewState } from "../view-model/index";
 import { WorkerViewState } from "../view-model/worker";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
@@ -64,7 +64,7 @@ export const visitor: Visitor = {
     },
 
     // tslint:disable-next-line:ban-types
-    beginVisitFunction(node: Function) {
+    beginVisitFunction(node: BalFunction) {
         if (node.lambda || !node.body) { return; }
         const viewState: FunctionViewState = node.viewState;
         const defaultWorker: WorkerViewState = node.viewState.defaultWorker;
@@ -151,14 +151,14 @@ export const visitor: Visitor = {
             elViewStatement.bBox.x = viewState.bBox.x;
             elViewStatement.bBox.y = viewState.bBox.y + elViewStatement.bBox.paddingTop + height;
             height += elViewStatement.bBox.h + elViewStatement.bBox.paddingTop;
-            if (elViewStatement.expanded) {
-                if (elViewStatement.expandedSubTree) {
-                    const expandedSubTree = elViewStatement.expandedSubTree as Function;
+            if (elViewStatement.expandContext) {
+                if (elViewStatement.expandContext.expandedSubTree) {
+                    const expandedSubTree = elViewStatement.expandContext.expandedSubTree as BalFunction;
                     if (expandedSubTree.body) {
                         const bodyViewState = expandedSubTree.body.viewState as BlockViewState;
                         bodyViewState.bBox.x = elViewStatement.bBox.x + config.statement.expanded.offset;
                         bodyViewState.bBox.y = elViewStatement.bBox.y + config.statement.expanded.header;
-                        ASTUtil.traversNode(expandedSubTree.body, visitor);
+                        ASTUtil.traversNode(expandedSubTree.body, visitor); // TODO create a 'new Visitor'
                     }
                 }
             }
@@ -201,7 +201,7 @@ export const visitor: Visitor = {
         const viewState: ViewState = node.viewState;
         let y = viewState.bBox.y + config.panelGroup.header.height;
         // tslint:disable-next-line:ban-types
-        node.resources.forEach((element: Function) => {
+        node.resources.forEach((element: BalFunction) => {
             element.viewState.bBox.x = viewState.bBox.x;
             element.viewState.bBox.y = y;
             y += element.viewState.bBox.h;
@@ -214,7 +214,7 @@ export const visitor: Visitor = {
         const viewState: ViewState = node.viewState;
         let y = viewState.bBox.y + config.panelGroup.header.height;
         // tslint:disable-next-line:ban-types
-        (node.typeNode as ObjectType).functions.forEach((element: Function) => {
+        (node.typeNode as ObjectType).functions.forEach((element: BalFunction) => {
             element.viewState.bBox.x = viewState.bBox.x;
             element.viewState.bBox.y = y;
             y += element.viewState.bBox.h;

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -171,7 +171,7 @@ export const visitor: Visitor = {
             height += elViewState.bBox.h + elViewState.bBox.paddingTop;
             if (elViewState.expandContext) {
                 if (elViewState.expandContext.expandedSubTree) {
-                    const expandedSubTree = elViewState.expandContext.expandedSubTree as BalFunction;
+                    const expandedSubTree = elViewState.expandContext.expandedSubTree;
                     const expandedFunctionVS = expandedSubTree.viewState as FunctionViewState;
 
                     expandedFunctionVS.bBox.x = elViewState.bBox.x;

--- a/composer/packages/diagram/src/visitors/sizing-visitor.ts
+++ b/composer/packages/diagram/src/visitors/sizing-visitor.ts
@@ -51,6 +51,18 @@ function sizeStatement(node: ASTNode) {
     if (node.viewState.hiddenBlock) {
         viewState.bBox.w = 60;
     }
+
+    if (viewState.expanded) {
+        if (viewState.expandedSubTree) {
+            const expandedSubTree = viewState.expandedSubTree as Function;
+
+            ASTUtil.traversNode(expandedSubTree, visitor);
+            if (expandedSubTree.body) {
+                const subTreeViewState = expandedSubTree.body.viewState;
+                viewState.bBox.h +=  (subTreeViewState.bBox.h + config.statement.expanded.header);
+            }
+        }
+    }
 }
 
 function sizeWorker(node: VariableDef, preWorkerHeight = 0, workerHolder: WorkerTuple[]) {

--- a/composer/packages/distribution/webpack.config.js
+++ b/composer/packages/distribution/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = {
         ]
     },
     devServer: {
+        disableHostCheck: true,
         contentBase: path.join(__dirname, 'build'),
         port: 9000
     },

--- a/composer/packages/lang-service/src/client/client.ts
+++ b/composer/packages/lang-service/src/client/client.ts
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:no-submodule-imports
 import { IConnection } from "monaco-languageclient/lib/connection";
-import { InitializeParams, InitializeResult } from "vscode-languageserver-protocol";
+import { InitializeParams, InitializeResult,
+    Location, TextDocumentPositionParams } from "vscode-languageserver-protocol";
 import { BallerinaASTNode, BallerinaEndpoint, BallerinaSourceFragment } from "./ast-models";
 import { ASTDidChangeParams, ASTDidChangeResponse, BallerinaExampleListParams,
     BallerinaExampleListResponse, BallerinaProject, GetASTParams, GetASTResponse,
@@ -46,6 +47,11 @@ export class BallerinaLangClient implements IBallerinaLangClient {
 
     public getBallerinaProject(params: GetBallerinaProjectParams): Thenable<BallerinaProject> {
         return this.lsConnection.sendRequest("ballerinaDocument/project", params);
+    }
+
+    public getDefinitionPosition(params: TextDocumentPositionParams): Thenable<Location> {
+        // TODO
+        return Promise.reject("Not implemented");
     }
 
     public goToSource(params: GoToSourceParams): void {

--- a/composer/packages/lang-service/src/client/model.ts
+++ b/composer/packages/lang-service/src/client/model.ts
@@ -1,4 +1,5 @@
-import { InitializeParams, InitializeResult, Position, Range } from "vscode-languageserver-protocol";
+import { InitializeParams, InitializeResult, Location, Position,
+    Range, TextDocumentPositionParams} from "vscode-languageserver-protocol";
 import { BallerinaAST, BallerinaASTNode, BallerinaEndpoint,
     BallerinaSourceFragment } from "./ast-models";
 
@@ -86,6 +87,8 @@ export interface IBallerinaLangClient {
     getEndpoints: () => Thenable<BallerinaEndpoint[]>;
 
     getBallerinaProject: (params: GetBallerinaProjectParams) => Thenable<BallerinaProject>;
+
+    getDefinitionPosition: (params: TextDocumentPositionParams) => Thenable<Location>;
 
     goToSource: (params: GoToSourceParams) => void;
 

--- a/composer/packages/lang-service/src/client/test-utils.ts
+++ b/composer/packages/lang-service/src/client/test-utils.ts
@@ -1,4 +1,5 @@
-import { InitializeParams, InitializeResult } from "vscode-languageserver-protocol";
+import { InitializeParams, InitializeResult,
+    Location, TextDocumentPositionParams } from "vscode-languageserver-protocol";
 import { BallerinaASTNode, BallerinaEndpoint, BallerinaSourceFragment } from "./ast-models";
 import { ASTDidChangeParams, ASTDidChangeResponse, BallerinaExampleListParams,
     BallerinaExampleListResponse, BallerinaProject, GetASTParams, GetASTResponse,
@@ -37,6 +38,10 @@ export class EmptyLanguageClient implements IBallerinaLangClient {
         return Promise.reject();
     }
 
+    public getDefinitionPosition(params: TextDocumentPositionParams): Thenable<Location> {
+        return Promise.reject();
+    }
+
     public goToSource(params: GoToSourceParams): void {
         // EMPTY
     }
@@ -46,6 +51,6 @@ export class EmptyLanguageClient implements IBallerinaLangClient {
     }
 
     public close(): void {
-        // EMTY
+        // EMPTY
     }
 }

--- a/composer/packages/theme/src/definitions/views/diagram.less
+++ b/composer/packages/theme/src/definitions/views/diagram.less
@@ -200,15 +200,21 @@
                         stroke: ~"@{@{color}-diagram-panel-body-background-color}";
                         stroke-width: 2px;
                     }
-                    .expanded-func-frame {
-                        stroke: color("#bbb");
-                        fill: none;
-                    }
-                    .expanded-func-name {
-                        font-weight: bold;
-                    }
-                    .expanded-func-collapser {
-                        stroke: color("#aaa");
+                    .expanded-func {
+                        .frame {
+                            stroke: ~"@{@{color}-diagram-expanded-func-frame-color}";
+                            fill: none;
+                        }
+                        .func-name {
+                            font-weight: bold;
+                        }
+                        .collapser {
+                            stroke: ~"@{@{color}-diagram-collapse-func-color}";
+                        }
+                        .life-line {
+                            stroke: ~"@{@{color}-diagram-condition-line-stroke-color}";
+                            stroke-width: @diagram-life-line-stroke-width;
+                        }
                     }
                 }
                 .worker-block-container {

--- a/composer/packages/theme/src/definitions/views/diagram.less
+++ b/composer/packages/theme/src/definitions/views/diagram.less
@@ -191,6 +191,11 @@
                         stroke: ~"@{@{color}-diagram-panel-body-background-color}";
                         stroke-width: 2px;
                     }
+                    .expanded-func-frame {
+                        stroke: ~"@{@{color}-diagram-condition-stroke-color}";
+                        stroke-dasharray: 3.5;
+                        fill: none;
+                    }
                 }
                 .worker-block-container {
                     .hover-rect {

--- a/composer/packages/theme/src/definitions/views/diagram.less
+++ b/composer/packages/theme/src/definitions/views/diagram.less
@@ -147,6 +147,15 @@
                     }
                     .statement {
                         font-size: @diagram-statement-font-size;
+                        .expander {
+                            visibility: hidden;
+                        }
+                    }
+                    .statement:hover > .expander {
+                        visibility: visible;
+                    }
+                    .expander:hover {
+                        visibility: visible;
                     }
                     .action-invocation {
                         line {

--- a/composer/packages/theme/src/definitions/views/diagram.less
+++ b/composer/packages/theme/src/definitions/views/diagram.less
@@ -201,9 +201,14 @@
                         stroke-width: 2px;
                     }
                     .expanded-func-frame {
-                        stroke: ~"@{@{color}-diagram-condition-stroke-color}";
-                        stroke-dasharray: 3.5;
+                        stroke: color("#bbb");
                         fill: none;
+                    }
+                    .expanded-func-name {
+                        font-weight: bold;
+                    }
+                    .expanded-func-collapser {
+                        stroke: color("#aaa");
                     }
                 }
                 .worker-block-container {

--- a/composer/packages/theme/src/themes/default/views/diagram.variables
+++ b/composer/packages/theme/src/themes/default/views/diagram.variables
@@ -43,6 +43,11 @@
 @dark-diagram-panel-header-text-color: @dark-diagram-base-text-color;
 @light-diagram-panel-body-background-color: @light-diagram-background-color;
 @dark-diagram-panel-body-background-color: @dark-diagram-background-color;
+@light-diagram-expanded-func-frame-color: #bbb;
+@dark-diagram-expanded-func-frame-color: #bbb;
+@light-diagram-collapse-func-color: #aaa;
+@dark-diagram-collapse-func-color: #aaa;
+
 
 
 /*-------------------

--- a/tool-plugins/vscode/.vscode/launch.json
+++ b/tool-plugins/vscode/.vscode/launch.json
@@ -15,7 +15,7 @@
         "env": {
             "LS_CUSTOM_CLASSPATH": "", 
             "LSDEBUG": "false",
-            "COMPOSER_DEBUG": "false",
+            "COMPOSER_DEBUG": "true",
             "COMPOSER_DEV_HOST": "http://localhost:9000"
         },
         "outFiles": [

--- a/tool-plugins/vscode/.vscode/launch.json
+++ b/tool-plugins/vscode/.vscode/launch.json
@@ -15,7 +15,7 @@
         "env": {
             "LS_CUSTOM_CLASSPATH": "", 
             "LSDEBUG": "false",
-            "COMPOSER_DEBUG": "true",
+            "COMPOSER_DEBUG": "false",
             "COMPOSER_DEV_HOST": "http://localhost:9000"
         },
         "outFiles": [

--- a/tool-plugins/vscode/resources/utils/messaging.js
+++ b/tool-plugins/vscode/resources/utils/messaging.js
@@ -119,6 +119,13 @@ function getLangClient() {
                     resolve(resp.samples);
                 });
             })
+        },
+        getDefinitionPosition: (params) => {
+            return new Promise((resolve, reject) => {
+                webViewRPCHandler.invokeRemoteMethod('getDefinitionPosition', [params], (resp) => {
+                    resolve(resp);
+                });
+            })
         }
     }
 }

--- a/tool-plugins/vscode/src/core/extended-language-client.ts
+++ b/tool-plugins/vscode/src/core/extended-language-client.ts
@@ -18,8 +18,8 @@
  *
  */
 
-import { LanguageClient } from "vscode-languageclient";
-import { Uri } from "vscode";
+import { LanguageClient, TextDocumentPositionParams } from "vscode-languageclient";
+import { Uri, Location, window } from "vscode";
 
 export const BALLERINA_LANG_ID = "ballerina";
 
@@ -186,5 +186,17 @@ export class ExtendedLangClient extends LanguageClient {
 
     getBallerinaProject(params: GetBallerinaProjectParams): Thenable<BallerinaProject> {
         return this.sendRequest("ballerinaDocument/project", params);
+    }
+
+    getDefinitionPosition(params: TextDocumentPositionParams): Thenable<Location> {
+        return this.sendRequest("textDocument/definition", params)
+        .then((res) => {
+            console.log(res);
+            const definitions = res as any;
+            if(!(definitions.length > 0)) {
+                return Promise.reject();
+            }
+            return definitions[0];
+        });
     }
 }

--- a/tool-plugins/vscode/src/core/extended-language-client.ts
+++ b/tool-plugins/vscode/src/core/extended-language-client.ts
@@ -19,7 +19,7 @@
  */
 
 import { LanguageClient, TextDocumentPositionParams } from "vscode-languageclient";
-import { Uri, Location, window } from "vscode";
+import { Uri, Location } from "vscode";
 
 export const BALLERINA_LANG_ID = "ballerina";
 

--- a/tool-plugins/vscode/src/diagram/activator.ts
+++ b/tool-plugins/vscode/src/diagram/activator.ts
@@ -90,21 +90,6 @@ function showDiagramEditor(context: ExtensionContext, langClient: ExtendedLangCl
 	if (diagramViewPanel && html) {
 		diagramViewPanel.webview.html = html;
 	}
-	// Handle messages from the webview
-	diagramViewPanel.webview.onDidReceiveMessage(message => {
-		switch (message.command) {
-			case 'astModified':
-				if (activeEditor && activeEditor.document.fileName.endsWith('.bal')) {
-					preventDiagramUpdate = true;
-					const ast = JSON.parse(message.ast);
-					langClient.triggerASTDidChange(ast, activeEditor.document.uri)
-						.then(() => {
-							preventDiagramUpdate = false;
-						});	
-				}
-				return;
-		}
-	}, undefined, context.subscriptions);
 
 	diagramViewPanel.onDidDispose(() => {
 		diagramViewPanel = undefined;

--- a/tool-plugins/vscode/src/diagram/renderer.ts
+++ b/tool-plugins/vscode/src/diagram/renderer.ts
@@ -57,6 +57,7 @@ function renderDiagram(context: ExtensionContext, docUri: Uri): string {
 
     const script = `
         function loadedScript() {
+            window.langclient = getLangClient();
             let docUri = ${JSON.stringify(docUri.toString())};
             function drawDiagram() {
                 try {

--- a/tool-plugins/vscode/src/utils/rpc/handler.ts
+++ b/tool-plugins/vscode/src/utils/rpc/handler.ts
@@ -89,7 +89,14 @@ const getLangClientMethods = (langClient: ExtendedLangClient): WebViewMethod[] =
                 return langClient.fetchExamples();
             });
         }
-    }];
+    },
+    {
+        methodName: 'getDefinitionPosition',
+        handler: (args: any[]) => {
+            return langClient.getDefinitionPosition(args[0]);
+        }
+    }
+    ];
 };
 
 const undoRedoMethods = [{
@@ -125,9 +132,9 @@ export class WebViewRPCHandler {
     private _getMethod(methodName: string) {
         return this.methods.find(method => (method.methodName === methodName));
     }
-    
+
     private _onRemoteMessage(msg: WebViewRPCMessage) {
-        if (msg.id) {
+        if (msg.id !== undefined) {
             // this is a request from remote
             const method = this._getMethod(msg.methodName);
             if (method) {
@@ -139,7 +146,7 @@ export class WebViewRPCHandler {
                         });
                     });
             }
-        } else if (msg.originId) {
+        } else if (msg.originId !== undefined) {
             // this is a response from remote to one of our requests
             const callback = this._callbacks.get(msg.originId);
             if (callback) {


### PR DESCRIPTION
## Purpose
Add feature of expanding function invocations to diagram editor

## Approach

* Simple function invocation
<img width="535" alt="image" src="https://user-images.githubusercontent.com/3872221/55054363-9740f580-5085-11e9-971a-453e6fe2fcf9.png">

* Invocation of a function with workers
<img width="719" alt="image" src="https://user-images.githubusercontent.com/3872221/55054516-2bab5800-5086-11e9-9c4a-6599fbd98437.png">

* Function with endpoint parameters
<img width="698" alt="image" src="https://user-images.githubusercontent.com/3872221/55054564-5c8b8d00-5086-11e9-8336-aaf938d12188.png">

* Function with an endpoint parameter and local endpoints
<img width="734" alt="image" src="https://user-images.githubusercontent.com/3872221/55054631-92307600-5086-11e9-8c4f-fdc06a552c27.png">
