### PR TITLE
Ignore visibility specifier of record typedesc for record subtyping

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -3753,6 +3753,21 @@ public class BVM {
 
     public static boolean checkRecordEquivalency(BRecordType lhsType, BRecordType rhsType,
                                                  List<TypePair> unresolvedTypes) {
+        // Both records should be public or private.
+        // Get the XOR of both flags(masks)
+        // If both are public, then public bit should be 0;
+        // If both are private, then public bit should be 0;
+        // The public bit is on means, one is public, and the other one is private.
+        if (Flags.isFlagOn(lhsType.flags ^ rhsType.flags, Flags.PUBLIC)) {
+            return false;
+        }
+
+        // If both records are private, they should be in the same package.
+        if (!Flags.isFlagOn(lhsType.flags, Flags.PUBLIC) &&
+                !rhsType.getPackagePath().equals(lhsType.getPackagePath())) {
+            return false;
+        }
+
         // Cannot assign open records to closed record types
         if (lhsType.sealed && !rhsType.sealed) {
             return false;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BVM.java
@@ -3753,21 +3753,6 @@ public class BVM {
 
     public static boolean checkRecordEquivalency(BRecordType lhsType, BRecordType rhsType,
                                                  List<TypePair> unresolvedTypes) {
-        // Both records should be public or private.
-        // Get the XOR of both flags(masks)
-        // If both are public, then public bit should be 0;
-        // If both are private, then public bit should be 0;
-        // The public bit is on means, one is public, and the other one is private.
-        if (Flags.isFlagOn(lhsType.flags ^ rhsType.flags, Flags.PUBLIC)) {
-            return false;
-        }
-
-        // If both records are private, they should be in the same package.
-        if (!Flags.isFlagOn(lhsType.flags, Flags.PUBLIC) &&
-                !rhsType.getPackagePath().equals(lhsType.getPackagePath())) {
-            return false;
-        }
-
         // Cannot assign open records to closed record types
         if (lhsType.sealed && !rhsType.sealed) {
             return false;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -827,20 +827,6 @@ public class Types {
     }
 
     public boolean checkRecordEquivalency(BRecordType rhsType, BRecordType lhsType, List<TypePair> unresolvedTypes) {
-        // Both records should be public or private.
-        // Get the XOR of both flags(masks)
-        // If both are public, then public bit should be 0;
-        // If both are private, then public bit should be 0;
-        // The public bit is on means, one is public, and the other one is private.
-        if (Symbols.isFlagOn(lhsType.tsymbol.flags ^ rhsType.tsymbol.flags, Flags.PUBLIC)) {
-            return false;
-        }
-
-        // If both records are private, they should be in the same package.
-        if (!Symbols.isPublic(lhsType.tsymbol) && rhsType.tsymbol.pkgID != lhsType.tsymbol.pkgID) {
-            return false;
-        }
-
         // If the LHS record is closed and the RHS record is open, the records aren't equivalent
         if (lhsType.sealed && !rhsType.sealed) {
             return false;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyRulesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyRulesTest.java
@@ -96,6 +96,18 @@ public class ClosedRecordEquivalencyRulesTest {
         BRunUtil.invoke(closedRecToClosedRec, "testOptFieldToOptField2");
     }
 
+    @Test(description = "RHS and LHS closed with RHS type being a public typedesc")
+    public void testCRToCRHeterogeneousTypedescEq() {
+        BValue[] returns = BRunUtil.invoke(closedRecToClosedRec, "testHeterogeneousTypedescEq");
+        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
+    }
+
+    @Test(description = "RHS and LHS closed with LHS type being a public typedesc")
+    public void testCRToCRHeterogeneousTypedescEq2() {
+        BValue[] returns = BRunUtil.invoke(closedRecToClosedRec, "testHeterogeneousTypedescEq2");
+        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
+    }
+
     @Test(description = "RHS open and LHS closed is disallowed")
     public void testORToCR() {
         CompileResult openRecToClosedRec = BCompileUtil.compile("test-src/record/equivalency_rules_or_to_cr.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyRulesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyRulesTest.java
@@ -185,4 +185,30 @@ public class OpenRecordEquivalencyRulesTest {
     public void testORToORRestFieldToRestField2() {
         BRunUtil.invoke(openRecToOpenRec, "testRestFieldToRestField2");
     }
+
+    @Test(description = "Closed record to open record with RHS type being a public typedesc")
+    public void testCRToORHeterogeneousTypedescEq() {
+        BValue[] returns = BRunUtil.invoke(closedRecToOpenRec, "testHeterogeneousTypedescEq");
+        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25, address:\"Colombo, Sri Lanka\"}");
+    }
+
+    @Test(description = "Closed record to open record with LHS type being a public typedesc")
+    public void testCRToORHeterogeneousTypedescEq2() {
+        BValue[] returns = BRunUtil.invoke(closedRecToOpenRec, "testHeterogeneousTypedescEq2");
+        assertEquals(returns[0].stringValue(),
+                     "{name:\"John Doe\", age:25, address:\"Colombo, Sri Lanka\", weight:70.0}");
+    }
+
+    @Test(description = "RHS and LHS open with RHS type being a public typedesc")
+    public void testORToORHeterogeneousTypedescEq1() {
+        BValue[] returns = BRunUtil.invoke(openRecToOpenRec, "testHeterogeneousTypedescEq3");
+        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25, address:\"Colombo, Sri Lanka\"}");
+    }
+
+    @Test(description = "RHS and LHS open with LHS type being a public typedesc")
+    public void testORToORHeterogeneousTypedescEq2() {
+        BValue[] returns = BRunUtil.invoke(openRecToOpenRec, "testHeterogeneousTypedescEq4");
+        assertEquals(returns[0].stringValue(),
+                     "{name:\"John Doe\", age:25, address:\"Colombo, Sri Lanka\"}");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_cr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_cr.bal
@@ -101,3 +101,20 @@ function testOptFieldToOptField2() returns (AnotherPerson4, int) {
 
     return (ap, ap2.age);
 }
+
+public type PublicPerson record {|
+    string name;
+    int age;
+|};
+
+function testHeterogeneousTypedescEq() returns Person1 {
+    PublicPerson p = {name:"John Doe", age:25};
+    Person1 p1 = p;
+    return p1;
+}
+
+function testHeterogeneousTypedescEq2() returns PublicPerson {
+    Person1 p1 = {name:"John Doe", age:25};
+    PublicPerson p = p1;
+    return p;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_or.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_or.bal
@@ -123,3 +123,27 @@ function testAdditionalFieldsToRest() returns AnotherPerson1 {
     AnotherPerson1 ap = p;
     return ap;
 }
+
+public type PublicPerson record {|
+    string name;
+    int age;
+    string address;
+|};
+
+function testHeterogeneousTypedescEq() returns AnotherPerson1 {
+    PublicPerson p = {name:"John Doe", age:25, address:"Colombo, Sri Lanka"};
+    AnotherPerson1 ap = p;
+    return ap;
+}
+
+public type OpenPublicPerson record {
+    string name;
+    int age;
+    string address;
+};
+
+function testHeterogeneousTypedescEq2() returns OpenPublicPerson {
+    Person3 p = {name:"John Doe", age:25, address:"Colombo, Sri Lanka", weight:70.0};
+    OpenPublicPerson p1 = p;
+    return p1;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_or_to_or.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_or_to_or.bal
@@ -138,3 +138,21 @@ function testAdditionalFieldsToRest() returns AnotherPerson1 {
     AnotherPerson1 ap = p;
     return ap;
 }
+
+public type OpenPublicPerson record {
+    string name;
+    int age;
+    string address;
+};
+
+function testHeterogeneousTypedescEq3() returns AnotherPerson1 {
+    OpenPublicPerson p = {name:"John Doe", age:25, address:"Colombo, Sri Lanka"};
+    AnotherPerson1 ap = p;
+    return ap;
+}
+
+function testHeterogeneousTypedescEq4() returns AnotherPerson1 {
+    OpenPublicPerson op = {name:"John Doe", age:25, address:"Colombo, Sri Lanka"};
+    AnotherPerson1 p = op;
+    return p;
+}


### PR DESCRIPTION
## Purpose
> Currently, when checking two records for equivalency, the visibility specifiers of the record type descriptors are taken into account as well. This PR is to fix that by ignoring the visibility specifiers of the record typedescs.

Fixes #15250

## Samples
Consider the following record typedescs. `Person` is now structurally equivalent to `PublicPerson`. 
```ballerina
public type PublicPerson record {
    string name;
    int age;
};

type Person record {
    string name;
    int age;
    string address;
};
```
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
