### PR TITLE
Fix testgen code action not working for functions with `error` params

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateTestExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateTestExecutor.java
@@ -208,11 +208,15 @@ public class CreateTestExecutor implements LSCommandExecutor {
             List<TextEdit> content = TestGenerator.generate(docManager, bLangNodePair, focusLineAcceptor,
                                                             builtSourceFile, pkgRelativeSourceFilePath, testFile);
 
-            // Send edits
+            // If not exists, create a new test file
             List<Either<TextDocumentEdit, ResourceOperation>> edits = new ArrayList<>();
+            if (!testFile.exists()) {
+                edits.add(Either.forRight(new CreateFile(testFile.toPath().toUri().toString())));
+            }
+
+            // Send edits
             VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier();
             identifier.setUri(testFile.toPath().toUri().toString());
-            edits.add(Either.forRight(new CreateFile(testFile.toPath().toUri().toString())));
 
             TextDocumentEdit textEdit = new TextDocumentEdit(identifier, content);
             edits.add(Either.forLeft(textEdit));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/TestGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/TestGenerator.java
@@ -29,8 +29,10 @@ import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentExceptio
 import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.TopLevelNode;
+import org.ballerinalang.model.types.TypeKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -44,6 +46,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeInit;
 import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangType;
+import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -234,6 +237,7 @@ public class TestGenerator {
         private String[] namesSpace;
         private String functionName;
         private String returnType;
+        private int paramsCount;
 
         public TestFunctionGenerator(BiConsumer<String, String> importsAcceptor, PackageID currentPkgId,
                                      BLangFunction function) {
@@ -248,6 +252,7 @@ public class TestGenerator {
         public TestFunctionGenerator(BiConsumer<String, String> importsAcceptor, PackageID currentPkgId,
                                      BLangFunctionTypeNode type) {
             List<BLangVariable> params = type.params;
+            this.paramsCount = type.params.size();
             List<BLangType> paramTypes = params.stream().map(variable -> variable.typeNode).collect(
                     Collectors.toList());
             List<String> paramNames = new ArrayList<>();
@@ -263,8 +268,14 @@ public class TestGenerator {
 
         public TestFunctionGenerator(BiConsumer<String, String> importsAcceptor, PackageID currentPkgId,
                                      BInvokableType invokableType) {
+            boolean hasReturnType = true;
+            if (invokableType.retType == null || invokableType.retType instanceof BNilType) {
+                // No return type
+                hasReturnType = false;
+            }
             this.functionName = "";
             List<BType> params = invokableType.paramTypes;
+            this.paramsCount = params.size();
             BType returnBType = invokableType.retType;
             this.valueSpace = new String[VALUE_SPACE_LENGTH][params.size() + 1];
             this.typeSpace = new String[params.size() + 1];
@@ -292,25 +303,34 @@ public class TestGenerator {
             }
 
             // Populate target function's return type
-            this.returnType = generateTypeDefinition(importsAcceptor, currentPkgId, returnBType);
-            String[] rtValSpace = getValueSpaceByType(importsAcceptor, currentPkgId, returnBType,
-                                                      createTemplateArray(VALUE_SPACE_LENGTH));
+            if (hasReturnType) {
+                this.returnType = generateTypeDefinition(importsAcceptor, currentPkgId, returnBType);
+                String[] rtValSpace = getValueSpaceByType(importsAcceptor, currentPkgId, returnBType,
+                                                          createTemplateArray(VALUE_SPACE_LENGTH));
 
-            this.typeSpace[params.size()] = returnType;
-            this.namesSpace[params.size()] = "expected";
+                this.typeSpace[params.size()] = returnType;
+                this.namesSpace[params.size()] = "expected";
 
-            IntStream.range(0, rtValSpace.length).forEach(index -> {
-                valueSpace[index][params.size()] = rtValSpace[index];
-            });
+                IntStream.range(0, rtValSpace.length).forEach(index -> {
+                    valueSpace[index][params.size()] = rtValSpace[index];
+                });
+            }
         }
 
         private void init(BiConsumer<String, String> importsAcceptor, PackageID currentPkgId,
                           String functionName,
                           List<String> paramNames, List<BLangType> paramTypes, BLangType returnTypeNode) {
+            boolean hasReturnType = true;
+            if (returnTypeNode instanceof BLangValueType &&
+                    (TypeKind.NIL.equals(((BLangValueType) returnTypeNode).getTypeKind()))) {
+                // No return type
+                hasReturnType = false;
+            }
             this.functionName = functionName;
-            this.valueSpace = new String[VALUE_SPACE_LENGTH][paramNames.size() + 1];
-            this.typeSpace = new String[paramNames.size() + 1];
-            this.namesSpace = new String[paramNames.size() + 1];
+            this.paramsCount = paramNames.size();
+            this.valueSpace = new String[VALUE_SPACE_LENGTH][paramNames.size() + ((hasReturnType ? 1 : 0))];
+            this.typeSpace = new String[paramNames.size() + ((hasReturnType ? 1 : 0))];
+            this.namesSpace = new String[paramNames.size() + ((hasReturnType ? 1 : 0))];
 
             // Populate target function's parameters
             Set<String> lookupSet = new HashSet<>();
@@ -336,17 +356,19 @@ public class TestGenerator {
             }
 
             // Populate target function's return type
-            this.returnType = generateTypeDefinition(importsAcceptor, currentPkgId,
-                                                     returnTypeNode);
-            String[] rtValSpace = getValueSpaceByNode(importsAcceptor, currentPkgId, returnTypeNode,
-                                                      createTemplateArray(VALUE_SPACE_LENGTH));
+            if (hasReturnType) {
+                this.returnType = generateTypeDefinition(importsAcceptor, currentPkgId,
+                                                         returnTypeNode);
+                String[] rtValSpace = getValueSpaceByNode(importsAcceptor, currentPkgId, returnTypeNode,
+                                                          createTemplateArray(VALUE_SPACE_LENGTH));
 
-            this.typeSpace[paramNames.size()] = returnType;
-            this.namesSpace[paramNames.size()] = "expected";
+                this.typeSpace[paramNames.size()] = returnType;
+                this.namesSpace[paramNames.size()] = "expected";
 
-            IntStream.range(0, rtValSpace.length).forEach(index -> {
-                valueSpace[index][paramNames.size()] = rtValSpace[index];
-            });
+                IntStream.range(0, rtValSpace.length).forEach(index -> {
+                    valueSpace[index][paramNames.size()] = rtValSpace[index];
+                });
+            }
         }
 
         /**
@@ -399,7 +421,7 @@ public class TestGenerator {
          */
         public String getTargetFuncInvocation() {
             StringJoiner paramsInvokeStr = new StringJoiner(", ");
-            IntStream.range(0, this.namesSpace.length - 1).forEach(i -> paramsInvokeStr.add(this.namesSpace[i]));
+            IntStream.range(0, this.paramsCount).forEach(i -> paramsInvokeStr.add(this.namesSpace[i]));
             return this.functionName + "(" + paramsInvokeStr.toString() + ")";
         }
 
@@ -471,6 +493,16 @@ public class TestGenerator {
          */
         public String[] getNamesSpace() {
             return namesSpace.clone();
+        }
+
+
+        /**
+         * Returns params count of the function.
+         *
+         * @return params count
+         */
+        public int getParamsCount() {
+            return paramsCount;
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
@@ -292,6 +292,10 @@ public class ValueSpaceGenerator {
                 String[] resultBlob = new String[]{"0"};
                 populateValueSpace(resultBlob, template, () -> String.valueOf("0"));
                 break;
+            case "error":
+                String[] resultErr = new String[]{"0"};
+                populateValueSpace(resultErr, template, () -> "error(\"\")");
+                break;
             default:
                 String[] result = new String[]{"()"};
                 populateValueSpace(result, template, () -> "()");

--- a/language-server/modules/langserver-core/src/main/resources/testgen/template/voidFunction.bal
+++ b/language-server/modules/langserver-core/src/main/resources/testgen/template/voidFunction.bal
@@ -1,5 +1,10 @@
-@test:Config
-function ${testFunctionName}() {
-    // Invoke function with test values
+@test:Config {
+    dataProvider: "${testFunctionName}DataProvider"
+}
+function ${testFunctionName}(${testFunctionParams}) {
 ${actual}
+}
+
+function ${testFunctionName}DataProvider() returns (${dataProviderReturnType}) {
+    return ${dataProviderReturnValue};
 }

--- a/language-server/modules/langserver-core/src/main/resources/testgen/template/voidFunctionNoParams.bal
+++ b/language-server/modules/langserver-core/src/main/resources/testgen/template/voidFunctionNoParams.bal
@@ -1,0 +1,5 @@
+@test:Config
+function ${testFunctionName}() {
+    // Invoke function with test values
+${actual}
+}


### PR DESCRIPTION
## Purpose
> Fix testgen code action not working for functions with `error` params.

Fixes #13774

## Approach
> Added `error` type for the ValueSpaceGenerator.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
