### PR TITLE
Add prior knowledge support to ballerina HTTP/2 client

### DIFF
--- a/distribution/zip/ballerina/build.gradle
+++ b/distribution/zip/ballerina/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     dist 'org.wso2.orbit.com.lmax:disruptor:3.3.2.wso2v2'
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'
     dist 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
-    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.0.290'
+    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.0.292'
 
     dist 'info.picocli:picocli:3.3.0'
     dist 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'

--- a/distribution/zip/jballerina/build.gradle
+++ b/distribution/zip/jballerina/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     dist 'org.wso2.orbit.com.lmax:disruptor:3.3.2.wso2v2'
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'
     dist 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
-    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.0.290'
+    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.0.292'
 
     dist 'info.picocli:picocli:3.3.0'
     dist 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -88,7 +88,7 @@ dependencies {
         implementation 'org.wso2.orbit.com.lmax:disruptor:3.3.2.wso2v2'
         implementation 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'
         implementation 'org.wso2.orbit.org.yaml:snakeyaml:1.16.0.wso2v1'
-        implementation 'org.wso2.transport.http:org.wso2.transport.http.netty:6.0.290'
+        implementation 'org.wso2.transport.http:org.wso2.transport.http.netty:6.0.292'
         implementation 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
         implementation 'org.wso2.staxon:staxon-core:1.2.0.wso2v2'
         implementation 'org.quartz-scheduler:quartz:2.3.1'

--- a/pom.xml
+++ b/pom.xml
@@ -2408,7 +2408,7 @@
         <osgi.api.version>6.0.0</osgi.api.version>
         <equinox.osgi.version>3.11.0.v20160603-1336</equinox.osgi.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
-        <transport.http.version>6.0.290</transport.http.version>
+        <transport.http.version>6.0.292</transport.http.version>
         <carbon.securevault.version>5.0.12</carbon.securevault.version>
         <carbon.utils.version>1.2.1</carbon.utils.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/stdlib/http/src/main/ballerina/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/client_endpoint.bal
@@ -227,6 +227,7 @@ public type TargetService record {|
 # + cache - HTTP caching related configurations
 # + compression - Specifies the way of handling compression (`accept-encoding`) header
 # + auth - HTTP authentication related configurations
+# + http2Settings - Configurations related to HTTP/2 protocol
 public type ClientEndpointConfig record {|
     CircuitBreakerConfig? circuitBreaker = ();
     int timeoutMillis = 60000;
@@ -242,11 +243,18 @@ public type ClientEndpointConfig record {|
     CacheConfig cache = {};
     Compression compression = COMPRESSION_AUTO;
     OutboundAuthConfig? auth = ();
+    Http2Settings http2Settings = {};
 |};
-
 
 function createSimpleHttpClient(string uri, ClientEndpointConfig config, PoolConfiguration globalPoolConfig)
                     returns Client = external;
+
+# Provides settings related to HTTP/2 protocol.
+#
+# + http2PriorKnowledge - Configuration to enable HTTP/2 prior knowledge
+public type Http2Settings record {|
+    boolean http2PriorKnowledge = false;
+|};
 
 # Provides configurations for controlling the retrying behavior in failure scenarios.
 #

--- a/stdlib/http/src/main/ballerina/http/http_headers.bal
+++ b/stdlib/http/src/main/ballerina/http/http_headers.bal
@@ -80,3 +80,10 @@ public const string WARNING = "warning";
 
 # HTTP header key `transfer-encoding`. Specifies what type of transformation has been applied to entity body. 
 public const string TRANSFER_ENCODING = "transfer-encoding";
+
+# HTTP header key `connection`. Allows the sender to specify options that are desired for that particular connection.
+public const string CONNECTION = "connection";
+
+# HTTP header key `upgrade`. Allows the client to specify what additional communication protocols it supports and
+# would like to use, if the server finds it appropriate to switch protocols.
+public const string UPGRADE = "upgrade";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -356,6 +356,8 @@ public class HttpConstants {
     public static final String CLIENT_EP_FORWARDED = "forwarded";
     public static final String TARGET_SERVICES = "targets";
     public static final String CLIENT_EP_ACCEPT_ENCODING = "acceptEncoding";
+    public static final String HTTP2_PRIOR_KNOWLEDGE = "http2PriorKnowledge";
+    public static final String HTTP2_SETTINGS = "http2Settings";
 
     //Connection Throttling field names
     public static final String CONNECTION_THROTTLING_STRUCT_REFERENCE = "connectionThrottling";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -23,6 +23,7 @@ import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
 import org.ballerinalang.connector.api.Struct;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.annotations.Argument;
@@ -41,10 +42,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
+import static org.ballerinalang.net.http.HttpConstants.HTTP2_PRIOR_KNOWLEDGE;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_CLIENT;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_PACKAGE_PATH;
 import static org.ballerinalang.net.http.HttpUtil.getConnectionManager;
 import static org.ballerinalang.net.http.HttpUtil.populateSenderConfigurations;
+import static org.wso2.transport.http.netty.contract.Constants.HTTP_2_0_VERSION;
 
 /**
  * Initialization of client endpoint.
@@ -89,6 +92,13 @@ public class CreateSimpleHttpClient extends BlockingNativeCallableUnit {
             senderConfiguration.setHttpTraceLogEnabled(true);
         }
         senderConfiguration.setTLSStoreType(HttpConstants.PKCS_STORE_TYPE);
+
+        String httpVersion = clientEndpointConfig.getRefField(HttpConstants.CLIENT_EP_HTTP_VERSION).getStringValue();
+        if (HTTP_2_0_VERSION.equals(httpVersion)) {
+            BMap<String, BValue> http2Settings = (BMap<String, BValue>) configBStruct.get(HttpConstants.HTTP2_SETTINGS);
+            boolean http2PriorKnowledge = ((BBoolean) http2Settings.get(HTTP2_PRIOR_KNOWLEDGE)).booleanValue();
+            senderConfiguration.setForceHttp2(http2PriorKnowledge);
+        }
 
         populateSenderConfigurations(senderConfiguration, clientEndpointConfig);
         ConnectionManager poolManager;

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2PriorKnowledgeTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2PriorKnowledgeTestCase.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.service.http2;
+
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+@Test(groups = "http2-test")
+public class Http2PriorKnowledgeTestCase extends Http2BaseTest {
+
+    @Test
+    public void testPriorKnowledgeOn() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9097, "priorKnowledge/on"));
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        String responseData = response.getData();
+        Assert.assertEquals("Connection and upgrade headers are not present--Prior knowledge is enabled", responseData,
+                            "HTTP/2 prior knowledge enabled scenario failed");
+    }
+
+    @Test
+    public void testPriorKnowledgeOff() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9097, "priorKnowledge/off"));
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        String responseData = response.getData();
+        Assert.assertEquals("HTTP2-Settings,upgrade--h2c--Prior knowledge is disabled", responseData,
+                            "HTTP/2 prior knowledge disabled scenario failed");
+    }
+}

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2PriorKnowledgeTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2PriorKnowledgeTestCase.java
@@ -25,6 +25,9 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+/**
+ * Test case for HTTP/2 prior knowledge.
+ */
 @Test(groups = "http2-test")
 public class Http2PriorKnowledgeTestCase extends Http2BaseTest {
 

--- a/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2PriorKnowledgeTestCase.java
+++ b/tests/ballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2PriorKnowledgeTestCase.java
@@ -37,7 +37,7 @@ public class Http2PriorKnowledgeTestCase extends Http2BaseTest {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         String responseData = response.getData();
-        Assert.assertEquals("Connection and upgrade headers are not present--Prior knowledge is enabled", responseData,
+        Assert.assertEquals(responseData, "Connection and upgrade headers are not present--Prior knowledge is enabled",
                             "HTTP/2 prior knowledge enabled scenario failed");
     }
 
@@ -47,7 +47,7 @@ public class Http2PriorKnowledgeTestCase extends Http2BaseTest {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         String responseData = response.getData();
-        Assert.assertEquals("HTTP2-Settings,upgrade--h2c--Prior knowledge is disabled", responseData,
+        Assert.assertEquals(responseData, "HTTP2-Settings,upgrade--h2c--Prior knowledge is disabled",
                             "HTTP/2 prior knowledge disabled scenario failed");
     }
 }

--- a/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
@@ -1,0 +1,5 @@
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
@@ -1,5 +1,69 @@
-import ballerina/io;
+import ballerina/http;
 
-public function main() {
-    io:println("Hello, World!");
+listener http:Listener ep1 = new(9097, config = { httpVersion: "2.0" });
+
+listener http:Listener ep2 = new(9098, config = { httpVersion: "2.0" });
+
+http:Client h2WithPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
+        http2PriorKnowledge: true
+    } });
+
+http:Client h2WithoutPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
+        http2PriorKnowledge: false
+    } });
+
+@http:ServiceConfig {
+    basePath: "/priorKnowledge"
+}
+service priorKnowledgeTest on ep1 {
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/on"
+    }
+    resource function priorOn(http:Caller caller, http:Request req) {
+        var response = h2WithPriorKnowledge->post("/backend", "Prior knowledge is enabled");
+        if (response is http:Response) {
+            checkpanic caller->respond(untaint response);
+        } else {
+            checkpanic caller->respond("Error in client post");
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/off"
+    }
+    resource function priorOff(http:Caller caller, http:Request req) {
+        var response = h2WithoutPriorKnowledge->post("/backend", "Prior knowledge is disabled");
+        if (response is http:Response) {
+            checkpanic caller->respond(untaint response);
+        } else {
+            checkpanic caller->respond("Error in client post");
+        }
+    }
+}
+
+@http:ServiceConfig {
+    basePath: "/backend"
+}
+service testBackEnd on ep2 {
+
+    @http:ResourceConfig {
+        methods: ["POST"],
+        path: "/"
+    }
+    resource function test(http:Caller caller, http:Request req) {
+        string outboundResponse = "";
+        if (req.hasHeader(http:CONNECTION) && req.hasHeader(http:UPGRADE)) {
+            string[] connHeaders = req.getHeaders(http:CONNECTION);
+            outboundResponse = connHeaders[1];
+            outboundResponse = outboundResponse + "--" + req.getHeader(http:UPGRADE);
+        } else {
+            outboundResponse = "Connection and upgrade headers are not present";
+        }
+
+        outboundResponse = outboundResponse + "--" + checkpanic req.getTextPayload();
+        checkpanic caller->respond(untaint outboundResponse);
+    }
 }

--- a/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
@@ -19,14 +19,6 @@ import ballerina/http;
 listener http:Listener ep1 = new(9097, config = { httpVersion: "2.0" });
 listener http:Listener ep2 = new(9098, config = { httpVersion: "2.0" });
 
-http:Client h2WithPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
-        http2PriorKnowledge: true
-    } });
-
-http:Client h2WithoutPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
-        http2PriorKnowledge: false
-    } });
-
 @http:ServiceConfig {
     basePath: "/priorKnowledge"
 }
@@ -37,6 +29,9 @@ service priorKnowledgeTest on ep1 {
         path: "/on"
     }
     resource function priorOn(http:Caller caller, http:Request req) {
+        http:Client h2WithPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
+                http2PriorKnowledge: true }, poolConfig: {} });
+
         var response = h2WithPriorKnowledge->post("/backend", "Prior knowledge is enabled");
         if (response is http:Response) {
             checkpanic caller->respond(untaint response);
@@ -50,6 +45,9 @@ service priorKnowledgeTest on ep1 {
         path: "/off"
     }
     resource function priorOff(http:Caller caller, http:Request req) {
+        http:Client h2WithoutPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
+                http2PriorKnowledge: false }, poolConfig: {} });
+
         var response = h2WithoutPriorKnowledge->post("/backend", "Prior knowledge is disabled");
         if (response is http:Response) {
             checkpanic caller->respond(untaint response);

--- a/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
+++ b/tests/ballerina-integration-test/src/test/resources/http2/http2services/http_2.0_prior_knowledge_test.bal
@@ -1,7 +1,22 @@
+// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.package http2;
+
 import ballerina/http;
 
 listener http:Listener ep1 = new(9097, config = { httpVersion: "2.0" });
-
 listener http:Listener ep2 = new(9098, config = { httpVersion: "2.0" });
 
 http:Client h2WithPriorKnowledge = new("http://localhost:9098", config = { httpVersion: "2.0", http2Settings: {
@@ -26,7 +41,7 @@ service priorKnowledgeTest on ep1 {
         if (response is http:Response) {
             checkpanic caller->respond(untaint response);
         } else {
-            checkpanic caller->respond("Error in client post");
+            checkpanic caller->respond("Error in client post with prior knowledge on");
         }
     }
 
@@ -39,7 +54,7 @@ service priorKnowledgeTest on ep1 {
         if (response is http:Response) {
             checkpanic caller->respond(untaint response);
         } else {
-            checkpanic caller->respond("Error in client post");
+            checkpanic caller->respond("Error in client post with prior knowledge off");
         }
     }
 }

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -91,6 +91,7 @@
             <class name="org.ballerinalang.test.service.http2.Http2ServerPushTestCase"/>
             <class name="org.ballerinalang.test.service.http2.Http2ToHttp1FallbackTestCase"/>
             <class name="org.ballerinalang.test.service.http2.RedirectTestCase"/>
+            <class name="org.ballerinalang.test.service.http2.Http2PriorKnowledgeTestCase"/>
         </classes>
     </test>
 

--- a/tests/ballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/ballerina-integration-test/src/test/resources/testng.xml
@@ -88,10 +88,10 @@
     <test name="ballerina-http2-tests" parallel="false">
         <classes>
             <class name="org.ballerinalang.test.service.http2.Http2BaseTest"/>
+            <class name="org.ballerinalang.test.service.http2.Http2PriorKnowledgeTestCase"/>
             <class name="org.ballerinalang.test.service.http2.Http2ServerPushTestCase"/>
             <class name="org.ballerinalang.test.service.http2.Http2ToHttp1FallbackTestCase"/>
             <class name="org.ballerinalang.test.service.http2.RedirectTestCase"/>
-            <class name="org.ballerinalang.test.service.http2.Http2PriorKnowledgeTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> Add prior knowledge support to ballerina HTTP/2 client

Fixes #15301

## Approach
> Add a flag to HTTPSettings record to enable disable prior knowledge

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#15380)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
