### PR TITLE
Fix picking up wrong version from pom.xml based on where you run gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // TODO: remove following, when moved to gradle release plugin
-def mvnVersion = new XmlSlurper().parse('pom.xml').version
+def mvnVersion = new XmlSlurper().parse("${project.rootDir}/pom.xml").version
 allprojects {
     group = 'org.ballerinalang'
     version = mvnVersion


### PR DESCRIPTION
## Purpose
> Fix pickingup wrong version from pom.xml based on where you run gradle

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
