### PR TITLE
Fix docs getting attached to lambda functions issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -636,10 +636,12 @@ public class BLangPackageBuilder {
         this.varListStack.push(new ArrayList<>());
     }
 
-    void startFunctionDef(int annotCount) {
+    void startFunctionDef(int annotCount, boolean isLambda) {
         FunctionNode functionNode = TreeBuilder.createFunctionNode();
         attachAnnotations(functionNode, annotCount);
-        attachMarkdownDocumentations(functionNode);
+        if (!isLambda) {
+            attachMarkdownDocumentations(functionNode);
+        }
         this.invokableNodeStack.push(functionNode);
     }
 
@@ -911,7 +913,7 @@ public class BLangPackageBuilder {
 
     void startLambdaFunctionDef(PackageID pkgID) {
         // Passing zero for annotation count as Lambdas can't have annotations.
-        startFunctionDef(0);
+        startFunctionDef(0, true);
         BLangFunction lambdaFunction = (BLangFunction) this.invokableNodeStack.peek();
         lambdaFunction.setName(createIdentifier(anonymousModelHelper.getNextAnonymousFunctionKey(pkgID)));
         lambdaFunction.addFlag(Flag.LAMBDA);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -289,7 +289,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         // Since the function definition's super parent is CompilationUnit and it is the only super parent for
         // FunctionDefinition, following cast is safe.
         int annotCount = ((BallerinaParser.CompilationUnitContext) ctx.parent.parent).annotationAttachment().size();
-        this.pkgBuilder.startFunctionDef(annotCount);
+        this.pkgBuilder.startFunctionDef(annotCount, false);
     }
 
     /**

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MarkdownDocumentationTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MarkdownDocumentationTest.java
@@ -464,4 +464,22 @@ public class MarkdownDocumentationTest {
                 "           return description line 2\n" +
                 "           return description line 3");
     }
+
+    @Test(description = "Test lambda in object init")
+    public void testMarkdownWithLambdaInObjectInit() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/documentation/markdown_with_lambda.bal");
+        Assert.assertEquals(compileResult.getErrorCount(), 0);
+        Assert.assertEquals(compileResult.getWarnCount(), 0);
+
+        PackageNode packageNode = compileResult.getAST();
+        BLangMarkdownDocumentation documentationAttachment =
+                packageNode.getTypeDefinitions().get(0).getMarkdownDocumentationAttachment();
+        Assert.assertNotNull(documentationAttachment);
+        Assert.assertEquals(documentationAttachment.getDocumentation(), "Documentation for TimeOrderWindow.\n");
+
+        LinkedList<BLangMarkdownParameterDocumentation> parameters = documentationAttachment.getParameters();
+        Assert.assertEquals(parameters.size(), 1);
+        Assert.assertEquals(parameters.get(0).getParameterName().getValue(), "f");
+        Assert.assertEquals(parameters.get(0).getParameterDocumentation(), "documentation");
+    }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/documentation/markdown_with_lambda.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/documentation/markdown_with_lambda.bal
@@ -1,0 +1,14 @@
+# Documentation for TimeOrderWindow.
+#
+# + f - documentation
+public type TimeOrderWindow object {
+
+    public function (int i) f;
+
+    public function __init() {
+        // Test lambda function in object init.
+        self.f = function (int i) {
+
+        };
+    }
+};


### PR DESCRIPTION
## Purpose
This PR fixes an issue in docs where the docs are getting attached to lambda functions defined in object `init` functions.

Fixes #15011
Fixes #15017

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
