### PR TITLE
Fix BallerinaException propagating to the transport layer and remove unused returns

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpResourceDataElement.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpResourceDataElement.java
@@ -162,18 +162,18 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HttpCa
         return DispatcherUtil.concatValues(methods, false);
     }
 
-    public HttpResource validateConsumes(HttpResource resource, HttpCarbonMessage cMsg) {
+    private void validateConsumes(HttpResource resource, HttpCarbonMessage cMsg) {
         String contentMediaType = extractContentMediaType(cMsg.getHeader(HttpHeaderNames.CONTENT_TYPE.toString()));
         List<String> consumesList = resource.getConsumes();
 
         if (consumesList == null) {
-            return resource;
+            return;
         }
         //when Content-Type header is not set, treat it as "application/octet-stream"
         contentMediaType = (contentMediaType != null ? contentMediaType : HttpConstants.VALUE_ATTRIBUTE);
         for (String consumeType : consumesList) {
             if (contentMediaType.equalsIgnoreCase(consumeType.trim())) {
-                return resource;
+                return;
             }
         }
         cMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 415);
@@ -190,16 +190,16 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HttpCa
         return header;
     }
 
-    public HttpResource validateProduces(HttpResource resource, HttpCarbonMessage cMsg) {
+    private void validateProduces(HttpResource resource, HttpCarbonMessage cMsg) {
         List<String> acceptMediaTypes = extractAcceptMediaTypes(cMsg.getHeader(HttpHeaderNames.ACCEPT.toString()));
         List<String> producesList = resource.getProduces();
 
         if (producesList == null || acceptMediaTypes == null) {
-            return resource;
+            return;
         }
         //If Accept header field is not present, then it is assumed that the client accepts all media types.
         if (acceptMediaTypes.contains("*/*")) {
-            return resource;
+            return;
         }
         if (acceptMediaTypes.stream().anyMatch(mediaType -> mediaType.contains("/*"))) {
             List<String> subTypeWildCardMediaTypes = acceptMediaTypes.stream()
@@ -208,7 +208,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HttpCa
                     .collect(Collectors.toList());
             for (String token : resource.getProducesSubTypes()) {
                 if (subTypeWildCardMediaTypes.contains(token)) {
-                    return resource;
+                    return;
                 }
             }
         }
@@ -216,7 +216,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HttpCa
                 .filter(mediaType -> !mediaType.contains("/*")).collect(Collectors.toList());
         for (String produceType : producesList) {
             if (noWildCardMediaTypes.stream().anyMatch(produceType::equalsIgnoreCase)) {
-                return resource;
+                return;
             }
         }
         cMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 406);

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -107,7 +107,8 @@ public class WebSocketDispatcher {
         } catch (BallerinaConnectorException | URITemplateException e) {
             String message = "No Service found to handle the service request";
             webSocketHandshaker.cancelHandshake(404, message);
-            throw new BallerinaConnectorException(message, e);
+            log.error(message, e);
+            return null;
         }
     }
 
@@ -184,7 +185,7 @@ public class WebSocketDispatcher {
                             null, null, bValues);
         } catch (BallerinaException ex) {
             webSocketConnection.terminateConnection(1003, ex.getMessage());
-            throw ex;
+            log.error("Data binding failed. Hence connection terminated. ", ex);
         }
     }
 

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketServerConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketServerConnectorListener.java
@@ -60,7 +60,9 @@ public class WebSocketServerConnectorListener implements WebSocketConnectorListe
     @Override
     public void onHandshake(WebSocketHandshaker webSocketHandshaker) {
         WebSocketService wsService = WebSocketDispatcher.findService(servicesRegistry, webSocketHandshaker);
-
+        if (wsService == null) {
+            return;
+        }
         HttpResource onUpgradeResource = wsService.getUpgradeResource();
         if (onUpgradeResource != null) {
             webSocketHandshaker.getHttpCarbonRequest().setProperty(HttpConstants.RESOURCES_CORS,


### PR DESCRIPTION
## Purpose
> If a `BallerinaException` is thrown before the dispatching of messages to a resource it goes to the transport layer. This code prevents it from happening.

## Approach
> Handle the `BallerinaException` and not throw it to reach the transport layer.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
