### PR TITLE
Increase test failure exception logs for Gradle

### DIFF
--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -43,4 +43,8 @@ spotbugsTest {
 test {
     systemProperty "ballerina.home", "$buildDir"
     systemProperty "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog"
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
 }


### PR DESCRIPTION
before
```
> Task :ballerina-bir:test

ballerina-test-suite > ballerina-lang-test-suite > org.ballerinalang.stdlib.io.bir.TypeGenTest > serializeAndDeserializeBTypeTest[6](string, strings) FAILED
    java.lang.AssertionError at TypeGenTest.java:91

17 tests completed, 1 failed

```

new
```
> Task :ballerina-bir:test

ballerina-test-suite > ballerina-lang-test-suite > org.ballerinalang.stdlib.io.bir.TypeGenTest > serializeAndDeserializeBTypeTest[6](string, strings) FAILED
    java.lang.AssertionError: Unable to recover type info from [5] expected [strings] but found [string]
        at org.testng.Assert.fail(Assert.java:96)
        at org.testng.Assert.failNotEquals(Assert.java:776)
        at org.testng.Assert.assertEqualsImpl(Assert.java:137)
        at org.testng.Assert.assertEquals(Assert.java:118)
        at org.testng.Assert.assertEquals(Assert.java:453)
        at org.ballerinalang.stdlib.io.bir.TypeGenTest.serializeAndDeserializeBTypeTest(TypeGenTest.java:91)

17 tests completed, 1 failed
```