### PR TITLE
 Fix panic propagation when a worker in a inner function panics

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Scheduler.java
@@ -306,7 +306,7 @@ public class Scheduler {
     }
 
     private void notifyChannels(SchedulerItem item, Throwable panic) {
-        ChannelDetails[] channels = item.future.strand.channelDetails;
+        Set<ChannelDetails> channels = item.future.strand.channelDetails;
         if (DEBUG) {
             debugLog("notifying channels:" + channels.toString());
         }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Strand.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Strand.java
@@ -24,8 +24,10 @@ import org.ballerinalang.jvm.values.FutureValue;
 import org.ballerinalang.jvm.values.MapValue;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -48,7 +50,7 @@ public class Strand {
     public WDChannels wdChannels;
     public FlushDetail flushDetail;
     public boolean blockedOnExtern;
-    public ChannelDetails[] channelDetails;
+    public Set<ChannelDetails> channelDetails;
     private Map<String, Object> globalProps;
     public boolean cancel;
 
@@ -56,7 +58,7 @@ public class Strand {
         this.scheduler = scheduler;
         this.wdChannels = new WDChannels();
         this.blockedOn = new CopyOnWriteArrayList();
-        this.channelDetails = new ChannelDetails[0];
+        this.channelDetails = new HashSet<>();
         this.globalProps = new HashMap<>();
     }
 
@@ -65,7 +67,7 @@ public class Strand {
         this.parent = parent;
         this.wdChannels = new WDChannels();
         this.blockedOn = new CopyOnWriteArrayList();
-        this.channelDetails = new ChannelDetails[0];
+        this.channelDetails = new HashSet<>();
         this.globalProps = new HashMap<>();
     }
 
@@ -74,7 +76,7 @@ public class Strand {
         this.globalProps = properties;
         this.wdChannels = new WDChannels();
         this.blockedOn = new CopyOnWriteArrayList();
-        this.channelDetails = new ChannelDetails[0];
+        this.channelDetails = new HashSet<>();
     }
 
     public void handleChannelError(ChannelDetails[] channels, ErrorValue error) {
@@ -208,6 +210,12 @@ public class Strand {
         }
 
         return waitResult;
+    }
+
+    public void updateChannelDetails(ChannelDetails[] channels) {
+        for (ChannelDetails details : channels) {
+            this.channelDetails.add(details);
+        }
     }
 
     private WorkerDataChannel getWorkerDataChannel(ChannelDetails channel) {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ChannelDetails.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ChannelDetails.java
@@ -39,4 +39,13 @@
          return name;
      }
 
+     @Override
+     public int hashCode() {
+         return name.hashCode();
+     }
+
+     @Override
+     public boolean equals(Object o) {
+         return (o instanceof ChannelDetails) && (((ChannelDetails) o).name.equals(this.name));
+     }
  }

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
@@ -84,7 +84,7 @@ function generateMethod(bir:Function func, jvm:ClassWriter cw, bir:Package modul
     // we cannot set this during strand creation, because function call do not have this info.
     mv.visitVarInsn(ALOAD, localVarOffset);
     loadChannelDetails(mv, func.workerChannels);
-    mv.visitFieldInsn(PUTFIELD, STRAND, "channelDetails", io:sprintf("[L%s;", CHANNEL_DETAILS));
+    mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "updateChannelDetails", io:sprintf("([L%s;)V", CHANNEL_DETAILS), false);
 
     // panic if this strand is cancelled
     checkStrandCancelled(mv, localVarOffset);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -299,4 +299,14 @@ public class WorkerTest {
         Assert.assertEquals(returns[0].getType().getName(), "Rec");
         Assert.assertEquals(((BMap) returns[0]).get("k"), new BInteger(10));
     }
+
+    @Test
+    public void innerWorkerPanicTest() {
+        try {
+            BRunUtil.invoke(result, "panicFunc");
+            Assert.fail("Worker did not panic");
+        } catch (BLangRuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("worker w5 panic"));
+        }
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -434,3 +434,24 @@ function add2(int i, int j) returns int {
 function singleAdd(int num) returns int{
    return num +1;
 }
+
+function innerWorkerPanicTest() {
+   worker w1 {
+       int k = <- default;
+   }
+
+   panicFunc();
+
+   10 -> w1;
+}
+
+function panicFunc() {
+    worker w5 {
+       if (true) {
+           error e = error("worker w5 panic");
+           panic e;
+       }
+       10 -> default;
+    }
+    int k = <- w5;
+}


### PR DESCRIPTION
## Purpose
> Fix worker hanging issue of the following code.

```
public function main() {
    worker w1 {
        int k = <- default;
    }
    otherFunc();
    10 -> w1;
}

public function otherFunc() {
    worker w5 {
       if (true) {
           error e = error("panic");
           panic e;
       }
       10 -> default;
    }
    int k = <- w5;
}
```

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, releated PRs, TODO items or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
