### PR TITLE
Configure vscode prelaunch task problem matchers

### DIFF
--- a/tool-plugins/vscode/.vscode/tasks.json
+++ b/tool-plugins/vscode/.vscode/tasks.json
@@ -6,7 +6,34 @@
         {
             "type": "npm",
             "script": "watch",
-            "problemMatcher": "$tsc-watch",
+            "problemMatcher": {
+                "owner": "typescript",
+                "source": "ts",
+                "applyTo": "closedDocuments",
+                "fileLocation": "absolute",
+                "severity": "error",
+                "pattern": [
+                    {
+                        "regexp": "\\[tsl\\] ERROR in (.*)?\\((\\d+),(\\d+)\\)",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3
+                    },
+                    {
+                        "regexp": "\\s*TS\\d+:\\s*(.*)",
+                        "message": 1
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": {
+                        "regexp": "Compilation (.*?)starting…"
+                    },
+                    "endsPattern": {
+                        "regexp": "Compilation (.*?)finished"
+                    }
+                }
+            },
             "isBackground": true,
             "presentation": {
                 "reveal": "never"

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -263,7 +263,7 @@
     "scripts": {
         "vscode:prepublish": "webpack --mode production",
         "compile": "webpack --mode none",
-        "watch": "webpack --mode none --watch",
+        "watch": "webpack --mode none --watch --info-verbosity verbose",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "update-version": "node ./scripts/update-version.js",
         "test-compile": "tsc -p ./",

--- a/tool-plugins/vscode/webpack.config.js
+++ b/tool-plugins/vscode/webpack.config.js
@@ -30,7 +30,10 @@ const config = {
         exclude: /node_modules/,
         use: [
           {
-            loader: 'ts-loader'
+            loader: 'ts-loader',
+            options: {
+              logLevel: "info"
+            }
           }
         ]
       }


### PR DESCRIPTION
Perviously we were using $tsc-watch pre configured
problem matcher to let vscode know when to start extension
development host, when running the extension locally.
Once we moved to webpack + typescript watch mode, this
wasn't working anymore, causing vscode to hang when
extension is launched, eventhough the comiplation
is successful.

Vscode doesn't have inbuilt problem matchers for webpack
output. Hence the need for this.

More Info: https://code.visualstudio.com/docs/editor/tasks#_defining-a-problem-matcher

Based on https://github.com/eamodio/vscode-tsl-problem-matcher

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
