### PR TITLE
Make ts compiler ignore the extracted distribution's src directory

### DIFF
--- a/tool-plugins/vscode/tsconfig.json
+++ b/tool-plugins/vscode/tsconfig.json
@@ -25,6 +25,7 @@
     "exclude": [
         "node_modules",
         ".vscode-test",
-        "target"
+        "target",
+        "extractedDistribution"
     ],
 }


### PR DESCRIPTION
## Purpose
Avoid vscode ts compiler trying to build the src directory inside extracted distribution. The distribution is extracted to this location to be used for vscode tests. No need to build its ts files.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
