### PR TITLE
Remove synchronization from getInvocationContext

### DIFF
--- a/stdlib/database/h2/src/test/resources/log4j.properties
+++ b/stdlib/database/h2/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p [%c] - %m%n
+
+log4j.logger.com.zaxxer.hikari=ERROR

--- a/stdlib/runtime/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/InvocationContextUtils.java
+++ b/stdlib/runtime/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/InvocationContextUtils.java
@@ -48,13 +48,8 @@ public class InvocationContextUtils {
         InvocationContext invocationContext = (InvocationContext) context.getProperty(InvocationContextUtils
                 .INVOCATION_CONTEXT_PROPERTY);
         if (invocationContext == null) {
-            synchronized (InvocationContextUtils.class) {
-                if (context.getProperty(InvocationContextUtils
-                        .INVOCATION_CONTEXT_PROPERTY) == null) {
-                    invocationContext = initInvocationContext(context);
-                    context.setProperty(InvocationContextUtils.INVOCATION_CONTEXT_PROPERTY, invocationContext);
-                }
-            }
+            invocationContext = initInvocationContext(context);
+            context.setProperty(InvocationContextUtils.INVOCATION_CONTEXT_PROPERTY, invocationContext);
         }
         return invocationContext;
     }

--- a/tests/ballerina-unit-test/src/test/resources/log4j.properties
+++ b/tests/ballerina-unit-test/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p [%c] - %m%n
+
+log4j.logger.com.zaxxer.hikari=ERROR


### PR DESCRIPTION
## Purpose
> There is no requirement to synchronize the getInvocationContext utility method. removed this unnecessary synchronization to overcome the thread contentions introduced as a result of the synchronization.

Ref https://github.com/ballerina-platform/ballerina-lang/pull/14705

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, releated PRs, TODO items or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
