### PR TITLE
Add recursive union and object types for BIR

### DIFF
--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
@@ -794,7 +794,7 @@ type BalToJVMIndexMap object {
     }
 
     function getVarRefName(bir:VariableDcl varDcl) returns string {
-        return io:sprintf("%s", varDcl);
+        return varDcl.name.value;
     }
 };
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -24,6 +24,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnnotationType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
@@ -52,6 +53,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLAttributesType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.LinkedList;
+
 /**
  * Writes bType to a Byte Buffer in binary format.
  * A ConstPool is used to store string typed information.
@@ -59,11 +62,13 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
  * @since 0.995.0
  */
 public class BIRTypeWriter implements TypeVisitor {
+    public static final int TYPE_TAG_SELF = 50;
     private final ByteBuf buff;
 
     private final ConstantPool cp;
     private final BMapType anydataMapType =
             new BMapType(TypeTags.MAP, new BAnydataType(TypeTags.ANYDATA, null), null);
+    private LinkedList<Object> compositeStack = new LinkedList<>();
 
     public BIRTypeWriter(ByteBuf buff, ConstantPool cp) {
         this.buff = buff;
@@ -95,9 +100,12 @@ public class BIRTypeWriter implements TypeVisitor {
     @Override
     public void visit(BErrorType bErrorType) {
         buff.writeByte(bErrorType.tag);
+        BTypeSymbol tsymbol = bErrorType.tsymbol;
+        compositeStack.push(tsymbol);
         bErrorType.reasonType.accept(this);
-        // Temporary fix to avoid recursive call, detail type needs to be visited once fixed
-        anydataMapType.accept(this);
+        bErrorType.detailType.accept(this);
+        Object popped = compositeStack.pop();
+        assert popped == tsymbol;
     }
 
     @Override
@@ -182,7 +190,9 @@ public class BIRTypeWriter implements TypeVisitor {
         buff.writeByte(bUnionType.tag);
         buff.writeInt(bUnionType.getMemberTypes().size());
         for (BType memberType : bUnionType.getMemberTypes()) {
-            memberType.accept(this);
+            if (!writeSelfRef(memberType.tsymbol)) {
+                memberType.accept(this);
+            }
         }
     }
 
@@ -202,8 +212,13 @@ public class BIRTypeWriter implements TypeVisitor {
 
     @Override
     public void visit(BObjectType bObjectType) {
-        buff.writeByte(bObjectType.tag);
         BObjectTypeSymbol tsymbol = (BObjectTypeSymbol) bObjectType.tsymbol;
+        if (writeSelfRef(bObjectType.tsymbol)) {
+            return;
+        }
+        compositeStack.push(tsymbol);
+
+        buff.writeByte(bObjectType.tag);
         buff.writeInt(addStringCPEntry(tsymbol.name.value));
         buff.writeInt(bObjectType.fields.size());
         for (BField field : bObjectType.fields) {
@@ -212,12 +227,24 @@ public class BIRTypeWriter implements TypeVisitor {
             buff.writeByte(getVisibility(field.symbol).value());
             field.type.accept(this);
         }
+        Object popped = compositeStack.pop();
+        assert popped == tsymbol;
         buff.writeInt(tsymbol.attachedFuncs.size());
         for (BAttachedFunction attachedFunc : tsymbol.attachedFuncs) {
             buff.writeInt(addStringCPEntry(attachedFunc.funcName.value));
             buff.writeByte(getVisibility(attachedFunc.symbol).value());
             attachedFunc.type.accept(this);
         }
+    }
+
+    private boolean writeSelfRef(BTypeSymbol tsymbol) {
+        int i = compositeStack.indexOf(tsymbol);
+        if (i >= 0) {
+            buff.writeByte(TYPE_TAG_SELF);
+            buff.writeInt(i);
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/stdlib/bir/src/main/ballerina/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_model.bal
@@ -206,6 +206,10 @@ public type BObjectType record {|
     BAttachedFunction?[] attachedFunctions = [];
 |};
 
+public type Self record {|
+    BType bType;
+|};
+
 public type BAttachedFunction record {|
     Name name = {};
     BInvokableType funcType;
@@ -239,7 +243,7 @@ public type BFutureType record {|
 
 public type BType BTypeInt | BTypeBoolean | BTypeAny | BTypeNil | BTypeByte | BTypeFloat | BTypeString | BUnionType |
                   BTupleType | BInvokableType | BArrayType | BRecordType | BObjectType | BMapType | BErrorType |
-                  BTypeAnyData | BTypeNone | BFutureType | BJSONType;
+                  BTypeAnyData | BTypeNone | BFutureType | BJSONType | Self;
 
 public type ModuleID record {|
     string org = "";

--- a/stdlib/bir/src/main/ballerina/bir/serializer.bal
+++ b/stdlib/bir/src/main/ballerina/bir/serializer.bal
@@ -37,6 +37,14 @@ public function serialize(BType bType) returns string {
         return serialize(bType.eType) + "[]";
     } else if (bType is BObjectType) {
         return "object {" + serializeFields(bType.fields) + serializeAttachedFunc(bType.attachedFunctions) + "}";
+    } else if (bType is Self) {
+        return "...";
+    } else if (bType is BMapType) {
+        return "map<"+ serialize(bType.constraint) +">";
+    } else if (bType is BTypeAnyData) {
+        return "anydata";
+    } else if (bType is BErrorType) {
+        return "error (" + serialize(bType.reasonType) + ", " + serialize(bType.detailType) + ")";
     }
 
     error err = error(io:sprintf("Unsupported serialization for type '%s'", bType));

--- a/stdlib/bir/src/main/ballerina/bir/type_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/type_parser.bal
@@ -60,6 +60,10 @@ public type TypeParser object {
     public int TYPE_TAG_CHANNEL = TYPE_TAG_BYTE_ARRAY + 1;
 
     public int TYPE_TAG_SERVICE = TYPE_TAG_OBJECT;
+    public int TYPE_TAG_SELF = 50;
+
+    BType[] compositeStack = [];
+    int compositeStackI = 0;
 
     public function __init(BirChannelReader reader) {
         self.reader = reader;
@@ -105,6 +109,10 @@ public type TypeParser object {
             return self.parseFutureType();
         } else if (typeTag == self.TYPE_TAG_JSON){
             return TYPE_JSON;
+        } else if (typeTag == self.TYPE_TAG_SELF){
+            int selfIndex = self.reader.readInt32();
+            Self t = {bType: self.compositeStack[self.compositeStackI - 1]};
+            return t;
         }
         error err = error("Unknown type tag :" + typeTag);
         panic err;
@@ -155,9 +163,15 @@ public type TypeParser object {
     }
 
     function parseObjectType() returns BObjectType {
-        return { name: { value: self.reader.readStringCpRef() },
-            fields: self.parseObjectFields(),
-            attachedFunctions:self.parseObjectAttachedFunctions() };
+        BObjectType obj = { name: { value: self.reader.readStringCpRef() },
+            fields: [],
+            attachedFunctions: [] };
+        self.compositeStack[self.compositeStackI] = obj;
+        self.compositeStackI = self.compositeStackI + 1;
+        obj.fields = self.parseObjectFields();
+        obj.attachedFunctions = self.parseObjectAttachedFunctions();
+        return obj;
+
     }
 
     function parseObjectAttachedFunctions() returns BAttachedFunction?[] {
@@ -197,7 +211,12 @@ public type TypeParser object {
     }
 
     function parseErrorType() returns BErrorType {
-        return {reasonType:self.parseType(), detailType:self.parseType()};
+        BErrorType err = {reasonType:TYPE_ANYDATA, detailType:TYPE_ANYDATA};
+        self.compositeStack[self.compositeStackI] = err;
+        self.compositeStackI = self.compositeStackI + 1;
+        err.reasonType = self.parseType();
+        err.detailType = self.parseType();
+        return err;
     }
 
     function parseTypes() returns BType[] {

--- a/stdlib/bir/src/test/java/org/ballerinalang/stdlib/io/bir/TypeGenTest.java
+++ b/stdlib/bir/src/test/java/org/ballerinalang/stdlib/io/bir/TypeGenTest.java
@@ -87,9 +87,13 @@ public class TypeGenTest {
         ConstantPool cp = new ConstantPool();
         byte[] typeBinary = serializeBType(type, cp);
         byte[] cpBinary = cp.serialize();
-        BValue[] testParseTypes = executeTestFuncInBalx(typeBinary, cpBinary);
-        Assert.assertEquals(testParseTypes[0].stringValue(), source,
-                            "Unable to recover type info from " + Arrays.toString(typeBinary));
+        try {
+            BValue[] testParseTypes = executeTestFuncInBalx(typeBinary, cpBinary);
+            Assert.assertEquals(testParseTypes[0].stringValue(), source,
+                                "Unable to recover type info from " + Arrays.toString(typeBinary));
+        } catch (Exception e) {
+            throw new AssertionError("Error deserializeing" + Arrays.toString(typeBinary), e);
+        }
 
     }
 

--- a/stdlib/bir/src/test/resources/test-src/bir/types.bal
+++ b/stdlib/bir/src/test/resources/test-src/bir/types.bal
@@ -3,6 +3,14 @@ import ballerina / io;
 type MyString string;
 type MyUnion int|boolean;
 type MyUnion2 string|byte;
+type RecursiveObj object{RecursiveObj me;};
+type RecursiveL2Obj object{RecursiveObj that;};
+type RecursiveL3Obj object{RecursiveL2Obj other;};
+
+
+type RecursiveDeepL0Obj object{RecursiveDeepL2Obj? a;};
+type RecursiveDeepL1Obj object{RecursiveDeepL0Obj b;};
+type RecursiveDeepL2Obj object{RecursiveDeepL1Obj c;};
 
 // expected: ()
 () nilType = ();
@@ -54,3 +62,16 @@ object {int age;} myPerson = new;
 
 // expected: object {int age; function () returns string getFullName; }
 object {int age;  function getFullName() returns string { return ""; }} myPerson2 = new;
+
+// expected: object {... me; }
+RecursiveObj myRecObj = new;
+
+// expected: object {object {object {... me; } that; } other; }
+RecursiveL3Obj myRecL2Obj = new;
+
+// expected: object {object {object {...|() a; } b; } c; }
+RecursiveDeepL2Obj deepRec = new;
+
+// expected: error (string, map<anydata|...>)
+error e = error("not good");
+


### PR DESCRIPTION
see `types.bal` for examples.