### PR TITLE
Enable unit tests written for Elvis and mod operators in jBallerina

### DIFF
--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_instruction_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_instruction_gen.bal
@@ -71,6 +71,8 @@ type InstructionGenerator object {
             self.generateDivIns(binaryIns);
         } else if (binaryIns.kind == bir:BINARY_MUL) {
             self.generateMulIns(binaryIns);
+        } else if (binaryIns.kind == bir:BINARY_MOD) {
+            self.generateRemIns(binaryIns);
         } else if (binaryIns.kind == bir:BINARY_AND) {
             self.generateAndIns(binaryIns);
         } else if (binaryIns.kind == bir:BINARY_OR) {
@@ -265,6 +267,21 @@ type InstructionGenerator object {
             panic err;
         }
         self.storeToVar(binaryIns.lhsOp.variableDcl);
+    }
+
+    function generateRemIns(bir:BinaryOp binaryIns) {
+            bir:BType bType = binaryIns.lhsOp.typeValue;
+            self.generateBinaryRhsAndLhsLoad(binaryIns);
+            if (bType is bir:BTypeInt) {
+                self.mv.visitInsn(LREM);
+            } else if (bType is bir:BTypeFloat) {
+                self.mv.visitInsn(DREM);
+            } else {
+                error err = error( "JVM generation is not supported for type " +
+                                io:sprintf("%s", binaryIns.lhsOp.typeValue));
+                panic err;
+            }
+            self.storeToVar(binaryIns.lhsOp.variableDcl);
     }
 
     function generateAndIns(bir:BinaryOp binaryIns) {

--- a/stdlib/bir/src/main/ballerina/bir/bir_func_body_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_func_body_parser.bal
@@ -429,6 +429,8 @@ public type FuncBodyParser object {
             kind = BINARY_MUL;
         } else if (kindTag == INS_DIV){
             kind = BINARY_DIV;
+        } else if (kindTag == INS_MOD){
+            kind = BINARY_MOD;
         } else if (kindTag == INS_EQUAL){
             kind = BINARY_EQUAL;
         } else if (kindTag == INS_NOT_EQUAL){

--- a/stdlib/bir/src/main/ballerina/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_model.bal
@@ -71,6 +71,7 @@ public const BINARY_ADD = "ADD";
 public const BINARY_SUB = "SUB";
 public const BINARY_MUL = "MUL";
 public const BINARY_DIV = "DIV";
+public const BINARY_MOD = "MOD";
 public const BINARY_EQUAL = "EQUAL";
 public const BINARY_NOT_EQUAL = "NOT_EQUAL";
 public const BINARY_GREATER_THAN = "GREATER_THAN";
@@ -80,9 +81,10 @@ public const BINARY_LESS_EQUAL = "LESS_EQUAL";
 public const BINARY_AND = "AND";
 public const BINARY_OR = "OR";
 
-public type BinaryOpInstructionKind BINARY_ADD|BINARY_SUB|BINARY_MUL|BINARY_DIV|BINARY_EQUAL|BINARY_NOT_EQUAL
-                                       |BINARY_GREATER_THAN|BINARY_GREATER_EQUAL|BINARY_LESS_THAN|BINARY_LESS_EQUAL
-                                       |BINARY_AND|BINARY_OR;
+public type BinaryOpInstructionKind BINARY_ADD|BINARY_SUB|BINARY_MUL|BINARY_DIV|BINARY_MOD
+                                        |BINARY_EQUAL|BINARY_NOT_EQUAL
+                                        |BINARY_GREATER_THAN|BINARY_GREATER_EQUAL|BINARY_LESS_THAN|BINARY_LESS_EQUAL
+                                        |BINARY_AND|BINARY_OR;
 
 public const INS_KIND_MOVE = "MOVE";
 public const INS_KIND_CONST_LOAD = "CONST_LOAD";

--- a/tests/ballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/ballerina-unit-test/src/test/resources/testng.xml
@@ -130,9 +130,15 @@ under the License.
                     <exclude name="testCheckExprInBinaryExpr7"/>
                 </methods>
             </class>
+            <class name="org.ballerinalang.test.expressions.elvis.ElvisExpressionTest"/>
             <class name="org.ballerinalang.test.expressions.binaryoperations.DivisionOperationTest">
                 <methods>
                     <exclude name="testIntDivideByZeroExpr"/>
+                </methods>
+            </class>
+            <class name="org.ballerinalang.test.expressions.binaryoperations.ModOperationTest">
+                <methods>
+                    <exclude name="testIntModZero"/>
                 </methods>
             </class>
             <class name="org.ballerinalang.test.expressions.typeof.TypeofOverLiteralExpressionTest" />


### PR DESCRIPTION
## Purpose
Enable unit tests related to the elvis and modulus operators.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
