### PR TITLE
Draw endpoints that are passed as parameters

### DIFF
--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -83,6 +83,26 @@ class PositioningVisitor implements Visitor {
         let visibleEndpoints: VisibleEndpoint[] = [];
         if (node.VisibleEndpoints) {
             visibleEndpoints = node.VisibleEndpoints.filter((ep) => !ep.caller && ep.viewState.visible);
+            if (!(node.viewState as FunctionViewState).isExpandedFunction) {
+                node.VisibleEndpoints.forEach((ep) => {
+                    // Find of one of the visible endpoints is actually a parameter to the function
+                    if (node.allParams) {
+                        node.allParams.forEach((p, i) => {
+                            let variableName = "";
+                            if (ASTKindChecker.isVariable(p)) {
+                                variableName = p.name.value;
+                            } else if (ASTKindChecker.isVariable(p.variable)) {
+                                variableName = p.variable.name.value;
+                            }
+
+                            if (variableName === ep.name) {
+                                // ep is a parameter to the function which is an endpoint
+                                visibleEndpoints.push(ep);
+                            }
+                        });
+                    }
+                });
+            }
         }
 
         // They way we position function components depends on whether this is an expanded function

--- a/composer/packages/diagram/src/visitors/sizing-visitor.ts
+++ b/composer/packages/diagram/src/visitors/sizing-visitor.ts
@@ -139,8 +139,31 @@ class SizingVisitor implements Visitor {
 
         // Size endpoints
         if (this.endpointHolder) {
+            const endpoints = this.endpointHolder.filter((ep) => (!ep.caller));
+
+            if (node.VisibleEndpoints) {
+                node.VisibleEndpoints.forEach((ep) => {
+                    // Find of one of the visible endpoints is actually a parameter to the function
+                    if (node.allParams) {
+                        node.allParams.forEach((p, i) => {
+                            let variableName = "";
+                            if (ASTKindChecker.isVariable(p)) {
+                                variableName = p.name.value;
+                            } else if (ASTKindChecker.isVariable(p.variable)) {
+                                variableName = p.variable.name.value;
+                            }
+
+                            if (variableName === ep.name) {
+                                // ep is a parameter to the function which is an endpoint
+                                endpoints.push(ep);
+                            }
+                        });
+                    }
+                });
+            }
+
             this.endpointHolder.forEach((endpoint: VisibleEndpoint) => {
-                if (!endpoint.caller && endpoint.viewState.visible) {
+                if (endpoint.viewState.visible) {
                     endpoint.viewState.bBox.w = config.lifeLine.width;
                     endpoint.viewState.bBox.h = client.bBox.h;
                     this.endpointWidth += endpoint.viewState.bBox.w + config.lifeLine.gutter.h;
@@ -387,7 +410,7 @@ class SizingVisitor implements Visitor {
                 }
             }
 
-            if (endpoint && !endpoint.caller) {
+            if (endpoint) {
                 viewState.endpoint = endpoint.viewState;
                 viewState.isAction = true;
                 viewState.bBox.h = config.statement.actionHeight;
@@ -442,6 +465,7 @@ class SizingVisitor implements Visitor {
         let visibleEndpoints = [];
         if (expandedFn.VisibleEndpoints) {
             visibleEndpoints = expandedFn.VisibleEndpoints.filter((ep) => !ep.caller && ep.viewState.visible);
+
             visibleEndpoints.forEach((endpoint: VisibleEndpoint) => {
                 endpoint.viewState.bBox.w = config.lifeLine.width;
                 expandedFnWidth += (endpoint.viewState.bBox.w + config.lifeLine.gutter.h);


### PR DESCRIPTION
## Purpose
Endpoints passed as parameters were not drawn previously. This was a workaround to avoid drawing endpoints that are not positioned. But this stopped some correctly positioned ep also to not be drawn.

This is a permanent fix to draw endpoint parameters properly

## Approach
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/3872221/58018530-b9ed0900-7b20-11e9-8744-28de0f8b88da.png">

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
