### PR TITLE
Switch thread model based on runtime parameter

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVMExecutor.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVMExecutor.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.bre.bvm;
 
 import org.ballerinalang.bre.bvm.Strand.State;
+import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BBoolean;
@@ -148,7 +149,11 @@ public class BVMExecutor {
         ObserveUtils.startResourceObservation(strand, observerContext);
 
         BVMScheduler.stateChange(strand, State.NEW, State.RUNNABLE);
-        BVMScheduler.schedule(strand);
+        if (ConfigRegistry.getInstance().getAsBoolean("b7a.http.worker.nonblocking")) {
+            BVMScheduler.execute(strand);
+        } else {
+            BVMScheduler.schedule(strand);
+        }
     }
 
     private static void infectResourceFunction(StrandResourceCallback strandResourceCallback, Strand strand) {


### PR DESCRIPTION
## Purpose
> Introduce a ballerina run-time parameter to switch between the two thread models where the worker pool is involved or not.
```
-e b7a.http.worker.nonblocking=true
```
> The default behavior is false which represents the current thread model with the ballerina worker pool. When user specifies the parameter as true, worker pool will not be applied but the single thread will perform operations in a non-blocking manner.

## Samples
> balleina run -e b7a.http.worker.nonblocking=true some_http_service.bal

## Remarks
> List any other known issues, releated PRs, TODO items or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
