### PR TITLE
Fix tuple syntax changes

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BTupleType.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BTupleType.java
@@ -65,7 +65,7 @@ public class BTupleType extends BType {
     @Override
     public String toString() {
         List<String> list = tupleTypes.stream().map(BType::toString).collect(Collectors.toList());
-        return "(" + String.join(",", list) + ")";
+        return "[" + String.join(",", list) + "]";
     }
 
     @Override

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BValueArray.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BValueArray.java
@@ -423,11 +423,7 @@ public class BValueArray extends BNewArray implements Serializable {
         }
 
         StringJoiner sj;
-        if (arrayType != null && (arrayType.getTag() == TypeTags.TUPLE_TAG)) {
-            sj = new StringJoiner(", ", "(", ")");
-        } else {
-            sj = new StringJoiner(", ", "[", "]");
-        }
+        sj = new StringJoiner(", ", "[", "]");
 
         for (int i = 0; i < size; i++) {
             if (refValues[i] != null) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/cli/ArgumentParser.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/cli/ArgumentParser.java
@@ -257,8 +257,8 @@ public class ArgumentParser {
                                       + " type: " + type + ": " + e.getLocalizedMessage().split(JSON_PARSER_ERROR)[0]);
                 }
             case TypeTags.TUPLE_TAG:
-                if (!value.startsWith("(") || !value.endsWith(")")) {
-                    throw new BLangUsageException("invalid argument '" + value + "', expected tuple notation (\"()\") "
+                if (!value.startsWith("[") || !value.endsWith("]")) {
+                    throw new BLangUsageException("invalid argument '" + value + "', expected tuple notation [\"[]\"] "
                                                           + "with tuple arg");
                 }
                 return parseTupleArg((BTupleType) type, value.substring(1, value.length() - 1));
@@ -387,7 +387,7 @@ public class ArgumentParser {
         String[] tupleElements = tupleArg.split(COMMA);
 
         if (tupleElements.length != type.getTupleTypes().size()) {
-            throw new BLangUsageException("invalid argument '(" + tupleArg + ")', element count mismatch for tuple "
+            throw new BLangUsageException("invalid argument '[" + tupleArg + "]', element count mismatch for tuple "
                                                   + "type: '" + type + "'");
         }
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BTupleType.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BTupleType.java
@@ -63,7 +63,7 @@ public class BTupleType extends BType {
     @Override
     public String toString() {
         List<String> list = tupleTypes.stream().map(BType::toString).collect(Collectors.toList());
-        return "(" + String.join(",", list) + ")";
+        return "[" + String.join(",", list) + "]";
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/TupleVariableNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/TupleVariableNode.java
@@ -23,8 +23,8 @@ import java.util.List;
  *
  * Represents a tuple variable node.
  * Example:
- *      (string, int, float) (s, i, f) = ("Foo", 12, 4.5);
- *      ((string, boolean), int) ((s, b), i) = expr;
+ *      [string, int, float] [s, i, f] = ["Foo", 12, 4.5];
+ *      [[string, boolean], int] [[s, b], i] = expr;
  *
  * @since 0.985.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/TupleVariableReferenceNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/TupleVariableReferenceNode.java
@@ -29,7 +29,7 @@ import java.util.List;
  *      int i;
  *      boolean b;
  *
- *      (s, i, b) = ("Foo", 12, true);
+ *      [s, i, b] = ["Foo", 12, true];
  *
  * @since 0.985.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TupleDestructureNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TupleDestructureNode.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.tree.expressions.VariableReferenceNode;
 import java.util.List;
 
 /**
- * var (a,b) = ("hello", 1).
+ * var [a,b] = ["hello", 1].
  *
  * @since 0.966.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/types/TupleTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/types/TupleTypeNode.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * {@code TupleTypeNode} represents a tuple type node in Ballerina
  * <p>
- * e.g. (int, float , string)
+ * e.g. [int, float, string]
  *
  * @since 0.966.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTupleVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTupleVariable.java
@@ -30,8 +30,8 @@ import java.util.stream.Collectors;
 /**
  * Represents a tuple variable node.
  * Example:
- *      (string, int, float) (s, i, f) = ("Foo", 12, 4.5);
- *      ((string, boolean), int) ((s, b), i) = expr;
+ *      [string, int, float] [s, i, f] = ["Foo", 12, 4.5];
+ *      [[string, boolean], int] [[s, b], i] = expr;
  *
  * @since 0.985.0
  */
@@ -67,7 +67,7 @@ public class BLangTupleVariable extends BLangVariable implements TupleVariableNo
 
     @Override
     public String toString() {
-        return "(" + memberVariables.stream().map(BLangVariable::toString).collect(Collectors.joining(",")) + ") " +
+        return "[" + memberVariables.stream().map(BLangVariable::toString).collect(Collectors.joining(",")) + "] " +
                 (expr != null ? " = " + String.valueOf(expr) : "");
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTupleVariableDef.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTupleVariableDef.java
@@ -24,7 +24,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 
 /**
- * (int, string) (i, s) = (5, "foo");.
+ * [int, string] [i, s] = [5, "foo"];.
  *
  * @since 0.985.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangTupleTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangTupleTypeNode.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 /**
  * {@code BLangUnionTypeNode} represents a tuple type node in Ballerina
  * <p>
- * e.g. (int, float , string)
+ * e.g. [int, float , string]
  *
  * @since 0.966.0
  */
@@ -53,6 +53,6 @@ public class BLangTupleTypeNode extends BLangType implements TupleTypeNode {
 
     @Override
     public String toString() {
-        return "(" + memberTypeNodes.stream().map(BLangType::toString).collect(Collectors.joining(",")) + ")";
+        return "[" + memberTypeNodes.stream().map(BLangType::toString).collect(Collectors.joining(",")) + "]";
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/CloneOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/CloneOperationTest.java
@@ -524,7 +524,7 @@ public class CloneOperationTest {
         Assert.assertNotSame(results[0], results[1]);
         Assert.assertSame(results[1].getType().getTag(), TypeTags.ERROR_TAG);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[1]).getDetails()).get("message").stringValue(),
-                "'clone()' not allowed on '(Employee,any)'");
+                "'clone()' not allowed on '[Employee,any]'");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
@@ -94,8 +94,8 @@ public class NativeConversionNegativeTest {
     public void testTupleConversionFail() {
         BValue[] returns = BRunUtil.invoke(negativeResult, "testTupleConversionFail");
         String errorMsg = ((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "incompatible convert operation: '(T1,T1)' value cannot be converted as '(T1," 
-                + "T2)'");
+        Assert.assertEquals(errorMsg, "incompatible convert operation: '[T1,T1]' value cannot be converted as '[T1,"
+                + "T2]'");
     }
 
     @Test(description = "Test converting an unsupported array to json")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserNegativeTest.java
@@ -201,7 +201,7 @@ public class ArgumentParserNegativeTest {
 
     @Test
     public void testInvalidStringElementTupleArg() {
-        String argument = "(101, {\"name\":\"Maryam\"}, finance)";
+        String argument = "[101, {\"name\":\"Maryam\"}, finance]";
         try {
             LauncherUtils.runProgram(Paths.get(MAIN_FUNCTION_TEST_SRC_DIR), Paths.get("test_main_with_tuple_param.bal"),
                                      runtimeParams, configFilePath, new String[]{argument}, offline, observe);
@@ -222,7 +222,7 @@ public class ArgumentParserNegativeTest {
                                      runtimeParams, configFilePath, new String[]{arg}, offline, observe);
         } catch (BLauncherException e) {
             Assert.assertTrue(e.getMessages().contains("ballerina: invalid argument '" + arg + "', expected tuple "
-                                                               + "notation (\"()\") with tuple arg"),
+                                                               + "notation [\"[]\"] with tuple arg"),
                               "invalid error message, error message for invalid tuple arg not found");
             return;
         }
@@ -236,7 +236,7 @@ public class ArgumentParserNegativeTest {
                                      runtimeParams, configFilePath, new String[]{arg}, offline, observe);
         } catch (BLauncherException e) {
             Assert.assertTrue(e.getMessages().contains("ballerina: invalid argument '" + arg + "', element count "
-                                                               + "mismatch for tuple type: '(int,Employee,string)'"),
+                                                               + "mismatch for tuple type: '[int,Employee,string]'"),
                               "invalid error message, error message for tuple element count mismatch not found");
             return;
         }
@@ -245,7 +245,7 @@ public class ArgumentParserNegativeTest {
 
     @Test
     public void testInvalidTupleArgWithIncorrectElementArg() {
-        String arg = "(\"101\", {\"name\":\"Maryam\"}, \"finance\")";
+        String arg = "[\"101\", {\"name\":\"Maryam\"}, \"finance\"]";
         try {
             LauncherUtils.runProgram(Paths.get(MAIN_FUNCTION_TEST_SRC_DIR), Paths.get("test_main_with_tuple_param.bal"),
                                      runtimeParams, configFilePath, new String[]{arg}, offline, observe);
@@ -466,8 +466,8 @@ public class ArgumentParserNegativeTest {
     @DataProvider(name = "tupleArgsWithoutBrackets")
     public Object[][] tupleArgsWithoutBrackets() {
         return new Object[][]{
-                {"(1, {\"name\":\"Maryam\"}, \"ABC\""},
-                {"1, {\"name\":\"Maryam\"}, \"ABC\")"},
+                {"[1, {\"name\":\"Maryam\"}, \"ABC\""},
+                {"1, {\"name\":\"Maryam\"}, \"ABC\"]"},
                 {"1, {\"name\":\"Maryam\"}, \"ABC\""}
         };
     }
@@ -475,8 +475,8 @@ public class ArgumentParserNegativeTest {
     @DataProvider(name = "tupleArgsWithIncorrectElementCount")
     public Object[][] tupleArgsWithIncorrectElementCount() {
         return new Object[][]{
-                {"(1, {\"name\":\"Maryam\"})"},
-                {"(1, {\"name\":\"Maryam\"}, \"ABC\", 1500)"}
+                {"[1, {\"name\":\"Maryam\"}]"},
+                {"[1, {\"name\":\"Maryam\"}, \"ABC\", 1500]"}
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
@@ -118,7 +118,7 @@ public class ArgumentParserPositiveTest {
         programFile = LauncherUtils.compile(Paths.get(MAIN_FUNCTION_TEST_SRC_DIR),
                                             Paths.get("test_main_with_tuple_param.bal"), false, true);
         resetTempOut();
-        runMain(programFile, new String[]{"(101, {\"name\":\"Maryam\"}, \"finance\")"});
+        runMain(programFile, new String[]{"[101, {\"name\":\"Maryam\"}, \"finance\"]"});
         Assert.assertEquals(tempOutStream.toString(), "Id: 101, Name: Maryam, Dept: finance",
                             "string arg parsed as invalid tuple");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
@@ -441,7 +441,7 @@ public class OpenRecordTest {
         Assert.assertTrue(miscInfo.getRefValue(2) instanceof BMap);
 
         Assert.assertEquals(person.stringValue(),
-                "{name:\"Foo\", age:25, misc:(5.9, \"Bar\", {kind:\"Cat\", name:\"Miaw\"})}");
+                "{name:\"Foo\", age:25, misc:[5.9, \"Bar\", {kind:\"Cat\", name:\"Miaw\"}]}");
     }
 
     @Test(description = "Test non-existent tuple rest field RHS access", expectedExceptions =

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -212,7 +212,7 @@ public class ArrayFillTest {
         }
 
         assertEquals(recordArr.getBValue(index).stringValue(),
-                     "{s:\"foo\", i:10, f:12.34, b:true, d:23.45, n:(), t:(\"Pubudu\", 27), m:{\"1\":1}, x: , bt:5," +
+                     "{s:\"foo\", i:10, f:12.34, b:true, d:23.45, n:(), t:[\"Pubudu\", 27], m:{\"1\":1}, x: , bt:5," +
                              " j:{\"name\":\"Pubudu\"}, ad:10}");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/IfElseStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/IfElseStmtTest.java
@@ -253,7 +253,7 @@ public class IfElseStmtTest {
         BAssertUtil.validateError(negativeResult, 3, "incompatible types: expected 'boolean', found 'string'", 28, 9);
         BAssertUtil.validateError(negativeResult, 4, "incompatible types: expected 'boolean', found 'string'", 35, 8);
         BAssertUtil.validateError(negativeResult, 5, "incompatible types: expected 'boolean', found 'int'", 37, 15);
-        BAssertUtil.validateError(negativeResult, 6, "incompatible types: expected 'boolean', found 'int|string[]'",
+        BAssertUtil.validateError(negativeResult, 6, "incompatible types: expected 'boolean', found 'int|string?[]'",
                 41, 8);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
@@ -124,6 +124,6 @@ public class WhileStmtTest {
         BAssertUtil.validateError(negativeCompileResult, 2, "incompatible types: expected 'boolean', found 'int'", 10,
                 8);
         BAssertUtil.validateError(negativeCompileResult, 3, "incompatible types: expected 'boolean', found " +
-                        "'int|string[]'", 14, 8);
+                        "'int|string?[]'", 14, 8);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
@@ -91,7 +91,7 @@ public class TypeDefinitionsTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testComplexTuple");
         Assert.assertEquals(returns[0].stringValue(), "[1, 2]");
         Assert.assertEquals(returns[1].stringValue(), "[3, 4]");
-        Assert.assertEquals(returns[2].stringValue(), "(2, \"Two\")");
+        Assert.assertEquals(returns[2].stringValue(), "[2, \"Two\"]");
         Assert.assertEquals(returns[3].stringValue(), "{\"k\":\"v\"}");
         Assert.assertEquals(returns[4].stringValue(), "{\"k\":1}");
         Assert.assertEquals(returns[5].stringValue(), "Ballerina");
@@ -114,7 +114,7 @@ public class TypeDefinitionsTest {
     public void testUnionInTuple() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testUnionInTuple");
         Assert.assertEquals(returns[0].stringValue(), "[4, 5, 6]");
-        Assert.assertEquals(returns[1].stringValue(), "(10, 20)");
+        Assert.assertEquals(returns[1].stringValue(), "[10, 20]");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTernaryConvTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTernaryConvTest.java
@@ -112,17 +112,17 @@ public class AnydataTernaryConvTest {
     public void testAnydataToTuple() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testAnydataToTuple");
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(returns[0].getType().toString(), "(int,float,boolean,string,byte)");
-        assertEquals(returns[0].stringValue(), "(123, 23.45, true, \"hello world!\", 255)");
+        assertEquals(returns[0].getType().toString(), "[int,float,boolean,string,byte]");
+        assertEquals(returns[0].stringValue(), "[123, 23.45, true, \"hello world!\", 255]");
     }
 
     @Test(description = "Test anydata to tuple conversion")
     public void testAnydataToTuple2() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testAnydataToTuple2");
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(returns[0].getType().toString(), "(json,xml)");
-        assertEquals(returns[0].stringValue(), "({\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>)");
+        assertEquals(returns[0].getType().toString(), "[json,xml]");
+        assertEquals(returns[0].stringValue(), "[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>]");
     }
 
     @Test(description = "Test anydata to tuple conversion")
@@ -130,10 +130,10 @@ public class AnydataTernaryConvTest {
         BValue[] returns = BRunUtil.invokeFunction(result, "testAnydataToTuple3");
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
         assertEquals(returns[0].getType().toString(),
-                     "((int|float|string|boolean|byte|table<any>|json|xml|ClosedFoo|Foo|map<anydata>|anydata[][]" +
-                             ",string),int,float)");
-        assertEquals(returns[0].stringValue(), "(([{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>], \"hello world!\"), 123, 23.45)");
+                     "[[int|float|string|boolean|byte|table<any>|json|xml|ClosedFoo|Foo|map<anydata>|anydata[][]" +
+                             ",string],int,float]");
+        assertEquals(returns[0].stringValue(), "[[[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>], \"hello world!\"], 123, 23.45]");
     }
 
     @Test(description = "Test anydata to nil conversion")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -182,22 +182,22 @@ public class AnydataTest {
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
         assertEquals(returns[1].getType().getTag(), TypeTags.TUPLE_TAG);
         assertEquals(returns[2].getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(returns[0].stringValue(), "(123, 23.45, true, \"hello world!\", 255)");
-        assertEquals(returns[1].stringValue(), "({\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>)");
-        assertEquals(returns[2].stringValue(), "([{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>], \"hello world!\")");
+        assertEquals(returns[0].stringValue(), "[123, 23.45, true, \"hello world!\", 255]");
+        assertEquals(returns[1].stringValue(), "[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>]");
+        assertEquals(returns[2].stringValue(), "[[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>], \"hello world!\"]");
 
         // Verifying nested tuple
         BValueArray tuple = (BValueArray) returns[3];
         assertEquals(tuple.getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(tuple.stringValue(), "(([{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The Lost " +
-                "World</book>], \"hello world!\"), 123, 23.45)");
+        assertEquals(tuple.stringValue(), "[[[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The Lost " +
+                "World</book>], \"hello world!\"], 123, 23.45]");
 
         BValueArray nestedTuple = (BValueArray) tuple.getRefValue(0);
         assertEquals(nestedTuple.getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(nestedTuple.stringValue(), "([{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>], \"hello world!\")");
+        assertEquals(nestedTuple.stringValue(), "[[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>], \"hello world!\"]");
     }
 
     @Test(description = "Test nil assignment")
@@ -311,17 +311,17 @@ public class AnydataTest {
     public void testAnydataToTuple() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testAnydataToTuple");
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(returns[0].getType().toString(), "(int,float,boolean,string,byte)");
-        assertEquals(returns[0].stringValue(), "(123, 23.45, true, \"hello world!\", 255)");
+        assertEquals(returns[0].getType().toString(), "[int,float,boolean,string,byte]");
+        assertEquals(returns[0].stringValue(), "[123, 23.45, true, \"hello world!\", 255]");
     }
 
     @Test(description = "Test anydata to tuple conversion")
     public void testAnydataToTuple2() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testAnydataToTuple2");
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
-        assertEquals(returns[0].getType().toString(), "(json,xml)");
-        assertEquals(returns[0].stringValue(), "({\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>)");
+        assertEquals(returns[0].getType().toString(), "[json,xml]");
+        assertEquals(returns[0].stringValue(), "[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>]");
     }
 
     @Test(description = "Test anydata to tuple conversion")
@@ -329,10 +329,10 @@ public class AnydataTest {
         BValue[] returns = BRunUtil.invokeFunction(result, "testAnydataToTuple3");
         assertEquals(returns[0].getType().getTag(), TypeTags.TUPLE_TAG);
         assertEquals(returns[0].getType().toString(),
-                     "((int|float|string|boolean|byte|table<any>|json|xml|ClosedFoo|Foo|map<anydata>|anydata" +
-                             "[][],string),int,float)");
-        assertEquals(returns[0].stringValue(), "(([{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
-                "Lost World</book>], \"hello world!\"), 123, 23.45)");
+                     "[[int|float|string|boolean|byte|table<any>|json|xml|ClosedFoo|Foo|map<anydata>|anydata" +
+                             "[][],string],int,float]");
+        assertEquals(returns[0].stringValue(), "[[[{\"name\":\"apple\", \"color\":\"red\", \"price\":40}, <book>The " +
+                "Lost World</book>], \"hello world!\"], 123, 23.45]");
     }
 
     @Test(description = "Test anydata to nil conversion")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
@@ -51,10 +51,9 @@ public class BasicTupleTest {
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), " test1 expr \n" +
                 " test2 \n" +
-                " test3 foo test3 \n" +
+                " test3 3 \n" +
                 " test4 4 \n" +
-                " test5 5 \n" +
-                " test6 foo test6 \n ");
+                " test5 foo test5 \n ");
     }
 
     @Test(description = "Test Function invocation using tuples")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
@@ -91,14 +91,14 @@ public class TypedescTests {
     public void testTupleUnionTypes() {
         BValue[] returns = BRunUtil.invoke(result, "testTupleUnionTypes");
         Assert.assertEquals(returns.length, 2);
-        Assert.assertEquals(returns[0].stringValue(), "(string,Person)");
+        Assert.assertEquals(returns[0].stringValue(), "[string,Person]");
         Assert.assertEquals(returns[1].stringValue(), "int|string");
     }
 
     @Test(description = "Test tuples with expressions")
     public void testTuplesWithExpressions() {
         BValue[] returns = BRunUtil.invoke(result, "testTuplesWithExpressions");
-        Assert.assertEquals(returns[0].stringValue(), "(string,int,string[],string,int)");
+        Assert.assertEquals(returns[0].stringValue(), "[string,int,string[],string,int]");
     }
 
     @Test(description = "Test Record types")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
@@ -175,14 +175,6 @@ public class VarDeclaredAssignmentStmtTest {
     }
 
     @Test
-    public void testVarDeclarationWithArrayInit() {
-        CompileResult res = BCompileUtil.compile("test-src/types/var/var-declaration-with-array-negative.bal");
-        Assert.assertEquals(res.getErrorCount(), 1);
-        BAssertUtil.validateError(res, 0, "array element type 'float|int' does not have an " +
-                "implicit initial value, use 'float|int?'", 2, 17);
-    }
-
-    @Test
     public void testVarDeclarationWithAllDeclaredSymbols() {
         CompileResult res = BCompileUtil.compile("test-src/types/var/var-declared-symbols-negative.bal");
         Assert.assertEquals(res.getErrorCount(), 3);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -11,30 +11,23 @@ function basicTupleTest () returns (string) {
     endTest();
 
     // Test 3
-    FooStruct foo = {x:"foo test3"};
-    var [a, b] = ["test3",foo];
-    addValue(a);
-    addValue(b.x);
-    endTest();
-
-    // Test 4
     string c;
     int d;
-    [c, d] = ["test4", 4];
+    [c, d] = ["test3", 3];
     addValue(c);
     addValue(string.convert(d));
     endTest();
 
-    // Test 5
-    [string,int] f = ["test5",5];
+    // Test 4
+    [string,int] f = ["test4", 4];
     var [g, h] = f;
     addValue(g);
     addValue(string.convert(h));
     endTest();
 
-    // Test 6
-    FooStruct foo6 = {x:"foo test6"};
-    [string, FooStruct] i = ["test6",foo6];
+    // Test 5
+    FooStruct foo5 = {x:"foo test5"};
+    [string, FooStruct] i = ["test5",foo5];
     var [j, k] = i;
     addValue(j);
     addValue(k.x);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/var/var-declaration-with-array-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/var/var-declaration-with-array-negative.bal
@@ -1,4 +1,0 @@
-function testVarDeclarationWithArrayInit() returns (int) {
-    var array = [1.2,3];
-    return 1;
-}


### PR DESCRIPTION
## Purpose
Purpose of this PR is to

1. Migrate tuple syntax changes
2. Fix issue with tuples in unions
3. Remove support for tuple destructuring when defined with `var` 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
