### PR TITLE
Improve decimal inference in literal expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1754,6 +1754,8 @@ public class TypeChecker extends BLangNodeVisitor {
             return;
         }
 
+        checkDecimalCompatibilityForBinaryArithmeticOverLiteralValues(binaryExpr);
+
         SymbolEnv rhsExprEnv;
         BType lhsType = checkExpr(binaryExpr.lhsExpr, env);
         if (binaryExpr.opKind == OperatorKind.AND) {
@@ -1793,6 +1795,24 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         resultType = types.checkType(binaryExpr, actualType, expType);
+    }
+
+    private void checkDecimalCompatibilityForBinaryArithmeticOverLiteralValues(BLangBinaryExpr binaryExpr) {
+        if (expType.tag != TypeTags.DECIMAL) {
+            return;
+        }
+
+        switch (binaryExpr.opKind) {
+            case ADD:
+            case SUB:
+            case MUL:
+            case DIV:
+                checkExpr(binaryExpr.lhsExpr, env, expType);
+                checkExpr(binaryExpr.rhsExpr, env, expType);
+                break;
+            default:
+                break;
+        }
     }
 
     public void visit(BLangElvisExpr elvisExpr) {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -57,13 +57,20 @@ public class BDecimalValueNegativeTest {
     @Test
     void testDecimalValueNegativeLiteral() {
         CompileResult negative = BCompileUtil.compile("test-src/types/decimal/decimal_value_negative_literal.bal");
-        Assert.assertEquals(negative.getErrorCount(), 6);
+        Assert.assertEquals(negative.getErrorCount(), 13);
         int i = 0;
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 20, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 21, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 22, 22);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 22);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 31);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 30, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 31, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 33, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 37);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -57,7 +57,13 @@ public class BDecimalValueNegativeTest {
     @Test
     void testDecimalValueNegativeLiteral() {
         CompileResult negative = BCompileUtil.compile("test-src/types/decimal/decimal_value_negative_literal.bal");
-        Assert.assertEquals(negative.getErrorCount(), 1);
-        BAssertUtil.validateError(negative, 0, "incompatible types: expected 'decimal', found 'float'", 20, 17);
+        Assert.assertEquals(negative.getErrorCount(), 6);
+        int i = 0;
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 20, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 21, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 22, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 31);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 22);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.types.decimaltype;
 import org.ballerinalang.model.util.DecimalValueKind;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BDecimal;
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
@@ -266,5 +267,17 @@ public class BDecimalValueTest {
         Assert.assertEquals(returns[1], new BDecimal("0.0", DecimalValueKind.ZERO));
         Assert.assertEquals(returns[2], new BDecimal("3.141592653589793238462643383279502", DecimalValueKind.OTHER));
         Assert.assertEquals(returns[3], new BDecimal("3.141592653589793238462643383279503", DecimalValueKind.OTHER));
+    }
+
+    @Test(description = "Test decimal inference for binary literal expressions")
+    public void testDecimalTypeInferenceInBinaryLiteralExpressions() {
+        BValue[] returns = BRunUtil.invoke(result, "testDecimalInferenceInMapContext", new BValue[]{});
+        BMap<String, BDecimal> map = (BMap<String, BDecimal>) returns[0];
+
+        Assert.assertEquals(map.get("a"), new BDecimal("33.3", DecimalValueKind.OTHER));
+        Assert.assertEquals(map.get("b"), new BDecimal("33.3", DecimalValueKind.OTHER));
+        Assert.assertEquals(map.get("c"), new BDecimal("0.1", DecimalValueKind.OTHER));
+        Assert.assertEquals(map.get("d"), new BDecimal("1", DecimalValueKind.OTHER));
+        Assert.assertEquals(map.get("e"), new BDecimal("10000000000000000000000.123", DecimalValueKind.OTHER));
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
@@ -280,4 +280,14 @@ public class BDecimalValueTest {
         Assert.assertEquals(map.get("d"), new BDecimal("1", DecimalValueKind.OTHER));
         Assert.assertEquals(map.get("e"), new BDecimal("10000000000000000000000.123", DecimalValueKind.OTHER));
     }
+
+    @Test(description = "Test decimal inference on binary literals")
+    public void testDecimalInferenceOnBinaryExpressions() {
+        BValue[] returns = BRunUtil.invoke(result, "decimalInferenceInLiterals");
+        Assert.assertEquals(returns[0], new BDecimal("0.5", DecimalValueKind.OTHER));
+        Assert.assertEquals(returns[1], new BDecimal("3.0", DecimalValueKind.OTHER));
+        Assert.assertEquals(returns[2], new BDecimal("-1.0", DecimalValueKind.OTHER));
+        Assert.assertEquals(returns[3], new BDecimal("2.0", DecimalValueKind.OTHER));
+        Assert.assertEquals(returns[4], new BDecimal("10000.5051", DecimalValueKind.OTHER));
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
@@ -152,3 +152,9 @@ function testPositivelySignedLiteralAssignment() returns (decimal, decimal, deci
     decimal d5 = d1 + d4;
     return (d1, d2, d5);
 }
+
+// Test decimal inference for binary expressions of literals
+function testDecimalInferenceInMapContext() returns map<decimal> {
+    map<decimal> md = { a: 33.3d, b: 33.3, c: 0.1, d: 1, e: 10000000000000000000000.123 };
+    return md;
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
@@ -153,8 +153,19 @@ function testPositivelySignedLiteralAssignment() returns (decimal, decimal, deci
     return (d1, d2, d5);
 }
 
-// Test decimal inference for binary expressions of literals
+// Test decimal inference for map literal context
 function testDecimalInferenceInMapContext() returns map<decimal> {
     map<decimal> md = { a: 33.3d, b: 33.3, c: 0.1, d: 1, e: 10000000000000000000000.123 };
     return md;
+}
+
+// Test decimal inference for binary expressions of literals
+function decimalInferenceInLiterals() returns (decimal, decimal, decimal, decimal, decimal) {
+    decimal a = 1.0/2.0;
+    decimal b = 1.0+2.0;
+    decimal c = 1.0 - 2.0;
+    decimal d = 1.0 * 2.0;
+    decimal k = 10000.0001;
+    decimal e = 1.0/2.0/1.0 + 1.0*0.005 + k;
+    return (a, b, c, d, e);
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
@@ -18,4 +18,9 @@
 function testInvlaidDecimalValue() {
     // This is to test a syntax issue.
     decimal a = 12.3f;
+    decimal b = 0x4fp1;
+    decimal[] ds1 = [12.3f, 22.4];
+    decimal[] ds2 = [0x3ap-1, 0x4bp3];
+    int|decimal md1 = 0x33p0;
+    int|decimal md2 = 22.22;
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
@@ -24,3 +24,15 @@ function testInvlaidDecimalValue() {
     int|decimal md1 = 0x33p0;
     int|decimal md2 = 22.22;
 }
+
+// Test invalid decimal inference.
+function testInvalidDecimalInference() {
+    decimal a = 1.0 / 2.0f;
+    decimal b = 1.0 + 2.0f;
+    decimal c = 1.0d + 2.0f;
+    decimal d = 1.0 * 2.0f;
+    decimal e = 1.0f + 2.0;
+    decimal f = 1.0f - 2.0;
+    float k = 2.0;
+    decimal g = 1.0 * 2.0 + 0.002 / k;
+}


### PR DESCRIPTION
## Purpose
```ballerina
decimal a = 1.0/2.0;
```
Literals 1.0 and 2.0 are infer to be of type decimal.

And also improve test coverage for floating point hex literals and decimal inference on map literal context.