### PR TITLE
Use composer libs from Ballerina home

### DIFF
--- a/tool-plugins/vscode/.vscodeignore
+++ b/tool-plugins/vscode/.vscodeignore
@@ -6,6 +6,7 @@ src/
 target/
 docs/
 extractedDistribution/
+resources/composer
 .gitignore
 tsconfig.json
 tslint.json

--- a/tool-plugins/vscode/build.gradle
+++ b/tool-plugins/vscode/build.gradle
@@ -20,12 +20,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply from: "$rootDir/gradle/jsProject.gradle"
 
 configurations {
-    composerDistribution {
-      transitive false
-    }
-    composerFonts {
-      transitive false
-    }
     ballerinaTools
 }
 
@@ -39,7 +33,6 @@ npmBuild() {
     FileTree src = files('.').asFileTree;
     inputs.files(src.matching(patternSet))
 
-    dependsOn(':composer-library:build')
     outputs.dir("out")
     outputs.dir("dist")
     outputs.cacheIf { true } 
@@ -65,30 +58,11 @@ task copyDistribution() {
     }
 }
 
-task copyComposerDistribution() {
-    dependsOn(':composer-library:assemble')
-    doFirst {
-        copy {
-            from file(configurations.composerDistribution.asPath)
-            exclude '**/*.map'
-            exclude '**/*.d.ts'
-            into "resources/composer"
-        }
-        copy {
-            from file(configurations.composerFonts.asPath)
-            into "resources/composer/font"
-        }
-    }
-}
-
 task assemble(overwrite: true) {
     dependsOn 'npmBuild'
-    dependsOn 'copyComposerDistribution'
 }
 
 dependencies {
-    composerDistribution project(path: ':composer-library', configuration: 'composer')
-    composerFonts project(path: ':composer-library', configuration: 'fonts')
     ballerinaTools project(path: ':ballerina-tools', configuration: 'unzipped')
 }
 

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -144,7 +144,7 @@
                             "debugServerTimeout": {
                                 "type": "integer",
                                 "default": 5000,
-                                "description": "How long to wait for the debug server to start up in miliseconds"
+                                "description": "How long to wait for the debug server to start up in milliseconds"
                             },
                             "debugTests": {
                                 "type": "boolean",

--- a/tool-plugins/vscode/pom.xml
+++ b/tool-plugins/vscode/pom.xml
@@ -56,12 +56,6 @@
     <dependencies>
         <dependency>
             <groupId>org.ballerinalang</groupId>
-            <artifactId>composer-library</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-tools</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
@@ -200,25 +194,6 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.basedir}/target" />
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="copy resources">
-                                <mkdir dir="${project.basedir}/resources/composer" />
-                                <copy todir="${project.basedir}/resources/composer" overwrite="true">
-                                    <fileset dir="${project.build.directory}/composer/composer-library-${project.version}">
-                                        <include name="**/*.*" />
-                                        <exclude name="**/*.map" />
-                                        <exclude name="**/*.d.ts" />
-                                    </fileset>
-                                </copy>
                             </target>
                         </configuration>
                     </execution>

--- a/tool-plugins/vscode/src/api-editor/activator.ts
+++ b/tool-plugins/vscode/src/api-editor/activator.ts
@@ -22,7 +22,7 @@ import * as _ from 'lodash';
 import { apiEditorRender } from './renderer';
 import { BallerinaExtension } from '../core';
 import { API_DESIGNER_NO_SERVICE } from '../core/messages';
-import { WebViewRPCHandler, WebViewMethod } from '../utils';
+import { WebViewRPCHandler, WebViewMethod, getCommonWebViewOptions } from '../utils';
 import { join } from "path";
 import { readFileSync } from "fs";
 
@@ -164,10 +164,7 @@ function createAPIEditorPanel(selectedService: string, renderHtml: string,
             'ballerinaOASEditor',
             'Ballerina API Designer - ' + selectedService,
             { viewColumn: ViewColumn.Two, preserveFocus: true } ,
-            {
-                enableScripts: true,
-                retainContextWhenHidden: true,
-            }
+            getCommonWebViewOptions()
         );
     }
 

--- a/tool-plugins/vscode/src/api-editor/renderer.ts
+++ b/tool-plugins/vscode/src/api-editor/renderer.ts
@@ -19,7 +19,7 @@
 
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { Uri, ExtensionContext } from 'vscode';
-import { getLibraryWebViewContent } from '../utils/index';
+import { getLibraryWebViewContent, WebViewOptions, getComposerJSFiles, getComposerCSSFiles } from '../utils/index';
 
 export function apiEditorRender(context: ExtensionContext, langClient: ExtendedLangClient,
     docUri: Uri, selectedService: string, retries: number = 1) : string {
@@ -34,7 +34,7 @@ export function apiEditorRender(context: ExtensionContext, langClient: ExtendedL
     `;
     const bodyCss = "api-designer";
     const styles = ``;
-    const script = `
+    const scripts = `
         function loadedScript() {
             let docUri = ${JSON.stringify(docUri.toString())};
             let updatedJSON = '';
@@ -85,5 +85,11 @@ export function apiEditorRender(context: ExtensionContext, langClient: ExtendedL
         }
     `;
 
-    return getLibraryWebViewContent(context, body, script, styles, bodyCss, true);
+    const webViewOptions: WebViewOptions = {
+        jsFiles: getComposerJSFiles(true),
+        cssFiles: getComposerCSSFiles(),
+        body, scripts, styles, bodyCss
+    };
+    
+    return getLibraryWebViewContent(webViewOptions);
 }

--- a/tool-plugins/vscode/src/bbe/activator.ts
+++ b/tool-plugins/vscode/src/bbe/activator.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import { render } from './renderer';
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { ballerinaExtInstance, BallerinaExtension } from '../core';
-import { WebViewRPCHandler, WebViewMethod } from '../utils';
+import { WebViewRPCHandler, WebViewMethod, getCommonWebViewOptions } from '../utils';
 
 let examplesPanel: WebviewPanel | undefined;
 
@@ -35,10 +35,7 @@ function showExamples(context: ExtensionContext, langClient: ExtendedLangClient)
         'ballerinaExamples',
         "Ballerina Examples",
         { viewColumn: ViewColumn.One, preserveFocus: false } ,
-        {
-            enableScripts: true,
-            retainContextWhenHidden: true,
-        }
+        getCommonWebViewOptions()
     );
     const remoteMethods: WebViewMethod[] = [
         {

--- a/tool-plugins/vscode/src/bbe/renderer.ts
+++ b/tool-plugins/vscode/src/bbe/renderer.ts
@@ -1,6 +1,6 @@
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { ExtensionContext } from 'vscode';
-import { getLibraryWebViewContent } from '../utils';
+import { getLibraryWebViewContent, WebViewOptions, getComposerWebViewOptions } from '../utils';
 
 export function render(context: ExtensionContext, langClient: ExtendedLangClient)
     : string {
@@ -8,7 +8,7 @@ export function render(context: ExtensionContext, langClient: ExtendedLangClient
     const body = `<div id="examples" class="examples-container" />`;
     const bodyCss = "examples";
     const styles = ``;
-    const script = `
+    const scripts = `
             function loadedScript() {
                     function openExample(url) {
                         webViewRPCHandler.invokeRemoteMethod("openExample", [url]);
@@ -21,5 +21,11 @@ export function render(context: ExtensionContext, langClient: ExtendedLangClient
             }
         `;
 
-    return getLibraryWebViewContent(context, body, script, styles, bodyCss);
+        const webViewOptions: WebViewOptions = {
+            ...getComposerWebViewOptions(),
+            body, scripts, styles, bodyCss
+        };
+        
+        return getLibraryWebViewContent(webViewOptions);
 }
+

--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -38,15 +38,15 @@ import { AssertionError } from "assert";
 export class BallerinaExtension {
 
     public ballerinaHome: string;
-    public extention: Extension<any>;
+    public extension: Extension<any>;
     private clientOptions: LanguageClientOptions;
     public langClient?: ExtendedLangClient;
     public context?: ExtensionContext;
 
     constructor() {
         this.ballerinaHome = '';
-        // Load the extention
-        this.extention = extensions.getExtension('ballerina.ballerina')!;
+        // Load the extension
+        this.extension = extensions.getExtension('ballerina.ballerina')!;
         this.clientOptions = {
             documentSelector: [{ scheme: 'file', language: 'ballerina' }],
             outputChannel: getOutputChannel(),
@@ -71,15 +71,15 @@ export class BallerinaExtension {
                 if (!this.isValidBallerinaHome(this.ballerinaHome)) {
                     info("Configured Ballerina home is not valid.");
                     // Ballerina home in setting is invalid show message and quit.
-                    // Prompt to correct the home. // TODO add auto ditection.
+                    // Prompt to correct the home. // TODO add auto detection.
                     this.showMessageInvalidBallerinaHome();
                     return Promise.resolve();
                 }
             } else {
                 info("Auto detecting Ballerina home.");
-                // If ballerina home is not set try to auto ditect ballerina home.
+                // If ballerina home is not set try to auto detect ballerina home.
                 // TODO If possible try to update the setting page.
-                this.ballerinaHome = this.autoDitectBallerinaHome();
+                this.ballerinaHome = this.autoDetectBallerinaHome();
                 if (!this.ballerinaHome) {
                     this.showMessageInstallBallerina();
                     info("Unable to auto detect Ballerina home.");
@@ -88,7 +88,7 @@ export class BallerinaExtension {
             }
             info("Using " + this.ballerinaHome + " as the Ballerina home.");
             // Validate the ballerina version.
-            const pluginVersion = this.extention.packageJSON.version.split('-')[0];
+            const pluginVersion = this.extension.packageJSON.version.split('-')[0];
             return this.getBallerinaVersion(this.ballerinaHome).then(ballerinaVersion => {
                 ballerinaVersion = ballerinaVersion.split('-')[0];
                 info(`Plugin version: ${pluginVersion}\nBallerina version: ${ballerinaVersion}`);
@@ -97,12 +97,12 @@ export class BallerinaExtension {
                 this.langClient = new ExtendedLangClient('ballerina-vscode', 'Ballerina LS Client',
                     getServerOptions(this.getBallerinaHome(), this.isExperimental()), this.clientOptions, false);
 
-                // 0.983.0 and 0.982.0 versions are incable of handling client capabilies 
+                // 0.983.0 and 0.982.0 versions are incapable of handling client capabilities 
                 if (ballerinaVersion !== "0.983.0" && ballerinaVersion !== "0.982.0") {
                     onBeforeInit(this.langClient);
                 }
 
-                // Following was put in to handle server startup failiers.
+                // Following was put in to handle server startup failures.
                 const disposeDidChange = this.langClient.onDidChangeState(stateChangeEvent => {
                     if (stateChangeEvent.newState === LS_STATE.Stopped) {
                         info("Couldn't establish language server connection.");
@@ -112,7 +112,7 @@ export class BallerinaExtension {
 
                 let disposable = this.langClient.start();
 
-                this.langClient.onReady().then(fullfilled => {
+                this.langClient.onReady().then(fulfilled => {
                     disposeDidChange.dispose();
                     this.context!.subscriptions.push(disposable);
                 });
@@ -122,7 +122,7 @@ export class BallerinaExtension {
 
         } catch (ex) {
             info("Error while activating plugin: " + (ex.message ? ex.message : ex));
-            // If any failure occurs while intializing show an error messege
+            // If any failure occurs while initializing show an error message
             this.showPluginActivationError();
             return Promise.resolve();
         }
@@ -137,8 +137,8 @@ export class BallerinaExtension {
     }
 
     showPluginActivationError(): any {
-        // message to display on Unknoen errors.
-        // ask to enable debuglogs.
+        // message to display on Unknown errors.
+        // ask to enable debug logs.
         // we can ask the user to report the issue.
 
         window.showErrorMessage(UNKNOWN_ERROR);
@@ -323,7 +323,7 @@ export class BallerinaExtension {
      * Get ballerina home path.
      *
      * @returns {string}
-     * @memberof BallerinaExtention
+     * @memberof BallerinaExtension
      */
     getBallerinaHome(): string {
         if (this.ballerinaHome) {
@@ -337,8 +337,8 @@ export class BallerinaExtension {
         return <boolean>workspace.getConfiguration().get('ballerina.allowExperimental');
     }
 
-    autoDitectBallerinaHome(): string {
-        // try to ditect the environment.
+    autoDetectBallerinaHome(): string {
+        // try to detect the environment.
         const platform: string = process.platform;
         let ballerinaPath = '';
         switch (platform) {
@@ -362,7 +362,7 @@ export class BallerinaExtension {
                     // remove ballerina bin from ballerinaPath
                     if (ballerinaPath) {
                         ballerinaPath = ballerinaPath.replace(/bin\/ballerina$/, '');
-                        // For homebrew installations ballerina executables are in libexcec
+                        // For homebrew installations ballerina executable is in libexcec
                         const homebrewBallerinaPath = path.join(ballerinaPath, 'libexec');
                         if (fs.existsSync(homebrewBallerinaPath)) {
                             ballerinaPath = homebrewBallerinaPath;

--- a/tool-plugins/vscode/src/core/messages.ts
+++ b/tool-plugins/vscode/src/core/messages.ts
@@ -18,7 +18,7 @@
  *
  */
 export const INVALID_HOME_MSG: string = "Ballerina Home is invalid, please check `ballerina.home` in settings";
-export const INSTALL_BALLERINA: string = "Unable to autoditect ballerina in your environment. Please download and install Ballerina or provide ballerina home path in settings.";
+export const INSTALL_BALLERINA: string = "Unable to auto detect ballerina in your environment. Please download and install Ballerina or provide ballerina home path in settings.";
 export const DOWNLOAD_BALLERINA: string = "https://ballerina.io/downloads/";
 export const CONFIG_CHANGED: string = "Ballerina plugin configuration changed. Please restart vscode for changes to take effect.";
 export const OLD_BALLERINA_VERSION: string ="Your Ballerina version does not match the Ballerina vscode plugin version. Some features may not work properly. Please download the latest Ballerina distribution.";

--- a/tool-plugins/vscode/src/debugger/channel.ts
+++ b/tool-plugins/vscode/src/debugger/channel.ts
@@ -26,18 +26,18 @@ const WS_PING_INTERVAL = 15000;
 interface WebSocketOnMessageEvt {
     data: WebSocket.Data; 
     type: string; 
-    target: WebSocket
+    target: WebSocket;
 }
 
 interface WebSocketOnCloseEvt {
     wasClean: boolean;
     code: number;
     reason: string;
-    target: WebSocket
+    target: WebSocket;
 }
 
 interface WebSocketOnOpenEvt {
-    target: WebSocket
+    target: WebSocket;
 }
 
 interface WebSocketOnErrorEvt {
@@ -48,7 +48,7 @@ interface WebSocketOnErrorEvt {
 }
 
 /**
- * Handles websocket communitation with debugger backend
+ * Handles websocket communication with debugger backend
  * @class DebugChannel
  * @extends {EventEmitter}
  */
@@ -80,7 +80,7 @@ export class DebugChannel extends EventEmitter {
         const websocket = new WebSocket(this._endpoint);
         websocket.onmessage = (message: WebSocketOnMessageEvt) => { this.parseMessage(message.data); };
         websocket.onopen = (event: WebSocketOnOpenEvt) => { this.onOpen(event); };
-        websocket.onclose = (event: WebSocketOnCloseEvt) => { this.onClose(event); }
+        websocket.onclose = (event: WebSocketOnCloseEvt) => { this.onClose(event); };
         websocket.onerror = (event: WebSocketOnErrorEvt) => { this.onError(event); };
         this._websocket = websocket;
     }

--- a/tool-plugins/vscode/src/diagram/activator.ts
+++ b/tool-plugins/vscode/src/diagram/activator.ts
@@ -86,7 +86,7 @@ function showDiagramEditor(context: ExtensionContext, langClient: ExtendedLangCl
 	}
 	activeEditor = editor;
 	rpcHandler = WebViewRPCHandler.create(diagramViewPanel.webview, langClient);
-	const html = render(context, langClient, editor.document.uri);
+	const html = render(editor.document.uri);
 	if (diagramViewPanel && html) {
 		diagramViewPanel.webview.html = html;
 	}

--- a/tool-plugins/vscode/src/diagram/activator.ts
+++ b/tool-plugins/vscode/src/diagram/activator.ts
@@ -20,8 +20,8 @@ import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEdi
 import * as _ from 'lodash';
 import { render } from './renderer';
 import { ExtendedLangClient } from '../core/extended-language-client';
-import { BallerinaExtension, ballerinaExtInstance } from '../core';
-import { WebViewRPCHandler, getComposerPath, getCommonWebViewOptions } from '../utils';
+import { BallerinaExtension } from '../core';
+import { WebViewRPCHandler, getCommonWebViewOptions } from '../utils';
 import { join } from "path";
 import { DidChangeConfigurationParams } from 'vscode-languageclient';
 

--- a/tool-plugins/vscode/src/diagram/activator.ts
+++ b/tool-plugins/vscode/src/diagram/activator.ts
@@ -20,8 +20,8 @@ import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEdi
 import * as _ from 'lodash';
 import { render } from './renderer';
 import { ExtendedLangClient } from '../core/extended-language-client';
-import { BallerinaExtension } from '../core';
-import { WebViewRPCHandler } from '../utils';
+import { BallerinaExtension, ballerinaExtInstance } from '../core';
+import { WebViewRPCHandler, getComposerPath, getCommonWebViewOptions } from '../utils';
 import { join } from "path";
 import { DidChangeConfigurationParams } from 'vscode-languageclient';
 
@@ -69,10 +69,7 @@ function showDiagramEditor(context: ExtensionContext, langClient: ExtendedLangCl
 		'ballerinaDiagram',
 		"Ballerina Diagram",
 		{ viewColumn: ViewColumn.Two, preserveFocus: true } ,
-		{
-			enableScripts: true,
-			retainContextWhenHidden: true,
-		}
+		getCommonWebViewOptions()
 	);
 
 	diagramViewPanel.iconPath = {

--- a/tool-plugins/vscode/src/diagram/renderer.ts
+++ b/tool-plugins/vscode/src/diagram/renderer.ts
@@ -1,13 +1,12 @@
-import { ExtendedLangClient } from '../core/extended-language-client';
-import { Uri, ExtensionContext } from 'vscode';
-import { getLibraryWebViewContent } from '../utils';
+import { Uri } from 'vscode';
+import { getLibraryWebViewContent, WebViewOptions, getComposerWebViewOptions } from '../utils';
 
-export function render (context: ExtensionContext, langClient: ExtendedLangClient, docUri: Uri, retries: number = 1)
+export function render (docUri: Uri)
         : string {       
-   return renderDiagram(context, docUri);
+   return renderDiagram(docUri);
 }
 
-function renderDiagram(context: ExtensionContext, docUri: Uri): string {
+function renderDiagram(docUri: Uri): string {
 
     const body = `
         <div id="warning"></div>
@@ -55,7 +54,7 @@ function renderDiagram(context: ExtensionContext, docUri: Uri): string {
         }
     `;
 
-    const script = `
+    const scripts = `
         function loadedScript() {
             window.langclient = getLangClient();
             let docUri = ${JSON.stringify(docUri.toString())};
@@ -100,8 +99,13 @@ function renderDiagram(context: ExtensionContext, docUri: Uri): string {
             enableUndoRedo();
         }
     `;
-
-    return getLibraryWebViewContent(context, body, script, styles, bodyCss);
+    
+    const webViewOptions: WebViewOptions = {
+        ...getComposerWebViewOptions(),
+        body, scripts, styles, bodyCss
+    };
+    
+    return getLibraryWebViewContent(webViewOptions);
 }
 
 export function renderError() {

--- a/tool-plugins/vscode/src/docs/activator.ts
+++ b/tool-plugins/vscode/src/docs/activator.ts
@@ -24,6 +24,7 @@ import * as _ from 'lodash';
 import { render } from './renderer';
 import { BallerinaAST, ExtendedLangClient } from '../core/extended-language-client';
 import { BallerinaExtension } from '../core';
+import { getCommonWebViewOptions } from '../utils';
 
 const DEBOUNCE_WAIT = 500;
 
@@ -81,10 +82,7 @@ function showDocs(context: ExtensionContext, langClient: ExtendedLangClient, nod
 		'ballerinaDocs',
 		"Ballerina Docs",
 		{ viewColumn: ViewColumn.Two, preserveFocus: true },
-		{
-			enableScripts: true,
-			retainContextWhenHidden: true,
-		}
+		getCommonWebViewOptions()
 	);
 	const editor = window.activeTextEditor;
 	if (!editor) {

--- a/tool-plugins/vscode/src/docs/renderer.ts
+++ b/tool-plugins/vscode/src/docs/renderer.ts
@@ -1,6 +1,6 @@
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { ExtensionContext } from 'vscode';
-import { getLibraryWebViewContent } from '../utils';
+import { getLibraryWebViewContent, WebViewOptions, getComposerWebViewOptions } from '../utils';
 
 export function render(context: ExtensionContext, langClient: ExtendedLangClient)
     : string {
@@ -12,7 +12,7 @@ export function render(context: ExtensionContext, langClient: ExtendedLangClient
     `;
     const bodyCss = "documentation";
     const styles = "";
-    const script = `
+    const scripts = `
         const el = document.getElementById("ballerina-documentation");
         window.addEventListener('message', event => {
             switch (event.data.command) {
@@ -34,5 +34,10 @@ export function render(context: ExtensionContext, langClient: ExtendedLangClient
         }
     `;
 
-    return getLibraryWebViewContent(context, body, script, styles, bodyCss);
+    const webViewOptions: WebViewOptions = {
+        ...getComposerWebViewOptions(),
+        body, scripts, styles, bodyCss
+    };
+    
+    return getLibraryWebViewContent(webViewOptions);
 }

--- a/tool-plugins/vscode/src/test-runner/activator.ts
+++ b/tool-plugins/vscode/src/test-runner/activator.ts
@@ -5,7 +5,7 @@ import { TestRunner } from "./runner";
 export function activateTestRunner(ballerinaExtInstance: BallerinaExtension) {
     const channel = window.createOutputChannel('Ballerina Tests');
 
-    // register run all tests hander
+    // register run all tests handler
     commands.registerCommand('ballerina.runAllTests', () => {
         const activeEditor = window.activeTextEditor;
         // if currently opened file is a bal file

--- a/tool-plugins/vscode/src/trace-logs/activator.ts
+++ b/tool-plugins/vscode/src/trace-logs/activator.ts
@@ -21,7 +21,7 @@ import { commands, window, ViewColumn, ExtensionContext, WebviewPanel, StatusBar
 import { render, renderDetailView } from './renderer';
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { BallerinaExtension } from '../core';
-import { WebViewRPCHandler, WebViewMethod } from '../utils';
+import { WebViewRPCHandler, WebViewMethod, getCommonWebViewOptions } from '../utils';
 import Traces from './traces';
 
 let traceLogsPanel: WebviewPanel | undefined;
@@ -39,10 +39,7 @@ function showTraces(context: ExtensionContext, langClient: ExtendedLangClient) {
         'ballerinaNetworkLogs',
         "Ballerina Network logs",
         { viewColumn: ViewColumn.Two, preserveFocus: true } ,
-        {
-            enableScripts: true,
-            retainContextWhenHidden: false,
-        }
+        getCommonWebViewOptions()
     );
 
     const html = render(context, langClient);
@@ -68,10 +65,7 @@ function showTraces(context: ExtensionContext, langClient: ExtendedLangClient) {
                     'ballerinaNetworkLogsDetails',
                     "Ballerina Network Log Details",
                     { viewColumn: ViewColumn.Beside } ,
-                    {
-                        enableScripts: true,
-                        retainContextWhenHidden: false,
-                    }
+                    getCommonWebViewOptions()
                 );
                 const html = renderDetailView(context, langClient, trace);
                 traceDetailsPanel.webview.html = html;

--- a/tool-plugins/vscode/src/trace-logs/renderer.ts
+++ b/tool-plugins/vscode/src/trace-logs/renderer.ts
@@ -18,11 +18,11 @@
 
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { ExtensionContext } from 'vscode';
-import { getLibraryWebViewContent } from '../utils';
+import { getLibraryWebViewContent, WebViewOptions, getComposerWebViewOptions } from '../utils';
 
 export function render(context: ExtensionContext, langClient: ExtendedLangClient) 
     : string {
-    const script = `
+    const scripts = `
         function loadedScript() {
             window.addEventListener('message', event => {
                 const message = event.data; // The JSON data our extension sent
@@ -127,7 +127,12 @@ export function render(context: ExtensionContext, langClient: ExtendedLangClient
             display: table-header-group!important;
         }
     `;
-    return getLibraryWebViewContent(context, body, script, styles, bodyCss);
+    const webViewOptions: WebViewOptions = {
+        ...getComposerWebViewOptions(),
+        body, scripts, styles, bodyCss
+    };
+    
+    return getLibraryWebViewContent(webViewOptions);
 }
 
 
@@ -174,7 +179,7 @@ export function renderDetailView (context: ExtensionContext, langClient: Extende
         }
         `;
 
-    const script = `
+    const scripts = `
         function loadedScript() {
             function renderDetailedTrace(trace) {
                 try {
@@ -189,5 +194,10 @@ export function renderDetailView (context: ExtensionContext, langClient: Extende
         }
     `;
 
-    return getLibraryWebViewContent(context, body, script, styles, bodyCss);
+    const webViewOptions: WebViewOptions = {
+        ...getComposerWebViewOptions(),
+        body, scripts, styles, bodyCss
+    };
+    
+    return getLibraryWebViewContent(webViewOptions);
 }

--- a/tool-plugins/vscode/src/utils/webview-utils.ts
+++ b/tool-plugins/vscode/src/utils/webview-utils.ts
@@ -1,15 +1,27 @@
-import { Uri, ExtensionContext } from "vscode";
+import { Uri, ExtensionContext, WebviewOptions, WebviewPanelOptions } from "vscode";
 import { join } from "path";
 import { ballerinaExtInstance } from "../core";
 
 export function getWebViewResourceRoot(): string {
-    return getVSCodeResourceURI(join((ballerinaExtInstance.context as ExtensionContext).extensionPath, 
-        'resources'));
+    return join((ballerinaExtInstance.context as ExtensionContext).extensionPath, 
+    'resources');
 }
 
 export function getNodeModulesRoot(): string {
-    return getVSCodeResourceURI(join((ballerinaExtInstance.context as ExtensionContext).extensionPath, 
-        'node_modules'));
+    return join((ballerinaExtInstance.context as ExtensionContext).extensionPath, 
+    'node_modules');
+}
+
+export function getCommonWebViewOptions(): Partial<WebviewOptions & WebviewPanelOptions> {
+    return {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots:[
+            Uri.file(getComposerPath()), 
+            Uri.file(getWebViewResourceRoot()),
+            Uri.file(getNodeModulesRoot())
+        ],
+    };
 }
 
 export function getVSCodeResourceURI(filePath: string): string {
@@ -35,16 +47,16 @@ export function getLibraryWebViewContent(options: WebViewOptions) {
         bodyCss 
     } = options;
 
-    const resourceRoot = getWebViewResourceRoot();
-    const nodeModulesRoot = getNodeModulesRoot();
+    const resourceRoot = getVSCodeResourceURI(getWebViewResourceRoot());
+    const nodeModulesRoot = getVSCodeResourceURI(getNodeModulesRoot());
     const externalScripts = jsFiles 
         ? jsFiles.map(jsFile => 
-            '<script charset="UTF-8" onload="loadedScript();" src="' + jsFile +'"></script>')
-        : [];
+            '<script charset="UTF-8" onload="loadedScript();" src="' + jsFile +'"></script>').join('\n')
+        : '';
     const externalStyles = cssFiles 
         ? cssFiles.map(cssFile => 
-            '<link rel="stylesheet" type="text/css" href="' + cssFile + '" />') 
-        : [];
+            '<link rel="stylesheet" type="text/css" href="' + cssFile + '" />').join('\n') 
+        : '';
 
     return `
             <!DOCTYPE html>
@@ -89,7 +101,7 @@ export function getComposerPath(): string {
 export function getComposerJSFiles(isAPIEditor: boolean = false): string[] {
     return [
         getVSCodeResourceURI(join(getComposerPath(), isAPIEditor ? 'apiEditor.js' : 'composer.js')),
-        getVSCodeResourceURI(join(getComposerPath(), 'font', 'codepoints.js')),
+        getVSCodeResourceURI(join(getComposerPath(), 'codepoints.js')),
         process.env.COMPOSER_DEBUG === "true" ? 'http://localhost:8097' : '' // For React Dev Tools
     ];
 }
@@ -97,7 +109,7 @@ export function getComposerJSFiles(isAPIEditor: boolean = false): string[] {
 export function getComposerCSSFiles(): string[] {
     return [
         getVSCodeResourceURI(join(getComposerPath(), 'themes', 'ballerina-default.min.css')),
-        getVSCodeResourceURI(join(getComposerPath(), 'font', 'font', 'font-ballerina.css'))
+        getVSCodeResourceURI(join(getComposerPath(), 'font', 'font-ballerina.css'))
     ];
 }
 

--- a/tool-plugins/vscode/src/utils/webview-utils.ts
+++ b/tool-plugins/vscode/src/utils/webview-utils.ts
@@ -1,6 +1,6 @@
 import { Uri, ExtensionContext } from "vscode";
 import { join } from "path";
-import { ballerinaExtInstance } from "src/core";
+import { ballerinaExtInstance } from "../core";
 
 export function getWebViewResourceRoot(): string {
     return getVSCodeResourceURI(join((ballerinaExtInstance.context as ExtensionContext).extensionPath, 

--- a/tool-plugins/vscode/test/core/ballerina-extention.test.ts
+++ b/tool-plugins/vscode/test/core/ballerina-extention.test.ts
@@ -39,17 +39,17 @@ suite("Ballerina Extension Core Tests", function () {
         assert.equal(ballerinaExtInstance.isValidBallerinaHome(__dirname), false);
     });
 
-    test("Test autoDitectBallerinaHome", function () {
+    test("Test autoDetectBallerinaHome", function () {
         // Following should not throw an error all times.
-        const path = ballerinaExtInstance.autoDitectBallerinaHome();
+        const path = ballerinaExtInstance.autoDetectBallerinaHome();
         if (path) {
             assert.equal(ballerinaExtInstance.isValidBallerinaHome(path), true);
         }
     });
 
     test("Test getBallerinaVersion", function () {
-        ballerinaExtInstance.getBallerinaVersion(testBallerinaHome).then(ditected=>{
-            assert.equal(ditected, testBallerinaVersion);
+        ballerinaExtInstance.getBallerinaVersion(testBallerinaHome).then(detected=>{
+            assert.equal(detected, testBallerinaVersion);
         });
     });
 

--- a/tool-plugins/vscode/test/trace-logs/tacelogs.test.ts
+++ b/tool-plugins/vscode/test/trace-logs/tacelogs.test.ts
@@ -32,7 +32,7 @@ suite("Ballerina Extension Network logs tests", function () {
         window.createWebviewPanel = (viewType: string, title: string, showOptions: ViewColumn | { viewColumn: ViewColumn }): WebviewPanel => {
             assert(viewType, "ballerina");
             return {} as WebviewPanel;
-        }
+        };
 
         TraceLogs.activate(ballerinaExtInstance);
         commands.executeCommand("ballerina.showTraces").then(() => { });


### PR DESCRIPTION
Previously composer libs were packed in vscode extension.
With https://github.com/ballerina-platform/ballerina-lang/pull/15412,
they have been added to Ballerina distribution. This is to change VScode
extension along with that. Includes some refactoring to webview utils
as well.

Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/15429

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
