### PR TITLE
Add cyclic module import detection support

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -26,6 +26,7 @@ public enum DiagnosticCode {
 
     UNDEFINED_MODULE("undefined.module"),
     UNUSED_IMPORT_MODULE("unused.import.module"),
+    SELF_IMPORT_NOT_ALLOWED("self.import.not.allowed"),
     MODULE_NOT_FOUND("module.not.found"),
     REDECLARED_IMPORT_MODULE("redeclared.import.module"),
     INVALID_MODULE_DECLARATION("invalid.module.declaration"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -25,6 +25,7 @@ package org.ballerinalang.util.diagnostic;
 public enum DiagnosticCode {
 
     UNDEFINED_MODULE("undefined.module"),
+    CYCLIC_MODULE_IMPORTS_DETECTED("cyclic.module.imports.detected"),
     UNUSED_IMPORT_MODULE("unused.import.module"),
     SELF_IMPORT_NOT_ALLOWED("self.import.not.allowed"),
     MODULE_NOT_FOUND("module.not.found"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -27,7 +27,6 @@ public enum DiagnosticCode {
     UNDEFINED_MODULE("undefined.module"),
     CYCLIC_MODULE_IMPORTS_DETECTED("cyclic.module.imports.detected"),
     UNUSED_IMPORT_MODULE("unused.import.module"),
-    SELF_IMPORT_NOT_ALLOWED("self.import.not.allowed"),
     MODULE_NOT_FOUND("module.not.found"),
     REDECLARED_IMPORT_MODULE("redeclared.import.module"),
     INVALID_MODULE_DECLARATION("invalid.module.declaration"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -205,12 +205,17 @@ public class SymbolEnter extends BLangNodeVisitor {
         SymbolEnv pkgEnv = SymbolEnv.createPkgEnv(pkgNode, pkgSymbol.scope, this.env);
         this.symTable.pkgEnvMap.put(pkgSymbol, pkgEnv);
 
+        // Add the current package node's ID to the imported package list. This is used to identify cyclic module
+        // imports.
         importedPackages.add(pkgNode.packageID);
 
         defineConstructs(pkgNode, pkgEnv);
         pkgNode.getTestablePkgs().forEach(testablePackage -> defineTestablePackage(testablePackage, pkgEnv,
                                                                                    pkgNode.imports));
         pkgNode.completedPhases.add(CompilerPhase.DEFINE);
+
+        // After we have visited a package node, we need to remove it from the imports list.
+        importedPackages.remove(pkgNode.packageID);
     }
 
     private void defineConstructs(BLangPackage pkgNode, SymbolEnv pkgEnv) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -315,6 +315,12 @@ public class SymbolEnter extends BLangNodeVisitor {
                 .collect(Collectors.toList());
 
         PackageID pkgId = new PackageID(orgName, nameComps, version);
+
+        if (pkgId.equals(enclPackageID)) {
+            dlog.error(importPkgNode.pos, DiagnosticCode.SELF_IMPORT_NOT_ALLOWED);
+            return;
+        }
+
         if (pkgId.name.getValue().startsWith(Names.BUILTIN_PACKAGE.value)) {
             dlog.error(importPkgNode.pos, DiagnosticCode.MODULE_NOT_FOUND,
                     importPkgNode.getQualifiedPackageName());

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -23,6 +23,9 @@
 error.undefined.module=\
   undefined module ''{0}''
 
+error.cyclic.module.imports.detected=\
+  cyclic module imports detected ''{0}''
+
 error.unused.import.module=\
   unused import module ''{0}''
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -29,9 +29,6 @@ error.cyclic.module.imports.detected=\
 error.unused.import.module=\
   unused import module ''{0}''
 
-error.self.import.not.allowed=\
-  module self import not allowed
-
 error.redeclared.symbol=\
   redeclared symbol ''{0}''
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -26,6 +26,9 @@ error.undefined.module=\
 error.unused.import.module=\
   unused import module ''{0}''
 
+error.self.import.not.allowed=\
+  module self import not allowed
+
 error.redeclared.symbol=\
   redeclared symbol ''{0}''
 

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -143,7 +143,8 @@ public class BCompileUtil {
      * @return Semantic errors
      */
     public static CompileResult compile(String sourceRoot, String packageName) {
-        Path rootPath = Paths.get(sourceRoot);
+        String filePath = concatFileName(sourceRoot, resourceDir);
+        Path rootPath = Paths.get(filePath);
         Path packagePath = Paths.get(packageName);
         return getCompileResult(packageName, rootPath, packagePath);
     }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
@@ -32,8 +32,17 @@ public class ImportsTest {
 
     @Test(description = "Test self import")
     public void testSelfImport() {
-        CompileResult result = BCompileUtil.compile("test-src/imports", "foo");
+        CompileResult result = BCompileUtil.compile("test-src/imports/self-import", "foo");
         assertEquals(result.getErrorCount(), 1);
-        validateError(result, 0, "module self import not allowed", 2, 1);
+        validateError(result, 0, "cyclic module imports detected 'foo -> foo'", 2, 1);
+    }
+
+    @Test(description = "Test cyclic imports")
+    public void testCyclicImports() {
+        CompileResult result = BCompileUtil.compile("test-src/imports/cyclic-imports", "abc");
+        assertEquals(result.getErrorCount(), 3);
+        validateError(result, 0, "cyclic module imports detected 'def -> ghi -> def'", 2, 1);
+        validateError(result, 1, "cyclic module imports detected 'abc -> def -> ghi -> jkl -> abc'", 2, 1);
+        validateError(result, 2, "cyclic module imports detected 'abc -> def -> ghi -> abc'", 3, 1);
     }
 }

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.imports;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.util.BAssertUtil.validateError;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for imports.
+ */
+public class ImportsTest {
+
+    @Test(description = "Test self import")
+    public void testSelfImport() {
+        CompileResult result = BCompileUtil.compile("test-src/imports", "foo");
+        assertEquals(result.getErrorCount(), 1);
+        validateError(result, 0, "module self import not allowed", 2, 1);
+    }
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/abc/main.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/abc/main.bal
@@ -1,0 +1,7 @@
+import ballerina/io;
+import def;
+import ballerina/runtime;
+
+function test() {
+    io:println("Hello world !!!");
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/def/main.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/def/main.bal
@@ -1,0 +1,7 @@
+import ballerina/io;
+import ghi;
+import ballerina/runtime;
+
+function test() {
+    io:println("Hello world !!!");
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/ghi/main.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/ghi/main.bal
@@ -1,0 +1,9 @@
+import ballerina/io;
+import def;
+import abc;
+import ballerina/runtime;
+import jkl;
+
+function test() {
+    io:println("Hello world !!!");
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/jkl/main.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/jkl/main.bal
@@ -1,0 +1,7 @@
+import ballerina/io;
+import abc;
+import ballerina/runtime;
+
+function test() {
+    io:println("Hello world !!!");
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/mno/main.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/mno/main.bal
@@ -1,6 +1,4 @@
 import ballerina/io;
-import def;
-import mno;
 import pqr;
 import ballerina/runtime;
 

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/pqr/main.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/pqr/main.bal
@@ -1,7 +1,4 @@
 import ballerina/io;
-import def;
-import mno;
-import pqr;
 import ballerina/runtime;
 
 function test() {

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/foo/self-import-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/foo/self-import-negative.bal
@@ -1,7 +1,0 @@
-import ballerina/runtime;
-import foo;
-import ballerina/io;
-
-function test() {
-    io:println("Hello Ballerina !!!");
-}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/foo/self-import-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/foo/self-import-negative.bal
@@ -1,0 +1,7 @@
+import ballerina/runtime;
+import foo;
+import ballerina/io;
+
+function test() {
+    io:println("Hello Ballerina !!!");
+}

--- a/tests/ballerina-unit-test/src/test/resources/test-src/imports/self-import/foo/self-import-negative.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/imports/self-import/foo/self-import-negative.bal
@@ -1,0 +1,3 @@
+import ballerina/runtime;
+import foo;
+import ballerina/io;

--- a/tests/ballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/ballerina-unit-test/src/test/resources/testng.xml
@@ -66,6 +66,7 @@ under the License.
             <package name="org.ballerinalang.test.serializer.json.*" />
             <package name="org.ballerinalang.test.dataflow.*" />
             <package name="org.ballerinalang.test.error.*" />
+            <package name="org.ballerinalang.test.imports.*" />
         </packages>
 
 		<!-- TODO: remove once constraint tests are fixed -->


### PR DESCRIPTION
## Purpose
This PR adds cyclic module imports detection support to the compiler.

Fixes #4878
Fixes #15031
Fixes #15035

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
