### PR TITLE
Downgrade mimepull version to 1.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2493,7 +2493,7 @@
         <quartz.version>2.3.1</quartz.version>
         <commons-net.version>3.6</commons-net.version>
         <jackson-core.version>2.9.8</jackson-core.version>
-        <mimepull.version>1.9.11</mimepull.version>
+        <mimepull.version>1.9.7</mimepull.version>
         <broker.version>0.970.5</broker.version>
         <netty-tcnative-boringssl-static.version>2.0.23.Final</netty-tcnative-boringssl-static.version>
 


### PR DESCRIPTION
## Purpose
$Subject. This is due to the incompatible license change in 1.9.11

