### PR TITLE
Add expanding support to invocations inside check expressions

### DIFF
--- a/composer/packages/diagram/src/views/components/expanded-function.tsx
+++ b/composer/packages/diagram/src/views/components/expanded-function.tsx
@@ -175,7 +175,6 @@ function getExpandFunctionHandler(
             startColumn: res.range.start.character + 1,
             startLine: res.range.start.line + 1,
         }, astRes.ast);
-
         const defTree = subTree as BallerinaFunction;
 
         expandContext.expandedSubTree = defTree;

--- a/composer/packages/diagram/src/views/components/expanded-function.tsx
+++ b/composer/packages/diagram/src/views/components/expanded-function.tsx
@@ -132,12 +132,14 @@ export const FunctionExpander: React.SFC<FunctionExpanderProps> = (
     return (
         <DiagramContext.Consumer>
             {({ langClient, docUri, update }) => (
-                <text x={x} y={y}
-                    className="expander"
-                    onClick={getExpandFunctionHandler(
-                        langClient, docUri, position, expandContext, update)}>
-                    {getCodePoint("down")}
-                </text>
+                <g className="expander">
+                    <circle className="circle" cx={x + 7} cy={y - 2} r={10}/>
+                    <text x={x} y={y}
+                        onClick={getExpandFunctionHandler(
+                            langClient, docUri, position, expandContext, update)}>
+                        {getCodePoint("down")}
+                    </text>
+                </g>
             )}
         </DiagramContext.Consumer>
     );

--- a/composer/packages/theme/src/definitions/views/diagram.less
+++ b/composer/packages/theme/src/definitions/views/diagram.less
@@ -149,6 +149,13 @@
                         font-size: @diagram-statement-font-size;
                         .expander {
                             visibility: hidden;
+                            .circle {
+                                fill: ~"@{@{color}-diagram-expanded-func-frame-color}";
+                                cursor: pointer;
+                            }
+                            text {
+                                cursor: pointer;
+                            }
                         }
                     }
                     .statement:hover > .expander {


### PR DESCRIPTION
## Purpose
Expanding function icon was not shown for statements with check expressions. This adds a fix for that.
Also adds a circle background to the expanding icon.

## Approach
<img width="271" alt="Screen Shot 2019-04-01 at 3 55 11 PM" src="https://user-images.githubusercontent.com/3872221/55321285-e4163900-5496-11e9-8b0a-ffeada4c0a0b.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
