### PR TITLE
Add annotation attachment values to BIR function nodes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -353,6 +353,10 @@ public class BIRPackageSymbolEnter {
             }
         }
 
+        // Read annotation attachments
+        // Skip annotation attachments for now
+        dataInStream.skip(dataInStream.readLong());
+
         // set parameter symbols to the function symbol
         setParamSymbols(invokableSymbol, dataInStream);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -24,6 +24,9 @@ import org.ballerinalang.model.tree.OperatorKind;
 import org.wso2.ballerinalang.compiler.bir.model.BIRInstruction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotation;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationValue;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationValueEntry;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRConstant;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
@@ -64,6 +67,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
@@ -154,6 +158,7 @@ import org.wso2.ballerinalang.programfile.CompiledBinaryFile.BIRPackageFile;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -331,6 +336,9 @@ public class BIRGen extends BLangNodeVisitor {
             i++;
         }
 
+        // Populate annotation attachments in BIRFunction node
+        populateBIRAnnotAttachments(astFunc.annAttachments, birFunc.annotAttachments, this.env);
+
         birFunc.argsCount = astFunc.requiredParams.size() + astFunc.defaultableParams.size()
                 + (astFunc.restParam != null ? 1 : 0) + astFunc.paramClosureMap.size();
         if (astFunc.flagSet.contains(Flag.ATTACHED) && typeDefs.containsKey(astFunc.receiver.type.tsymbol)) {
@@ -385,6 +393,40 @@ public class BIRGen extends BLangNodeVisitor {
         // Rearrange error entries.
         birFunc.errorTable.sort(Comparator.comparingInt(o -> Integer.parseInt(o.trapBB.id.value.replace("bb", ""))));
         this.env.clear();
+    }
+
+    @Override
+    public void visit(BLangAnnotationAttachment astAnnotAttach) {
+        // ------------------------------------------------------
+        // In the current implementation of the compiler, there two possible values for `astAnnotAttach.expr`
+        //  1) null
+        //  2) BLangRecordLiteral
+        // In this implementation, we support only the BLangRecordLiteral expressions
+        //   which have only key:BLangLiteral key/value pairs
+        // ------------------------------------------------------
+        if (astAnnotAttach.expr == null) {
+            return;
+        }
+
+        Map<String, BIRAnnotationValueEntry> annotValueEntryMap = new HashMap<>();
+        BLangRecordLiteral recordLiteral = (BLangRecordLiteral) astAnnotAttach.expr;
+        for (BLangRecordKeyValue keyValuePair : recordLiteral.keyValuePairs) {
+            if (NodeKind.LITERAL != keyValuePair.valueExpr.getKind()) {
+                return;
+            }
+            BLangLiteral valueLiteral = (BLangLiteral) keyValuePair.valueExpr;
+            BIRAnnotationValueEntry entryValue = new BIRAnnotationValueEntry(valueLiteral.type, valueLiteral.value);
+
+            // The keyexpr is also  a string literal
+            BLangLiteral keyLiteral = (BLangLiteral) keyValuePair.key.expr;
+            String entryKey = (String) keyLiteral.value;
+            annotValueEntryMap.put(entryKey, entryValue);
+        }
+
+        Name annotTagRef = this.names.fromIdNode(astAnnotAttach.annotationName);
+        BIRAnnotationAttachment annotAttachment = new BIRAnnotationAttachment(astAnnotAttach.pos, annotTagRef);
+        annotAttachment.annotValues.add(new BIRAnnotationValue(annotValueEntryMap));
+        this.env.enclAnnotAttachments.add(annotAttachment);
     }
 
     private TaintTable populateTaintTable(Map<Integer, TaintRecord> taintRecords) {
@@ -2091,5 +2133,13 @@ public class BIRGen extends BLangNodeVisitor {
 
         emit(new BIRNonTerminator.FPLoad(fpVarRef.pos, funcSymbol.pkgID, funcName, lhsOp, params, new ArrayList<>()));
         this.env.targetOperand = lhsOp;
+    }
+
+    private void populateBIRAnnotAttachments(List<BLangAnnotationAttachment> astAnnotAttachments,
+                                             List<BIRAnnotationAttachment> birAnnotAttachments,
+                                             BIRGenEnv currentEnv) {
+        currentEnv.enclAnnotAttachments = birAnnotAttachments;
+        astAnnotAttachments.forEach(annotAttach -> annotAttach.accept(this));
+        currentEnv.enclAnnotAttachments = null;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGenEnv.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGenEnv.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.bir;
 
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRGlobalVariableDcl;
@@ -58,6 +59,8 @@ class BIRGenEnv {
     BIROperand targetOperand;
     BIRBasicBlock enclLoopBB;
     BIRBasicBlock enclLoopEndBB;
+
+    List<BIRAnnotationAttachment> enclAnnotAttachments;
 
     // This is the basic block that contains the return instruction for the current function.
     // A function can have only one basic block that has a return instruction.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -287,6 +287,8 @@ public abstract class BIRNode {
          */
         public TaintTable taintTable;
 
+        public List<BIRAnnotationAttachment> annotAttachments;
+
         public BIRFunction(DiagnosticPos pos, Name name, int flags, BInvokableType type, BType receiverType,
                            Name workerName, int sendInsCount, TaintTable taintTable) {
             super(pos);
@@ -303,6 +305,7 @@ public abstract class BIRNode {
             this.workerName = workerName;
             this.workerChannels = new ChannelDetails[sendInsCount];
             this.taintTable = taintTable;
+            this.annotAttachments = new ArrayList<>();
         }
 
         @Override
@@ -488,7 +491,7 @@ public abstract class BIRNode {
         public ConstValue constValue;
 
         public BIRConstant(DiagnosticPos pos, Name name, int flags,
-                             BType type, ConstValue constValue) {
+                           BType type, ConstValue constValue) {
             super(pos);
             this.name = name;
             this.flags = flags;
@@ -501,6 +504,59 @@ public abstract class BIRNode {
             visitor.visit(this);
         }
 
+    }
+
+    /**
+     * Represents an annotation attachment in BIR node tree.
+     *
+     * @since 1.0.0
+     */
+    public static class BIRAnnotationAttachment extends BIRNode {
+
+        public Name annotTagRef;
+
+        // The length == 0 means that the value of this attachment is 'true'
+        // The length > 1 means that there are one or more attachments of this annotation
+        public List<BIRAnnotationValue> annotValues;
+
+        public BIRAnnotationAttachment(DiagnosticPos pos, Name annotTagRef) {
+            super(pos);
+            this.annotTagRef = annotTagRef;
+            this.annotValues = new ArrayList<>();
+        }
+
+        @Override
+        public void accept(BIRVisitor visitor) {
+            visitor.visit(this);
+        }
+    }
+
+    /**
+     * Represents the record value of an annotation attachment.
+     *
+     * @since 1.0.0
+     */
+    public static class BIRAnnotationValue {
+        public Map<String, BIRAnnotationValueEntry> annotValEntryMap;
+
+        public BIRAnnotationValue(Map<String, BIRAnnotationValueEntry> annotValEntryMap) {
+            this.annotValEntryMap = annotValEntryMap;
+        }
+    }
+
+    /**
+     * Represent one key/value pair entry in an annotation attachment value.
+     *
+     * @since 1.0.0
+     */
+    public static class BIRAnnotationValueEntry {
+        public BType type;
+        public Object value;
+
+        public BIRAnnotationValueEntry(BType type, Object value) {
+            this.type = type;
+            this.value = value;
+        }
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRVisitor.java
@@ -18,6 +18,7 @@
 package org.wso2.ballerinalang.compiler.bir.model;
 
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotation;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRConstant;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
@@ -88,6 +89,10 @@ public abstract class BIRVisitor {
     }
 
     public void visit(BIRConstant birConstant) {
+        throw new AssertionError();
+    }
+
+    public void visit(BIRAnnotationAttachment birAnnotAttach) {
         throw new AssertionError();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -408,7 +408,6 @@ public class BIRBinaryWriter {
         for (Map.Entry<String, BIRAnnotationValueEntry> annotValueEntry : entryMap.entrySet()) {
             annotBuf.writeInt(addStringCPEntry(annotValueEntry.getKey()));
             BIRAnnotationValueEntry valueEntry = annotValueEntry.getValue();
-//            writeType(annotBuf, valueEntry.type);
             writeConstValue(annotBuf, valueEntry.type, valueEntry.value);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
@@ -521,6 +521,7 @@ public class BIRInstructionWriter extends BIRVisitor {
     }
 
     // Positions
+    // TODO Refactor duplicate methods
     void writePosition(DiagnosticPos pos) {
         int sLine = Integer.MIN_VALUE;
         int eLine = Integer.MIN_VALUE;
@@ -543,17 +544,39 @@ public class BIRInstructionWriter extends BIRVisitor {
         buf.writeInt(addStringCPEntry(sourceFileName));
     }
 
-    // private methods
-
-    private void addCpAndWriteString(String string) {
-        buf.writeInt(addStringCPEntry(string));
+    void writePosition(ByteBuf buf, DiagnosticPos pos) {
+        int sLine = Integer.MIN_VALUE;
+        int eLine = Integer.MIN_VALUE;
+        int sCol = Integer.MIN_VALUE;
+        int eCol = Integer.MIN_VALUE;
+        String sourceFileName = "";
+        if (pos != null) {
+            sLine = pos.sLine;
+            eLine = pos.eLine;
+            sCol = pos.sCol;
+            eCol = pos.eCol;
+            if (pos.src != null) {
+                sourceFileName = pos.src.cUnitName;
+            }
+        }
+        buf.writeInt(sLine);
+        buf.writeInt(eLine);
+        buf.writeInt(sCol);
+        buf.writeInt(eCol);
+        buf.writeInt(addStringCPEntry(sourceFileName));
     }
 
-    private int addPkgCPEntry(PackageID packageID) {
+    int addPkgCPEntry(PackageID packageID) {
         int orgCPIndex = addStringCPEntry(packageID.orgName.value);
         int nameCPIndex = addStringCPEntry(packageID.name.value);
         int versionCPIndex = addStringCPEntry(packageID.version.value);
         return cp.addCPEntry(new CPEntry.PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
+    }
+
+    // private methods
+
+    private void addCpAndWriteString(String string) {
+        buf.writeInt(addStringCPEntry(string));
     }
 
     private int addStringCPEntry(String value) {

--- a/stdlib/bir/src/main/ballerina/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_model.bal
@@ -58,6 +58,7 @@ public type Function record {|
     ChannelDetail[] workerChannels;
     BType? receiverType;
     boolean restParamExist;
+    AnnotationAttachment?[] annotAttachments = [];
 |};
 
 public type BasicBlock record {|
@@ -79,6 +80,22 @@ public type ChannelDetail record {|
 
 public type Name record {|
     string value = "";
+|};
+
+public type AnnotationAttachment record {|
+    ModuleID moduleId;
+    DiagnosticPos pos;
+    Name annotTagRef;
+    AnnotationValue?[] annotValues = [];
+|};
+
+public type AnnotationValue record {|
+    map<AnnotationValueEntry> valueEntryMap = {};
+|};
+
+public type AnnotationValueEntry record {|
+    BType literalType;
+    anydata value;
 |};
 
 public const BINARY_ADD = "ADD";

--- a/stdlib/bir/src/main/ballerina/bir/bir_pkg_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_pkg_parser.bal
@@ -96,6 +96,10 @@ public type PackageParser object {
         var name = self.reader.readStringCpRef();
         int flags = self.reader.readInt32();
         var sig = self.parseInvokableType();
+
+        // Read annotation Attachments
+        AnnotationAttachment?[] annotAttachments = self.parseAnnotAttachments();
+
         // Read and ignore parameter details, not used in jvm gen
         self.readAndIgnoreParamDetails();
 
@@ -172,7 +176,8 @@ public type PackageParser object {
             typeValue: sig,
             workerChannels:workerChannels,
             receiverType : receiverType,
-            restParamExist : restParamExist
+            restParamExist : restParamExist,
+            annotAttachments: annotAttachments
         };
     }
 
@@ -312,7 +317,78 @@ public type PackageParser object {
         };
     }
 
+    function parseAnnotAttachments() returns AnnotationAttachment?[] {
+        AnnotationAttachment?[] annotAttachments = [];
+        int annotNoBytes_ignored = self.reader.readInt64();
+        int noOfAnnotAttachments = self.reader.readInt32();
+        if (noOfAnnotAttachments == 0) {
+            return annotAttachments;
+        }
+
+        foreach var i in 0..<noOfAnnotAttachments {
+            annotAttachments[annotAttachments.length()] = self.parseAnnotAttachment();
+        }
+
+        return annotAttachments;
+    }
+
+    function parseAnnotAttachment() returns AnnotationAttachment {
+        // Read ModuleID
+        ModuleID modId = self.reader.readModuleIDCpRef();
+        // Read DiagnosticPos
+        DiagnosticPos pos = parseDiagnosticPos(self.reader);
+        // Read AnnotTagRef
+        string annotTagRef = self.reader.readStringCpRef();
+        // Read AnnotationValue values
+        AnnotationValue?[] annotValues = [];
+        int noOfAnnotValue = self.reader.readInt32();
+        foreach var i in 0..<noOfAnnotValue {
+            annotValues[annotValues.length()] = self.parseAnnotAttachValue();
+        }
+
+        return {
+            moduleId: modId,
+            pos: pos,
+            annotTagRef: {value:annotTagRef},
+            annotValues:annotValues
+        };
+    }
+
+    function parseAnnotAttachValue() returns AnnotationValue {
+        AnnotationValue annotValue = {};
+        var noOfAnnotValueEntries = self.reader.readInt32();
+        foreach var i in 0..<noOfAnnotValueEntries {
+            var key = self.reader.readStringCpRef();
+            var bType = self.reader.readTypeCpRef();
+            var value = parseLiteralValue(self.reader, bType);
+            AnnotationValueEntry valueEntry = {literalType: bType, value: value};
+            annotValue.valueEntryMap[key] = valueEntry;
+        }
+        return annotValue;
+    }
+
 };
+
+function parseLiteralValue(BirChannelReader reader, BType bType) returns anydata {
+    anydata value;
+    if (bType is BTypeByte) {
+        value = reader.readIntCpRef();
+    } else if (bType is BTypeInt) {
+        value = reader.readByteCpRef();
+    } else if (bType is BTypeString) {
+        value = reader.readStringCpRef();
+    } else if (bType is BTypeDecimal) {
+        value = reader.readStringCpRef();
+    } else if (bType is BTypeBoolean) {
+        value = reader.readBoolean();
+    } else if (bType is BTypeFloat) {
+        value = reader.readFloatCpRef();
+    } else {
+        error err = error("unsupported literal value type in annotation attachment value", {"type":bType});
+        panic err;
+    }
+    return value;
+}
 
 public function parseVarKind(BirChannelReader reader) returns VarKind {
     int b = reader.readInt8();


### PR DESCRIPTION
## Purpose
Java interoperability design described in #15783 requires annotation attachments in function nodes in the BIR model. Java bytecode generation phase uses these annotations to link with existing Java classes that the developer wants to interoperate with.  Annotation attachments are not available anywhere in the current BIR model implementation. Therefore this PR improve the current codebase by adding annotation attachment values to BIR function nodes. Ideally, we should add annotation attachment all nodes if the language spec permits. But this PR improves BIR just enough to implement Java interop.

## Check List 
- [x ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
