### PR TITLE
Closure desugar: Rewrite only var decls with RHS expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -339,9 +339,13 @@ public class ClosureDesugar extends BLangNodeVisitor {
             return;
         }
 
-        // If its a variable that is a closure.
-        BLangAssignment stmt = createAssignment(varDefNode);
-        result = rewrite(stmt, env);
+        // If its a variable declaration with a RHS value, and also a closure.
+        if (varDefNode.var.expr != null) {
+            BLangAssignment stmt = createAssignment(varDefNode);
+            result = rewrite(stmt, env);
+        } else {
+            result = varDefNode;
+        }
     }
 
     /**

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/closures/ClosureTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.closures;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BValueArray;
 import org.ballerinalang.test.util.BCompileUtil;
@@ -252,5 +253,11 @@ public class ClosureTest {
     public void testComplexlosureWithTypeGuard() {
         BValue[] returns = BRunUtil.invoke(compileResult, "test31");
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 31);
+    }
+
+    @Test(description = "Test closure capture of variable not initialized at declaration")
+    public void testClosureCaptureLaterInitializedVar() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "laterInitCapture");
+        Assert.assertEquals(((BString) returns[0]).stringValue(), "aa");
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/closures/closure.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/closures/closure.bal
@@ -702,3 +702,20 @@ function test31() returns int|string {
     }
     return x;
 }
+
+public function laterInitCapture() returns string {
+    string a;
+    boolean test = true;
+    if test {
+        a = "a";
+    } else {
+        a = "b";
+    }
+
+    var bar = function () returns string {
+        a = a + "a";
+        return a;
+    };
+
+    return bar.call();
+}


### PR DESCRIPTION
## Purpose
```ballerina
public function laterInitCapture() returns string {
    string a; // This should not be re-written to map access.
    boolean test = true;
    if test {
        a = "a";
    } else {
        a = "b";
    }

    var bar = function () returns string {
        a = a + "a";
        return a;
    };

    return bar.call();
}
```

Declaration of ```string s;``` should not re-written to map access, as we do for other closure variable references.

This PR fixes https://github.com/ballerina-platform/ballerina-lang/issues/14779