### PR TITLE
Fix port already open error occurring locally

### DIFF
--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/socket/SocketBaseTest.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/socket/SocketBaseTest.java
@@ -42,7 +42,6 @@ public class SocketBaseTest extends BaseTest {
     public void start() throws BallerinaTestException {
         executor = Executors.newSingleThreadExecutor();
         MockSocketServer mockSocketServer = new MockSocketServer();
-        executor.execute(mockSocketServer);
         String privateKey = StringEscapeUtils.escapeJava(
                 Paths.get("src", "test", "resources", "certsAndKeys", "private.key").toAbsolutePath().toString());
         String publicCert = StringEscapeUtils.escapeJava(
@@ -55,6 +54,7 @@ public class SocketBaseTest extends BaseTest {
         String[] args = new String[] { "-e", "certificate.key=" + privateKey, "-e", "public.cert=" + publicCert };
         serverInstance = new BServerInstance(balServer);
         serverInstance.startServer(balFile, "services", args, requiredPorts);
+        executor.execute(mockSocketServer);
     }
 
     @AfterGroups(value = "socket-test",


### PR DESCRIPTION
## Purpose
SocketBaseTest always fails in mac as MockSocketServer.SERVER_PORT is open when control reaches serverInstance.startServer() line.
