### PR TITLE
[IntelliJ Plugin] Change documentation synchronization mode

### DIFF
--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/extensions/BallerinaEditorEventManager.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/extensions/BallerinaEditorEventManager.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.ballerina.plugins.idea.extensions;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.event.DocumentEvent;
+import com.intellij.openapi.editor.event.DocumentListener;
+import com.intellij.openapi.editor.event.EditorMouseListener;
+import com.intellij.openapi.editor.event.EditorMouseMotionListener;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
+import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.editor.EditorEventManager;
+
+/**
+ * Editor event manager extension for Ballerina language.
+ */
+class BallerinaEditorEventManager extends EditorEventManager {
+
+    private static final Logger LOG = Logger.getInstance(BallerinaEditorEventManager.class);
+
+    BallerinaEditorEventManager(Editor editor, DocumentListener documentListener,
+                                EditorMouseListener mouseListener, EditorMouseMotionListener mouseMotionListener,
+                                RequestManager requestManager, ServerOptions serverOptions,
+                                LanguageServerWrapper wrapper) {
+        super(editor, documentListener, mouseListener, mouseMotionListener, requestManager, serverOptions, wrapper);
+    }
+
+    @Override
+    public void documentChanged(DocumentEvent event) {
+        if (editor.isDisposed()) {
+            return;
+        }
+        if (event.getDocument() == editor.getDocument()) {
+            DidChangeTextDocumentParams changeParams = getChangesParams();
+            changeParams.getContentChanges().get(0).setText(editor.getDocument().getText());
+            this.getRequestManager().didChange(changeParams);
+        } else {
+            LOG.error("Wrong document for the EditorEventManager");
+        }
+    }
+}

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/extensions/BallerinaLSPExtensionManager.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/extensions/BallerinaLSPExtensionManager.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.ballerina.plugins.idea.extensions;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.event.DocumentListener;
+import com.intellij.openapi.editor.event.EditorMouseListener;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.wso2.lsp4intellij.client.ClientContext;
+import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
+import org.wso2.lsp4intellij.client.languageserver.requestmanager.DefaultRequestManager;
+import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.editor.EditorEventManager;
+import org.wso2.lsp4intellij.editor.listeners.EditorMouseMotionListenerImpl;
+import org.wso2.lsp4intellij.extensions.LSPExtensionManager;
+
+/**
+ * Contains extended LSP components which serves  ballerina language server related specific capabilities.
+ */
+public class BallerinaLSPExtensionManager implements LSPExtensionManager {
+
+    @Override
+    public <T extends DefaultRequestManager> T getExtendedRequestManagerFor(LanguageServerWrapper wrapper,
+                        LanguageServer server, LanguageClient client, ServerCapabilities serverCapabilities) {
+        return null;
+    }
+
+    @Override
+    public <T extends EditorEventManager> T getExtendedEditorEventManagerFor(Editor editor,
+                         DocumentListener documentListener, EditorMouseListener mouseListener,
+                         EditorMouseMotionListenerImpl mouseMotionListener, RequestManager requestManager,
+                         ServerOptions serverOptions, LanguageServerWrapper wrapper) {
+        return (T) new BallerinaEditorEventManager(editor, documentListener, mouseListener, mouseMotionListener,
+                requestManager, serverOptions, wrapper);
+    }
+
+    @Override
+    public Class<? extends LanguageServer> getExtendedServerInterface() {
+        return null;
+    }
+
+    @Override
+    public LanguageClient getExtendedClientFor(ClientContext context) {
+        return null;
+    }
+}

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/preloading/LanguageServerRegisterService.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/preloading/LanguageServerRegisterService.java
@@ -15,6 +15,7 @@
  */
 package io.ballerina.plugins.idea.preloading;
 
+import io.ballerina.plugins.idea.extensions.BallerinaLSPExtensionManager;
 import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.RawCommandServerDefinition;
 
@@ -22,8 +23,8 @@ import org.wso2.lsp4intellij.client.languageserver.serverdefinition.RawCommandSe
  * Language Server Definition Register Service.
  */
 public class LanguageServerRegisterService {
-
     static void register(String[] args) {
         IntellijLanguageClient.addServerDefinition(new RawCommandServerDefinition("bal", args));
+        IntellijLanguageClient.addExtensionManager("bal", new BallerinaLSPExtensionManager());
     }
 }


### PR DESCRIPTION
## Purpose
Current ballerina intellij plugin uses incremental synchronization to sync documents with the ballerina language server. But since incremental syncing has a less stability and reliability as synchronization errors get accumulated over the time without being correct like in full sync mode, this PR proposes to override the default intellij language client to always use full document synchronization.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
