### PR TITLE
Enable filter desugar for resources

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -213,6 +213,6 @@ public class ServiceDesugar {
     }
 
     private void engageCustomResourceDesugar(BLangService service, BLangFunction functionNode, SymbolEnv env) {
-//        httpFiltersDesugar.addHttpFilterStatementsToResource(functionNode, env); // TODO fix - rajith
+        httpFiltersDesugar.addHttpFilterStatementsToResource(functionNode, env);
     }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/MockHTTPConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/MockHTTPConnectorListener.java
@@ -52,12 +52,20 @@ public class MockHTTPConnectorListener {
      * Holder class to hold registry and the endpoint config.
      */
     public static class RegistryHolder {
-        public final HTTPServicesRegistry registry;
-        public final MapValue endpointConfig;
+        private final HTTPServicesRegistry registry;
+        private final MapValue endpointConfig;
 
         public RegistryHolder(HTTPServicesRegistry registry, MapValue endpointConfig) {
             this.registry = registry;
             this.endpointConfig = endpointConfig;
+        }
+
+        public HTTPServicesRegistry getRegistry() {
+            return registry;
+        }
+
+        public MapValue getEndpointConfig() {
+            return endpointConfig;
         }
     }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/MockHTTPConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/MockHTTPConnectorListener.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.net.http.mock.nonlistening;
 
+import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.net.http.HTTPServicesRegistry;
 
 import java.util.HashMap;
@@ -29,7 +30,7 @@ import java.util.Map;
 public class MockHTTPConnectorListener {
 
     private static MockHTTPConnectorListener testListener = new MockHTTPConnectorListener();
-    private Map<Integer, HTTPServicesRegistry> listenerServicesRegistries = new HashMap<>();
+    private Map<Integer, RegistryHolder> listenerServicesRegistries = new HashMap<>();
 
     private MockHTTPConnectorListener() {
     }
@@ -38,11 +39,22 @@ public class MockHTTPConnectorListener {
         return testListener;
     }
 
-    public HTTPServicesRegistry getHttpServicesRegistry(int listenerPort) {
+    public RegistryHolder getHttpServicesRegistry(int listenerPort) {
         return listenerServicesRegistries.get(listenerPort);
     }
 
-    public void setHttpServicesRegistry(int listenerPort, HTTPServicesRegistry httpServicesRegistry) {
-        listenerServicesRegistries.put(listenerPort, httpServicesRegistry);
+    public void setHttpServicesRegistry(int listenerPort, HTTPServicesRegistry httpServicesRegistry,
+                                        MapValue endpointConfig) {
+        listenerServicesRegistries.put(listenerPort, new RegistryHolder(httpServicesRegistry, endpointConfig));
+    }
+
+    public static class RegistryHolder {
+        public final HTTPServicesRegistry registry;
+        public final MapValue endpointConfig;
+
+        public RegistryHolder(HTTPServicesRegistry registry, MapValue endpointConfig) {
+            this.registry = registry;
+            this.endpointConfig = endpointConfig;
+        }
     }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/MockHTTPConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/MockHTTPConnectorListener.java
@@ -48,6 +48,9 @@ public class MockHTTPConnectorListener {
         listenerServicesRegistries.put(listenerPort, new RegistryHolder(httpServicesRegistry, endpointConfig));
     }
 
+    /**
+     * Holder class to hold registry and the endpoint config.
+     */
     public static class RegistryHolder {
         public final HTTPServicesRegistry registry;
         public final MapValue endpointConfig;

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/NonListeningStart.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/NonListeningStart.java
@@ -28,6 +28,7 @@ import org.ballerinalang.net.http.HTTPServicesRegistry;
 import org.ballerinalang.net.http.HttpConstants;
 
 import static org.ballerinalang.net.http.HttpConstants.MOCK_LISTENER_ENDPOINT;
+import static org.ballerinalang.net.http.HttpConstants.SERVICE_ENDPOINT_CONFIG;
 
 /**
  * Get the ID of the connection.
@@ -53,6 +54,6 @@ public class NonListeningStart extends org.ballerinalang.net.http.serviceendpoin
         HTTPServicesRegistry httpServicesRegistry = getHttpServicesRegistry(listener);
         MockHTTPConnectorListener httpListener = MockHTTPConnectorListener.getInstance();
         httpListener.setHttpServicesRegistry(((Long) listener.get(HttpConstants.ENDPOINT_CONFIG_PORT)).intValue(),
-                                             httpServicesRegistry);
+                                             httpServicesRegistry, listener.getMapValue(SERVICE_ENDPOINT_CONFIG));
     }
 }

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/utils/Services.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/utils/Services.java
@@ -24,12 +24,12 @@ import org.ballerinalang.jvm.util.exceptions.BallerinaConnectorException;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.connector.Executor;
-import org.ballerinalang.net.http.HTTPServicesRegistry;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpDispatcher;
 import org.ballerinalang.net.http.HttpResource;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.mock.nonlistening.MockHTTPConnectorListener;
+import org.ballerinalang.net.http.mock.nonlistening.MockHTTPConnectorListener.RegistryHolder;
 import org.ballerinalang.test.util.CompileResult;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
@@ -64,13 +64,13 @@ public class Services {
     }
 
     public static HttpCarbonMessage invoke(int listenerPort, HTTPTestRequest request) {
-        HTTPServicesRegistry httpServicesRegistry = MockHTTPConnectorListener.getInstance()
+        RegistryHolder registryHolder = MockHTTPConnectorListener.getInstance()
                                                             .getHttpServicesRegistry(listenerPort);
         TestCallableUnitCallback callback = new TestCallableUnitCallback(request);
         request.setCallback(callback);
         HttpResource resource = null;
         try {
-            resource = HttpDispatcher.findResource(httpServicesRegistry, request);
+            resource = HttpDispatcher.findResource(registryHolder.registry, request);
         } catch (BallerinaException ex) {
             HttpUtil.handleFailure(request, new BallerinaConnectorException(ex.getMessage()));
         }
@@ -87,7 +87,8 @@ public class Services {
 
         // Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource, request,
         // (MapValue) connectorEndpoint.get(SERVICE_ENDPOINT_CONFIG));
-        Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource, request, null);
+        Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource,
+                request, registryHolder.endpointConfig);
         callback.setRequestStruct(signatureParams[0]);
 
         ObjectValue service = resource.getParentService().getBalService();

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/utils/Services.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/utils/Services.java
@@ -70,7 +70,7 @@ public class Services {
         request.setCallback(callback);
         HttpResource resource = null;
         try {
-            resource = HttpDispatcher.findResource(registryHolder.registry, request);
+            resource = HttpDispatcher.findResource(registryHolder.getRegistry(), request);
         } catch (BallerinaException ex) {
             HttpUtil.handleFailure(request, new BallerinaConnectorException(ex.getMessage()));
         }
@@ -88,7 +88,7 @@ public class Services {
         // Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource, request,
         // (MapValue) connectorEndpoint.get(SERVICE_ENDPOINT_CONFIG));
         Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource,
-                request, registryHolder.endpointConfig);
+                request, registryHolder.getEndpointConfig());
         callback.setRequestStruct(signatureParams[0]);
 
         ObjectValue service = resource.getParentService().getBalService();

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/utils/Services.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/utils/Services.java
@@ -92,7 +92,7 @@ public class Services {
         callback.setRequestStruct(signatureParams[0]);
 
         ObjectValue service = resource.getParentService().getBalService();
-        Scheduler scheduler = httpServicesRegistry.getScheduler();
+        Scheduler scheduler = registryHolder.getRegistry().getScheduler();
         Executor.submit(scheduler, service, resource.getName(), callback, properties, signatureParams);
         Executors.newSingleThreadExecutor().submit(scheduler::start);
         callback.sync();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
@@ -88,7 +88,7 @@ public class Services {
         callback.setRequestStruct(signatureParams[0]);
 
         ObjectValue service = resource.getParentService().getBalService();
-        Scheduler scheduler = httpServicesRegistry.getScheduler();
+        Scheduler scheduler = registryHolder.getRegistry().getScheduler();
         Executor.submit(scheduler, service, resource.getName(), callback, properties, signatureParams);
         Executors.newSingleThreadExecutor().submit(scheduler::start);
         callback.sync();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
@@ -22,12 +22,12 @@ import io.netty.handler.codec.http.HttpContent;
 import org.ballerinalang.jvm.util.exceptions.BallerinaConnectorException;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.connector.Executor;
-import org.ballerinalang.net.http.HTTPServicesRegistry;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpDispatcher;
 import org.ballerinalang.net.http.HttpResource;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.mock.nonlistening.MockHTTPConnectorListener;
+import org.ballerinalang.net.http.mock.nonlistening.MockHTTPConnectorListener.RegistryHolder;
 import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
@@ -56,14 +56,14 @@ public class Services {
     }
 
     public static HttpCarbonMessage invoke(int listenerPort, HTTPTestRequest request) {
-        HTTPServicesRegistry httpServicesRegistry =
+        RegistryHolder registryHolder =
                 MockHTTPConnectorListener.getInstance().getHttpServicesRegistry(listenerPort);
         TestCallableUnitCallback callback = new TestCallableUnitCallback(request);
         request.setCallback(callback);
 
         HttpResource resource = null;
         try {
-            resource = HttpDispatcher.findResource(httpServicesRegistry, request);
+            resource = HttpDispatcher.findResource(registryHolder.registry, request);
         } catch (BallerinaException ex) {
             // throwing an error here to terminate the flow. This should be properly implemented if
             // testing error scenarios are needed.
@@ -81,7 +81,8 @@ public class Services {
             properties = Collections.singletonMap(HttpConstants.SRC_HANDLER, srcHandler);
         }
 
-        Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource, request, null);
+        Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource,
+                request, registryHolder.endpointConfig);
         callback.setRequestStruct(signatureParams[0]);
 
         ObjectValue service = resource.getParentService().getBalService();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
@@ -63,7 +63,7 @@ public class Services {
 
         HttpResource resource = null;
         try {
-            resource = HttpDispatcher.findResource(registryHolder.registry, request);
+            resource = HttpDispatcher.findResource(registryHolder.getRegistry(), request);
         } catch (BallerinaException ex) {
             // throwing an error here to terminate the flow. This should be properly implemented if
             // testing error scenarios are needed.
@@ -82,7 +82,7 @@ public class Services {
         }
 
         Object[] signatureParams = HttpDispatcher.getSignatureParameters(resource,
-                request, registryHolder.endpointConfig);
+                request, registryHolder.getEndpointConfig());
         callback.setRequestStruct(signatureParams[0]);
 
         ObjectValue service = resource.getParentService().getBalService();


### PR DESCRIPTION
## Purpose
Http resource filter desugar was disabled in the master, this PR is to re-enable that again

Fixes #15492

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, releated PRs, TODO items or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
