### PR TITLE
Exclude spotbug warning in gradle build

### DIFF
--- a/stdlib/grpc/spotbugs-exclude.xml
+++ b/stdlib/grpc/spotbugs-exclude.xml
@@ -16,4 +16,9 @@
   ~ under the License.
   -->
 <FindBugsFilter>
+    <Match>
+        <Class name="org.ballerinalang.net.grpc.proto.ServiceProtoBuilder" />
+        <Method name="process" />
+        <Bug pattern="BC_IMPOSSIBLE_CAST" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Purpose
Exclude spotbug warning in gradle build in gRPC module.
