### PR TITLE
Add missing pieces for decimal support in db clients

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/DataIterator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/DataIterator.java
@@ -20,6 +20,7 @@ package org.ballerinalang.model;
 import org.ballerinalang.model.types.BStructureType;
 import org.ballerinalang.model.values.BMap;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -46,6 +47,8 @@ public interface DataIterator {
     Boolean getBoolean(int columnIndex);
 
     String getBlob(int columnIndex);
+
+    BigDecimal getDecimal(int columnIndex);
 
     Object[] getStruct(int columnIndex);
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/TableJSONDataSource.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/TableJSONDataSource.java
@@ -27,6 +27,7 @@ import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.util.JsonGenerator;
 import org.ballerinalang.model.util.JsonParser;
 import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BDecimal;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
@@ -140,6 +141,10 @@ public class TableJSONDataSource implements JSONDataSource {
             case FLOAT:
                 Double floatVal = df.getFloat(index);
                 jsonObject.put(name, floatVal == null ? null : new BFloat(floatVal));
+                break;
+            case DECIMAL:
+                BigDecimal decimalVal = df.getDecimal(index);
+                jsonObject.put(name, decimalVal == null ? null : new BDecimal(decimalVal));
                 break;
             case BOOLEAN:
                 Boolean boolVal = df.getBoolean(index);

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/TableOMDataSource.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/TableOMDataSource.java
@@ -102,6 +102,9 @@ public class TableOMDataSource extends AbstractPushOMDataSource {
         case FLOAT:
             value = String.valueOf(table.getFloat(index));
             break;
+        case DECIMAL:
+            value = String.valueOf(table.getDecimal(index));
+            break;
         case BLOB:
             value = table.getBlob(index);
             break;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
@@ -34,6 +34,7 @@ import org.ballerinalang.util.codegen.FunctionInfo;
 import org.ballerinalang.util.exceptions.BallerinaErrorReasons;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -306,6 +307,10 @@ public class BTable implements BRefType<Object>, BCollection {
 
     public Double getFloat(int columnIndex) {
         return iterator.getFloat(columnIndex);
+    }
+
+    public BigDecimal getDecimal(int columnIndex) {
+        return iterator.getDecimal(columnIndex);
     }
 
     public Boolean getBoolean(int columnIndex) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableIterator.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableIterator.java
@@ -157,6 +157,16 @@ public class TableIterator implements DataIterator {
     }
 
     @Override
+    public BigDecimal getDecimal(int columnIndex) {
+        try {
+            BigDecimal val = rs.getBigDecimal(columnIndex);
+            return rs.wasNull() ? null : val;
+        } catch (SQLException e) {
+            throw new BallerinaException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public Object[] getStruct(int columnIndex) {
         Object[] objArray = null;
         try {

--- a/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/SQLDatasourceUtils.java
+++ b/stdlib/database/sql/src/main/java/org/ballerinalang/database/sql/SQLDatasourceUtils.java
@@ -963,9 +963,10 @@ public class SQLDatasourceUtils {
         case Types.BIT:
         case Types.BOOLEAN:
             return TypeKind.BOOLEAN;
-        case Types.REAL:
         case Types.NUMERIC:
         case Types.DECIMAL:
+            return TypeKind.DECIMAL;
+        case Types.REAL:
         case Types.FLOAT:
         case Types.DOUBLE:
             return TypeKind.FLOAT;

--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -215,7 +215,7 @@ public class TableTest {
                 + "<FLOAT_ARRAY><element>245.23</element><element>5559.49</element>"
                 + "<element>8796.123</element></FLOAT_ARRAY><DOUBLE_TYPE>2.139095039E9</DOUBLE_TYPE>"
                 + "<BOOLEAN_TYPE>true</BOOLEAN_TYPE><STRING_TYPE>Hello</STRING_TYPE>"
-                + "<DECIMAL_TYPE>234.56</DECIMAL_TYPE>"
+                + "<DECIMAL_TYPE>342452151425.4556</DECIMAL_TYPE>"
                 + "<DOUBLE_ARRAY><element>245.23</element><element>5559.49</element><element>8796.123</element>"
                 + "</DOUBLE_ARRAY><BOOLEAN_ARRAY><element>true</element><element>false</element>"
                 + "<element>true</element></BOOLEAN_ARRAY><STRING_ARRAY><element>Hello</element>"
@@ -250,7 +250,7 @@ public class TableTest {
                 + "\"LONG_TYPE\":9223372036854774807, \"LONG_ARRAY\":[100000000, 200000000, 300000000], "
                 + "\"FLOAT_TYPE\":123.34, \"FLOAT_ARRAY\":[245.23, 5559.49, 8796.123], "
                 + "\"DOUBLE_TYPE\":2.139095039E9, \"BOOLEAN_TYPE\":true, \"STRING_TYPE\":\"Hello\", "
-                + "\"DECIMAL_TYPE\":234.56, \"DOUBLE_ARRAY\":[245.23, 5559.49, 8796.123], "
+                + "\"DECIMAL_TYPE\":342452151425.4556, \"DOUBLE_ARRAY\":[245.23, 5559.49, 8796.123], "
                 + "\"BOOLEAN_ARRAY\":[true, false, true], \"STRING_ARRAY\":[\"Hello\", \"Ballerina\"]}]";
         Assert.assertEquals(returns[0].stringValue(), expected);
     }

--- a/tests/ballerina-unit-test/src/test/resources/datafiles/sql/TableTest_H2_Data.sql
+++ b/tests/ballerina-unit-test/src/test/resources/datafiles/sql/TableTest_H2_Data.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS MixTypes (
 /
 INSERT INTO MixTypes (row_id, int_type, long_type, float_type, double_type, boolean_type, string_type, decimal_type,
   int_array, long_array, float_array, double_array, boolean_array, string_array)
-VALUES (1, 1, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello', 234.56, (1, 2, 3),
+VALUES (1, 1, 9223372036854774807, 123.34, 2139095039, TRUE, 'Hello', 342452151425.4556, (1, 2, 3),
   (100000000, 200000000, 300000000), (245.23, 5559.49, 8796.123),
   (245.23, 5559.49, 8796.123), (TRUE, FALSE, TRUE), ('Hello', 'Ballerina'));
 /


### PR DESCRIPTION
## Purpose
During table to JSON/XML conversion decimal values are treated as float. Because of this, very small/large decimal values which can actually be represented with fixed number of digits, are shown in scientific notation, once converted to JSON. This is fixed with this PR.

Samples can be found at #15234

Fixes #15234

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
