### PR TITLE
Add missing API doc generation

### DIFF
--- a/distribution/zip/ballerina-tools/pom.xml
+++ b/distribution/zip/ballerina-tools/pom.xml
@@ -453,6 +453,7 @@
                                 ballerina-privacy,
                                 ballerina-jvm,
                                 ballerina-bir,
+                                ballerina-nats,
                                 <!-- other artifacts -->
                                 ballerina,
                                 testerina-core,
@@ -660,6 +661,11 @@
                                 <resource>
                                     <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-bir-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-nats-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                             </resources>

--- a/distribution/zip/ballerina-tools/pom.xml
+++ b/distribution/zip/ballerina-tools/pom.xml
@@ -419,7 +419,9 @@
                         <configuration>
                             <includeArtifactIds>
                                 <!-- stdlib artifacts -->
+                                ballerina-activemq-artemis,
                                 ballerina-auth,
+                                ballerina-bir,
                                 ballerina-builtin,
                                 ballerina-cache,
                                 ballerina-config-api,
@@ -432,28 +434,29 @@
                                 ballerina-http,
                                 ballerina-internal,
                                 ballerina-io,
-                                ballerina-socket,
+                                ballerina-jvm,
                                 ballerina-jms,
                                 ballerina-log-api,
                                 ballerina-math,
                                 ballerina-mime,
                                 ballerina-mysql,
+                                ballerina-nats,
                                 ballerina-observability,
+                                ballerina-openapi,
+                                ballerina-privacy,
+                                ballerina-rabbitmq,
                                 ballerina-reflect,
                                 ballerina-runtime-api,
+                                ballerina-socket,
                                 ballerina-sql,
                                 ballerina-streams,
-                                ballerina-openapi,
                                 ballerina-system,
                                 ballerina-task,
                                 ballerina-time,
                                 ballerina-transactions,
                                 ballerina-utils,
                                 ballerina-websub,
-                                ballerina-privacy,
-                                ballerina-jvm,
-                                ballerina-bir,
-                                ballerina-nats,
+
                                 <!-- other artifacts -->
                                 ballerina,
                                 testerina-core,
@@ -490,7 +493,17 @@
                             <resources>
                                 <resource>
                                     <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-activemq-artemis-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-auth-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-bir-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
@@ -555,12 +568,12 @@
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-socket-ballerina-sources-zip/ballerina
+                                        ${project.build.directory}/extracted-distributions/ballerina-jms-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-jms-ballerina-sources-zip/ballerina
+                                        ${project.build.directory}/extracted-distributions/ballerina-jvm-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
@@ -585,7 +598,27 @@
                                 </resource>
                                 <resource>
                                     <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-nats-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-observability-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-openapi-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-privacy-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-rabbitmq-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
@@ -605,12 +638,12 @@
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-streams-ballerina-sources-zip/ballerina
+                                        ${project.build.directory}/extracted-distributions/ballerina-socket-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-openapi-ballerina-sources-zip/ballerina
+                                        ${project.build.directory}/extracted-distributions/ballerina-streams-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
@@ -645,27 +678,7 @@
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-privacy-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
                                         ${project.build.directory}/extracted-distributions/testerina-core-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-jvm-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-bir-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-nats-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                             </resources>

--- a/distribution/zip/ballerina/pom.xml
+++ b/distribution/zip/ballerina/pom.xml
@@ -846,45 +846,45 @@
                         <configuration>
                             <includeArtifactIds>
                                 <!-- stdlib dependencies -->
+                                ballerina-activemq-artemis,
                                 ballerina-auth,
                                 ballerina-builtin,
                                 ballerina-cache,
                                 ballerina-config-api,
                                 ballerina-crypto,
                                 ballerina-encoding,
-                                ballerina-database,
                                 ballerina-file,
                                 ballerina-filepath,
                                 ballerina-grpc,
                                 ballerina-h2,
                                 ballerina-http,
-                                ballerina-io,
-                                ballerina-socket,
                                 ballerina-internal,
+                                ballerina-io,
                                 ballerina-jms,
-                                ballerina-activemq-artemis,
-                                ballerina-rabbitmq,
                                 ballerina-log-api,
                                 ballerina-math,
                                 ballerina-mime,
                                 ballerina-mysql,
+                                ballerina-nats,
                                 ballerina-observability,
+                                ballerina-openapi,
+                                ballerina-privacy,
+                                ballerina-rabbitmq,
                                 ballerina-reflect,
                                 ballerina-runtime-api,
+                                ballerina-socket,
                                 ballerina-sql,
                                 ballerina-streams,
                                 ballerina-system,
-                                ballerina-openapi,
                                 ballerina-task,
                                 ballerina-time,
                                 ballerina-transactions,
                                 ballerina-utils,
                                 ballerina-websub,
-                                ballerina-privacy,
+
                                 <!-- other dependencies -->
                                 ballerina-config,
-                                strip-bouncycastle,
-                                ballerina-nats
+                                strip-bouncycastle
                             </includeArtifactIds>
                             <outputDirectory>${project.build.directory}/extracted-distributions
                             </outputDirectory>
@@ -913,6 +913,11 @@
                             <outputDirectory>${project.build.directory}/extracted-distributions/ballerina-all-sources
                             </outputDirectory>
                             <resources>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-activemq-artemis-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
                                 <resource>
                                     <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-auth-ballerina-sources-zip/ballerina
@@ -980,11 +985,6 @@
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-socket-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-jms-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
@@ -1005,17 +1005,32 @@
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-nats-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-mysql-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
                                     <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-nats-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-observability-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-openapi-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-privacy-ballerina-sources-zip/ballerina
+                                    </directory>
+                                </resource>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/extracted-distributions/ballerina-rabbitmq-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
@@ -1035,12 +1050,12 @@
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-streams-ballerina-sources-zip/ballerina
+                                        ${project.build.directory}/extracted-distributions/ballerina-socket-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-openapi-ballerina-sources-zip/ballerina
+                                        ${project.build.directory}/extracted-distributions/ballerina-streams-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                                 <resource>
@@ -1071,11 +1086,6 @@
                                 <resource>
                                     <directory>
                                         ${project.build.directory}/extracted-distributions/ballerina-websub-ballerina-sources-zip/ballerina
-                                    </directory>
-                                </resource>
-                                <resource>
-                                    <directory>
-                                        ${project.build.directory}/extracted-distributions/ballerina-privacy-ballerina-sources-zip/ballerina
                                     </directory>
                                 </resource>
                             </resources>


### PR DESCRIPTION
## Purpose
This PR adds support to generate API docs for `nats`, `artemis` and `rabbitmq` modules. This PR also sorts artifacts in alphabetical order. 

Fixes #15131
Fixes #15132
Fixes #15133

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
