### PR TITLE
Remove synchronization from getInvocationContext

### DIFF
--- a/stdlib/runtime-api/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/InvocationContextUtils.java
+++ b/stdlib/runtime-api/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/InvocationContextUtils.java
@@ -48,13 +48,8 @@ public class InvocationContextUtils {
         InvocationContext invocationContext = (InvocationContext) context.getProperty(InvocationContextUtils
                 .INVOCATION_CONTEXT_PROPERTY);
         if (invocationContext == null) {
-            synchronized (InvocationContextUtils.class) {
-                if (context.getProperty(InvocationContextUtils
-                        .INVOCATION_CONTEXT_PROPERTY) == null) {
-                    invocationContext = initInvocationContext(context);
-                    context.setProperty(InvocationContextUtils.INVOCATION_CONTEXT_PROPERTY, invocationContext);
-                }
-            }
+            invocationContext = initInvocationContext(context);
+            context.setProperty(InvocationContextUtils.INVOCATION_CONTEXT_PROPERTY, invocationContext);
         }
         return invocationContext;
     }


### PR DESCRIPTION
There is no requirement to synchronize the getInvocationContext utility method. removed this unnecessary synchronization to overcome the thread contentions introduced as a result of the synchronization.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/14704

## Approach
> Remove synchronization from getInvocationContext

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
