### PR TITLE
Fix build bug - print errors when compiling balos

### DIFF
--- a/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/GenerateBalo.java
+++ b/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/GenerateBalo.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.FileSystemProjectDirectory;
 import org.wso2.ballerinalang.compiler.SourceDirectory;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -113,8 +114,7 @@ public class GenerateBalo {
         SymbolTable symbolTable = SymbolTable.getInstance(context);
 
         Compiler compiler = Compiler.getInstance(context);
-        compiler.write(compiler.build());
-
+        List<BLangPackage> buildPackages = compiler.compilePackages(false);
 
         List<Diagnostic> diagnostics = diagListner.getDiagnostics();
         if (diagListner.getErrorCount() > 0 || (reportWarnings && diagListner.getWarnCount() > 0)) {
@@ -124,6 +124,8 @@ public class GenerateBalo {
             throw new BLangCompilerException("Compilation failed with " + diagListner.getErrorCount() +
                                              " error(s)" + warnMsg + " " + "\n  " + sj.toString());
         }
+
+        compiler.write(buildPackages);
 
         BinaryFileWriter writer = BinaryFileWriter.getInstance(context);
         BPackageSymbol buitlinSymbol = symbolTable.builtInPackageSymbol;


### PR DESCRIPTION
Errors should print as follows
```
> Task :ballerina-runtime-api:createBalo FAILED
Exception in thread "main" org.ballerinalang.compiler.BLangCompilerException: Compilation failed with 4 error(s) and 0 warning(s) 
  ERROR: ballerina/runtime::errors.bal:33:7:: extraneous input 'function'
  ERROR: ballerina/runtime::errors.bal:33:28:: missing token '=' before '('
  ERROR: ballerina/runtime::errors.bal:33:31:: mismatched input 'returns'. expecting {'is', ';', '?', '+', '-', '*', '/', '%', '==', '!=', '>', '<', '>=', '<=', '&&', '||', '===', '!==', '&', '^', '...', '|', '?:', '->>', '..<'}
  ERROR: ballerina/runtime::errors.bal:33:58:: extraneous input '='
        at org.ballerinalang.stdlib.utils.GenerateBalo.genBalo(GenerateBalo.java:125)
        at org.ballerinalang.stdlib.utils.GenerateBalo.main(GenerateBalo.java:79)

```