### PR TITLE
Add formatting support for index access

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingNodeTree.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingNodeTree.java
@@ -640,16 +640,6 @@ public class FormattingNodeTree {
     }
 
     /**
-     * format Compensate node.
-     *
-     * @param node {JsonObject} node as json object
-     */
-    public void formatCompensateNode(JsonObject node) {
-        // TODO: fix formatting for check expression.
-        this.skipFormatting(node, true);
-    }
-
-    /**
      * format Compilation Unit node.
      *
      * @param node {JsonObject} node as json object
@@ -2071,8 +2061,41 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatIndexBasedAccessExprNode(JsonObject node) {
-        // TODO: fix formatting for index based access expression.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+
+            this.preserveHeight(ws, formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean()
+                    ? indentationOfParent : indentation);
+
+            // Iterate and update index based access expr.
+            for (JsonElement wsItem : ws) {
+                JsonObject currentWS = wsItem.getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                    if (text.equals("[") || text.equals("]")) {
+                        currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                    }
+                }
+            }
+
+            // Handle formatting for the expression.
+            if (node.has(FormattingConstants.EXPRESSION)) {
+                node.getAsJsonObject(FormattingConstants.EXPRESSION).add(FormattingConstants.FORMATTING_CONFIG,
+                        formatConfig);
+            }
+
+            // Handle formatting for the index.
+            if (node.has("index")) {
+                node.getAsJsonObject("index").add(FormattingConstants.FORMATTING_CONFIG,
+                        this.getFormattingConfig(0, 0, 0, false,
+                                this.getWhiteSpaceCount(formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION)
+                                        .getAsBoolean() ? indentationOfParent : indentation), true));
+            }
+        }
     }
 
     /**
@@ -2193,16 +2216,6 @@ public class FormattingNodeTree {
                         argumentExpressions);
             }
         }
-    }
-
-    /**
-     * format Is Like node.
-     *
-     * @param node {JsonObject} node as json object
-     */
-    public void formatIsLikeNode(JsonObject node) {
-        // TODO: fix formatting for Is Like.
-        this.skipFormatting(node, true);
     }
 
     /**
@@ -4050,16 +4063,6 @@ public class FormattingNodeTree {
                                 this.getWhiteSpaceCount(indentationOfParent), true));
             }
         }
-    }
-
-    /**
-     * format Throw node.
-     *
-     * @param node {JsonObject} node as json object
-     */
-    public void formatThrowNode(JsonObject node) {
-        // TODO: fix formatting for throw.
-        this.skipFormatting(node, true);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -138,6 +138,7 @@ public class FormattingTest {
                 {"expectedErrorVariableDefinition.bal", "errorVariableDefinition.bal"},
                 {"expectedErrorVariableReference.bal", "errorVariableReference.bal"},
                 {"expectedErrorType.bal", "errorType.bal"},
+                {"expectedIndexBasedAccess.bal", "indexBasedAccess.bal"},
 //                {"expectedImportOrder.bal", "importOrder.bal"},
         };
     }

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedIndexBasedAccess.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedIndexBasedAccess.bal
@@ -1,0 +1,63 @@
+function mapAccessTest(int x, int y) returns (int) {
+    map<any> testMap = {
+        last: "last"
+    };
+    int xx = 0;
+    int yy = 0;
+    testMap["first"] = x;
+    testMap["second"] = y;
+    testMap
+    [
+    "third"
+    ]
+    =
+    x
+    +
+    y
+    ;
+    testMap["forth"] = x - y;
+    xx = <int> testMap.first;
+    yy = <int> testMap.second;
+
+    return xx + yy;
+}
+
+function testArrayAccessAsIndexOfMapt() returns (string) {
+    map<any> namesMap = {
+        fname: "Supun",
+        lname: "Setunga"
+    };
+    string[] keys = ["fname", "lname"];
+    string key = "";
+    var a = namesMap[keys[0]];
+    var b =
+    namesMap
+    [
+    keys
+    [
+    0
+    ]
+    ]
+    ;
+    key = a is string ? a : "";
+    return key;
+}
+
+function constructString(map<any> m) returns (string) {
+    string[] keys = m.keys();
+    int len = keys.length();
+    int i = 0;
+    string returnStr = "";
+    while (i < len) {
+        string key = keys[i];
+        var a = m
+        [
+        key
+        ]
+        ;
+        string val = a is string ? a : "";
+        returnStr = returnStr + key + ":" + val + ", ";
+        i = i + 1;
+    }
+    return returnStr;
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/indexBasedAccess.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/indexBasedAccess.bal
@@ -1,0 +1,57 @@
+function mapAccessTest(int x, int y) returns (int) {
+    map<any> testMap = {last: "last"};
+    int xx = 0;
+    int yy = 0;
+testMap  [ "first" ] = x;   testMap  [ "second"  ]=y ;
+        testMap
+            [
+                   "third"
+              ]
+        =
+            x
+              +
+       y
+            ;
+testMap[ "forth" ]=x - y;
+    xx = <int> testMap.first;
+    yy = <int> testMap.second;
+
+    return xx + yy;
+}
+
+function testArrayAccessAsIndexOfMapt() returns (string) {
+    map<any> namesMap = {fname:"Supun",lname:"Setunga"};
+    string [] keys = ["fname","lname"];
+    string key = "";
+    var a=namesMap    [    keys    [ 0  ] ] ;
+    var b=
+namesMap
+        [
+          keys
+        [
+        0
+           ]
+  ]
+         ;
+    key =  a is string ? a : "";
+    return key;
+}
+
+function constructString(map<any> m) returns (string) {
+    string [] keys = m.keys();
+    int len = keys.length();
+    int i = 0;
+    string returnStr = "";
+    while (i < len) {
+        string key =    keys  [ i  ]   ;
+    var a =          m
+                [
+  key
+                   ]
+   ;
+        string val = a is string ? a : "";
+        returnStr = returnStr + key + ":" + val + ", ";
+        i = i + 1;
+    }
+    return returnStr;
+}


### PR DESCRIPTION
## Purpose
This will add formatting support for index based access expression for maps and arrays... 

Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/13280