### PR TITLE
Change the ballerina command to jballerina in vscode extension

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -240,9 +240,9 @@ export class BallerinaExtension {
                 message: "Trying to get ballerina version without setting ballerina home."
             });
         }
-        let command = `${path.join(ballerinaHome, 'bin', 'ballerina')} version`;
+        let command = `${path.join(ballerinaHome, 'bin', 'jballerina')} version`;
         if (process.platform === 'win32') {
-            command = `"${path.join(ballerinaHome, 'bin', 'ballerina.bat')}" version`;
+            command = `"${path.join(ballerinaHome, 'bin', 'jballerina.bat')}" version`;
         }
         return new Promise((resolve, reject) => {
             exec(command, (err, stdout, stderr) => {
@@ -312,7 +312,7 @@ export class BallerinaExtension {
 
 
     isValidBallerinaHome(homePath: string = this.ballerinaHome): boolean {
-        const ballerinaCmd = process.platform === 'win32' ? 'ballerina.bat' : 'ballerina';
+        const ballerinaCmd = process.platform === 'win32' ? 'jballerina.bat' : 'jballerina';
         if (fs.existsSync(path.join(homePath, 'bin', ballerinaCmd))) {
             return true;
         }
@@ -347,12 +347,12 @@ export class BallerinaExtension {
                     return process.env.BALLERINA_HOME;
                 }
                 try {
-                    ballerinaPath = execSync('where ballerina').toString().trim();
+                    ballerinaPath = execSync('where jballerina').toString().trim();
                 } catch (error) {
                     return ballerinaPath;
                 }
                 if (ballerinaPath) {
-                    ballerinaPath = ballerinaPath.replace(/bin\\ballerina.bat$/, '');
+                    ballerinaPath = ballerinaPath.replace(/bin\\jballerina.bat$/, '');
                 }
                 break;
             case 'darwin': // Mac OS
@@ -361,7 +361,7 @@ export class BallerinaExtension {
                     ballerinaPath = fs.realpathSync(output.toString().trim());
                     // remove ballerina bin from ballerinaPath
                     if (ballerinaPath) {
-                        ballerinaPath = ballerinaPath.replace(/bin\/ballerina$/, '');
+                        ballerinaPath = ballerinaPath.replace(/bin\/jballerina$/, '');
                         // For homebrew installations ballerina executables are in libexcec
                         const homebrewBallerinaPath = path.join(ballerinaPath, 'libexec');
                         if (fs.existsSync(homebrewBallerinaPath)) {
@@ -375,11 +375,11 @@ export class BallerinaExtension {
             case 'linux': // Linux
                 // lets see where the ballerina command is.
                 try {
-                    const output = execSync('which ballerina');
+                    const output = execSync('which jballerina');
                     ballerinaPath = fs.realpathSync(output.toString().trim());
                     // remove ballerina bin from path
                     if (ballerinaPath) {
-                        ballerinaPath = ballerinaPath.replace(/bin\/ballerina$/, '');
+                        ballerinaPath = ballerinaPath.replace(/bin\/jballerina$/, '');
                     }
                 } catch {
                     return ballerinaPath;


### PR DESCRIPTION
## Purpose
> Change the ballerina command to jballerina in vscode extension to work with the jballerina tools

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
