### PR TITLE
Fix issue in removing table rows when closures are used.

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
@@ -22,6 +22,7 @@ import org.ballerinalang.bre.bvm.BVM;
 import org.ballerinalang.bre.bvm.BVMExecutor;
 import org.ballerinalang.model.ColumnDefinition;
 import org.ballerinalang.model.DataIterator;
+import org.ballerinalang.model.types.BFunctionType;
 import org.ballerinalang.model.types.BStructureType;
 import org.ballerinalang.model.types.BTableType;
 import org.ballerinalang.model.types.BType;
@@ -29,12 +30,14 @@ import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.util.TableIterator;
 import org.ballerinalang.util.TableProvider;
 import org.ballerinalang.util.TableUtils;
+import org.ballerinalang.util.codegen.FunctionInfo;
 import org.ballerinalang.util.exceptions.BallerinaErrorReasons;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.util.FreezeUtils.handleInvalidUpdate;
 import static org.ballerinalang.model.util.FreezeUtils.isOpenForFreeze;
@@ -264,23 +267,27 @@ public class BTable implements BRefType<Object>, BCollection {
         }
 
         try {
-            BType functionInputType = lambdaFunction.value().getParamTypes()[0];
+            BType functionInputType = ((BFunctionType) lambdaFunction.type).paramTypes[0];
             if (functionInputType != this.constraintType) {
                 throw new BallerinaException("incompatible types: function with record type:"
                         + functionInputType.getName() + " cannot be used to remove records from a table with type:"
                         + this.constraintType.getName());
             }
-            int deletedCount = 0;
-            while (this.hasNext()) {
 
+            FunctionInfo functionInfo = lambdaFunction.value();
+            int deletedCount = 0;
+            List<BValue> fnArgs = lambdaFunction.getClosureVars().stream()
+                    .map(BClosure::value).collect(Collectors.toList());
+            while (this.hasNext()) {
                 BMap<String, BValue> data = this.getNext();
-                BValue[] args = {data};
-                BValue[] returns = BVMExecutor.executeFunction(lambdaFunction.value().getPackageInfo()
-                        .getProgramFile(), lambdaFunction.value(), args);
+                fnArgs.add(data);
+                BValue[] returns = BVMExecutor.executeFunction(functionInfo.getPackageInfo().getProgramFile(),
+                                                               functionInfo, fnArgs.toArray(new BValue[0]));
                 if (((BBoolean) returns[0]).booleanValue()) {
                     ++deletedCount;
                     tableProvider.deleteData(tableName, data);
                 }
+                fnArgs.remove(fnArgs.size() - 1);
             }
             context.setReturnValues(new BInteger(deletedCount));
             reset();

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -1421,6 +1421,12 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), "Hello");
     }
 
+    @Test(description = "Test removing data from a table using a given lambda as a filter")
+    public void testRemoveOp() {
+        BValue[] returns = BRunUtil.invoke(result, "testRemoveOp");
+        Assert.assertEquals(returns[0].stringValue(), "table<Order> {index: [], primaryKey: [], data: []}");
+    }
+
     @AfterClass(alwaysRun = true)
     public void closeConnectionPool() {
         BRunUtil.invokeStateful(service, "closeConnectionPool");

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -1734,3 +1734,24 @@ function testAssignStringValueToJsonField() returns json {
     checkpanic testDB.stop();
     return val;
 }
+
+type Order record {
+    int id;
+    string name;
+};
+
+function testRemoveOp() returns table<Order> {
+    table<Order> orderTable = table {
+        { id, name },
+        [
+            {1, "BTC"},
+            {2, "LTC"}
+        ]
+    };
+
+    int invalid = 0;
+    var s = orderTable.remove(function (Order ord) returns boolean {
+                        return ord.id > invalid;
+                    });
+    return orderTable;
+}


### PR DESCRIPTION
## Purpose
> There was an issue with removing a row in a table when the lambda function passed to remove() uses closure vars since the native implementation of remove() hasn't taken closures into account.

Fixes #15047 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
