### PR TITLE
Fix maven dependency cycle

### DIFF
--- a/compiler/ballerina-backend-jvm/pom.xml
+++ b/compiler/ballerina-backend-jvm/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-io</artifactId>
+            <version>${ballerina.milestone.version}</version>
             <type>zip</type>
             <classifier>ballerina-binary-repo</classifier>
         </dependency>
@@ -57,6 +58,7 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-internal</artifactId>
+            <version>${ballerina.milestone.version}</version>
             <type>zip</type>
             <classifier>ballerina-binary-repo</classifier>
         </dependency>

--- a/stdlib/bir/pom.xml
+++ b/stdlib/bir/pom.xml
@@ -56,12 +56,14 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-io</artifactId>
+            <version>${ballerina.milestone.version}</version>
             <type>zip</type>
             <classifier>ballerina-binary-repo</classifier>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-internal</artifactId>
+            <version>${ballerina.milestone.version}</version>
             <type>zip</type>
             <classifier>ballerina-binary-repo</classifier>
         </dependency>
@@ -96,6 +98,7 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-cli-utils</artifactId>
+            <version>${ballerina.milestone.version}</version>
             <!--<scope>test</scope>-->
         </dependency>
         <dependency>

--- a/stdlib/io/src/test/resources/testng.xml
+++ b/stdlib/io/src/test/resources/testng.xml
@@ -27,7 +27,14 @@
     <test name="ballerina-lang-test-suite" preserve-order="true" parallel="false">
         <parameter name="enableJBallerinaTests" value="true"/>
         <packages>
-            <package name="org.ballerinalang.stdlib.io.*"/>
+            <package name="org.ballerinalang.stdlib.io.bytes"/>
+            <package name="org.ballerinalang.stdlib.io.characters"/>
+            <package name="org.ballerinalang.stdlib.io.data"/>
+            <package name="org.ballerinalang.stdlib.io.records"/>
         </packages>
+        <classes>
+            <!--<class name="org.ballerinalang.stdlib.io.IOPrintTest"/>-->
+            <class name="org.ballerinalang.stdlib.io.IOTest"/>
+        </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> $Subject

## Approach
> Make BIR and Backend-jvm depend on milestone versions of IO and Internal modules.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
