### PR TITLE
Display local client endpoints in diagram

### DIFF
--- a/composer/packages/ast-model/src/ast-interfaces.ts
+++ b/composer/packages/ast-model/src/ast-interfaces.ts
@@ -462,6 +462,7 @@ export interface FiniteTypeNode extends ASTNode {
 }
 
 export interface Foreach extends ASTNode {
+  VisibleEndpoints?: VisibleEndpoint[];
   body: Block;
   collection:
     | BinaryExpr
@@ -577,6 +578,7 @@ export interface Identifier extends ASTNode {
 }
 
 export interface If extends ASTNode {
+  VisibleEndpoints?: VisibleEndpoint[];
   body: Block;
   condition:
     | BinaryExpr
@@ -1494,6 +1496,7 @@ export interface Where extends ASTNode {
 }
 
 export interface While extends ASTNode {
+  VisibleEndpoints?: VisibleEndpoint[];
   body: Block;
   condition: BinaryExpr | BracedTupleExpr;
   ws: any[];

--- a/composer/packages/ast-model/src/ast-interfaces.ts
+++ b/composer/packages/ast-model/src/ast-interfaces.ts
@@ -1466,6 +1466,7 @@ export interface VariableDef extends ASTNode {
 
 export interface VisibleEndpoint extends ASTNode {
   caller: boolean;
+  isLocal: boolean;
   name: string;
   pkgAlias: string;
   pkgName: string;

--- a/composer/packages/diagram/src/views/components/block.tsx
+++ b/composer/packages/diagram/src/views/components/block.tsx
@@ -1,22 +1,29 @@
 
 import { ASTKindChecker, ASTNode, ASTUtil, Block as BlockNode,
-        Function as FunctionNode } from "@ballerina/ast-model";
+        Function as FunctionNode, 
+        VisibleEndpoint} from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramUtils } from "../../diagram/diagram-utils";
 import { BlockViewState } from "../../view-model/block";
 import { FunctionViewState, ViewState } from "../../view-model/index";
 import { ReturnViewState } from "../../view-model/return";
 import { BlockDropdown } from "./block-dropdown";
+import { LifeLine } from "./life-line";
 import { Return } from "./return";
 
-export class Block extends React.Component<{ model: BlockNode }, { isHovered: boolean }> {
+export interface BlockNodeProps {
+    model: BlockNode;
+    visibleEndpoints?: VisibleEndpoint[];
+}
+
+export class Block extends React.Component<BlockNodeProps, { isHovered: boolean }> {
 
     public state = {
         isHovered: false
     };
 
     public render() {
-        const { model }  = this.props;
+        const { model, visibleEndpoints }  = this.props;
         const { isHovered } = this.state;
         const statements: React.ReactNode[] = [];
         const viewState: BlockViewState = model.viewState;
@@ -60,6 +67,18 @@ export class Block extends React.Component<{ model: BlockNode }, { isHovered: bo
                 />
                 {statements}
                 {...additionalComponents}
+                {visibleEndpoints && visibleEndpoints
+                    .filter((element) => element.viewState.visible)
+                    .map((element: VisibleEndpoint) => {
+                        return <LifeLine
+                            title={element.name}
+                            icon="endpoint"
+                            model={element.viewState.bBox}
+                            astModel={element}
+                            activeRange={[y, y + height]}
+                        />;
+                    })
+                }
                 {<BlockDropdown {...dropDownProps} />}
             </g>);
     }

--- a/composer/packages/diagram/src/views/components/block.tsx
+++ b/composer/packages/diagram/src/views/components/block.tsx
@@ -1,6 +1,6 @@
 
 import { ASTKindChecker, ASTNode, ASTUtil, Block as BlockNode,
-        Function as FunctionNode, 
+        Function as FunctionNode,
         VisibleEndpoint} from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramUtils } from "../../diagram/diagram-utils";

--- a/composer/packages/diagram/src/views/components/foreach.tsx
+++ b/composer/packages/diagram/src/views/components/foreach.tsx
@@ -1,5 +1,5 @@
 
-import { ASTUtil, Foreach as ForeachNode, VisibleEndpoint} from "@ballerina/ast-model";
+import { ASTUtil, Foreach as ForeachNode } from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
@@ -7,7 +7,6 @@ import { ViewState } from "../../view-model/index";
 import { ArrowHead } from "./arrow-head";
 import { Block } from "./block";
 import { ForeachBox } from "./foreach-box";
-import { LifeLine } from "./life-line";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
@@ -74,14 +73,7 @@ export const Foreach: React.StatelessComponent<{
                     <line className="hide-line" x1={p1.x} y1={p1.y + 1} x2={r4.x} y2={r4.y - 1} strokeLinecap="round" />
                     <ArrowHead direction={"right"} className="condition-arrow-head" {...p4} />
                     <ForeachBox {...conditionProps}/>
-                    {model.body && <Block model={model.body} />}
+                    {model.body && <Block model={model.body} visibleEndpoints={model.VisibleEndpoints} />}
                 </g>
-                {model.VisibleEndpoints && model.VisibleEndpoints
-                    .filter((element) => element.viewState.visible)
-                    .map((element: VisibleEndpoint) => {
-                        return <LifeLine title={element.name} icon="endpoint"
-                            model={element.viewState.bBox} astModel={element} />;
-                    })
-                }
             </g>);
     };

--- a/composer/packages/diagram/src/views/components/foreach.tsx
+++ b/composer/packages/diagram/src/views/components/foreach.tsx
@@ -1,5 +1,5 @@
 
-import { ASTUtil, Foreach as ForeachNode} from "@ballerina/ast-model";
+import { ASTUtil, Foreach as ForeachNode, VisibleEndpoint} from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
@@ -7,6 +7,7 @@ import { ViewState } from "../../view-model/index";
 import { ArrowHead } from "./arrow-head";
 import { Block } from "./block";
 import { ForeachBox } from "./foreach-box";
+import { LifeLine } from "./life-line";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
@@ -75,5 +76,12 @@ export const Foreach: React.StatelessComponent<{
                     <ForeachBox {...conditionProps}/>
                     {model.body && <Block model={model.body} />}
                 </g>
+                {model.VisibleEndpoints && model.VisibleEndpoints
+                    .filter((element) => element.viewState.visible)
+                    .map((element: VisibleEndpoint) => {
+                        return <LifeLine title={element.name} icon="endpoint"
+                            model={element.viewState.bBox} astModel={element} />;
+                    })
+                }
             </g>);
     };

--- a/composer/packages/diagram/src/views/components/if.tsx
+++ b/composer/packages/diagram/src/views/components/if.tsx
@@ -1,12 +1,12 @@
 
-import { ASTUtil, If as IfNode, VisibleEndpoint } from "@ballerina/ast-model";
+import { ASTUtil, If as IfNode } from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
 import { ViewState } from "../../view-model";
 import { ArrowHead } from "./arrow-head";
+import { Block } from "./block";
 import { Condition } from "./condition";
-import { LifeLine } from "./life-line";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
@@ -44,7 +44,6 @@ export const If: React.StatelessComponent<{
         p4.x = p1.x - (config.flowCtrl.condition.height / 2);
         p4.y = conditionProps.y;
 
-        children.push(DiagramUtils.getComponents(model.body));
         if (model.elseStatement) {
             children.push(DiagramUtils.getComponents(model.elseStatement));
         }
@@ -78,14 +77,8 @@ export const If: React.StatelessComponent<{
                     />
                     <ArrowHead direction={"left"} className="condition-arrow-head" {...r4} />
                     <Condition {...conditionProps} astModel={model} />
+                    {model.body && <Block model={model.body} visibleEndpoints={model.VisibleEndpoints} />}
                     {children}
                 </g>
-                {model.VisibleEndpoints && model.VisibleEndpoints
-                    .filter((element) => element.viewState.visible)
-                    .map((element: VisibleEndpoint) => {
-                        return <LifeLine title={element.name} icon="endpoint"
-                            model={element.viewState.bBox} astModel={element} />;
-                    })
-                }
             </g>);
     };

--- a/composer/packages/diagram/src/views/components/if.tsx
+++ b/composer/packages/diagram/src/views/components/if.tsx
@@ -1,11 +1,12 @@
 
-import { ASTUtil, If as IfNode } from "@ballerina/ast-model";
+import { ASTUtil, If as IfNode, VisibleEndpoint } from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
 import { ViewState } from "../../view-model";
 import { ArrowHead } from "./arrow-head";
 import { Condition } from "./condition";
+import { LifeLine } from "./life-line";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
@@ -79,5 +80,12 @@ export const If: React.StatelessComponent<{
                     <Condition {...conditionProps} astModel={model} />
                     {children}
                 </g>
+                {model.VisibleEndpoints && model.VisibleEndpoints
+                    .filter((element) => element.viewState.visible)
+                    .map((element: VisibleEndpoint) => {
+                        return <LifeLine title={element.name} icon="endpoint"
+                            model={element.viewState.bBox} astModel={element} />;
+                    })
+                }
             </g>);
     };

--- a/composer/packages/diagram/src/views/components/life-line.tsx
+++ b/composer/packages/diagram/src/views/components/life-line.tsx
@@ -14,13 +14,15 @@ export const LifeLine: React.StatelessComponent<{
     model: SimpleBBox,
     title: string,
     icon: string,
-    astModel?: ASTNode
+    astModel?: ASTNode,
+    activeRange?: [number, number]
 }> = ({
     model,
     title,
     children,
     astModel,
-    icon
+    icon,
+    activeRange
 }) => {
 
         const topLabel = { x: 0, y: 0 };
@@ -51,7 +53,12 @@ export const LifeLine: React.StatelessComponent<{
 
         return (
             <g className={classNames("life-line", `life-line-${icon}`)}>
-                <line {...lifeLine} />
+                <line {...lifeLine} strokeDasharray={(activeRange ? 4 : 0)} />
+                {activeRange && <line
+                    x1={lifeLine.x1} x2={lifeLine.x2}
+                    y1={activeRange[0]}
+                    y2={activeRange[1]}
+                /> }
                 <rect {...topBox} />
                 <rect {...bottomBox} />
                 {!astModel && <text {...topLabel}>{title}</text>}

--- a/composer/packages/diagram/src/views/components/while.tsx
+++ b/composer/packages/diagram/src/views/components/while.tsx
@@ -1,5 +1,5 @@
 
-import { ASTUtil, While as WhileNode} from "@ballerina/ast-model";
+import { ASTUtil, VisibleEndpoint, While as WhileNode} from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
@@ -7,6 +7,7 @@ import { ViewState } from "../../view-model";
 import { ArrowHead } from "./arrow-head";
 import { Block } from "./block";
 import { Condition } from "./condition";
+import { LifeLine } from "./life-line";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
@@ -74,5 +75,12 @@ export const While: React.StatelessComponent<{
                     <Condition {...conditionProps} astModel={model} />
                     {model.body && <Block model={model.body} />}
                 </g>
+                {model.VisibleEndpoints && model.VisibleEndpoints
+                    .filter((element) => element.viewState.visible)
+                    .map((element: VisibleEndpoint) => {
+                        return <LifeLine title={element.name} icon="endpoint"
+                            model={element.viewState.bBox} astModel={element} />;
+                    })
+                }
             </g>);
     };

--- a/composer/packages/diagram/src/views/components/while.tsx
+++ b/composer/packages/diagram/src/views/components/while.tsx
@@ -1,5 +1,5 @@
 
-import { ASTUtil, VisibleEndpoint, While as WhileNode} from "@ballerina/ast-model";
+import { ASTUtil, While as WhileNode} from "@ballerina/ast-model";
 import * as React from "react";
 import { DiagramConfig } from "../../config/default";
 import { DiagramUtils } from "../../diagram/diagram-utils";
@@ -7,7 +7,6 @@ import { ViewState } from "../../view-model";
 import { ArrowHead } from "./arrow-head";
 import { Block } from "./block";
 import { Condition } from "./condition";
-import { LifeLine } from "./life-line";
 
 const config: DiagramConfig = DiagramUtils.getConfig();
 
@@ -73,14 +72,7 @@ export const While: React.StatelessComponent<{
                     <line className="hide-line" x1={p1.x} y1={p1.y + 1} x2={r4.x} y2={r4.y - 1} strokeLinecap="round" />
                     <ArrowHead direction={"right"} className="condition-arrow-head" {...p4} />
                     <Condition {...conditionProps} astModel={model} />
-                    {model.body && <Block model={model.body} />}
+                    {model.body && <Block model={model.body} visibleEndpoints={model.VisibleEndpoints} />}
                 </g>
-                {model.VisibleEndpoints && model.VisibleEndpoints
-                    .filter((element) => element.viewState.visible)
-                    .map((element: VisibleEndpoint) => {
-                        return <LifeLine title={element.name} icon="endpoint"
-                            model={element.viewState.bBox} astModel={element} />;
-                    })
-                }
             </g>);
     };

--- a/composer/packages/diagram/src/views/components/worker.tsx
+++ b/composer/packages/diagram/src/views/components/worker.tsx
@@ -22,6 +22,7 @@ export const Worker: React.SFC<WorkerProps> = ({ model, startY, client }) => {
             y={startY} label="start" />
         <LifeLine title={workerViewState.name} icon="worker"
             model={workerViewState.lifeline.bBox} astModel={model} />
-        {functionNode.body && <Block model={functionNode.body} />}
+        {functionNode.body && <Block model={functionNode.body} 
+            visibleEndpoints={functionNode.VisibleEndpoints!.filter(ep => ep.isLocal)} />}
     </g>;
 };

--- a/composer/packages/diagram/src/views/components/worker.tsx
+++ b/composer/packages/diagram/src/views/components/worker.tsx
@@ -22,7 +22,7 @@ export const Worker: React.SFC<WorkerProps> = ({ model, startY, client }) => {
             y={startY} label="start" />
         <LifeLine title={workerViewState.name} icon="worker"
             model={workerViewState.lifeline.bBox} astModel={model} />
-        {functionNode.body && <Block model={functionNode.body} 
-            visibleEndpoints={functionNode.VisibleEndpoints!.filter(ep => ep.isLocal)} />}
+        {functionNode.body && <Block model={functionNode.body}
+            visibleEndpoints={functionNode.VisibleEndpoints!.filter((ep) => ep.isLocal)} />}
     </g>;
 };

--- a/composer/packages/diagram/src/visitors/init-visitor.ts
+++ b/composer/packages/diagram/src/visitors/init-visitor.ts
@@ -156,7 +156,8 @@ export const visitor: Visitor = {
         if (!node.viewState) {
             node.viewState = new EndpointViewState();
         }
-        (node.viewState as EndpointViewState).visible = false;
+        // show locally defined endpoints by default
+        (node.viewState as EndpointViewState).visible = node.isLocal;
     },
 
     beginVisitReturn(node: Return) {

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -17,7 +17,7 @@ function positionWorkerLine(worker: WorkerViewState) {
 }
 
 class PositioningVisitor implements Visitor {
-    private epH: number = 0; // FIXME: Figure out how to do this inside sizing visitor
+
     private epX: number = 0;
     private epY: number = 0;
 
@@ -25,7 +25,6 @@ class PositioningVisitor implements Visitor {
 
         this.epX = 0;
         this.epY = 0;
-        this.epH = 0;
         const viewState: CompilationUnitViewState = node.viewState;
 
         // filter out visible children from top level nodes.
@@ -152,7 +151,6 @@ class PositioningVisitor implements Visitor {
             endpoint.viewState.bBox.y = this.epY;
             this.epX = this.epX + endpoint.viewState.bBox.w + config.lifeLine.gutter.h;
         });
-        this.epH = viewState.client.bBox.h; // FIXME: Figure out how to do this in sizing visitor
 
         // Position drop down menu for adding workers and endpoints
         viewState.menuTrigger.x = this.epX;
@@ -222,10 +220,6 @@ class PositioningVisitor implements Visitor {
         if (node.VisibleEndpoints) {
             // Position endpoints
             node.VisibleEndpoints.forEach((endpoint: VisibleEndpoint) => {
-                // FIXME: Figure out how to do this in sizing visitor
-                endpoint.viewState.bBox.h = this.epH;
-                endpoint.viewState.bBox.w = config.lifeLine.width;
-                //////////////////////////////////////////////////
                 endpoint.viewState.bBox.x = this.epX;
                 endpoint.viewState.bBox.y = this.epY;
                 this.epX = this.epX + endpoint.viewState.bBox.w + config.lifeLine.gutter.h;
@@ -240,10 +234,6 @@ class PositioningVisitor implements Visitor {
         if (node.VisibleEndpoints) {
             // Position endpoints
             node.VisibleEndpoints.forEach((endpoint: VisibleEndpoint) => {
-                // FIXME: Figure out how to do this in sizing visitor
-                endpoint.viewState.bBox.h = this.epH;
-                endpoint.viewState.bBox.w = config.lifeLine.width;
-                //////////////////////////////////////////////////
                 endpoint.viewState.bBox.x = this.epX;
                 endpoint.viewState.bBox.y = this.epY;
                 this.epX = this.epX + endpoint.viewState.bBox.w + config.lifeLine.gutter.h;
@@ -265,10 +255,6 @@ class PositioningVisitor implements Visitor {
         if (node.VisibleEndpoints) {
             // Position endpoints
             node.VisibleEndpoints.forEach((endpoint: VisibleEndpoint) => {
-                // FIXME: Figure out how to do this in sizing visitor
-                endpoint.viewState.bBox.h = this.epH;
-                endpoint.viewState.bBox.w = config.lifeLine.width;
-                //////////////////////////////////////////////////
                 endpoint.viewState.bBox.x = this.epX;
                 endpoint.viewState.bBox.y = this.epY;
                 this.epX = this.epX + endpoint.viewState.bBox.w + config.lifeLine.gutter.h;

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -21,7 +21,7 @@ class PositioningVisitor implements Visitor {
     private epX: number = 0;
     private epY: number = 0;
 
-    beginVisitCompilationUnit(node: CompilationUnit) {
+    public beginVisitCompilationUnit(node: CompilationUnit) {
 
         this.epX = 0;
         this.epY = 0;
@@ -70,7 +70,7 @@ class PositioningVisitor implements Visitor {
     }
 
     // tslint:disable-next-line:ban-types
-    beginVisitFunction(node: BalFunction) {
+    public beginVisitFunction(node: BalFunction) {
         if (node.lambda || !node.body) { return; }
         const viewState: FunctionViewState = node.viewState;
         const defaultWorker: WorkerViewState = node.viewState.defaultWorker;
@@ -161,7 +161,7 @@ class PositioningVisitor implements Visitor {
         viewState.header.w = viewState.bBox.w;
     }
 
-    beginVisitBlock(node: Block) {
+    public beginVisitBlock(node: Block) {
         const viewState: BlockViewState = node.viewState;
         let height = 0;
 
@@ -228,8 +228,7 @@ class PositioningVisitor implements Visitor {
         }
     }
 
-
-    beginVisitWhile(node: While) {
+    public beginVisitWhile(node: While) {
         const viewState: ViewState = node.viewState;
         node.body.viewState.bBox.x = viewState.bBox.x;
         node.body.viewState.bBox.y = viewState.bBox.y + + config.flowCtrl.condition.bottomMargin
@@ -244,7 +243,7 @@ class PositioningVisitor implements Visitor {
         }
     }
 
-    beginVisitForeach(node: Foreach) {
+    public beginVisitForeach(node: Foreach) {
         const viewState: ViewState = node.viewState;
         node.body.viewState.bBox.x = viewState.bBox.x;
         node.body.viewState.bBox.y = viewState.bBox.y + config.flowCtrl.foreach.height;
@@ -258,7 +257,7 @@ class PositioningVisitor implements Visitor {
         }
     }
 
-    beginVisitIf(node: If) {
+    public beginVisitIf(node: If) {
         const viewState: ViewState = node.viewState;
         node.body.viewState.bBox.x = viewState.bBox.x;
         node.body.viewState.bBox.y = viewState.bBox.y + config.flowCtrl.condition.bottomMargin
@@ -279,7 +278,7 @@ class PositioningVisitor implements Visitor {
         }
     }
 
-    beginVisitService(node: Service) {
+    public beginVisitService(node: Service) {
         const viewState: ViewState = node.viewState;
         let y = viewState.bBox.y + config.panelGroup.header.height;
         // tslint:disable-next-line:ban-types
@@ -290,7 +289,7 @@ class PositioningVisitor implements Visitor {
         });
     }
 
-    beginVisitTypeDefinition(node: TypeDefinition) {
+    public beginVisitTypeDefinition(node: TypeDefinition) {
         // If it is a service do nothing.
         if (node.service || !ASTUtil.isValidObjectType(node)) { return; }
         const viewState: ViewState = node.viewState;
@@ -303,14 +302,14 @@ class PositioningVisitor implements Visitor {
         });
     }
 
-    beginVisitMatchStaticPatternClause(node: MatchStaticPatternClause) {
+    public beginVisitMatchStaticPatternClause(node: MatchStaticPatternClause) {
         const viewState: ViewState = node.viewState;
         node.statement.viewState.bBox.x = viewState.bBox.x;
         node.statement.viewState.bBox.y = viewState.bBox.y
         + config.statement.height; // To print literal;
     }
 
-    beginVisitMatch(node: Match) {
+    public beginVisitMatch(node: Match) {
         const viewState: ViewState = node.viewState;
         let height = config.frame.topMargin + config.frame.header.height;
         node.patternClauses.forEach((element) => {
@@ -320,7 +319,7 @@ class PositioningVisitor implements Visitor {
         });
     }
 
-    endVisitFunction(node: BalFunction) {
+    public endVisitFunction(node: BalFunction) {
         const viewState: FunctionViewState = node.viewState;
         viewState.menuTrigger.x = this.epX;
     }

--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -212,6 +212,23 @@ class PositioningVisitor implements Visitor {
         viewState.hoverRect.y = viewState.bBox.y;
     }
 
+    public beginVisitVariableDef(node: VariableDef) {
+        if (ASTUtil.isWorker(node)) {
+            const variable = node.variable;
+            const lambda: Lambda = variable.initialExpression as Lambda;
+            const functionNode = lambda.functionNode;
+            if (functionNode.VisibleEndpoints) {
+                // Position endpoints
+                functionNode.VisibleEndpoints.forEach((endpoint: VisibleEndpoint) => {
+                    endpoint.viewState.bBox.x = this.epX;
+                    endpoint.viewState.bBox.y = this.epY;
+                    this.epX = this.epX + endpoint.viewState.bBox.w + config.lifeLine.gutter.h;
+                });
+            }
+        }
+    }
+
+
     beginVisitWhile(node: While) {
         const viewState: ViewState = node.viewState;
         node.body.viewState.bBox.x = viewState.bBox.x;

--- a/composer/packages/diagram/src/visitors/sizing-visitor.ts
+++ b/composer/packages/diagram/src/visitors/sizing-visitor.ts
@@ -47,6 +47,17 @@ class SizingVisitor implements Visitor {
         }
     }
 
+    public beginVisitVariableDef(node: VariableDef) {
+        if (ASTUtil.isWorker(node)) {
+            const variable = node.variable;
+            const lambda: Lambda = variable.initialExpression as Lambda;
+            const functionNode = lambda.functionNode;
+            if (functionNode.VisibleEndpoints) {
+                this.endpointHolder = [...functionNode.VisibleEndpoints, ...this.endpointHolder];
+            }
+        }
+    }
+
     public beginVisitIf(node: If) {
         node.viewState.bBox.paddingTop = config.flowCtrl.paddingTop;
         if (node.VisibleEndpoints) {

--- a/composer/packages/diagram/src/visitors/sizing-visitor.ts
+++ b/composer/packages/diagram/src/visitors/sizing-visitor.ts
@@ -1,6 +1,6 @@
 import {
     Assignment, ASTKindChecker,
-    ASTNode, ASTUtil, Block, Break, CompilationUnit, CompoundAssignment, Constant,
+    ASTNode, ASTUtil, Block, Break, CompoundAssignment, Constant,
     ExpressionStatement, Foreach, Function as BalFunction, If, Invocation, Lambda,
     Literal, Match, MatchStaticPatternClause, ObjectType,
     Panic, Return, Service, TypeDefinition, UnionTypeNode,
@@ -21,11 +21,8 @@ class SizingVisitor implements Visitor {
     private endpointWidth: number = 0;
     private returnStatements: Return[] = [];
 
-    public beginVisitCompilationUnit(node: CompilationUnit) {
-        this.endpointWidth = 0;
-    }
-
     public beginVisitFunction(node: BalFunction) {
+        this.endpointWidth = 0;
         const viewState: FunctionViewState = node.viewState;
         if (!node.lambda) {
             this.endpointHolder = (node.viewState as FunctionViewState).containingVisibleEndpoints;
@@ -124,8 +121,8 @@ class SizingVisitor implements Visitor {
         });
 
         // Size endpoints
-        if (node.VisibleEndpoints) {
-            node.VisibleEndpoints.forEach((endpoint: VisibleEndpoint) => {
+        if (this.endpointHolder) {
+            this.endpointHolder.forEach((endpoint: VisibleEndpoint) => {
                 if (!endpoint.caller && endpoint.viewState.visible) {
                     endpoint.viewState.bBox.w = config.lifeLine.width;
                     endpoint.viewState.bBox.h = client.bBox.h;

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/common/modal/SymbolMetaInfo.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/common/modal/SymbolMetaInfo.java
@@ -17,7 +17,9 @@ package org.ballerinalang.langserver.compiler.common.modal;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 /**
  * Meta information of a symbol.
@@ -25,6 +27,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
  * @since 0.985
  */
 public final class SymbolMetaInfo {
+
     private String name;
     private String pkgOrgName;
     private String pkgName;
@@ -33,9 +36,12 @@ public final class SymbolMetaInfo {
     private String kind;
     private BSymbol bSymbol;
     private String typeName;
+    private boolean isLocal;
+    private DiagnosticPos position;
+
 
     private SymbolMetaInfo(String name, String pkgOrgName, String pkgName, String pkgAlias, boolean caller,
-                           String kind, BSymbol bSymbol, String typeName) {
+                           String kind, BSymbol bSymbol, String typeName, boolean isLocal, DiagnosticPos position) {
         this.name = name;
         this.pkgOrgName = pkgOrgName;
         this.pkgName = pkgName;
@@ -44,6 +50,8 @@ public final class SymbolMetaInfo {
         this.kind = kind;
         this.bSymbol = bSymbol;
         this.typeName = typeName;
+        this.isLocal = isLocal;
+        this.position = position;
     }
 
     public String getName() {
@@ -80,7 +88,24 @@ public final class SymbolMetaInfo {
 
     public JsonElement getJson() {
         Gson gson = new Gson();
-        return gson.toJsonTree(this);
+        JsonElement element = gson.toJsonTree(this);
+        if (this.position != null) {
+            JsonObject positionJson = new JsonObject();
+            positionJson.addProperty("startColumn", position.getStartColumn());
+            positionJson.addProperty("startLine", position.getStartLine());
+            positionJson.addProperty("endColumn", position.getEndColumn());
+            positionJson.addProperty("endLine", position.getEndLine());
+            element.getAsJsonObject().add("position", positionJson);
+        }
+        return element;
+    }
+
+    public boolean isLocal() {
+        return isLocal;
+    }
+
+    public DiagnosticPos getPosition() {
+        return position;
     }
 
     /**
@@ -97,6 +122,8 @@ public final class SymbolMetaInfo {
         private String kind = "";
         private BSymbol bSymbol;
         private String typeName;
+        private boolean isLocal;
+        private DiagnosticPos pos;
 
         public SymbolMetaInfoBuilder setName(String name) {
             this.name = name;
@@ -138,9 +165,19 @@ public final class SymbolMetaInfo {
             return this;
         }
 
+        public SymbolMetaInfoBuilder setLocal(boolean local) {
+            isLocal = local;
+            return this;
+        }
+
+        public SymbolMetaInfoBuilder setPos(DiagnosticPos pos) {
+            this.pos = pos;
+            return this;
+        }
+
         public SymbolMetaInfo build() {
             return new SymbolMetaInfo(this.name, this.pkgOrgName, this.pkgName, this.pkgAlias, this.caller,
-                    this.kind, this.bSymbol, this.typeName);
+                    this.kind, this.bSymbol, this.typeName, this.isLocal, this.pos);
         }
     }
 }

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/TextDocumentFormatUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/TextDocumentFormatUtil.java
@@ -135,12 +135,12 @@ public class TextDocumentFormatUtil {
      *
      * @param node              Node to get the json representation
      * @param anonStructs       Map of anonymous structs
-     * @param symbolMetaInfoMap symbol meta information map
+     * @param visibleEPsByNode        Visible endpoints by node map
      * @return {@link JsonElement}          Json Representation of the node
      * @throws JSONGenerationException when Json error occurs
      */
     public static JsonElement generateJSON(Node node, Map<String, Node> anonStructs,
-                                           Map<BLangNode, List<SymbolMetaInfo>> symbolMetaInfoMap)
+                                           Map<BLangNode, List<SymbolMetaInfo>> visibleEPsByNode)
             throws JSONGenerationException {
         if (node == null) {
             return JsonNull.INSTANCE;
@@ -179,8 +179,8 @@ public class TextDocumentFormatUtil {
         nodeJson.addProperty("id", UUID.randomUUID().toString());
 
         // Add the visible endpoints for a given node
-        if (symbolMetaInfoMap.containsKey(node)) {
-            List<SymbolMetaInfo> endpointMetaList = symbolMetaInfoMap.get(node);
+        if (visibleEPsByNode.containsKey(node)) {
+            List<SymbolMetaInfo> endpointMetaList = visibleEPsByNode.get(node);
             JsonArray endpoints = new JsonArray();
             endpointMetaList.forEach(symbolMetaInfo -> endpoints.add(symbolMetaInfo.getJson()));
             nodeJson.add("VisibleEndpoints", endpoints);
@@ -252,7 +252,7 @@ public class TextDocumentFormatUtil {
 
             /* Node classes */
             if (prop instanceof Node) {
-                nodeJson.add(jsonName, generateJSON((Node) prop, anonStructs, symbolMetaInfoMap));
+                nodeJson.add(jsonName, generateJSON((Node) prop, anonStructs, visibleEPsByNode));
             } else if (prop instanceof List) {
                 List listProp = (List) prop;
                 JsonArray listPropJson = new JsonArray();
@@ -266,17 +266,17 @@ public class TextDocumentFormatUtil {
                                 continue;
                             }
                         }
-                        listPropJson.add(generateJSON((Node) listPropItem, anonStructs, symbolMetaInfoMap));
+                        listPropJson.add(generateJSON((Node) listPropItem, anonStructs, visibleEPsByNode));
                     } else if (listPropItem instanceof BLangRecordVarRef.BLangRecordVarRefKeyValue) {
                         listPropJson.add(generateJSON(((BLangRecordVarRef.BLangRecordVarRefKeyValue) listPropItem)
-                                .getVariableName(), anonStructs, symbolMetaInfoMap));
+                                .getVariableName(), anonStructs, visibleEPsByNode));
                         listPropJson.add(generateJSON(((BLangRecordVarRef.BLangRecordVarRefKeyValue) listPropItem)
-                                .getBindingPattern(), anonStructs, symbolMetaInfoMap));
+                                .getBindingPattern(), anonStructs, visibleEPsByNode));
                     } else if (listPropItem instanceof BLangRecordVariable.BLangRecordVariableKeyValue) {
                         listPropJson.add(generateJSON(((BLangRecordVariable.BLangRecordVariableKeyValue) listPropItem)
-                                .getKey(), anonStructs, symbolMetaInfoMap));
+                                .getKey(), anonStructs, visibleEPsByNode));
                         listPropJson.add(generateJSON(((BLangRecordVariable.BLangRecordVariableKeyValue) listPropItem)
-                                .getValue(), anonStructs, symbolMetaInfoMap));
+                                .getValue(), anonStructs, visibleEPsByNode));
                     } else if (listPropItem instanceof String) {
                         listPropJson.add((String) listPropItem);
                     } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/EndpointFindVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/EndpointFindVisitor.java
@@ -23,7 +23,12 @@ import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
+import org.wso2.ballerinalang.compiler.tree.BLangWorker;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -95,5 +100,31 @@ public class EndpointFindVisitor extends LSNodeVisitor {
             list.add(variable);
         }
         return list;
+    }
+
+    @Override
+    public void visit(BLangBlockStmt blockNode) {
+        blockNode.stmts.forEach(this::acceptNode);
+    }
+
+    @Override
+    public void visit(BLangIf ifNode) {
+        this.acceptNode(ifNode.body);
+        this.acceptNode(ifNode.elseStmt);
+    }
+
+    @Override
+    public void visit(BLangWhile whileNode) {
+        this.acceptNode(whileNode.body);
+    }
+
+    @Override
+    public void visit(BLangWorker workerNode) {
+        this.acceptNode(workerNode.body);
+    }
+
+    @Override
+    public void visit(BLangForeach foreach) {
+        this.acceptNode(foreach.body);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -332,11 +332,11 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
     private JsonElement getTreeForContent(LSContext context) throws LSCompilerException, JSONGenerationException {
         BLangPackage bLangPackage = context.get(DocumentServiceKeys.CURRENT_BLANG_PACKAGE_CONTEXT_KEY);
         CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
-        SymbolFindVisitor symbolFindVisitor = new SymbolFindVisitor(compilerContext);
+        VisibleEndpointVisitor visibleEndpointVisitor = new VisibleEndpointVisitor(compilerContext);
 
         if (bLangPackage.symbol != null) {
-            symbolFindVisitor.visit(bLangPackage);
-            Map<BLangNode, List<SymbolMetaInfo>> symbolMetaInfoMap = symbolFindVisitor.getVisibleSymbolsMap();
+            visibleEndpointVisitor.visit(bLangPackage);
+            Map<BLangNode, List<SymbolMetaInfo>> visibleEPsByNode = visibleEndpointVisitor.getVisibleEPsByNode();
             String relativeFilePath = context.get(DocumentServiceKeys.RELATIVE_FILE_PATH_KEY);
             BLangCompilationUnit compilationUnit = bLangPackage.getCompilationUnits().stream()
                     .filter(cUnit -> cUnit.getPosition().getSource().cUnitName.replace("/", CommonUtil.FILE_SEPARATOR)
@@ -344,7 +344,7 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
                     .findFirst()
                     .orElse(null);
             JsonElement jsonAST = TextDocumentFormatUtil.generateJSON(compilationUnit, new HashMap<>(),
-                    symbolMetaInfoMap);
+                    visibleEPsByNode);
             FormattingSourceGen.build(jsonAST.getAsJsonObject(), "CompilationUnit");
             return jsonAST;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/VisibleEndpointVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/VisibleEndpointVisitor.java
@@ -183,7 +183,7 @@ class VisibleEndpointVisitor extends LSNodeVisitor {
                 .map(entry -> entry.getValue().symbol)
                 .collect(Collectors.toList()).stream()
                 .filter(symbol -> symbol instanceof BVarSymbol && CommonUtil.isClientObject(symbol)
-                    && symbol.owner instanceof BPackageSymbol)
+                    && (parameters.contains(symbol) || symbol.owner instanceof BPackageSymbol))
                 .map(symbol -> {
 
                     BLangImportPackage importPackage = this.packageMap.get(symbol.type.tsymbol.pkgID);


### PR DESCRIPTION
## Purpose
Previously there were some restrictions on where client endpoints can be declared. With #14415, it is removed. This PR add support for that change in Diagram

Fixes #14479

## Approach
During AST generation in lang-server side, enhance tree with information on declared endpoint objects within the block nodes

## Samples
```ballerina
import ballerina/http;

http:Client moduleUnusedEp = new("");
http:Client moduleUsedEp = new("");

// Only show used eps coming from 
// current modules or other modules.
// However, show locally declared endpoints 
// eventhough they are unused.
function demoLocalEPsOne() {
   var e = moduleUsedEp->get("path", message = ());
   http:Client fnLocalUnusedEp = new("");
}

// Display locally declared endpoints
// within block nodes
function demoLocalEPsTwo() {
    if (true) {
        http:Client ifLocalEp = new("");
        var e = ifLocalEp->get("path", message = ());
    }

    while (true) {
        http:Client whileLocalEp = new("");
        var e = whileLocalEp->get("path", message = ());
    }

    foreach var item in [] {
        http:Client foreachLocalEp = new("");
        var e = foreachLocalEp->get("path", message = ());
    }
}
```

<img width="1680" alt="Screen Shot 2019-03-31 at 4 50 25 PM" src="https://user-images.githubusercontent.com/1505855/55288485-0005d600-53d6-11e9-9850-e75f665de128.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
