### PR TITLE
Remove andes client and update examples

### DIFF
--- a/distribution/zip/ballerina/build.gradle
+++ b/distribution/zip/ballerina/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     dist 'org.quartz-scheduler:quartz:2.3.0'
     dist 'org.slf4j:slf4j-api:1.7.22'
     dist 'org.slf4j:slf4j-jdk14:1.7.22'
-    dist 'org.wso2.andes.wso2:andes-client:3.2.55'
     dist 'org.wso2.carbon:org.wso2.carbon.core:5.1.0'
     dist 'org.wso2.orbit.com.lmax:disruptor:3.3.2.wso2v2'
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'

--- a/distribution/zip/ballerina/pom.xml
+++ b/distribution/zip/ballerina/pom.xml
@@ -166,6 +166,7 @@
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-privacy</artifactId>
         </dependency>
+        <!-- This dependency is required for WebSocket Compression -->
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jzlib</artifactId>
@@ -223,10 +224,6 @@
         <dependency>
             <groupId>javax.jms</groupId>
             <artifactId>javax.jms-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.andes.wso2</groupId>
-            <artifactId>andes-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.securevault</groupId>

--- a/distribution/zip/ballerina/src/assembly/bin.xml
+++ b/distribution/zip/ballerina/src/assembly/bin.xml
@@ -225,7 +225,6 @@
 
                 <!-- JMS connector dependencies -->
                 <include>javax.jms:javax.jms-api:jar</include>
-                <include>org.wso2.andes.wso2:andes-client:jar</include>
                 <include>org.wso2.securevault:org.wso2.securevault:jar</include>
 
                 <!-- Check-pointing dependencies -->

--- a/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.bal
+++ b/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.bal
@@ -1,11 +1,14 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider. This example makes use
+// of the ActiveMQ Artemis broker for demonstration while it can be tried with
+// other brokers that support JMS.
+
 jms:Connection conn = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon?"
-            + "brokerlist='tcp://localhost:5672'"
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.

--- a/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.out
+++ b/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # To run this sample, navigate to the directory that contains the
 # `.bal` file and issue the `ballerina run` command.

--- a/examples/jms-headers-and-properties/jms_headers_and_properties.bal
+++ b/examples/jms-headers-and-properties/jms_headers_and_properties.bal
@@ -3,9 +3,9 @@ import ballerina/log;
 
 // Initialize a JMS connection with the provider.
 jms:Connection conn = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory:
+         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // Initialize a JMS session on top of the created connection.
@@ -26,9 +26,9 @@ service jmsListener on consumerEndpoint {
                                 jms:Message message) {
         // Create a queue sender.
         jms:QueueSender queueSender = new({
-                initialContextFactory: "bmbInitialContextFactory",
-                providerUrl: "amqp://admin:admin@carbon/carbon"
-                    + "?brokerlist='tcp://localhost:5672'"
+                initialContextFactory: 
+                "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+                providerUrl: "tcp://localhost:61616"
             }, queueName = "RequestQueue");
 
         var content = message.getTextMessageContent();

--- a/examples/jms-headers-and-properties/jms_headers_and_properties.out
+++ b/examples/jms-headers-and-properties/jms_headers_and_properties.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # To run this sample, navigate to the directory that contains the
 # `.bal` file and issue the `ballerina run` command.

--- a/examples/jms-queue-message-producer/jms_queue_message_producer.bal
+++ b/examples/jms-queue-message-producer/jms_queue_message_producer.bal
@@ -1,11 +1,14 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider.  This example makes use
+// of the ActiveMQ Artemis broker for demonstration while it can be tried with
+// other brokers that support JMS.
+
 jms:Connection jmsConnection = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon?"
-            + "brokerlist='tcp://localhost:5672'"
+        initialContextFactory:
+         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.

--- a/examples/jms-queue-message-producer/jms_queue_message_producer.description
+++ b/examples/jms-queue-message-producer/jms_queue_message_producer.description
@@ -1,1 +1,4 @@
-// In this example, a message is published to a queue using a Java Message Service (JMS) publisher.
+// In this example, a message is published to a queue using a
+// Java Message Service (JMS) publisher.  Here Connection and Session are
+// created explicitly to allow reusability.
+

--- a/examples/jms-queue-message-producer/jms_queue_message_producer.out
+++ b/examples/jms-queue-message-producer/jms_queue_message_producer.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # To run this sample, navigate to the directory that contains the
 # `.bal` file and issue the `ballerina run` command.

--- a/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.bal
+++ b/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.bal
@@ -1,11 +1,13 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider. This example makes use
+// of the ActiveMQ Artemis broker for demonstration while it can be tried with
+// other brokers that support JMS.
 jms:Connection conn = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory:
+         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.
@@ -22,7 +24,7 @@ service jmsListener on consumerEndpoint {
 
     // This resource is invoked when a message is received.
     resource function onMessage(jms:QueueReceiverCaller consumer,
-                                jms:Message message) {
+    jms:Message message) {
         // This retrieves the text message.
         var result = message.getTextMessageContent();
         if (result is string) {

--- a/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.out
+++ b/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the
 # 'jms_queue_message_receiver_with_client_acknowledgment.bal' file and issue the 'ballerina run' command.

--- a/examples/jms-queue-message-receiver/jms_queue_message_receiver.bal
+++ b/examples/jms-queue-message-receiver/jms_queue_message_receiver.bal
@@ -1,11 +1,13 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider. This example makes use
+// of the ActiveMQ Artemis broker for demonstration while it can be tried with
+// other brokers that support JMS.
+
 jms:Connection conn = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.

--- a/examples/jms-queue-message-receiver/jms_queue_message_receiver.description
+++ b/examples/jms-queue-message-receiver/jms_queue_message_receiver.description
@@ -1,1 +1,3 @@
-// Ballerina natively supports Java Message Service (JMS). In this example, a simple JMS queue receiver is created.
+// Ballerina natively supports Java Message Service (JMS). In this example,
+// a JMS queue receiver is created. Here Connection and Session are created
+// explicitly to allow reusability.

--- a/examples/jms-queue-message-receiver/jms_queue_message_receiver.out
+++ b/examples/jms-queue-message-receiver/jms_queue_message_receiver.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the
 # 'jms_queue_message_receiver.bal' file and issue the 'ballerina run' command.

--- a/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.bal
+++ b/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.bal
@@ -1,13 +1,15 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This creates a simple durable topic subscriber.
+// This creates a simple durable topic subscriber.  This example makes use of
+// the ActiveMQ Artemis broker for demonstration while it can be tried with
+// other brokers that support JMS.
 listener jms:DurableTopicSubscriber subscriberEndpoint = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'",
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
-    }, "BallerinaTopic", "sub1");
+    }, "MyTopic", "sub1");
 
 // This binds the created consumer to the listener service.
 service jmsListener on subscriberEndpoint {

--- a/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.out
+++ b/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the 'jms_simple_durable_topic_message_subscriber.bal' file and issue the
 # 'ballerina run' command.

--- a/examples/jms-simple-queue-message-producer/jms_simple_queue_message_producer.bal
+++ b/examples/jms-simple-queue-message-producer/jms_simple_queue_message_producer.bal
@@ -1,11 +1,13 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This creates a queue sender.
+// This creates a queue sender. This example makes use of the ActiveMQ Artemis
+// broker for demonstration while it can be tried with other brokers that
+// support JMS.
 jms:QueueSender queueSender = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon?"
-            + "brokerlist='tcp://localhost:5672'",
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
     }, queueName = "MyQueue");
 

--- a/examples/jms-simple-queue-message-producer/jms_simple_queue_message_producer.out
+++ b/examples/jms-simple-queue-message-producer/jms_simple_queue_message_producer.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the'jms_simple_queue_message_producer.bal' file and issue the
 # 'ballerina run' command.

--- a/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.bal
+++ b/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.bal
@@ -1,11 +1,14 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This creates a simple queue receiver.
+// This creates a simple queue receiver. This example makes use of the ActiveMQ
+// Artemis broker for demonstration while it can be tried with other brokers
+// that support JMS.
+
 listener jms:QueueReceiver consumerEndpoint = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'",
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
     }, queueName = "MyQueue");
 
@@ -14,7 +17,7 @@ service jmsListener on consumerEndpoint {
 
     // This resource is invoked when a message is received.
     resource function onMessage(jms:QueueReceiverCaller consumer,
-                                jms:Message message) {
+    jms:Message message) {
         // Retrieve the text message.
         var messageText = message.getTextMessageContent();
         if (messageText is string) {

--- a/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.out
+++ b/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the 'jms_simple_queue_message_receiver.bal' file and issue the
 # 'ballerina run' command.

--- a/examples/jms-simple-topic-message-producer/jms_simple_topic_message_producer.bal
+++ b/examples/jms-simple-topic-message-producer/jms_simple_topic_message_producer.bal
@@ -1,13 +1,16 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This creates a topic publisher.
+// This creates a topic publisher.  This example makes use of the ActiveMQ'
+// Artemis broker for demonstration while it can be tried with other brokers
+// that support JMS.
+
 jms:TopicPublisher topicPublisher = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'",
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
-    }, topicPattern = "BallerinaTopic");
+    }, topicPattern = "MyTopic");
 
 public function main() {
     // This creates a Text message.

--- a/examples/jms-simple-topic-message-producer/jms_simple_topic_message_producer.out
+++ b/examples/jms-simple-topic-message-producer/jms_simple_topic_message_producer.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the 'jms_simple_topic_message_producer.bal' file and issue the
 # 'ballerina run' command.

--- a/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.bal
+++ b/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.bal
@@ -1,20 +1,22 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This creates a simple topic listener.
+// This creates a simple topic listener. This example makes use of the ActiveMQ
+// Artemis broker for demonstration while it can be tried with other brokers
+// that support JMS.
 listener jms:TopicSubscriber subscriberEndpoint = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon?"
-            + "brokerlist='tcp://localhost:5672'",
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
-    }, topicPattern = "BallerinaTopic");
+    }, topicPattern = "MyTopic");
 
 // This binds the created subscriber to the listener service.
 service jmsListener on subscriberEndpoint {
 
     //This resource is invoked when a message is received.
     resource function onMessage(jms:TopicSubscriberCaller consumer,
-                                jms:Message message) {
+    jms:Message message) {
         // Retrieve the text message.
         var messageText = message.getTextMessageContent();
         if (messageText is string) {

--- a/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.out
+++ b/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.out
@@ -1,11 +1,8 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the
 # 'jms_simple_topic_message_subscriber.bal' file and issue the 'ballerina run' command.
 $ ballerina run jms_simple_topic_message_subscriber.bal
 # The JMS subscriber runs as a Ballerina service and listens to the subscribed topic.
 Initiating service(s) in 'jms_simple_topic_message_subscriber.bal'
-2018-06-14 15:29:50,366 INFO  [ballerina/jms] - Subscriber created for topic BallerinaTopic

--- a/examples/jms-synchronous-queue-message-receiver/jms_synchronous_queue_message_receiver.bal
+++ b/examples/jms-synchronous-queue-message-receiver/jms_synchronous_queue_message_receiver.bal
@@ -1,11 +1,14 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider. This example makes
+// use of the ActiveMQ Artemis broker for demonstration while it can be tried
+// with other brokers that support JMS.
+
 jms:Connection jmsConnection = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.

--- a/examples/jms-synchronous-queue-message-receiver/jms_synchronous_queue_message_receiver.out
+++ b/examples/jms-synchronous-queue-message-receiver/jms_synchronous_queue_message_receiver.out
@@ -1,10 +1,7 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the
 # 'jms_synchronous_queue_message_receiver.bal' file and issue the 'ballerina run' command.
 $ ballerina run jms_synchronous_queue_message_receiver.bal
 2018-06-14 15:31:51,884 INFO  [ballerina/jms] - Message receiver created for queue MyQueue
-2018-06-14 15:31:56,895 INFO  [] - Message not received

--- a/examples/jms-topic-message-producer/jms_topic_message_producer.bal
+++ b/examples/jms-topic-message-producer/jms_topic_message_producer.bal
@@ -1,11 +1,14 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider. This example makes use
+// of the ActiveMQ Artemis broker for demonstration while it can be tried with
+// other brokers that support JMS.
+
 jms:Connection jmsConnection = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.

--- a/examples/jms-topic-message-producer/jms_topic_message_producer.description
+++ b/examples/jms-topic-message-producer/jms_topic_message_producer.description
@@ -1,1 +1,4 @@
-// In this example,  a message is published to a topic using a Java Message Service (JMS) publisher.
+// In this example,  a message is published to a topic using a Java Message
+// Service (JMS) publisher.  Here Connection and Session are created explicitly
+// to allow reusability.
+

--- a/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.bal
+++ b/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.bal
@@ -1,11 +1,13 @@
 import ballerina/jms;
 import ballerina/log;
 
-// This initializes a JMS connection with the provider.
+// This initializes a JMS connection with the provider. Here Connection and
+// Session are created explicitly to allow reusability.
+
 jms:Connection conn = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory:
+         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // This initializes a JMS session on top of the created connection.

--- a/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.out
+++ b/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # Navigate to the directory that contains the 'jms_topic_message_subscriber.bal' file and issue the
 # 'ballerina run' command.

--- a/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.bal
+++ b/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.bal
@@ -2,11 +2,14 @@ import ballerina/http;
 import ballerina/jms;
 import ballerina/log;
 
-// Create a simple queue receiver.
+// Create a simple queue receiver.  This example makes use of the
+// ActiveMQ Artemis broker for demonstration while it can be tried with other
+// brokers that support JMS.
+
 listener jms:QueueReceiver consumerEndpoint = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'",
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
     }, queueName = "MyQueue");
 

--- a/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.out
+++ b/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run` command.

--- a/examples/transactional-queue-message-producer/transactional_queue_message_producer.bal
+++ b/examples/transactional-queue-message-producer/transactional_queue_message_producer.bal
@@ -1,11 +1,14 @@
 import ballerina/jms;
 import ballerina/log;
 
-// Initialize a JMS connection with the provider.
+// Initialize a JMS connection with the provider. This example makes use of the
+// ActiveMQ Artemis broker for demonstration while it can be tried with other
+// brokers that support JMS.
+
 jms:Connection jmsConnection = new({
-        initialContextFactory: "bmbInitialContextFactory",
-        providerUrl: "amqp://admin:admin@carbon/carbon"
-            + "?brokerlist='tcp://localhost:5672'"
+        initialContextFactory: 
+        "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+        providerUrl: "tcp://localhost:61616"
     });
 
 // Initialize a JMS session on top of the created connection.

--- a/examples/transactional-queue-message-producer/transactional_queue_message_producer.out
+++ b/examples/transactional-queue-message-producer/transactional_queue_message_producer.out
@@ -1,7 +1,5 @@
-# Download Ballerina message broker from [here](https://github.com/ballerina-platform/ballerina-message-broker/releases/download/v0.970.5/message-broker-0.970.5.zip)
-# Extract the zip file and navigate to <BROKER_HOME>/bin
-# Start Ballerina message broker by executing either the `broker` or the `broker.bat` command.
-$ ./broker
+# Start the Artemis message broker
+# Copy the artemis-jms-client-<version>.jar and artemis-selector-<version>.jar files to <BALLERINA_HOME>/bre/lib
 
 # To start the service, navigate to the directory that contains the
 # `.bal` file and use the `ballerina run --experimental` command (since transaction is an experimental feature).

--- a/pom.xml
+++ b/pom.xml
@@ -1274,6 +1274,7 @@
                 <artifactId>netty-resolver</artifactId>
                 <version>${netty.version}</version>
             </dependency>
+            <!-- This dependency is required for WebSocket Compression -->
             <dependency>
                 <groupId>com.jcraft</groupId>
                 <artifactId>jzlib</artifactId>
@@ -1592,11 +1593,6 @@
             </dependency>
             <!-- JMS connector dependencies -->
             <dependency>
-                <groupId>org.wso2.transport.jms</groupId>
-                <artifactId>transport-jms</artifactId>
-                <version>${wso2.transport.jms.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.jms</groupId>
                 <artifactId>javax.jms-api</artifactId>
                 <version>${javax.jms.version}</version>
@@ -1605,11 +1601,6 @@
                 <groupId>org.bytedeco.javacpp-presets</groupId>
                 <artifactId>llvm-platform</artifactId>
                 <version>${javacpp.llvm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.andes.wso2</groupId>
-                <artifactId>andes-client</artifactId>
-                <version>${andes.client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.securevault</groupId>
@@ -2499,10 +2490,8 @@
         <hdrhistogram.version>2.1.11</hdrhistogram.version>
 
         <!-- JMS Connector -->
-        <wso2.transport.jms.version>6.0.51</wso2.transport.jms.version>
         <javax.jms.version>2.0.1</javax.jms.version>
         <javacpp.llvm.version>6.0.1-1.4.2</javacpp.llvm.version>
-        <andes.client.version>3.2.87</andes.client.version>
         <wso2.securevault.version>1.1.2</wso2.securevault.version>
 
         <!-- Artemis connector -->

--- a/stdlib/jms/src/main/ballerina/jms/Module.md
+++ b/stdlib/jms/src/main/ballerina/jms/Module.md
@@ -32,8 +32,8 @@ import ballerina/log;
 
 // Create a simple queue receiver.
 listener jms:SimpleQueueReceiver consumerEP = new({
-    initialContextFactory: "bmbInitialContextFactory",
-    providerUrl: "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'",
+    initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+    providerUrl: "tcp://localhost:61616",
     acknowledgementMode: "AUTO_ACKNOWLEDGE",
     queueName: "MyQueue"
 });
@@ -62,8 +62,8 @@ import ballerina/log;
 
 // Create a topic publisher.
 jms:SimpleTopicPublisher topicPublisher = new({
-    initialContextFactory: "bmbInitialContextFactory",
-    providerUrl: "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'",
+    initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+    providerUrl: "tcp://localhost:61616",
     acknowledgementMode: "AUTO_ACKNOWLEDGE",
     topicPattern: "BallerinaTopic"
 });
@@ -92,8 +92,8 @@ import ballerina/log;
 
 // Initialize a JMS connection with the provider.
 jms:Connection conn = new({
-    initialContextFactory: "bmbInitialContextFactory",
-    providerUrl: "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'"
+    initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+    providerUrl: "tcp://localhost:61616"
 });
 
 // Initialize a JMS session on top of the created connection.
@@ -135,8 +135,8 @@ import ballerina/log;
 
 // Initialize a JMS connection with the provider.
 jms:Connection jmsConnection = new({
-    initialContextFactory: "bmbInitialContextFactory",
-    providerUrl: "amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'"
+    initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+    providerUrl: "tcp://localhost:61616"
 });
 
 // Initialize a JMS session on top of the created connection.
@@ -172,8 +172,8 @@ import ballerina/jms;
 import ballerina/log;
 
 jms:Connection conn = new({
-    initialContextFactory: "bmbInitialContextFactory",
-    providerUrl: "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
+    initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+    providerUrl: "tcp://localhost:61616"
 });
 
 jms:Session jmsSession = new(conn, {
@@ -206,8 +206,8 @@ import ballerina/jms;
 import ballerina/log;
 
 jms:Connection jmsConnection = new({
-    initialContextFactory: "bmbInitialContextFactory",
-    providerUrl: "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
+    initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
+    providerUrl: "tcp://localhost:61616"
 });
 
 jms:Session jmsSession = new(jmsConnection, {

--- a/stdlib/jms/src/main/ballerina/jms/durable_topic_subscriber.bal
+++ b/stdlib/jms/src/main/ballerina/jms/durable_topic_subscriber.bal
@@ -56,7 +56,7 @@ public type DurableTopicSubscriber object {
     # Binds the durable topic subscriber endpoint to a service
     #
     # + serviceType - Type descriptor of the service
-    # + data - Service annotations
+    # + name - The name of the service
     # + return - Nil or error upon failure to register listener
     public function __attach(service serviceType, string? name = ()) returns error? {
         return self.registerListener(serviceType, self.consumerActions, name);
@@ -71,8 +71,9 @@ public type DurableTopicSubscriber object {
     #
     # + return - Nil or error upon failure to start
     public function __start() returns error? {
-        return ();
+        return self.start();
     }
+    private function start() returns error? = external;
 
     # Return the subscrber caller actions
     #

--- a/stdlib/jms/src/main/ballerina/jms/queue_receiver.bal
+++ b/stdlib/jms/src/main/ballerina/jms/queue_receiver.bal
@@ -27,7 +27,7 @@ public type QueueReceiver object {
     *AbstractListener;
 
     public QueueReceiverCaller consumerActions = new;
-    public Session? session;
+    public Session session;
     public string messageSelector = "";
     public string identifier = "";
 
@@ -36,7 +36,7 @@ public type QueueReceiver object {
     # + c - The JMS Session object or Configurations related to the receiver
     # + queueName - Name of the queue
     # + messageSelector - The message selector for the queue
-    # + identifier - Unique identifier for the reciever
+    # + identifier - Unique identifier for the receiver
     public function __init(Session|ReceiverEndpointConfiguration c, string? queueName = (), string messageSelector = "",
                            string identifier = "") {
         self.consumerActions.queueReceiver = self;
@@ -61,8 +61,8 @@ public type QueueReceiver object {
 
     # Binds the queue receiver endpoint to a service
     #
-    # + serviceType - Type descriptor of the service to bind to
-    # + data - Name of the service
+    # + serviceType - The service instance
+    # + name - Name of the service
     # + return - Nil or error upon failure to register listener
     public function __attach(service serviceType, string? name = ()) returns error? {
         return self.registerListener(serviceType, self.consumerActions, name);
@@ -72,13 +72,14 @@ public type QueueReceiver object {
 
     function createQueueReceiver(Session? session, string messageSelector, string|Destination dest) = external;
 
-    # Starts the endpoint. Function is ignored by the receiver endpoint
+    # Starts the endpoint
     #
     # + return - Nil or error upon failure to start
     public function __start() returns error? {
-        return ();
-        // Ignore
+        return self.start();
     }
+
+    private function start() returns error? = external;
 
     # Retrieves the QueueReceiver consumer action handler
     #
@@ -127,13 +128,8 @@ public type QueueReceiverCaller client object {
         var queueReceiver = self.queueReceiver;
         if (queueReceiver is QueueReceiver) {
             var session = queueReceiver.session;
-            if (session is Session) {
-                validateQueue(destination);
-                queueReceiver.createQueueReceiver(session, queueReceiver.messageSelector, destination);
-            } else {
-                log:printInfo("Session is (), Message receiver is not properly initialized for queue " +
-                        destination.destinationName);
-            }
+            validateQueue(destination);
+            queueReceiver.createQueueReceiver(session, queueReceiver.messageSelector, destination);
         } else {
             log:printInfo("Message receiver is not properly initialized for queue " + destination.destinationName);
         }

--- a/stdlib/jms/src/main/ballerina/jms/session.bal
+++ b/stdlib/jms/src/main/ballerina/jms/session.bal
@@ -19,11 +19,13 @@
 # + config - Used to store configurations related to a JMS session
 public type Session object {
 
-    public SessionConfiguration config;
+    private SessionConfiguration config;
+    private Connection conn;
 
     # Default constructor of the JMS session
     public function __init(Connection connection, SessionConfiguration c) {
         self.config = c;
+        self.conn = connection;
         self.initEndpoint(connection);
     }
 

--- a/stdlib/jms/src/main/ballerina/jms/topic_subscriber.bal
+++ b/stdlib/jms/src/main/ballerina/jms/topic_subscriber.bal
@@ -26,7 +26,7 @@ public type TopicSubscriber object {
     *AbstractListener;
 
     public TopicSubscriberCaller consumerActions = new;
-    public Session? session;
+    public Session session;
     public string messageSelector = "";
 
     # Initialize the TopicSubscriber endpoint
@@ -59,8 +59,8 @@ public type TopicSubscriber object {
 
     # Register TopicSubscriber endpoint
     #
-    # + serviceType - Type descriptor of the service
-    # + data - Service annotations
+    # + serviceType - The service instance
+    # + name - Name of the service
     # + return - Nil or error upon failure to register listener
     public function __attach(service serviceType, string? name = ()) returns error? {
         return self.registerListener(serviceType, self.consumerActions, name);
@@ -74,7 +74,7 @@ public type TopicSubscriber object {
     #
     # + return - Nil or error upon failure to start
     public function __start() returns error? {
-        return ();
+        return self.start();
     }
 
     # Get TopicSubscriber actions handler
@@ -92,6 +92,7 @@ public type TopicSubscriber object {
     }
 
     function closeSubscriber(TopicSubscriberCaller actions) returns error? = external;
+    private function start() returns error? = external;
 };
 
 # Remote functions that topic subscriber endpoint could perform
@@ -123,13 +124,9 @@ public type TopicSubscriberCaller client object {
         var subscriber = self.topicSubscriber;
         if (subscriber is TopicSubscriber) {
             var session = subscriber.session;
-            if (session is Session) {
-                validateTopic(destination);
-                subscriber.createSubscriber(session, subscriber.messageSelector, destination);
-                log:printInfo("Subscriber created for topic " + destination.destinationName);
-            } else {
-                log:printInfo("Session is (), Topic subscriber is not properly initialized");
-            }
+            validateTopic(destination);
+            subscriber.createSubscriber(session, subscriber.messageSelector, destination);
+            log:printInfo("Subscriber created for topic " + destination.destinationName);
         } else {
             log:printInfo("Topic subscriber is not properly initialized");
         }

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/JmsConstants.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/JmsConstants.java
@@ -40,6 +40,7 @@ public class JmsConstants {
 
     // Others
     private static final String COLON = ":";
+    public static final String COUNTDOWN_LATCH = "countdown-latch";
 
     // The object types
     public static final String QUEUE_RECEIVER_OBJ_NAME = "QueueReceiver";
@@ -145,6 +146,10 @@ public class JmsConstants {
 
     public static final String MB_ICF_NAME = "org.wso2.andes.jndi.PropertiesFileInitialContextFactory";
     public static final String MB_CF_NAME_PREFIX = "connectionfactory.";
+
+    public static final String NON_DAEMON_THREAD_RUNNING = "non-daemon-thread-running.";
+    public static final String ARTEMIS_ICF = "artemis";
+
 
     private static Map<String, String> mappingParameters;
 

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/JmsUtils.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/JmsUtils.java
@@ -85,16 +85,16 @@ public class JmsUtils {
         return configParams;
     }
 
-    public static Connection createConnection(Struct connectionConfig) {
+    public static Connection createConnection(BMap<String, BValue> connectionConfig) {
         Map<String, String> configParams = new HashMap<>();
 
-        String initialContextFactory = connectionConfig.getStringField(JmsConstants.ALIAS_INITIAL_CONTEXT_FACTORY);
+        String initialContextFactory = connectionConfig.get(JmsConstants.ALIAS_INITIAL_CONTEXT_FACTORY).stringValue();
         configParams.put(JmsConstants.ALIAS_INITIAL_CONTEXT_FACTORY, initialContextFactory);
 
-        String providerUrl = connectionConfig.getStringField(JmsConstants.ALIAS_PROVIDER_URL);
+        String providerUrl = connectionConfig.get(JmsConstants.ALIAS_PROVIDER_URL).stringValue();
         configParams.put(JmsConstants.ALIAS_PROVIDER_URL, providerUrl);
 
-        String factoryName = connectionConfig.getStringField(JmsConstants.ALIAS_CONNECTION_FACTORY_NAME);
+        String factoryName = connectionConfig.get(JmsConstants.ALIAS_CONNECTION_FACTORY_NAME).stringValue();
         configParams.put(JmsConstants.ALIAS_CONNECTION_FACTORY_NAME, factoryName);
 
         preProcessIfWso2MB(configParams);
@@ -104,10 +104,11 @@ public class JmsUtils {
         configParams.forEach(properties::put);
 
         //check for additional jndi properties
-        Map<String, Value> props = connectionConfig.getMapField(JmsConstants.PROPERTIES_MAP);
+        @SuppressWarnings(JmsConstants.UNCHECKED)
+        Map<String, BValue> props = ((BMap<String, BValue>) connectionConfig.get(JmsConstants.PROPERTIES_MAP)).getMap();
         if (props != null) {
-            for (Map.Entry<String, Value> entry : props.entrySet()) {
-                properties.put(entry.getKey(), entry.getValue().getStringValue());
+            for (Map.Entry<String, BValue> entry : props.entrySet()) {
+                properties.put(entry.getKey(), entry.getValue().stringValue());
             }
         }
 
@@ -116,10 +117,10 @@ public class JmsUtils {
             ConnectionFactory connectionFactory = (ConnectionFactory) initialContext.lookup(factoryName);
             String username = null;
             String password = null;
-            if (connectionConfig.getRefField(JmsConstants.ALIAS_USERNAME) != null &&
-                    connectionConfig.getRefField(JmsConstants.ALIAS_PASSWORD) != null) {
-                username = connectionConfig.getRefField(JmsConstants.ALIAS_USERNAME).getStringValue();
-                password = connectionConfig.getRefField(JmsConstants.ALIAS_PASSWORD).getStringValue();
+            if (connectionConfig.get(JmsConstants.ALIAS_USERNAME) != null &&
+                    connectionConfig.get(JmsConstants.ALIAS_PASSWORD) != null) {
+                username = connectionConfig.get(JmsConstants.ALIAS_USERNAME).stringValue();
+                password = connectionConfig.get(JmsConstants.ALIAS_PASSWORD).stringValue();
             }
 
             if (!JmsUtils.isNullOrEmptyAfterTrim(username) && password != null) {

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/CloseConsumerHandler.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/CloseConsumerHandler.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.net.jms.JmsConstants;
 import org.ballerinalang.net.jms.utils.BallerinaAdapter;
 
+import java.util.concurrent.CountDownLatch;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 
@@ -38,12 +39,10 @@ public class CloseConsumerHandler {
 
     public static void handle(Context context) {
         @SuppressWarnings(JmsConstants.UNCHECKED)
-        BMap<String, BValue> connectorBObject = (BMap<String, BValue>) context.getRefArgument(1);
-        if (connectorBObject.getNativeData(JmsConstants.JMS_CONSUMER_OBJECT) != null) {
-            MessageConsumer consumer = BallerinaAdapter.getNativeObject(connectorBObject,
-                                                                        JmsConstants.JMS_CONSUMER_OBJECT,
-                                                                        MessageConsumer.class,
-                                                                        context);
+        BMap<String, BValue> listenerObj = (BMap<String, BValue>) context.getRefArgument(1);
+        if (listenerObj.getNativeData(JmsConstants.JMS_CONSUMER_OBJECT) != null) {
+            MessageConsumer consumer = BallerinaAdapter.getNativeObject(
+                    listenerObj, JmsConstants.JMS_CONSUMER_OBJECT, MessageConsumer.class, context);
             try {
                 if (consumer != null) {
                     consumer.close();
@@ -52,6 +51,14 @@ public class CloseConsumerHandler {
                 BallerinaAdapter.throwBallerinaException("Error closing message consumer.", context, e);
             }
         }
+        releaseNonDaemonThreadIfRunning(listenerObj);
     }
 
+    private static void releaseNonDaemonThreadIfRunning(BMap<String, BValue> listenerObj) {
+        CountDownLatch countDownLatch =
+                (CountDownLatch) listenerObj.getNativeData(JmsConstants.COUNTDOWN_LATCH);
+        if (countDownLatch != null) {
+            countDownLatch.countDown();
+        }
+    }
 }

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/StartNonDaemonThreadHandler.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/common/StartNonDaemonThreadHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.common;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.jms.JmsConstants;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Close the message consumer object.
+ */
+public class StartNonDaemonThreadHandler {
+
+    private StartNonDaemonThreadHandler() {
+    }
+
+    public static void handle(Context context) {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        @SuppressWarnings(JmsConstants.UNCHECKED)
+        BMap<String, BValue> listenerObj = (BMap<String, BValue>) context.getRefArgument(0);
+        @SuppressWarnings(JmsConstants.UNCHECKED)
+        BMap<String, BValue> sessionObj = (BMap<String, BValue>) listenerObj.get("session");
+        @SuppressWarnings(JmsConstants.UNCHECKED)
+        BMap<String, BValue> connectionObj = (BMap<String, BValue>) sessionObj.get("conn");
+
+        // It is essential to keep a non-daemon thread running in order to avoid the java program or the
+        // Ballerina service from exiting
+        boolean nonDaemonThread = (boolean) connectionObj.getNativeData(JmsConstants.NON_DAEMON_THREAD_RUNNING);
+        if (!nonDaemonThread) {
+            listenerObj.addNativeData(JmsConstants.COUNTDOWN_LATCH, countDownLatch);
+            new Thread(() -> {
+                try {
+                    countDownLatch.await();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+            }).start();
+        }
+    }
+
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/connection/CreateConnection.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/connection/CreateConnection.java
@@ -20,10 +20,10 @@
 package org.ballerinalang.net.jms.nativeimpl.endpoint.connection;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.CallableUnitCallback;
-import org.ballerinalang.connector.api.Struct;
-import org.ballerinalang.model.NativeCallableUnit;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
@@ -32,6 +32,7 @@ import org.ballerinalang.net.jms.JmsUtils;
 import org.ballerinalang.net.jms.LoggingExceptionListener;
 import org.ballerinalang.net.jms.utils.BallerinaAdapter;
 
+import java.util.UUID;
 import javax.jms.Connection;
 import javax.jms.JMSException;
 
@@ -50,27 +51,43 @@ import javax.jms.JMSException;
         },
         isPublic = true
 )
-public class CreateConnection implements NativeCallableUnit {
+public class CreateConnection extends BlockingNativeCallableUnit {
 
     @Override
-    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
-        Struct connectionBObject = BallerinaAdapter.getReceiverObject(context);
-        Struct connectionConfig = connectionBObject.getStructField(JmsConstants.CONNECTION_CONFIG);
+    public void execute(Context context) {
+        @SuppressWarnings(JmsConstants.UNCHECKED)
+        BMap<String, BValue> connectionObject = (BMap<String, BValue>) context.getRefArgument(0);
+        @SuppressWarnings(JmsConstants.UNCHECKED)
+        BMap<String, BValue> connectionConfig =
+                (BMap<String, BValue>) connectionObject.get(JmsConstants.CONNECTION_CONFIG);
 
         Connection connection = JmsUtils.createConnection(connectionConfig);
+        setIfNonDaemonThreadRunningAtAllTimes(connectionObject, connectionConfig);
         try {
+            if (connection.getClientID() == null) {
+                connection.setClientID(UUID.randomUUID().toString());
+            }
             connection.setExceptionListener(new LoggingExceptionListener());
             connection.start();
         } catch (JMSException e) {
             BallerinaAdapter.throwBallerinaException("Error occurred while starting connection.", context, e);
         }
-        connectionBObject.addNativeData(JmsConstants.JMS_CONNECTION, connection);
+        connectionObject.addNativeData(JmsConstants.JMS_CONNECTION, connection);
     }
 
-    @Override
-    public boolean isBlocking() {
-        return true;
+    /**
+     * Most of the brokers keep a single non-daemon thread running at all times in order to prevent the program from
+     * exiting during the JMS asynchronous scenario. This is not always the case for all brokers as it is not in the
+     * JMS spec. One broker (among the brokers tested so far) that deviates is the ActiveMQ Artemis broker. This
+     * method is to see if a non-daemon thread is always running based on broker kind. We check only for Artemis here
+     * because it is the only deviation identified so far.
+     *
+     * @param connectionObject The Ballerina connection object to set the native data on
+     * @param connectionConfig The connection configuration to get the initial context factory
+     */
+    private void setIfNonDaemonThreadRunningAtAllTimes(BMap<String, BValue> connectionObject,
+                                                       BMap<String, BValue> connectionConfig) {
+        connectionObject.addNativeData(JmsConstants.NON_DAEMON_THREAD_RUNNING, !connectionConfig.get(
+                JmsConstants.ALIAS_INITIAL_CONTEXT_FACTORY).stringValue().contains(JmsConstants.ARTEMIS_ICF));
     }
-
-
 }

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/CreateQueueReceiver.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/CreateQueueReceiver.java
@@ -20,8 +20,7 @@
 package org.ballerinalang.net.jms.nativeimpl.endpoint.queue.receiver;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.CallableUnitCallback;
-import org.ballerinalang.model.NativeCallableUnit;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
@@ -58,11 +57,11 @@ import javax.jms.Session;
         },
         isPublic = true
 )
-public class CreateQueueReceiver implements NativeCallableUnit {
+public class CreateQueueReceiver extends BlockingNativeCallableUnit {
     @Override
-    public void execute(Context context, CallableUnitCallback callableUnitCallback) {
+    public void execute(Context context) {
         @SuppressWarnings(JmsConstants.UNCHECKED)
-        BMap<String, BValue> queueConsumerBObject = (BMap<String, BValue>) context.getRefArgument(0);
+        BMap<String, BValue> queueConsumerObject = (BMap<String, BValue>) context.getRefArgument(0);
         @SuppressWarnings(JmsConstants.UNCHECKED)
         BMap<String, BValue> sessionBObject = (BMap<String, BValue>) context.getRefArgument(1);
         String messageSelector = context.getStringArgument(0);
@@ -88,17 +87,12 @@ public class CreateQueueReceiver implements NativeCallableUnit {
             MessageConsumer consumer = session.createConsumer(queue, messageSelector);
             @SuppressWarnings(JmsConstants.UNCHECKED)
             BMap<String, BValue> consumerConnectorBObject =
-                    (BMap<String, BValue>) queueConsumerBObject.get(JmsConstants.CONSUMER_ACTIONS);
+                    (BMap<String, BValue>) queueConsumerObject.get(JmsConstants.CONSUMER_ACTIONS);
             consumerConnectorBObject.addNativeData(JmsConstants.JMS_CONSUMER_OBJECT, consumer);
             consumerConnectorBObject.addNativeData(JmsConstants.SESSION_CONNECTOR_OBJECT,
                                                    new SessionConnector(session));
         } catch (JMSException e) {
             BallerinaAdapter.throwBallerinaException("Error while creating queue consumer.", context, e);
         }
-    }
-
-    @Override
-    public boolean isBlocking() {
-        return true;
     }
 }

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/Start.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/Start.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.queue.receiver;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.jms.JmsConstants;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.StartNonDaemonThreadHandler;
+
+/**
+ * Extern function to start the JMS QueueReceiver.
+ *
+ * @since 0.995
+ */
+
+@BallerinaFunction(
+        orgName = JmsConstants.BALLERINA, packageName = JmsConstants.JMS,
+        functionName = "start",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = JmsConstants.QUEUE_RECEIVER_OBJ_NAME,
+                             structPackage = JmsConstants.PROTOCOL_PACKAGE_JMS)
+)
+public class Start extends BlockingNativeCallableUnit {
+
+    @Override
+    public void execute(Context context) {
+        StartNonDaemonThreadHandler.handle(context);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/durable/subscriber/Start.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/durable/subscriber/Start.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.topic.durable.subscriber;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.jms.JmsConstants;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.StartNonDaemonThreadHandler;
+
+/**
+ * Extern function to start the JMS DurableTopicSubscriber.
+ *
+ * @since 0.995
+ */
+
+@BallerinaFunction(
+        orgName = JmsConstants.BALLERINA, packageName = JmsConstants.JMS,
+        functionName = "start",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = JmsConstants.DURABLE_TOPIC_SUBSCRIBER,
+                             structPackage = JmsConstants.PROTOCOL_PACKAGE_JMS)
+)
+public class Start extends BlockingNativeCallableUnit {
+    @Override
+    public void execute(Context context) {
+        StartNonDaemonThreadHandler.handle(context);
+    }
+}

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/subscriber/Start.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/subscriber/Start.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.ballerinalang.net.jms.nativeimpl.endpoint.topic.subscriber;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.jms.JmsConstants;
+import org.ballerinalang.net.jms.nativeimpl.endpoint.common.StartNonDaemonThreadHandler;
+
+/**
+ * Extern function to start the JMS TopicSubscriber.
+ *
+ * @since 0.995
+ */
+
+@BallerinaFunction(
+        orgName = JmsConstants.BALLERINA, packageName = JmsConstants.JMS,
+        functionName = "start",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = JmsConstants.TOPIC_SUBSCRIBER_OBJ_NAME,
+                             structPackage = JmsConstants.PROTOCOL_PACKAGE_JMS)
+)
+public class Start extends BlockingNativeCallableUnit {
+    @Override
+    public void execute(Context context) {
+        StartNonDaemonThreadHandler.handle(context);
+    }
+}


### PR DESCRIPTION
## Purpose
 - Removes andes client
Resolve https://github.com/ballerina-platform/ballerina-lang/issues/14374
- Update examples to use ActiveMQ Artemis
- Fix the issue of Artemis broker not having a non-daemon thread always running.
- Fix the issue of client id not being automatically set by the ActiveMQ Artemis JMS client

## Approach
> Remove maven and gradle dependencies and update examples to use ActiveMQ Artemis

## Samples
> Updated existing examples

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [x] Ballerina By Examples
