### PR TITLE
 Add formatting for worker sync send and flush.

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingNodeTree.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/FormattingNodeTree.java
@@ -5978,8 +5978,31 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatWorkerFlushNode(JsonObject node) {
-        // TODO: fix formatting for Worker Flush node.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+            boolean useParentIndentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
+
+            // Preserve the already available new lines.
+            this.preserveHeight(ws, useParentIndentation ? indentationOfParent : indentation);
+
+            // Iterate and format the node.
+            for (JsonElement wsItem : ws) {
+                JsonObject currentWS = wsItem.getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                    if (text.equals(Tokens.FLUSH)) {
+                        currentWS.addProperty(FormattingConstants.WS,
+                                this.getWhiteSpaces(formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                    } else {
+                        currentWS.addProperty(FormattingConstants.WS, FormattingConstants.SINGLE_SPACE);
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -6066,8 +6089,31 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatWorkerSyncSendNode(JsonObject node) {
-        // TODO: fix formatting for Worker Sync Send.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+            boolean useParentIndentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
+
+            // Preserve available new lines.
+            this.preserveHeight(ws, useParentIndentation ? indentationOfParent : indentation);
+
+            // Iterate and format the node.
+            for (JsonElement wsItem : ws) {
+                JsonObject currentWS = wsItem.getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    currentWS.addProperty(FormattingConstants.WS, FormattingConstants.SINGLE_SPACE);
+                }
+            }
+
+            // Handle formatting of the expression.
+            if (node.has(FormattingConstants.EXPRESSION)) {
+                node.getAsJsonObject(FormattingConstants.EXPRESSION).add(FormattingConstants.FORMATTING_CONFIG,
+                        formatConfig);
+            }
+        }
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/Tokens.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/formatting/Tokens.java
@@ -110,4 +110,5 @@ public class Tokens {
     public static final String TRAP = "trap";
     public static final String TYPEOF = "typeof";
     public static final String UNTAINT = "untaint";
+    public static final String FLUSH = "flush";
 }

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedWorkerInteractions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedWorkerInteractions.bal
@@ -13,12 +13,35 @@ public function main() {
         };
         j = <- w2;
 
-        () send = i ->> w2;
+        () send1 = i ->> w2;
         k -> w3;
         k -> w3;
         k -> w3;
 
-        error? flushResult = flush w3;
+        () send2 =
+        i
+        ->>
+        w2
+        ;
+
+        () send3 =
+        i
+        ->>
+        default
+        ;
+
+        () send4 = i ->> default;
+
+        error? flushResult1 = flush w3;
+        error? flushResult2 = flush;
+
+        error? flushResult3 =
+        flush
+        w2
+        ;
+        error? flushResult4 =
+        flush
+        ;
     }
 
     worker w2 {

--- a/language-server/modules/langserver-core/src/test/resources/formatting/workerInteractions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/workerInteractions.bal
@@ -12,11 +12,34 @@ public function main() {
         };
           j = <- w2;
 
-            () send = i ->> w2;k->w3 ;
+            () send1 =i    ->>w2   ;k->w3 ;
       k -> w3;
                k -> w3;
 
-            error? flushResult = flush w3;
+               () send2 =
+                                  i
+    ->>
+                                      w2
+            ;
+
+            () send3 =
+                                     i
+       ->>
+                            default
+       ;
+
+                    () send4 =i    ->>default    ;
+
+    error? flushResult1 =flush    w3 ;
+                    error? flushResult2    =    flush ;
+
+                    error? flushResult3 =
+                                   flush
+                     w2
+                                       ;
+                            error? flushResult4 =
+           flush
+                                        ;
     }
 
     worker w2 {


### PR DESCRIPTION
## Purpose
This will add formatting support for working sync send and worker flush syntaxes.

Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/13280

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [x] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
