### PR TITLE
Fix endpoint code lense for client endpoints in blocks

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/EndpointFindVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/EndpointFindVisitor.java
@@ -23,7 +23,12 @@ import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
+import org.wso2.ballerinalang.compiler.tree.BLangWorker;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -95,5 +100,31 @@ public class EndpointFindVisitor extends LSNodeVisitor {
             list.add(variable);
         }
         return list;
+    }
+
+    @Override
+    public void visit(BLangBlockStmt blockNode) {
+        blockNode.stmts.forEach(this::acceptNode);
+    }
+
+    @Override
+    public void visit(BLangIf ifNode) {
+        this.acceptNode(ifNode.body);
+        this.acceptNode(ifNode.elseStmt);
+    }
+
+    @Override
+    public void visit(BLangWhile whileNode) {
+        this.acceptNode(whileNode.body);
+    }
+
+    @Override
+    public void visit(BLangWorker workerNode) {
+        this.acceptNode(workerNode.body);
+    }
+
+    @Override
+    public void visit(BLangForeach foreach) {
+        this.acceptNode(foreach.body);
     }
 }


### PR DESCRIPTION
## Purpose
Previously there were some restrictions on where client endpoints can be declared. With https://github.com/ballerina-platform/ballerina-lang/pull/14415, it is removed. This PR fixes it for code lense support in LS.

## Approach
Visit block level statements to identify endpoints.

## Samples
<img width="843" alt="Screen Shot 2019-03-28 at 5 29 00 PM" src="https://user-images.githubusercontent.com/1505855/55156178-3eee1e80-517f-11e9-9fa9-2b111c20389b.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
