### PR TITLE
Fix package init and void return functions for strand scheduler

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Scheduler.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -41,10 +42,23 @@ public class Scheduler {
      * @return - Reference to the scheduled task
      */
     public FutureValue schedule(Object[] params, Function function) {
-        Strand newStrand = new Strand(this);
-        FutureValue future = new FutureValue(newStrand);
+        FutureValue future = createFuture();
         params[0] = future.strand;
         SchedulerItem item = new SchedulerItem(function, params, future);
+        runnableList.add(item);
+        return future;
+    }
+
+    /**
+     * Add a void returning task to the runnable list, which will eventually be executed by the Scheduler.
+     * @param params - parameters to be passed to the function
+     * @param consumer - consumer to be executed
+     * @return - Reference to the scheduled task
+     */
+    public FutureValue schedule(Object[] params, Consumer consumer) {
+        FutureValue future = createFuture();
+        params[0] = future.strand;
+        SchedulerItem item = new SchedulerItem(consumer, params, future);
         runnableList.add(item);
         return future;
     }
@@ -55,7 +69,14 @@ public class Scheduler {
     public void execute() {
         while (!runnableList.isEmpty()) {
             SchedulerItem item = runnableList.poll();
-            Object result = item.function.apply(item.params);
+            Object result = null;
+
+            if (item.isVoid) {
+                item.consumer.accept(item.params);
+            } else {
+                result = item.function.apply(item.params);
+            }
+
             if (item.future.strand.yield) {
                 item.future.strand.yield = false;
                 runnableList.add(item);
@@ -77,6 +98,11 @@ public class Scheduler {
             }
         }
     }
+
+    private FutureValue createFuture() {
+        Strand newStrand = new Strand(this);
+        return new FutureValue(newStrand);
+    }
 }
 
 /**
@@ -86,6 +112,8 @@ public class Scheduler {
  */
 class SchedulerItem {
     Function function;
+    Consumer consumer;
+    boolean isVoid;
     Object[] params;
     FutureValue future;
 
@@ -93,5 +121,13 @@ class SchedulerItem {
         this.future = future;
         this.function = function;
         this.params = params;
+        this.isVoid = false;
+    }
+
+    public SchedulerItem(Consumer consumer, Object[] params, FutureValue future) {
+        this.future = future;
+        this.consumer = consumer;
+        this.params = params;
+        this.isVoid = true;
     }
 }

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_constants.bal
@@ -228,6 +228,7 @@ const string SCHEDULER = "org/ballerinalang/jvm/Scheduler";
 const string JSON_UTILS = "org/ballerinalang/jvm/JSONUtils";
 const string STRAND = "org/ballerinalang/jvm/Strand";
 const string FUNCTION = "java/util/function/Function";
+const string CONSUMER = "java/util/function/Consumer";
 const string STRING_BUILDER = "java/lang/StringBuilder";
 
 // types related classes

--- a/stdlib/jvm/src/main/ballerina/jvm/types.bal
+++ b/stdlib/jvm/src/main/ballerina/jvm/types.bal
@@ -64,7 +64,7 @@ public type MethodVisitor object {
 
     public function visitLookupSwitchInsn(Label defaultLabel, int[] keys, Label[] labels) = external;
 
-    public function visitInvokeDynamicInsn(string className, string lambdaName) = external;
+    public function visitInvokeDynamicInsn(string className, string lambdaName, boolean isVoid) = external;
     
     public function visitTryCatchBlock(Label startLabel, Label endLabel, Label handlerLabel,
                                         string exceptionType) = external;

--- a/stdlib/jvm/src/main/java/org/ballerinalang/nativeimpl/jvm/methodvisitor/VisitInvokeDynamicInsn.java
+++ b/stdlib/jvm/src/main/java/org/ballerinalang/nativeimpl/jvm/methodvisitor/VisitInvokeDynamicInsn.java
@@ -28,6 +28,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import static org.ballerinalang.model.types.TypeKind.BOOLEAN;
 import static org.ballerinalang.model.types.TypeKind.OBJECT;
 import static org.ballerinalang.model.types.TypeKind.STRING;
 import static org.ballerinalang.nativeimpl.jvm.ASMUtil.FUNCTION_DESC;
@@ -49,6 +50,7 @@ import static org.ballerinalang.nativeimpl.jvm.ASMUtil.STRING_DESC;
         args = {
                 @Argument(name = "className", type = STRING),
                 @Argument(name = "lambdaName", type = STRING),
+                @Argument(name = "isVoid", type = BOOLEAN)
         }
 )
 public class VisitInvokeDynamicInsn extends BlockingNativeCallableUnit {
@@ -58,15 +60,26 @@ public class VisitInvokeDynamicInsn extends BlockingNativeCallableUnit {
 
         String className = context.getStringArgument(0);
         String lambdaName = context.getStringArgument(1);
+        boolean isVoid = context.getBooleanArgument(0);
 
 
         //Function<Object[], Object> - create a dynamic lambda invocation with object[] param and returns object
         MethodVisitor mv = ASMUtil.getRefArgumentNativeData(context, 0);
-        mv.visitInvokeDynamicInsn("apply", "()" + FUNCTION_DESC,
-                new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory",
-                        "metafactory", "(Ljava/lang/invoke/MethodHandles$Lookup;"
-                        + STRING_DESC + METHOD_TYPE_DESC + METHOD_TYPE_DESC + "Ljava/lang/invoke/MethodHandle;"
-                        + METHOD_TYPE_DESC + ")Ljava/lang/invoke/CallSite;", false),
+        Handle handle = new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory",
+                "metafactory", "(Ljava/lang/invoke/MethodHandles$Lookup;"
+                + STRING_DESC + METHOD_TYPE_DESC + METHOD_TYPE_DESC + "Ljava/lang/invoke/MethodHandle;"
+                + METHOD_TYPE_DESC + ")Ljava/lang/invoke/CallSite;", false);
+
+        if (isVoid) {
+            mv.visitInvokeDynamicInsn("accept", "()Ljava/util/function/Consumer;", handle,
+                    new Object[]{Type.getType("(" + OBJECT_DESC + ")V"),
+                            new Handle(Opcodes.H_INVOKESTATIC, className, lambdaName,
+                                    "([" + OBJECT_DESC + ")V", false),
+                            Type.getType("([" + OBJECT_DESC + ")V")});
+            return;
+        }
+
+        mv.visitInvokeDynamicInsn("apply", "()" + FUNCTION_DESC, handle,
                 new Object[]{Type.getType("(" + OBJECT_DESC + ")" + OBJECT_DESC),
                         new Handle(Opcodes.H_INVOKESTATIC, className, lambdaName,
                                 "([" + OBJECT_DESC + ")" + OBJECT_DESC, false),

--- a/tests/ballerina-unit-test/src/test/resources/test-src/jvm/types.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/jvm/types.bal
@@ -217,15 +217,14 @@ function acceptAnydata(anydata data) returns anydata {
 int global = 0;
 
 function futuresTest() returns anydata {
-   future<int> p = start foo("abc", 7);
+   future<()> p = start foo("abc", 7);
    future<string> p2 = start foo2("yy");
    future<string> p3 = acceptFuture(p2);
    return global;
 }
 
-public function foo(string r, int j) returns int {
+public function foo(string r, int j) {
    global = global + 100;
-   return 700;
 }
 
 public function foo2(string k) returns string {


### PR DESCRIPTION
## Purpose
> Package init and void return functions were failing with java runtime errors after adding new Strand based Scheduler.

Fixes #<Issue Number>

## Approach
> Void returning functions are modeled as java.util.Consumer instances.

> Package init also modeled as a Java Consumer and scheduled before the main.

> Modified the Scheduler to schedule and execute Java Consumers as well.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
