### PR TITLE
Fix concurrent modification issue with finite type merge

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1903,18 +1903,6 @@ public class Types {
             return symTable.semanticError;
         }
 
-        if (intersection.size() > 1 && intersection.stream().filter(type -> type.tag == TypeTags.FINITE).count() > 1) {
-            // merge > 1 finite types into one finite type
-            Set<BLangExpression> valueSpace = new LinkedHashSet<>();
-            intersection.forEach(bType -> {
-                if (bType.tag == TypeTags.FINITE) {
-                    intersection.remove(bType);
-                    valueSpace.addAll(((BFiniteType) bType).valueSpace);
-                }
-            });
-            intersection.add(new BFiniteType(null, valueSpace));
-        }
-
         if (intersection.size() == 1) {
             return intersection.get(0);
         } else {

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -500,6 +500,18 @@ public class TypeGuardTest {
     }
 
     @Test
+    public void testFiniteTypeUnionAsFiniteTypeUnionPositive() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypeUnionAsFiniteTypeUnionPositive");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
+    public void testFiniteTypeUnionAsFiniteTypeUnionNegative() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypeUnionAsFiniteTypeUnionNegative");
+        Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
     public void testTypeGuardForErrorPositive() {
         BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForErrorPositive");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());

--- a/tests/ballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -845,6 +845,29 @@ function testFiniteTypeReassignmentToBroaderType() returns boolean {
     return false;
 }
 
+type Foo "foo";
+type Bar "bar";
+
+type X "x";
+type Y "y";
+
+function testFiniteTypeUnionAsFiniteTypeUnionPositive() returns boolean {
+    Foo|Bar|X|int q = 1;
+    if (q is Foo|Bar|Y|int) {
+        Foo|Bar|int w = q;
+        return q == w;
+    }
+    return false;
+}
+
+function testFiniteTypeUnionAsFiniteTypeUnionNegative() returns boolean {
+    Foo|Bar|X|int q = "x";
+    if (q is Foo|Bar|int|Y) {
+        return true;
+    }
+    return q != "x";
+}
+
 string reason = "error reason";
 map<anydata> detail = { code: 11, detail: "detail message" };
 


### PR DESCRIPTION
## Purpose
Fix concurrent modification issue with finite type merge.

The change done was to remove the merging of multiple finite types as a single finite type since it is not needed at the moment.