### PR TITLE
Add workers support in jBallerina

### DIFF
--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
@@ -304,7 +304,7 @@ function generateMethod(bir:Function func, jvm:ClassWriter cw, bir:Package modul
         } else if (terminator is bir:Wait) {
             termGen.generateWaitIns(terminator, funcName);
         } else if (terminator is bir:FPCall) {
-            termGen.genFPCallIns(terminator);
+            termGen.genFPCallIns(terminator, funcName);
         } else {
             error err = error( "JVM generation is not supported for terminator instruction " +
                                         io:sprintf("%s", terminator));

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_terminator_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_terminator_gen.bal
@@ -531,13 +531,9 @@ type TerminatorGenerator object {
 
     function submitToScheduler(bir:VarRef? lhsOp) {
         bir:BType? futureType = lhsOp.typeValue;
-        boolean isVoid;
+        boolean isVoid = false;
         if (futureType is bir:BFutureType) {
             isVoid = futureType.returnType is bir:BTypeNil;
-        } else {
-            error err = error( "Invalid return type for async function pointer call" +
-                            io:sprintf("%s", futureType));
-            panic err;
         }
 
         if (isVoid) {
@@ -549,7 +545,7 @@ type TerminatorGenerator object {
         }
 
         // store return
-        if(lhsOp is bir:VarRef) {
+        if (lhsOp is bir:VarRef) {
             bir:VariableDcl? lhsOpVarDcl = lhsOp.variableDcl;
             // store the returned strand as the future
             self.mv.visitVarInsn(ASTORE, self.getJVMIndexOfVarRef(getVariableDcl(lhsOpVarDcl)));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -493,7 +493,7 @@ public class BIRGen extends BLangNodeVisitor {
         Name funcName = getFuncName((BInvokableSymbol) invocationExpr.symbol);
         if (invocationExpr.functionPointerInvocation) {
             this.env.enclBB.terminator = new BIRTerminator.FPCall(invocationExpr.pos, InstructionKind.FP_CALL,
-                    fp, args, lhsOp, thenBB);
+                    fp, args, lhsOp, invocationExpr.async, thenBB);
         } else if (invocationExpr.async) {
             this.env.enclBB.terminator = new BIRTerminator.AsyncCall(invocationExpr.pos, InstructionKind.ASYNC_CALL,
                     isVirtual, invocationExpr.symbol.pkgID, funcName, args, lhsOp, thenBB);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
@@ -147,17 +147,20 @@ public abstract class BIRTerminator extends BIRNode implements BIRInstruction {
         public BIROperand lhsOp;
         public List<BIROperand> args;
         public BIRBasicBlock thenBB;
+        public boolean isAsync;
 
         public FPCall(DiagnosticPos pos,
                       InstructionKind kind,
                       BIROperand fp,
                       List<BIROperand> args,
                       BIROperand lhsOp,
+                      boolean isAsync,
                       BIRBasicBlock thenBB) {
             super(pos, kind);
             this.fp = fp;
             this.lhsOp = lhsOp;
             this.args = args;
+            this.isAsync = isAsync;
             this.thenBB = thenBB;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
@@ -192,6 +192,7 @@ public class BIRInstructionWriter extends BIRVisitor {
         } else {
             buf.writeByte(0);
         }
+        buf.writeBoolean(fpCall.isAsync);
         addCpAndWriteString(fpCall.thenBB.id.value);
     }
 

--- a/stdlib/bir/src/main/ballerina/bir/bir_emitter.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_emitter.bal
@@ -273,7 +273,7 @@ type InstructionEmitter object {
             print(tabs);
             self.opEmitter.emitOp(ins.lhsOp);
             print(" = ");
-            print(" ", ins.kind, " ");
+            print(ins.kind, " ");
             print(ins.pkgID.org, "/", ins.pkgID.name, "::", ins.pkgID.modVersion, ":", ins.name.value, "(");
 
             foreach var v in ins.closureMaps {
@@ -359,7 +359,7 @@ type TerminalEmitter object {
                 self.opEmitter.emitOp(lhsOp);
                 print(" = ");
             }
-            print(" START ");
+            print("START ");
             print(term.pkgID.org, "/", term.pkgID.name, "::", term.pkgID.modVersion, ":", term.name.value, "(");
             int i = 0;
             foreach var arg in term.args {
@@ -378,6 +378,9 @@ type TerminalEmitter object {
             if (lhsOp is VarRef) {
                 self.opEmitter.emitOp(lhsOp);
                 print(" = ");
+            }
+            if (term.isAsync) {
+                print("START ");
             }
             print(term.kind, " ");
             self.opEmitter.emitOp(term.fp);

--- a/stdlib/bir/src/main/ballerina/bir/bir_func_body_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_func_body_parser.bal
@@ -397,9 +397,9 @@ public type FuncBodyParser object {
             if (hasLhs){
                 lhsOp = self.parseVarRef();
             }
-
+            var isAsync = self.reader.readBoolean();
             BasicBlock thenBB = self.parseBBRef();
-            FPCall fpCall = {pos:pos, kind:kind, fp:fp, lhsOp:lhsOp, args:args, thenBB:thenBB};
+            FPCall fpCall = {pos:pos, kind:kind, fp:fp, lhsOp:lhsOp, args:args, thenBB:thenBB, isAsync:isAsync};
             return fpCall;
         }
         error err = error("term instrucion kind " + kindTag + " not impl.");

--- a/stdlib/bir/src/main/ballerina/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_model.bal
@@ -514,6 +514,7 @@ public type FPCall record {|
     VarRef fp;
     VarRef? lhsOp;
     VarRef?[] args;
+    boolean isAsync;
     BasicBlock thenBB;
 |};
 

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/AnonymousFunctionsTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/AnonymousFunctionsTest.java
@@ -63,4 +63,10 @@
          BValue[] result = BRunUtil.invoke(compileResult, "testMultilevelClosure");
          Assert.assertEquals(result[0].stringValue(), "72");
      }
+
+     @Test(description = "Test basic worker")
+     public void testWorkerBasic() {
+         BValue[] result = BRunUtil.invoke(compileResult, "basicWorkerTest");
+         Assert.assertEquals(result[0].stringValue(), "120");
+     }
  }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/jvm/anon-funcs.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/jvm/anon-funcs.bal
@@ -69,3 +69,24 @@ function multilevelClosure() returns (function (int) returns int) {
     };
     return func1;
 }
+
+function basicWorkerTest() returns int {
+    int global = 10;
+
+    worker w1 {
+       global += 10;
+    }
+
+    worker w2 returns int {
+       int i = 0;
+       while(i < 100) {
+          i +=1;
+       }
+       return i;
+    }
+
+    int result = wait w2;
+    wait w1;
+    
+    return global + result;
+}


### PR DESCRIPTION
## Purpose
> Enable workers in jBallerina.

## Approach
> Worker is an async function pointer invocation. Those are submitted to the scheduler to be scheduled. 

## Samples
> BIR snippet for a worker
```
%8 = FP_LOAD $anon/.::0.0.0:$lambda$0();
23-28:04-05	%7 = MOVE %8;
01-01:4294967295-4294967295	%10 = MOVE %7;
23-28:04-05	%11 = START FP_CALL %10() -> bb1;
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
