### PR TITLE
Replace dot with underscore for metrics reported to Prometheus

### DIFF
--- a/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/ballerina/prometheus/reporter.bal
+++ b/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/ballerina/prometheus/reporter.bal
@@ -52,7 +52,7 @@ service PrometheusReporter on prometheusListener {
         string payload = EMPTY_STRING;
         foreach var m in metrics {
             observe:Metric metric = <observe:Metric> m;
-            string  qualifiedMetricName = metric.name.replaceAll("/", "_");
+            string  qualifiedMetricName = metric.name.replaceAll("/", "_").replaceAll("\\.", "_");
             string metricReportName = getMetricName(qualifiedMetricName, "value");
             payload += generateMetricHelp(metricReportName, metric.desc);
             payload += generateMetricInfo(metricReportName, metric.metricType);


### PR DESCRIPTION
## Purpose
When using a connector, the module version which includes full stops, renders the published metrics invalid. Hence, replacing the "." character with "_" when reporting to Prometheus

Fixes #14927

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
