### PR TITLE
Fix error equality and clone and freeze default error detail

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -5141,6 +5141,9 @@ public class BVM {
             case TypeTags.TUPLE_TAG:
             case TypeTags.ARRAY_TAG:
                 return isListType(rhsValTypeTag) && isEqual((BNewArray) lhsValue, (BNewArray) rhsValue, checkedValues);
+            case TypeTags.ERROR_TAG:
+                return rhsValTypeTag == TypeTags.ERROR_TAG &&
+                        isEqual((BError) lhsValue, (BError) rhsValue, checkedValues);
             case TypeTags.SERVICE_TAG:
                 break;
         }
@@ -5215,6 +5218,24 @@ public class BVM {
         return true;
     }
 
+    /**
+     * Deep equality check for error.
+     *
+     * @param lhsError      The error on the left hand side
+     * @param rhsError      The error on the right hand side
+     * @param checkedValues Errors already compared or being compared
+     * @return True if the error values are equal, else false.
+     */
+    private static boolean isEqual(BError lhsError, BError rhsError, List<ValuePair> checkedValues) {
+        ValuePair compValuePair = new ValuePair(lhsError, rhsError);
+        if (checkedValues.contains(compValuePair)) {
+            return true;
+        }
+        checkedValues.add(compValuePair);
+
+        return isEqual(new BString(lhsError.getReason()), new BString(rhsError.getReason()), checkedValues) &&
+                isEqual((BMap) lhsError.getDetails(), (BMap) rhsError.getDetails(), checkedValues);
+    }
 
     /**
      * Maintains the frozen status of a freezable {@link BValue}.

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -155,6 +155,7 @@ public enum DiagnosticCode {
     UNDEFINED_ACTION("undefined.action"),
 
     TYPE_CAST_NOT_YET_SUPPORTED("type.cast.not.yet.supported.for.type"),
+    EQUALITY_NOT_YET_SUPPORTED("equality.not.yet.supported.for.type"),
 
     // Cast and conversion related codes
     INCOMPATIBLE_TYPES_CAST("incompatible.types.cast"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3063,8 +3063,11 @@ public class Desugar extends BLangNodeVisitor {
         errConstExpr.reasonExpr = addConversionExprIfRequired(errConstExpr.reasonExpr, symTable.stringType);
         errConstExpr.reasonExpr = rewriteExpr(errConstExpr.reasonExpr);
         if (errConstExpr.detailsExpr == null) {
-            errConstExpr.detailsExpr = rewriteExpr(
-                    ASTBuilderUtil.createEmptyRecordLiteral(errConstExpr.pos, symTable.mapType));
+            errConstExpr.detailsExpr = visitUtilMethodInvocation(errConstExpr.pos,
+                                                                 BLangBuiltInMethod.FREEZE,
+                                                                 Lists.of(rewriteExpr(
+                                                                         ASTBuilderUtil.createEmptyRecordLiteral(
+                                                                                 errConstExpr.pos, symTable.mapType))));
         } else {
             errConstExpr.detailsExpr = visitUtilMethodInvocation(errConstExpr.detailsExpr.pos,
                                                                  BLangBuiltInMethod.FREEZE,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3067,7 +3067,8 @@ public class Desugar extends BLangNodeVisitor {
                                                                  BLangBuiltInMethod.FREEZE,
                                                                  Lists.of(rewriteExpr(
                                                                          ASTBuilderUtil.createEmptyRecordLiteral(
-                                                                                 errConstExpr.pos, symTable.mapType))));
+                                                                                 errConstExpr.pos,
+                                                                                 symTable.pureTypeConstrainedMap))));
         } else {
             errConstExpr.detailsExpr = visitUtilMethodInvocation(errConstExpr.detailsExpr.pos,
                                                                  BLangBuiltInMethod.FREEZE,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1923,7 +1923,7 @@ public class Types {
     }
 
     boolean validEqualityIntersectionExists(BType lhsType, BType rhsType) {
-        if (!isAnydata(lhsType) || !isAnydata(rhsType)) {
+        if (!isPureType(lhsType) || !isPureType(rhsType)) {
             return false;
         }
 
@@ -1931,13 +1931,16 @@ public class Types {
             return true;
         }
 
-        Set<BType> lhsTypes = new LinkedHashSet<>(expandAndGetMemberTypesRecursive(lhsType));
-        Set<BType> rhsTypes = new LinkedHashSet<>(expandAndGetMemberTypesRecursive(rhsType));
+        Set<BType> lhsTypes = expandAndGetMemberTypesRecursive(lhsType);
+        Set<BType> rhsTypes = expandAndGetMemberTypesRecursive(rhsType);
         return equalityIntersectionExists(lhsTypes, rhsTypes);
     }
 
     private boolean equalityIntersectionExists(Set<BType> lhsTypes, Set<BType> rhsTypes) {
-        if (lhsTypes.contains(symTable.anydataType) || rhsTypes.contains(symTable.anydataType)) {
+        if ((lhsTypes.contains(symTable.anydataType) &&
+                     rhsTypes.stream().anyMatch(type -> type.tag != TypeTags.ERROR)) ||
+                (rhsTypes.contains(symTable.anydataType) &&
+                         lhsTypes.stream().anyMatch(type -> type.tag != TypeTags.ERROR))) {
             return true;
         }
 
@@ -2039,6 +2042,7 @@ public class Types {
                 case TypeTags.INT:
                 case TypeTags.STRING:
                 case TypeTags.FLOAT:
+                case TypeTags.DECIMAL:
                 case TypeTags.BOOLEAN:
                 case TypeTags.NIL:
                     if (rhsTypes.stream().anyMatch(rhsMemberType -> rhsMemberType.tag == TypeTags.JSON)) {
@@ -2046,7 +2050,7 @@ public class Types {
                     }
                     break;
                 case TypeTags.JSON:
-                    if (jsonEqualityIntersectionExists((BJSONType) lhsMemberType, rhsTypes)) {
+                    if (jsonEqualityIntersectionExists(rhsTypes)) {
                         return true;
                     }
                     break;
@@ -2091,7 +2095,8 @@ public class Types {
                         return true;
                     }
 
-                    if (rhsTypes.stream().anyMatch(rhsMemberType -> rhsMemberType.tag == TypeTags.JSON)) {
+                    if (!isAssignable(((BMapType) lhsMemberType).constraint, symTable.errorType) &&
+                            rhsTypes.stream().anyMatch(rhsMemberType -> rhsMemberType.tag == TypeTags.JSON)) {
                         // at this point it is guaranteed that the map is anydata
                         return true;
                     }
@@ -2118,7 +2123,8 @@ public class Types {
                         return true;
                     }
 
-                    if (rhsTypes.stream().anyMatch(rhsMemberType -> rhsMemberType.tag == TypeTags.JSON)) {
+                    if (rhsTypes.stream().anyMatch(rhsMemberType -> rhsMemberType.tag == TypeTags.JSON) &&
+                            jsonEqualityIntersectionExists(expandAndGetMemberTypesRecursive(lhsMemberType))) {
                         return true;
                     }
 
@@ -2134,20 +2140,6 @@ public class Types {
         return false;
     }
 
-    private boolean recordEqualityIntersectionExists(BRecordType lhsType, BRecordType rhsType) {
-        if (Symbols.isFlagOn(lhsType.tsymbol.flags ^ rhsType.tsymbol.flags, Flags.PUBLIC)) {
-            return false;
-        }
-
-        // If both records are private, they should be in the same package.
-        if (Symbols.isPrivate(lhsType.tsymbol) && rhsType.tsymbol.pkgID != lhsType.tsymbol.pkgID) {
-            return false;
-        }
-
-        return allRecordFieldsEqualityIntersectionExists(lhsType, rhsType) ||
-                allRecordFieldsEqualityIntersectionExists(rhsType, lhsType);
-    }
-
     private boolean arrayTupleEqualityIntersectionExists(BArrayType arrayType, BTupleType tupleType) {
         Set<BType> elementTypes = expandAndGetMemberTypesRecursive(arrayType.eType);
 
@@ -2156,9 +2148,11 @@ public class Types {
                                                                      expandAndGetMemberTypesRecursive(tupleMemType)));
     }
 
-    private boolean allRecordFieldsEqualityIntersectionExists(BRecordType lhsType, BRecordType rhsType) {
+    private boolean recordEqualityIntersectionExists(BRecordType lhsType, BRecordType rhsType) {
         List<BField> lhsFields = lhsType.fields;
         List<BField> rhsFields = rhsType.fields;
+
+        List<Name> matchedFieldNames = new ArrayList<>();
         for (BField lhsField : lhsFields) {
             Optional<BField> match =
                     rhsFields.stream().filter(rhsField -> lhsField.name.equals(rhsField.name)).findFirst();
@@ -2168,6 +2162,7 @@ public class Types {
                                                 expandAndGetMemberTypesRecursive(match.get().type))) {
                     return false;
                 }
+                matchedFieldNames.add(lhsField.getName());
             } else {
                 if (Symbols.isFlagOn(lhsField.symbol.flags, Flags.OPTIONAL)) {
                     break;
@@ -2183,34 +2178,58 @@ public class Types {
                 }
             }
         }
+
+        for (BField rhsField : rhsFields) {
+            if (matchedFieldNames.contains(rhsField.getName())) {
+                continue;
+            }
+
+            if (!Symbols.isFlagOn(rhsField.symbol.flags, Flags.OPTIONAL)) {
+                if (lhsType.sealed) {
+                    return false;
+                }
+
+                if (!equalityIntersectionExists(expandAndGetMemberTypesRecursive(rhsField.type),
+                                                expandAndGetMemberTypesRecursive(lhsType.restFieldType))) {
+                    return false;
+                }
+            }
+        }
+
         return true;
     }
 
     private boolean mapRecordEqualityIntersectionExists(BMapType mapType, BRecordType recordType) {
         Set<BType> mapConstrTypes = expandAndGetMemberTypesRecursive(mapType.getConstraint());
 
-        if (!recordType.sealed &&
-                !equalityIntersectionExists(mapConstrTypes,
-                                            expandAndGetMemberTypesRecursive(recordType.restFieldType))) {
-            return false;
-        }
-
-        return recordType.fields.stream().allMatch(
-                fieldType -> equalityIntersectionExists(mapConstrTypes,
-                                                        expandAndGetMemberTypesRecursive(fieldType.type)));
+        return recordType.fields.stream()
+                .allMatch(field -> Symbols.isFlagOn(field.symbol.flags, Flags.OPTIONAL) ||
+                        equalityIntersectionExists(mapConstrTypes, expandAndGetMemberTypesRecursive(field.type)));
     }
 
-    private boolean jsonEqualityIntersectionExists(BJSONType jsonType, Set<BType> typeSet) {
-        if (typeSet.stream().anyMatch(rhsMemberType -> rhsMemberType.tag == TypeTags.JSON ||
-                rhsMemberType.tag == TypeTags.STRING || rhsMemberType.tag == TypeTags.INT ||
-                rhsMemberType.tag == TypeTags.FLOAT || rhsMemberType.tag == TypeTags.BOOLEAN ||
-                rhsMemberType.tag == TypeTags.NIL)) {
-            return true;
+    private boolean jsonEqualityIntersectionExists(Set<BType> typeSet) {
+        for (BType type : typeSet) {
+            switch (type.tag) {
+                case TypeTags.MAP:
+                    if (!isAssignable(((BMapType) type).constraint, symTable.errorType)) {
+                        return true;
+                    }
+                    break;
+                case TypeTags.RECORD:
+                    BRecordType recordType = (BRecordType) type;
+                    if (recordType.fields.stream()
+                            .allMatch(field -> Symbols.isFlagOn(field.symbol.flags, Flags.OPTIONAL) ||
+                                    !isAssignable(field.type, symTable.errorType))) {
+                        return true;
+                    }
+                    break;
+                default:
+                    if (isAssignable(type, symTable.jsonType)) {
+                        return true;
+                    }
+            }
         }
-
-        // We only reach here, if unconstrained and at this point it is guaranteed that the map/record is anydata
-        return typeSet.stream().anyMatch(typeToCheck -> typeToCheck.tag == TypeTags.MAP ||
-                typeToCheck.tag == TypeTags.RECORD);
+        return false;
     }
 
     public BType getRemainingType(BType originalType, BType typeToRemove) {

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -248,6 +248,9 @@ error.assignment.required=\
 error.type.cast.not.yet.supported.for.type=\
   type cast not yet supported for type ''{0}''
 
+error.equality.not.yet.supported.for.type=\
+  equality not yet supported for type ''{0}''
+
 error.incompatible.types.cast=\
   incompatible types: ''{0}'' cannot be cast to ''{1}''
 

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/test/assert.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/test/assert.bal
@@ -70,7 +70,7 @@ public function assertFalse(boolean condition, string msg = "Assertion Failed!")
 # + msg - Assertion error message
 public function assertEquals(any|error actual, any|error expected, string msg = "Assertion Failed!") {
     boolean isEqual = false;
-    if (actual is anydata && expected is anydata) {
+    if (actual is anydata|error && expected is anydata|error) {
         isEqual = actual == expected;
     } else {
         isEqual = actual === expected;
@@ -91,7 +91,7 @@ public function assertEquals(any|error actual, any|error expected, string msg = 
 # + msg - Assertion error message
 public function assertNotEquals(any|error actual, any|error expected, string msg = "Assertion Failed!") {
     boolean isEqual = false;
-    if (actual is anydata && expected is anydata) {
+    if (actual is anydata|error && expected is anydata|error) {
         isEqual = actual == expected;
     } else {
         isEqual = actual === expected;

--- a/stdlib/privacy/build.gradle
+++ b/stdlib/privacy/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     baloImplementation project(path: ':ballerina-h2', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-mysql', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-system', configuration: 'baloImplementation')
+    baloImplementation project(path: ':ballerina-utils', configuration: 'baloImplementation')
 
     // transitive
     baloImplementation project(path: ':ballerina-sql', configuration: 'baloImplementation')

--- a/stdlib/privacy/pom.xml
+++ b/stdlib/privacy/pom.xml
@@ -50,6 +50,12 @@
             <type>zip</type>
             <classifier>ballerina-binary-repo</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-utils</artifactId>
+            <type>zip</type>
+            <classifier>ballerina-binary-repo</classifier>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -207,6 +207,20 @@ public class ErrorTest {
     }
 
     @Test
+    public void testUnspecifiedErrorDetailFrozenness() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testUnspecifiedErrorDetailFrozenness");
+        Assert.assertTrue(returns[0] instanceof BBoolean);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
+    public void testErrorDetailCloneAndFreeze() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testErrorDetailCloneAndFreeze");
+        Assert.assertTrue(returns[0] instanceof BBoolean);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
     public void testErrorNegative() {
         Assert.assertEquals(negativeCompileResult.getErrorCount(), 10);
         BAssertUtil.validateError(negativeCompileResult, 0,

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -845,7 +845,7 @@ public class EqualAndNotEqualOperationsTest {
 
     @Test(description = "Test equal and not equal with errors")
     public void testEqualAndNotEqualNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 32);
+        Assert.assertEquals(resultNegative.getErrorCount(), 34);
         validateError(resultNegative, 0, "operator '==' not defined for 'int' and 'string'", 20, 12);
         validateError(resultNegative, 1, "operator '!=' not defined for 'int' and 'string'", 20, 24);
         validateError(resultNegative, 2, "operator '==' not defined for 'int[2]' and 'string[2]'", 26, 21);
@@ -888,6 +888,8 @@ public class EqualAndNotEqualOperationsTest {
         validateError(resultNegative, 29, "operator '!=' not defined for 'int' and 'any'", 115, 26);
         validateError(resultNegative, 30, "operator '==' not defined for 'map<int|string>' and 'map'", 119, 14);
         validateError(resultNegative, 31, "operator '!=' not defined for 'map' and 'map<int|string>'", 119, 26);
+        validateError(resultNegative, 32, "equality not yet supported for type 'table'", 131, 17);
+        validateError(resultNegative, 33, "equality not yet supported for type 'table'", 132, 9);
     }
 
     @DataProvider(name = "equalIntValues")

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -44,8 +44,8 @@ import static org.ballerinalang.test.util.BAssertUtil.validateError;
  */
 public class EqualAndNotEqualOperationsTest {
 
-    CompileResult result;
-    CompileResult resultNegative;
+    private CompileResult result;
+    private CompileResult resultNegative;
 
     @BeforeClass
     public void setup() {
@@ -162,6 +162,21 @@ public class EqualAndNotEqualOperationsTest {
         Assert.assertSame(returns[0].getClass(), BBoolean.class);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue(), "Expected value to be identified as not equal to " +
                 "nil");
+    }
+
+    @Test(description = "Test equals/unequals operation with two equal errors")
+    public void testErrorEqualityPositive() {
+        BValue[] returns = BRunUtil.invoke(result, "testErrorEqualityPositive", new BValue[0]);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BBoolean.class);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected errors to be identified as equal");
+    }
+
+    @Test(description = "Test equals/unequals operation with two unequal errors")
+    public void testErrorEqualityNegative() {
+        BValue[] returns = BRunUtil.invoke(result, "testErrorEqualityNegative", new BValue[0]);
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertFalse(((BBoolean) returns[0]).booleanValue(), "Expected errors to be identified as not equal");
     }
 
     @Test(description = "Test equals/unequals operation with two equal open records")
@@ -819,6 +834,13 @@ public class EqualAndNotEqualOperationsTest {
         Assert.assertEquals(returns.length, 1);
         Assert.assertSame(returns[0].getClass(), BBoolean.class);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue(), "Expected values to be identified as unequal.");
+    }
+
+    @Test
+    public void testEmptyMapAndRecordEquality() {
+        BValue[] returns = BRunUtil.invoke(result, "testEmptyMapAndRecordEquality");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected values to be identified as equal.");
     }
 
     @Test(description = "Test equal and not equal with errors")

--- a/tests/ballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -183,3 +183,32 @@ function testCustomErrorWithMappingOfSelf() returns boolean {
                 e2.detail().err.reason() == ERROR_REASON_ONE && e2.detail().err.detail().length() == 0;
     return errOneInitSuccesful && errTwoInitSuccesful;
 }
+
+function testUnspecifiedErrorDetailFrozenness() returns boolean {
+    error e1 = error("reason 1");
+    map<anydata|error> m1 = e1.detail();
+    error? err = trap addValueToMap(m1, "k", 1);
+    return err is error && err.reason() == "{ballerina}InvalidUpdate";
+}
+
+function testErrorDetailCloneAndFreeze() returns boolean {
+    map<anydata|error> m = { one: 1 };
+    error e1 = error("reason 1", m);
+    map<anydata|error> m1 = e1.detail();
+    boolean cloneSuccessful = m !== m1 && m == m1;
+    error? err1 = trap addValueToMap(m1, "k", 1);
+
+    MyError e2 = error(ERROR_REASON_ONE, {});
+    map<MyError> m2 = { err: e2 };
+    MyError e3 = error(ERROR_REASON_TWO, m2);
+    map<MyError> m3 = e3.detail();
+    cloneSuccessful = m2 !== m3 && m2 == m3;
+    error? err2 = trap addValueToMap(m3, "k", e2);
+
+    return err1 is error && err1.reason() == "{ballerina}InvalidUpdate" &&
+            err2 is error && err2.reason() == "{ballerina}InvalidUpdate" && cloneSuccessful;
+}
+
+function addValueToMap(map<anydata|error> m, string key, anydata|error value) {
+    m[key] = value;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -101,6 +101,29 @@ function checkEqualityToNilNegative(any a) returns boolean {
     return (a == ()) || !(a != ());
 }
 
+type ErrorDetail record {
+    string message?;
+};
+
+type MyError error<string, ErrorDetail>;
+
+function testErrorEqualityPositive() returns boolean {
+    error e1 = error("reason 1");
+    error e2 = error("reason 1");
+    MyError e3 = error("reason 1", {});
+
+    error e4 = error("reason 1", { message: "error message", intVal: 5 });
+    MyError e5 = error("reason 1", { message: "error message", intVal: 5 });
+    return e1 == e2 && !(e1 != e2) && e2 == e3 && !(e2 != e3)&& e4 == e5 && !(e4 != e5);
+}
+
+function testErrorEqualityNegative() returns boolean {
+    error e1 = error("reason 1");
+    error e2 = error("reason 2");
+    MyError e3 = error("reason 1", { message: "error message" });
+    return e1 == e2 && !(e1 != e2) && e1 == e3 && !(e1 != e3);
+}
+
 function checkOpenRecordEqualityPositive() returns boolean {
     OpenEmployee e1 = { name: "Em", id: 4000 };
     OpenEmployee e2 = e1;
@@ -1205,6 +1228,12 @@ public function testSelfAndCyclicReferencingTupleEqualityNegative() returns bool
     p[3] = n;
 
     return equals || o == p || !(o != p);
+}
+
+function testEmptyMapAndRecordEquality() returns boolean {
+    map<error> m = {};
+    record { string s?; int...; } r = {};
+    return m == r;
 }
 
 function isEqual(anydata a, anydata b) returns boolean {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation_negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation_negative.bal
@@ -120,6 +120,18 @@ function testEqualityWithNonAnydataType() returns boolean {
     return equals;
 }
 
+function testEqualityWithTable() {
+    table<ClosedDept> t1 = table{};
+    table<ClosedDept> t2 = table{};
+    table<EmployeeWithOptionalId> t3 = table{};
+
+    table<ClosedDept>|map<string> t4 = t1;
+    table<ClosedDept>|map<string> t5 = t2;
+
+    boolean b = t1 == t2;
+    b = t4 != t5;
+}
+
 type Employee record {
     string name;
     int id = 0;


### PR DESCRIPTION
## Purpose

- With changes to `anydata`, we now allow ==/!= with structures with errors even though we don't support ==/!= with errors yet. This PR introduces support for ==/!= with errors. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/13528 

- This PR also disallows ==/!= checks with tables at compile time, since this is not yet supported (currently just returns false at run time)

- This PR also updates `test:assertEquals` and `test:assertNotEquals` to perform deep equality checks for errors.

- This PR also freezes the empty mapping introduced when an error constructor expression does not contain a detail expression, and adds tests for cloning the error detail specified.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
