### PR TITLE
Resolve Maven and Gradle versioning inconsistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,11 @@ plugins {
     id "com.github.johnrengelman.shadow" version "5.0.0"
 }
 
+// TODO: remove following, when moved to gradle release plugin
+def mvnVersion = new XmlSlurper().parse('pom.xml').version
 allprojects {
     group = 'org.ballerinalang'
-    version = '0.990.4-SNAPSHOT'
+    version = mvnVersion
 
     task printPath {
         doLast{

--- a/composer/package.json
+++ b/composer/package.json
@@ -11,7 +11,8 @@
     "test-coverage": "lerna run test-coverage && node scripts/create-coverage-report.js",
     "fix-versions": "node scripts/fix-version.js",
     "reset-pkg-jsons": "node scripts/reset-pkg-json.js",
-    "bump-version": "lerna version --no-git-tag-version"
+    "bump-version": "lerna version --no-git-tag-version",
+    "update-version": "node ./scripts/update-version.js"
   },
   "author": "ballerina.io",
   "license": "Apache-2.0",

--- a/composer/scripts/npm-postinstall.js
+++ b/composer/scripts/npm-postinstall.js
@@ -1,0 +1,19 @@
+const { log } = console;
+const path = require('path');
+const fs = require('fs');
+
+const cwd = process.cwd();
+
+const readablePl = fs.createReadStream(path.join(cwd, 'package-lock.json.bak'));
+readablePl.on("error", function(err) {
+    log(err);
+});
+
+const writablePlb = fs.createWriteStream(path.join(cwd, 'package-lock.json'));
+writablePlb.on("error", function(err) {
+    log(err);
+});
+
+readablePl.pipe(writablePlb);
+
+fs.unlinkSync(path.join(cwd, 'package-lock.json.bak'));

--- a/composer/scripts/npm-preinstall.js
+++ b/composer/scripts/npm-preinstall.js
@@ -1,0 +1,19 @@
+const { log } = console;
+const path = require('path');
+const fs = require('fs');
+
+
+log('\x1b[36mNote:\x1b[0m', 'package-lock.json won\'t be updated during the build');
+const cwd = process.cwd();
+
+const readablePl = fs.createReadStream(path.join(cwd, 'package-lock.json'));
+readablePl.on("error", function(error) {
+    log(error);
+});
+
+const writablePlb = fs.createWriteStream(path.join(cwd, 'package-lock.json.bak'));
+writablePlb.on("error", function(error) {
+    log(error);
+});
+
+readablePl.pipe(writablePlb);

--- a/composer/scripts/update-version.js
+++ b/composer/scripts/update-version.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+const packageJson = require("../package.json");
+packageJson.version = process.argv[2].match(/\d+/g).slice(0,3).join(".");
+
+fs.writeFileSync(
+    path.join(__dirname, "../package.json"),
+    JSON.stringify(packageJson, null, 4)+"\n");

--- a/composer/scripts/update-version.js
+++ b/composer/scripts/update-version.js
@@ -4,5 +4,5 @@ const packageJson = require("../package.json");
 packageJson.version = process.argv[2].match(/\d+/g).slice(0,3).join(".");
 
 fs.writeFileSync(
-    path.join(__dirname, "../package.json"),
+    path.join(__dirname, "..", "package.json"),
     JSON.stringify(packageJson, null, 4)+"\n");

--- a/gradle/jsProject.gradle
+++ b/gradle/jsProject.gradle
@@ -20,6 +20,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'base'
 
 task npmInstall() {
+    dependsOn 'updateVersion'
     inputs.file("package-lock.json")
     outputs.dir("node_modules")
     doFirst {
@@ -40,4 +41,17 @@ task npmBuild() {
 
 assemble {
     dependsOn npmBuild
+}
+
+
+task updateVersion(type: Exec) {
+    inputs.file("package.json")
+    outputs.file("package.json")
+    doFirst {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            commandLine 'cmd', '/c', 'npm', 'run', 'update-version', '--', project.version
+        } else {
+            commandLine 'npm', 'run', 'update-version', '--', project.version
+        }
+    }
 }

--- a/tests/jballerina-unit-test/build.gradle
+++ b/tests/jballerina-unit-test/build.gradle
@@ -127,7 +127,7 @@ configurations {
 
 configurations.all {
     resolutionStrategy {
-        force 'org.ballerinalang:ballerina-lang:0.990.4-SNAPSHOT'
-        force 'org.ballerinalang:ballerina-core:0.990.4-SNAPSHOT'
+        force "org.ballerinalang:ballerina-lang:${project.version}"
+        force "org.ballerinalang:ballerina-core:${project.version}"
     }
 }

--- a/tool-plugins/vscode/scripts/update-version.js
+++ b/tool-plugins/vscode/scripts/update-version.js
@@ -4,5 +4,5 @@ const packageJson = require("../package.json");
 packageJson.version = process.argv[2].match(/\d+/g).slice(0,3).join(".");
 
 fs.writeFileSync(
-    path.join(__dirname, "../package.json"),
+    path.join(__dirname, "..", "package.json"),
     JSON.stringify(packageJson, null, 4)+"\n");


### PR DESCRIPTION
## Purpose
> Resolves Maven and Gradle versioning inconsistency. Added gradle tasks to execute version-updates for the package.json of the **composer-library** and **vscode** plugin.

Fixes #15445

## Approach
> Added a **temporary** fix to pick project version from the root `pom.xml`. This fix can be removed when we move into the **gradle release plugin**.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
