### PR TITLE
Add flag to enable siddhi runtime in ballerina build command

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/BuilderUtils.java
@@ -40,6 +40,7 @@ import static org.ballerinalang.compiler.CompilerOptionName.EXPERIMENTAL_FEATURE
 import static org.ballerinalang.compiler.CompilerOptionName.LOCK_ENABLED;
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
+import static org.ballerinalang.compiler.CompilerOptionName.SIDDHI_RUNTIME_ENABLED;
 import static org.ballerinalang.compiler.CompilerOptionName.SKIP_TESTS;
 import static org.ballerinalang.compiler.CompilerOptionName.TEST_ENABLED;;
 
@@ -82,6 +83,39 @@ public class BuilderUtils {
         }
     }
 
+    public static void compileWithTestsAndWrite(Path sourceRootPath,
+                                                String packagePath,
+                                                String targetPath,
+                                                boolean buildCompiledPkg,
+                                                boolean offline,
+                                                boolean lockEnabled,
+                                                boolean skiptests,
+                                                boolean enableExperimentalFeatures,
+                                                boolean siddhiRuntimeEnabled) {
+        CompilerContext context = new CompilerContext();
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        options.put(PROJECT_DIR, sourceRootPath.toString());
+        options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
+        options.put(BUILD_COMPILED_MODULE, Boolean.toString(buildCompiledPkg));
+        options.put(OFFLINE, Boolean.toString(offline));
+        options.put(LOCK_ENABLED, Boolean.toString(lockEnabled));
+        options.put(SKIP_TESTS, Boolean.toString(skiptests));
+        options.put(TEST_ENABLED, "true");
+        options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExperimentalFeatures));
+        options.put(SIDDHI_RUNTIME_ENABLED, Boolean.toString(siddhiRuntimeEnabled));
+
+        Compiler compiler = Compiler.getInstance(context);
+        BLangPackage bLangPackage = compiler.build(packagePath);
+
+        if (skiptests) {
+            outStream.println();
+            compiler.write(bLangPackage, targetPath);
+        } else {
+            runTests(compiler, sourceRootPath, Collections.singletonList(bLangPackage));
+            compiler.write(bLangPackage, targetPath);
+        }
+    }
+
     public static void compileWithTestsAndWrite(Path sourceRootPath, boolean offline, boolean lockEnabled,
                                                 boolean skiptests, boolean enableExperimentalFeatures) {
         CompilerContext context = new CompilerContext();
@@ -93,6 +127,38 @@ public class BuilderUtils {
         options.put(SKIP_TESTS, Boolean.toString(skiptests));
         options.put(TEST_ENABLED, "true");
         options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExperimentalFeatures));
+
+        Compiler compiler = Compiler.getInstance(context);
+        List<BLangPackage> packages = compiler.build();
+
+        if (skiptests) {
+            if (packages.size() == 0) {
+                throw new BLangCompilerException("no ballerina source files found to compile");
+            }
+            outStream.println();
+            compiler.write(packages);
+        } else {
+            if (packages.size() == 0) {
+                throw new BLangCompilerException("no ballerina source files found to compile");
+            }
+            runTests(compiler, sourceRootPath, packages);
+            compiler.write(packages);
+        }
+    }
+
+    public static void compileWithTestsAndWrite(Path sourceRootPath, boolean offline, boolean lockEnabled,
+                                                boolean skiptests, boolean enableExperimentalFeatures,
+                                                boolean siddhiRuntimeEnabled) {
+        CompilerContext context = new CompilerContext();
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        options.put(PROJECT_DIR, sourceRootPath.toString());
+        options.put(OFFLINE, Boolean.toString(offline));
+        options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
+        options.put(LOCK_ENABLED, Boolean.toString(lockEnabled));
+        options.put(SKIP_TESTS, Boolean.toString(skiptests));
+        options.put(TEST_ENABLED, "true");
+        options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(enableExperimentalFeatures));
+        options.put(SIDDHI_RUNTIME_ENABLED, Boolean.toString(siddhiRuntimeEnabled));
 
         Compiler compiler = Compiler.getInstance(context);
         List<BLangPackage> packages = compiler.build();

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/PushUtils.java
@@ -131,7 +131,7 @@ public class PushUtils {
         // Always build if the flag is not given
         if (!noBuild) {
             BuilderUtils.compileWithTestsAndWrite(prjDirPath, packageName, packageName, false, false, false, false,
-                    enableExperimentalFeatures);
+                    enableExperimentalFeatures, false);
         } else if (Files.notExists(pkgPathFromPrjtDir)) {
             // If --no-build is given, first check if the module artifact exists. If it does not exist prompt the user
             // to run "ballerina push" without the --no-build flag

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -78,6 +78,9 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--experimental", description = "enable experimental language features")
     private boolean experimentalFlag;
 
+    @CommandLine.Option(names = "--siddhiruntime", description = "enable siddhi runtime for stream processing")
+    private boolean siddhiRuntimeFlag;
+
     public void execute() {
         if (helpFlag) {
             String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(BUILD_COMMAND);
@@ -95,7 +98,8 @@ public class BuildCommand implements BLauncherCmd {
             genNativeBinary(sourceRootPath, argList);
         } else if (argList == null || argList.size() == 0) {
             // ballerina build
-            BuilderUtils.compileWithTestsAndWrite(sourceRootPath, offline, lockEnabled, skiptests, experimentalFlag);
+            BuilderUtils.compileWithTestsAndWrite(sourceRootPath, offline, lockEnabled, skiptests, experimentalFlag,
+                    siddhiRuntimeFlag);
         } else {
             // ballerina build pkgName [-o outputFileName]
             String targetFileName;
@@ -175,7 +179,7 @@ public class BuildCommand implements BLauncherCmd {
                                                             + BLangConstants.BLANG_SRC_FILE_SUFFIX + "\' extension");
             }
             BuilderUtils.compileWithTestsAndWrite(sourceRootPath, pkgName, targetFileName, buildCompiledPkg,
-                                                  offline, lockEnabled, skiptests, experimentalFlag);
+                    offline, lockEnabled, skiptests, experimentalFlag, siddhiRuntimeFlag);
         }
         Runtime.getRuntime().exit(0);
     }


### PR DESCRIPTION
## Purpose
The flag was missing from the 'build' command in Ballerina. This PR adds the --siddhiruntime flag to the build command. A user can build the. bal file using --siddhiruntime to compile the ballerina files to instruct the ballerina runtime to use the siddhi runtime. Following is an example command to build the ballerina project called 'simple-filtering' inside the examples folder.

`Gimantha:examples gimantha$ ballerina build --experimental simple-filtering/`


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, releated PRs, TODO items or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
