### PR TITLE
Add BIR gen for anonymous functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIREmitter.java
@@ -264,6 +264,14 @@ public class BIREmitter extends BIRVisitor {
         sb.append(";\n");
     }
 
+    public void visit(BIRNonTerminator.FPLoad fpLoad) {
+        sb.append("\t\t");
+        fpLoad.lhsOp.accept(this);
+        sb.append(" = ").append(fpLoad.kind.name().toLowerCase(Locale.ENGLISH)).append(" ");
+        sb.append(fpLoad.funcName.getValue()).append("()");
+        sb.append(";");
+    }
+
     public void visit(BIRTerminator.Panic birPanic) {
         sb.append("\t\t").append(birPanic.kind.name().toLowerCase(Locale.ENGLISH)).append(" ");
         birPanic.errorOp.accept(this);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -33,7 +33,6 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.FieldAccess;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.Move;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
-import org.wso2.ballerinalang.compiler.bir.model.BIRVisitor;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarScope;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.ballerinalang.compiler.bir.model;
 
+import org.ballerinalang.model.Name;
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
@@ -349,6 +351,34 @@ public abstract class BIRNonTerminator extends BIRNode implements BIRInstruction
             this.type = type;
             this.lhsOp = lhsOp;
             this.rhsOp = rhsOp;
+        }
+
+        @Override
+        public void accept(BIRVisitor visitor) {
+            visitor.visit(this);
+        }
+    }
+
+    /**
+     * A FP load instruction.
+     * <p>
+     * e.g., function (string, string) returns (string) anonFunction =
+     *             function (string x, string y) returns (string) {
+     *                 return x + y;
+     *             };
+     *
+     * @since 0.995.0
+     */
+    public static class FPLoad extends BIRNonTerminator {
+        public BIROperand lhsOp;
+        public Name funcName;
+        public PackageID pkgId;
+
+        public FPLoad(DiagnosticPos pos, PackageID pkgId, Name funcName, BIROperand lhsOp) {
+            super(pos, InstructionKind.FP_LOAD);
+            this.lhsOp = lhsOp;
+            this.funcName = funcName;
+            this.pkgId = pkgId;
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRVisitor.java
@@ -122,6 +122,10 @@ public abstract class BIRVisitor {
         throw new AssertionError();
     }
 
+    public void visit(BIRNonTerminator.FPLoad fpLoad) {
+        throw new AssertionError();
+    }
+
     public void visit(BIRTerminator.Panic birPanic) {
         throw new AssertionError();
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/InstructionKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/InstructionKind.java
@@ -47,6 +47,7 @@ public enum InstructionKind {
     OBJECT_STORE((byte) 33),
     OBJECT_LOAD((byte) 34),
     PANIC((byte) 35),
+    FP_LOAD((byte) 36),
 
     // Binary expression related instructions.
     ADD((byte) 50),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
@@ -257,6 +257,19 @@ public class BIRInstructionWriter extends BIRVisitor {
         birNewError.detailOp.accept(this);
     }
 
+    public void visit(BIRNonTerminator.FPLoad fpLoad) {
+        buf.writeByte(fpLoad.kind.getValue());
+        fpLoad.lhsOp.accept(this);
+
+        PackageID pkgId = fpLoad.pkgId;
+        int orgCPIndex = addStringCPEntry(pkgId.orgName.value);
+        int nameCPIndex = addStringCPEntry(pkgId.name.value);
+        int versionCPIndex = addStringCPEntry(pkgId.version.value);
+        int pkgIndex = cp.addCPEntry(new CPEntry.PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
+        buf.writeInt(pkgIndex);
+
+        buf.writeInt(addStringCPEntry(fpLoad.funcName.getValue()));
+    }
 
     public void visit(BIRTerminator.Panic birPanic) {
         buf.writeByte(birPanic.kind.getValue());

--- a/stdlib/bir/src/main/ballerina/bir/bir_emitter.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_emitter.bal
@@ -240,6 +240,13 @@ type InstructionEmitter object {
             print(" ", ins.kind, " ");
             self.typeEmitter.emitType(ins.typeValue);
             println(";");
+        } else if (ins is FPLoad) {
+            print(tabs);
+            self.opEmitter.emitOp(ins.lhsOp);
+            print(" = ");
+            print(" ", ins.kind, " ");
+            print(ins.pkgID.org, "/", ins.pkgID.name, "::", ins.pkgID.modVersion, ":", ins.name.value, "()");
+            println(";");
         }
     }
 };

--- a/stdlib/bir/src/main/ballerina/bir/bir_func_body_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_func_body_parser.bal
@@ -165,6 +165,13 @@ public type FuncBodyParser object {
             var detailsOp = self.parseVarRef();
             NewError newError = {kind:kind, lhsOp:lhsOp, reasonOp:reasonOp, detailsOp:detailsOp};
             return newError;
+        } else if (kindTag == INS_FP_LOAD) {
+            kind = INS_KIND_FP_LOAD;
+            var lhsOp = self.parseVarRef();
+            var pkgId = self.reader.readModuleIDCpRef();
+            var name = self.reader.readStringCpRef();
+            FPLoad fpLoad = {kind:kind, lhsOp:lhsOp, pkgID:pkgId, name:{ value: name }};
+            return fpLoad;
         } else {
             return self.parseBinaryOpInstruction(kindTag);
         }

--- a/stdlib/bir/src/main/ballerina/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_model.bal
@@ -96,12 +96,13 @@ public const INS_KIND_IS_LIKE = "IS_LIKE";
 public const INS_KIND_TYPE_TEST = "TYPE_TEST";
 public const INS_KIND_OBJECT_STORE = "OBJECT_STORE";
 public const INS_KIND_OBJECT_LOAD = "OBJECT_LOAD";
+public const INS_KIND_FP_LOAD = "FP_LOAD";
 
 public type InstructionKind INS_KIND_MOVE | INS_KIND_CONST_LOAD | INS_KIND_NEW_MAP | INS_KIND_NEW_INST | 
                                 INS_KIND_MAP_STORE | INS_KIND_NEW_ARRAY | INS_KIND_NEW_ERROR | INS_KIND_ARRAY_STORE |
                                 INS_KIND_MAP_LOAD | INS_KIND_ARRAY_LOAD | INS_KIND_TYPE_CAST | INS_KIND_IS_LIKE |
                                 INS_KIND_TYPE_TEST | BinaryOpInstructionKind | INS_KIND_OBJECT_STORE |
-                                INS_KIND_OBJECT_LOAD;
+                                INS_KIND_OBJECT_LOAD | INS_KIND_FP_LOAD;
 
 
 public const TERMINATOR_GOTO = "GOTO";
@@ -321,6 +322,13 @@ public type NewError record {|
     VarRef lhsOp;
     VarRef reasonOp;
     VarRef detailsOp;
+|};
+
+public type FPLoad record {|
+    InstructionKind kind;
+    VarRef lhsOp;
+    ModuleID pkgID;
+    Name name;
 |};
 
 public type FieldAccess record {|

--- a/stdlib/bir/src/main/ballerina/bir/ins_codes.bal
+++ b/stdlib/bir/src/main/ballerina/bir/ins_codes.bal
@@ -37,6 +37,7 @@ public const int INS_NEW_INST = 32;
 public const int INS_OBJECT_STORE = 33;
 public const int INS_OBJECT_LOAD = 34;
 public const int INS_PANIC = 35;
+public const int INS_FP_LOAD = 36;
 
 // Binary expression related instructions.
 public const int INS_ADD = 50;


### PR DESCRIPTION
## Purpose
> Support anonymous functions in BIR

Fixes #<Issue Number>

## Approach
> Anonymous functions are already desugared to a function. BIR will keep referance to that function.
```
%3 =  FP_LOAD $anon/.::0.0.0:$lambda$0();
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
