### PR TITLE
Add comment for project.scm.id property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2525,6 +2525,8 @@
         <apache.directory.server.version>2.0.0-M24</apache.directory.server.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <asm.version>6.2.1</asm.version>
+        <!-- This property is unused inside the project, but used during the release process,
+        therefore, DO NOT remove this -->
         <project.scm.id>ballerina-scm-server</project.scm.id>
     </properties>
 


### PR DESCRIPTION
## Purpose
Adding a description comment for project.scm.id maven property, to avoid getting removed by accident.
