### PR TITLE
Enable tests related to Add operation

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
@@ -84,23 +84,15 @@ public class XMLFactory {
     static {
         Canonicalizer.init();
         try {
-            if (Canonicalizer.getInstance(CANONICALIZER_OMIT_COMMENTS) == null) {
-                Canonicalizer.register(CANONICALIZER_OMIT_COMMENTS,
-                        "org.apache.axiom.c14n.impl.Canonicalizer20010315OmitComments");
-            }
-            if (Canonicalizer.getInstance(CANONICALIZER_WITH_COMMENTS) == null) {
-                Canonicalizer.register(CANONICALIZER_WITH_COMMENTS,
-                        "org.apache.axiom.c14n.impl.Canonicalizer20010315WithComments");
-            }
-            if (Canonicalizer.getInstance(CANONICALIZER_EXCL_OMIT_COMMENTS) == null) {
-                Canonicalizer.register(CANONICALIZER_EXCL_OMIT_COMMENTS,
-                        "org.apache.axiom.c14n.impl.Canonicalizer20010315ExclOmitComments");
-            }
-            if (Canonicalizer.getInstance(CANONICALIZER_EXCL_WITH_COMMENTS) == null) {
-                Canonicalizer.register(CANONICALIZER_EXCL_WITH_COMMENTS,
-                        "org.apache.axiom.c14n.impl.Canonicalizer20010315ExclWithComments");
-            }
-            canonicalizer = Canonicalizer.getInstance(CANONICALIZER_WITH_COMMENTS);
+            Canonicalizer.register("http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+                    "org.apache.axiom.c14n.impl.Canonicalizer20010315OmitComments");
+            Canonicalizer.register("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments",
+                    "org.apache.axiom.c14n.impl.Canonicalizer20010315WithComments");
+            Canonicalizer.register("http://www.w3.org/2001/10/xml-exc-c14n#",
+                    "org.apache.axiom.c14n.impl.Canonicalizer20010315ExclOmitComments");
+            Canonicalizer.register("http://www.w3.org/2001/10/xml-exc-c14n#WithComments",
+                    "org.apache.axiom.c14n.impl.Canonicalizer20010315ExclWithComments");
+            canonicalizer = Canonicalizer.getInstance("http://www.w3.org/2001/10/xml-exc-c14n#WithComments");
         } catch (InvalidCanonicalizerException | AlgorithmAlreadyRegisteredException e) {
             throw new BallerinaException("Error initializing canonicalizer: " + e.getMessage());
         }
@@ -239,7 +231,7 @@ public class XMLFactory {
      * @return Concatenated XML sequence
      */
     public static XMLValue<?> concatenate(XMLValue<?> firstSeq, XMLValue<?> secondSeq) {
-        ArrayValue concatSeq = new ArrayValue();
+        ArrayValue concatSeq = new ArrayValue(new BArrayType(firstSeq.getType()), -1);
         int j = 0;
 
         // Load the content fully before concat the two

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_instruction_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_instruction_gen.bal
@@ -179,6 +179,12 @@ type InstructionGenerator object {
 
             self.mv.visitInsn(DADD);
             self.storeToVar(binaryIns.lhsOp.variableDcl);
+        } else if (bType is bir:BXMLType) {
+            self.loadVar(binaryIns.rhsOp1.variableDcl);
+            self.loadVar(binaryIns.rhsOp2.variableDcl);
+            self.mv.visitMethodInsn(INVOKESTATIC, XML_FACTORY, "concatenate",
+                        io:sprintf("(L%s;L%s;)L%s;", XML_VALUE, XML_VALUE, XML_VALUE), false);
+            self.storeToVar(binaryIns.lhsOp.variableDcl);
         } else {
             error err = error( "JVM generation is not supported for type " +
                             io:sprintf("%s", binaryIns.lhsOp.typeValue));

--- a/tests/ballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/ballerina-unit-test/src/test/resources/testng.xml
@@ -90,6 +90,7 @@ under the License.
         </packages>
 
         <classes>
+            <class name="org.ballerinalang.test.expressions.binaryoperations.AddOperationTest" />
             <class name="org.ballerinalang.test.functions.FunctionSignatureTest" >
                 <methods>
                     <exclude name="testOptionalArgsInNativeFunc" />


### PR DESCRIPTION
## Purpose
This PR enables unit tests written to test the Add operation in jBallerina.

## Remarks
In this process, I found an issue in the XMLFactory.concatenate method and fixed it. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
