### PR TITLE
Exclude `grpc-server-streaming` example

### DIFF
--- a/tests/ballerina-examples-test/src/main/resources/run.sh
+++ b/tests/ballerina-examples-test/src/main/resources/run.sh
@@ -47,6 +47,7 @@ exclude=("proto-to-ballerina"
         "docker-deployment"
         "kubernetes-deployment"
         "awslambda-deployment"
+        "grpc-server-streaming"
         )
 
 packages=($( sed -n 's/.*"url": "\([^"]*\)"/\1/p' index.json ))


### PR DESCRIPTION
## Purpose
This PR excludes `grpc-server-streaming` since it has been intermittently failing often in Travis.