### PR TITLE
Fix compilation failure in maven

### DIFF
--- a/stdlib/messaging/activemq-artemis/pom.xml
+++ b/stdlib/messaging/activemq-artemis/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
         <groupId>org.ballerinalang</groupId>
         <artifactId>ballerina-core</artifactId>
-        <version>${ballerina.milestone.version}</version>
     </dependency>
     <dependency>
         <groupId>org.ballerinalang</groupId>
@@ -42,7 +41,6 @@
     <dependency>
         <groupId>org.ballerinalang</groupId>
         <artifactId>ballerina-lang</artifactId>
-        <version>${ballerina.milestone.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
## Purpose
> There is a compilation failure in maven build for the Artemis connector. This fixes it.

## Approach
> Modify pom file

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
