### PR TITLE
[JMS] Rename Receiver/Subscriber to Listener

### DIFF
--- a/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.bal
+++ b/examples/jms-durable-topic-message-subscriber/jms_durable_topic_message_subscriber.bal
@@ -18,7 +18,7 @@ jms:Session jmsSession = new(conn, {
     });
 
 // This initializes a durable topic subscriber using the created session.
-listener jms:DurableTopicSubscriber subscriberEndpoint = new(jmsSession,
+listener jms:DurableTopicListener subscriberEndpoint = new(jmsSession,
     "BallerinaTopic", "sub1");
 
 // This binds the created consumer to the listener service.

--- a/examples/jms-headers-and-properties/jms_headers_and_properties.bal
+++ b/examples/jms-headers-and-properties/jms_headers_and_properties.bal
@@ -15,7 +15,7 @@ jms:Session jmsSession = new(conn, {
     });
 
 // Initialize a queue receiver using the created session.
-listener jms:QueueReceiver consumerEndpoint = new(jmsSession,
+listener jms:QueueListener consumerEndpoint = new(jmsSession,
     queueName = "MyQueue");
 
 // Bind the created consumer to the listener service.

--- a/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.bal
+++ b/examples/jms-queue-message-receiver-with-client-acknowledgment/jms_queue_message_receiver_with_client_acknowledgment.bal
@@ -17,7 +17,7 @@ jms:Session jmsSession = new(conn, {
     });
 
 // This initializes a queue receiver using the created session.
-listener jms:QueueReceiver consumerEndpoint = new(jmsSession, queueName = "MyQueue");
+listener jms:QueueListener consumerEndpoint = new(jmsSession, queueName = "MyQueue");
 
 // This binds the created consumer to the listener service.
 service jmsListener on consumerEndpoint {

--- a/examples/jms-queue-message-receiver/jms_queue_message_receiver.bal
+++ b/examples/jms-queue-message-receiver/jms_queue_message_receiver.bal
@@ -17,7 +17,7 @@ jms:Session jmsSession = new(conn, {
     });
 
 // This initializes a queue receiver using the created session.
-listener jms:QueueReceiver consumerEndpoint = new(jmsSession, queueName = "MyQueue");
+listener jms:QueueListener consumerEndpoint = new(jmsSession, queueName = "MyQueue");
 
 // This binds the created consumer to the listener service.
 service jmsListener on consumerEndpoint {

--- a/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.bal
+++ b/examples/jms-simple-durable-topic-message-subscriber/jms_simple_durable_topic_message_subscriber.bal
@@ -4,12 +4,12 @@ import ballerina/log;
 // This creates a simple durable topic subscriber.  This example makes use of
 // the ActiveMQ Artemis broker for demonstration while it can be tried with
 // other brokers that support JMS.
-listener jms:DurableTopicSubscriber subscriberEndpoint = new({
+listener jms:DurableTopicListener subscriberEndpoint = new({
         initialContextFactory: 
         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
         providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
-    }, "MyTopic", "sub1");
+    }, "BallerinaTopic", "sub1");
 
 // This binds the created consumer to the listener service.
 service jmsListener on subscriberEndpoint {

--- a/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.bal
+++ b/examples/jms-simple-queue-message-receiver/jms_simple_queue_message_receiver.bal
@@ -5,7 +5,7 @@ import ballerina/log;
 // Artemis broker for demonstration while it can be tried with other brokers
 // that support JMS.
 
-listener jms:QueueReceiver consumerEndpoint = new({
+listener jms:QueueListener consumerEndpoint = new({
         initialContextFactory: 
         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
         providerUrl: "tcp://localhost:61616",

--- a/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.bal
+++ b/examples/jms-simple-topic-message-subscriber/jms_simple_topic_message_subscriber.bal
@@ -4,12 +4,12 @@ import ballerina/log;
 // This creates a simple topic listener. This example makes use of the ActiveMQ
 // Artemis broker for demonstration while it can be tried with other brokers
 // that support JMS.
-listener jms:TopicSubscriber subscriberEndpoint = new({
+listener jms:TopicListener subscriberEndpoint = new({
         initialContextFactory: 
         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
         providerUrl: "tcp://localhost:61616",
         acknowledgementMode: "AUTO_ACKNOWLEDGE"
-    }, topicPattern = "MyTopic");
+    }, topicPattern = "BallerinaTopic");
 
 // This binds the created subscriber to the listener service.
 service jmsListener on subscriberEndpoint {

--- a/examples/jms-synchronous-queue-message-receiver/jms_synchronous_queue_message_receiver.bal
+++ b/examples/jms-synchronous-queue-message-receiver/jms_synchronous_queue_message_receiver.bal
@@ -17,7 +17,7 @@ jms:Session jmsSession = new(jmsConnection, {
     });
 
 // This initializes a queue receiver on top of the created sessions.
-listener jms:QueueReceiver queueReceiver = new(jmsSession, queueName = "MyQueue");
+listener jms:QueueListener queueReceiver = new(jmsSession, queueName = "MyQueue");
 
 public function main() {
     jms:QueueReceiverCaller caller = queueReceiver.getCallerActions();

--- a/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.bal
+++ b/examples/jms-topic-message-subscriber/jms_topic_message_subscriber.bal
@@ -17,7 +17,7 @@ jms:Session jmsSession = new(conn, {
     });
 
 // This initializes a topic subscriber using the created session.
-listener jms:TopicSubscriber subscriberEndpoint = new(jmsSession, topicPattern = "BallerinaTopic");
+listener jms:TopicListener subscriberEndpoint = new(jmsSession, topicPattern = "BallerinaTopic");
 
 // This binds the created subscriber to the listener service.
 service jmsListener on subscriberEndpoint {

--- a/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.bal
+++ b/examples/send-jms-message-to-http-endpoint/send_jms_message_to_http_endpoint.bal
@@ -6,7 +6,7 @@ import ballerina/log;
 // ActiveMQ Artemis broker for demonstration while it can be tried with other
 // brokers that support JMS.
 
-listener jms:QueueReceiver consumerEndpoint = new({
+listener jms:QueueListener consumerEndpoint = new({
         initialContextFactory: 
         "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
         providerUrl: "tcp://localhost:61616",

--- a/stdlib/jms/src/main/ballerina/jms/Module.md
+++ b/stdlib/jms/src/main/ballerina/jms/Module.md
@@ -6,16 +6,11 @@ ActiveMQ.
 The module provides consumer and producer endpoint types for queues and topics. Following are the endpoint types
 supported by this module:
 
-- QueueReceiver
-- TopicSubscriber
-- DurableTopicSubscriber
-- SimpleQueueReceiver
-- SimpleTopicSubscriber
-- SimpleDurableTopicSubscriber
+- QueueListener
+- TopicListener
+- DurableTopicListener
 - QueueSender
 - TopicPublisher
-- SimpleQueueSender
-- SimpleTopicPublisher
 
 The endpoints prefixed with `Simple` will automatically create a JMS connection and a JMS session when the endpoint is
 initialized. For other endpoints, the developer must explicitly provide a properly initialized JMS Session.
@@ -31,7 +26,7 @@ import ballerina/jms;
 import ballerina/log;
 
 // Create a simple queue receiver.
-listener jms:QueueReceiver consumerEP = new({
+listener jms:QueueListener consumerEP = new({
     initialContextFactory: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory",
     providerUrl: "tcp://localhost:61616",
     acknowledgementMode: "AUTO_ACKNOWLEDGE"
@@ -172,7 +167,7 @@ jms:Session jmsSession = new(conn, {
     acknowledgementMode: "AUTO_ACKNOWLEDGE"
 });
 
-listener jms:TopicSubscriber subscriberEndpoint = new(jmsSession, topicPattern = "MyTopic");
+listener jms:TopicListener subscriberEndpoint = new(jmsSession, topicPattern = "MyTopic");
 
 service jmsListener on subscriberEndpoint {
     resource function onMessage(jms:TopicSubscriberCaller subscriber, jms:Message message) {

--- a/stdlib/jms/src/main/ballerina/jms/durable_topic_subscriber.bal
+++ b/stdlib/jms/src/main/ballerina/jms/durable_topic_subscriber.bal
@@ -16,18 +16,18 @@
 
 import ballerina/log;
 
-# JMS DurableTopicSubscriber endpoint
+# JMS DurableTopicListener endpoint
 #
 # + consumerActions - Object that handles network operations related to the subscriber
-# + session - Session of the topic subscriber
-public type DurableTopicSubscriber object {
+# + session - Session of the topic listener
+public type DurableTopicListener object {
 
     *AbstractListener;
 
     public DurableTopicSubscriberCaller consumerActions = new;
     public Session? session;
 
-    # Initialize DurableTopicSubscriber endpoint.
+    # Initialize DurableTopicListener endpoint.
     #
     # + c - The JMS Session object or Configurations related to the receiver
     # + topicPattern - Name or the pattern of the topic subscription
@@ -77,12 +77,12 @@ public type DurableTopicSubscriber object {
 
     # Return the subscrber caller actions
     #
-    # + return - DurableTopicSubscriber actions handler
+    # + return - DurableTopicListener actions handler
     public function getCallerActions() returns DurableTopicSubscriberCaller {
         return self.consumerActions;
     }
 
-    # Ends consuming messages from the DurableTopicSubscriber endpoint
+    # Ends consuming messages from the DurableTopicListener
     #
     # + return - Nil or error upon failure to close subscriber
     public function __stop() returns error? {
@@ -92,7 +92,7 @@ public type DurableTopicSubscriber object {
     function closeSubscriber(DurableTopicSubscriberCaller actions) returns error? = external;
 };
 
-# Caller actions related to DurableTopicSubscriber endpoint
+# Caller actions related to DurableTopicSubscriber
 public type DurableTopicSubscriberCaller client object {
 
     # Acknowledges a received message

--- a/stdlib/jms/src/main/ballerina/jms/queue_receiver.bal
+++ b/stdlib/jms/src/main/ballerina/jms/queue_receiver.bal
@@ -18,11 +18,11 @@ import ballerina/log;
 
 # Queue Receiver endpoint
 #
-# + consumerActions - handles all the caller actions related to the QueueReceiver endpoint
+# + consumerActions - handles all the caller actions related to the QueueListener
 # + session - Session of the queue receiver
 # + messageSelector - The message selector for the queue receiver
 # + identifier - Unique identifier for the reciever
-public type QueueReceiver object {
+public type QueueListener object {
 
     *AbstractListener;
 
@@ -31,7 +31,7 @@ public type QueueReceiver object {
     public string messageSelector = "";
     public string identifier = "";
 
-    # Initializes the QueueReceiver endpoint
+    # Initializes the QueueListener
     #
     # + c - The JMS Session object or Configurations related to the receiver
     # + queueName - Name of the queue
@@ -39,7 +39,7 @@ public type QueueReceiver object {
     # + identifier - Unique identifier for the receiver
     public function __init(Session|ReceiverEndpointConfiguration c, string? queueName = (), string messageSelector = "",
                            string identifier = "") {
-        self.consumerActions.queueReceiver = self;
+        self.consumerActions.queueListener = self;
         if (c is Session) {
             self.session = c;
         } else {
@@ -81,14 +81,14 @@ public type QueueReceiver object {
 
     private function start() returns error? = external;
 
-    # Retrieves the QueueReceiver consumer action handler
+    # Retrieves the QueueReceiver
     #
-    # + return - QueueReceiver actions handler
+    # + return - the QueueReceiver
     public function getCallerActions() returns QueueReceiverCaller {
         return self.consumerActions;
     }
 
-    # Stops consuming messages through QueueReceiver endpoint
+    # Stops consuming messages through QueueListener
     #
     # + return - Nil or error upon failure to close queue receiver
     public function __stop() returns error? {
@@ -101,10 +101,10 @@ public type QueueReceiver object {
 
 # Caller actions related to queue receiver endpoint.
 #
-# + queueReceiver - queue receiver endpoint
+# + queueListener - the QueueListener
 public type QueueReceiverCaller client object {
 
-    public QueueReceiver? queueReceiver = ();
+    public QueueListener? queueListener = ();
 
     # Acknowledges a received message
     #
@@ -125,16 +125,16 @@ public type QueueReceiverCaller client object {
     # + return - Returns a message or () if the timeout exceeds, returns an error on JMS provider internal error
     public remote function receiveFrom(Destination destination, int timeoutInMilliSeconds = 0) returns (Message|error)?
     {
-        var queueReceiver = self.queueReceiver;
-        if (queueReceiver is QueueReceiver) {
-            var session = queueReceiver.session;
+        var queueListener = self.queueListener;
+        if (queueListener is QueueListener) {
+            var session = queueListener.session;
             validateQueue(destination);
-            queueReceiver.createQueueReceiver(session, queueReceiver.messageSelector, destination);
+            queueListener.createQueueReceiver(session, queueListener.messageSelector, destination);
         } else {
             log:printInfo("Message receiver is not properly initialized for queue " + destination.destinationName);
         }
         var result = self->receive(timeoutInMilliSeconds = timeoutInMilliSeconds);
-        self.queueReceiver.closeQueueReceiver(self);
+        self.queueListener.closeQueueReceiver(self);
         return result;
     }
 };

--- a/stdlib/jms/src/main/ballerina/jms/topic_subscriber.bal
+++ b/stdlib/jms/src/main/ballerina/jms/topic_subscriber.bal
@@ -16,12 +16,12 @@
 
 import ballerina/log;
 
-# JMS TopicSubscriber endpoint
+# JMS TopicListener
 #
-# + consumerActions - Handles all the caller actions related to the TopicSubscriber endpoint
+# + consumerActions - Handles all the caller actions related to the TopicSubscriber
 # + session - Session of the topic subscriber
 # + messageSelector - The message selector for the topic subscriber
-public type TopicSubscriber object {
+public type TopicListener object {
 
     *AbstractListener;
 
@@ -29,7 +29,7 @@ public type TopicSubscriber object {
     public Session session;
     public string messageSelector = "";
 
-    # Initialize the TopicSubscriber endpoint
+    # Initialize the TopicListener
     #
     # + c - The JMS Session object or Configurations related to the receiver
     # + topicPattern - Name or the pattern of the topic subscription
@@ -37,7 +37,7 @@ public type TopicSubscriber object {
     # + identifier - Unique identifier for the subscription
     public function __init(Session|ReceiverEndpointConfiguration c, string? topicPattern = (), string messageSelector =
         "") {
-        self.consumerActions.topicSubscriber = self;
+        self.consumerActions.topicListener = self;
         self.messageSelector = messageSelector;
         if (c is Session) {
             self.session = c;
@@ -57,7 +57,7 @@ public type TopicSubscriber object {
         }
     }
 
-    # Register TopicSubscriber endpoint
+    # Register TopicListener
     #
     # + serviceType - The service instance
     # + name - Name of the service
@@ -70,7 +70,7 @@ public type TopicSubscriber object {
 
     function createSubscriber(Session? session, string messageSelector, string|Destination dest) = external;
 
-    # Start TopicSubscriber endpoint
+    # Start TopicListener
     #
     # + return - Nil or error upon failure to start
     public function __start() returns error? {
@@ -84,7 +84,7 @@ public type TopicSubscriber object {
         return self.consumerActions;
     }
 
-    # Stop TopicSubscriber endpoint
+    # Stop TopicListener
     #
     # + return - Nil or error upon failure to close subscriber
     public function __stop() returns error? {
@@ -97,10 +97,10 @@ public type TopicSubscriber object {
 
 # Remote functions that topic subscriber endpoint could perform
 #
-# + topicSubscriber - JMS TopicSubscriber
+# + topicListener - JMS TopicListener
 public type TopicSubscriberCaller client object {
 
-    public TopicSubscriber? topicSubscriber = ();
+    public TopicListener? topicListener = ();
 
     # Acknowledges a received message
     #
@@ -121,8 +121,8 @@ public type TopicSubscriberCaller client object {
     # + return - Returns a message or nil if the timeout exceeds, returns an error on JMS provider internal error
     public remote function receiveFrom(Destination destination, int timeoutInMilliSeconds = 0) returns (Message|error)?
     {
-        var subscriber = self.topicSubscriber;
-        if (subscriber is TopicSubscriber) {
+        var subscriber = self.topicListener;
+        if (subscriber is TopicListener) {
             var session = subscriber.session;
             validateTopic(destination);
             subscriber.createSubscriber(session, subscriber.messageSelector, destination);
@@ -131,7 +131,7 @@ public type TopicSubscriberCaller client object {
             log:printInfo("Topic subscriber is not properly initialized");
         }
         var result = self->receive(timeoutInMilliSeconds = timeoutInMilliSeconds);
-        var returnVal = self.topicSubscriber.closeSubscriber(self);
+        var returnVal = self.topicListener.closeSubscriber(self);
         return result;
     }
 };

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/JmsConstants.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/JmsConstants.java
@@ -44,13 +44,13 @@ public class JmsConstants {
     public static final String COUNTDOWN_LATCH = "countdown-latch";
 
     // The object types
-    public static final String QUEUE_RECEIVER_OBJ_NAME = "QueueReceiver";
+    public static final String QUEUE_RECEIVER_OBJ_NAME = "QueueListener";
     public static final String QUEUE_RECEIVER_CALLER_OBJ_NAME = "QueueReceiverCaller";
     public static final String MESSAGE_OBJ_NAME = "Message";
     public static final String MESSAGE_OBJ_FULL_NAME = PROTOCOL_PACKAGE_JMS + COLON + MESSAGE_OBJ_NAME;
     public static final String QUEUE_RECEIVER_CALLER_FULL_NAME = PROTOCOL_PACKAGE_JMS + COLON +
             QUEUE_RECEIVER_CALLER_OBJ_NAME;
-    public static final String TOPIC_SUBSCRIBER_OBJ_NAME = "TopicSubscriber";
+    public static final String TOPIC_SUBSCRIBER_OBJ_NAME = "TopicListener";
     public static final String TOPIC_SUBSCRIBER_CALLER_OBJ_NAME = "TopicSubscriberCaller";
     public static final String TOPIC_SUBSCRIBER_CALLER_FULL_NAME =
             PROTOCOL_PACKAGE_JMS + COLON + TOPIC_SUBSCRIBER_CALLER_OBJ_NAME;
@@ -59,7 +59,7 @@ public class JmsConstants {
     public static final String QUEUE_SENDER_OBJ_NAME = "QueueSender";
     public static final String DESTINATION_OBJ_NAME = "Destination";
     public static final String DURABLE_TOPIC_SUBSCRIBER_CALLER_OBJ_NAME = "DurableTopicSubscriberCaller";
-    public static final String DURABLE_TOPIC_SUBSCRIBER = "DurableTopicSubscriber";
+    public static final String DURABLE_TOPIC_SUBSCRIBER = "DurableTopicListener";
     public static final String TOPIC_PUBLISHER_OBJ_NAME = "TopicPublisher";
     public static final String ERROR_OBJ_NAME = "Error";
 

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/Start.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/queue/receiver/Start.java
@@ -28,7 +28,7 @@ import org.ballerinalang.net.jms.JmsConstants;
 import org.ballerinalang.net.jms.nativeimpl.endpoint.common.StartNonDaemonThreadHandler;
 
 /**
- * Extern function to start the JMS QueueReceiver.
+ * Extern function to start the JMS QueueListener.
  *
  * @since 0.995
  */

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/durable/subscriber/Start.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/durable/subscriber/Start.java
@@ -28,7 +28,7 @@ import org.ballerinalang.net.jms.JmsConstants;
 import org.ballerinalang.net.jms.nativeimpl.endpoint.common.StartNonDaemonThreadHandler;
 
 /**
- * Extern function to start the JMS DurableTopicSubscriber.
+ * Extern function to start the JMS DurableTopicListener.
  *
  * @since 0.995
  */

--- a/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/subscriber/Start.java
+++ b/stdlib/jms/src/main/java/org/ballerinalang/net/jms/nativeimpl/endpoint/topic/subscriber/Start.java
@@ -28,7 +28,7 @@ import org.ballerinalang.net.jms.JmsConstants;
 import org.ballerinalang.net.jms.nativeimpl.endpoint.common.StartNonDaemonThreadHandler;
 
 /**
- * Extern function to start the JMS TopicSubscriber.
+ * Extern function to start the JMS TopicListener.
  *
  * @since 0.995
  */


### PR DESCRIPTION
 ## Purpose
>    Rename QueueReceiver, TopicSubscriber, DurableTopicSubscriber to QueueListener, TopicListener, DurableTopicListener

## Approach
>    Rename QueueReceiver, TopicSubscriber, DurableTopicSubscriber to QueueListener, TopicListener, DurableTopicListener
 
## Samples
> Updated examples

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [x] Module documentation in Module.md files
  - [x] Ballerina By Examples
