### PR TITLE
Remove generate TOC option from docerina mvn plugin

### DIFF
--- a/misc/ballerina-maven-plugins/docerina-maven-plugin/src/main/java/org/ballerinalang/plugin/maven/doc/DocerinaMojo.java
+++ b/misc/ballerina-maven-plugins/docerina-maven-plugin/src/main/java/org/ballerinalang/plugin/maven/doc/DocerinaMojo.java
@@ -23,7 +23,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.docgen.docs.BallerinaDocConstants;
 import org.ballerinalang.docgen.docs.BallerinaDocGenerator;
 import org.ballerinalang.launcher.LauncherUtils;
@@ -85,12 +84,6 @@ public class DocerinaMojo extends AbstractMojo {
 
     @Parameter(property = "outputZip", required = false)
     private String outputZip;
-    
-    /**
-     * Generates the table of content file for the package.
-     */
-    @Parameter(property = "generateTOC", required = false, defaultValue = "false")
-    private boolean generateTOC;
 
     /**
      * enable debug level logs.
@@ -118,8 +111,6 @@ public class DocerinaMojo extends AbstractMojo {
         if (orgName != null) {
             System.setProperty(BallerinaDocConstants.ORG_NAME, orgName);
         }
-        
-        ConfigRegistry.getInstance().addConfiguration(BallerinaDocConstants.GENERATE_TOC, generateTOC);
 
         Path sourceRootPath = LauncherUtils.getSourceRootPath(sourceRoot);
         List<String> sources;
@@ -140,7 +131,6 @@ public class DocerinaMojo extends AbstractMojo {
             System.clearProperty(BallerinaDocConstants.TEMPLATES_FOLDER_PATH_KEY);
             System.clearProperty(BallerinaDocConstants.OUTPUT_ZIP_PATH);
             System.clearProperty(BallerinaDocConstants.ORG_NAME);
-            ConfigRegistry.getInstance().removeConfiguration(BallerinaDocConstants.GENERATE_TOC);
         }
     }
 }


### PR DESCRIPTION
## Purpose

This was previously used in Ballerina Central to generate
an index page for a given module in central front end.
However, going forward, we will not be maintaing a custom
doc page per each module on central. Hence this is now
removed from docerina and mvn plugin.

## Approach
Remove GenarateTOC option from CLI.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
