### PR TITLE
[Intellij Plugin] Detach plugin build from the gradle build

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -99,7 +99,7 @@ include(':jballerina-integration-test')
 // and 'mustRunAfter' of vs-code-pluggin
 
 include(':plugin-vscode')
-include(':ballerina-intellij-idea-plugin')
+// include(':ballerina-intellij-idea-plugin')
 include(':benchmarks')
 include(':ballerina-activemq-artemis')
 include(':ballerina-rabbitmq')
@@ -202,7 +202,7 @@ project(':jballerina-integration-test').projectDir = file('tests/jballerina-inte
 // project(':ballerina-tools-integration-test').projectDir = file('tests/ballerina-tools-integration-test')
 // project(':examples-test').projectDir = file('tests/ballerina-examples-test')
 project(':plugin-vscode').projectDir = file('tool-plugins/vscode')
-project(':ballerina-intellij-idea-plugin').projectDir = file('tool-plugins/intellij')
+//project(':ballerina-intellij-idea-plugin').projectDir = file('tool-plugins/intellij')
 project(':ballerina-activemq-artemis').projectDir = file('stdlib/messaging/activemq-artemis')
 project(':ballerina-rabbitmq').projectDir = file('stdlib/messaging/rabbitmq')
 project(':ballerina-nats').projectDir = file('stdlib/nats')

--- a/settings.gradle
+++ b/settings.gradle
@@ -99,7 +99,6 @@ include(':jballerina-integration-test')
 // and 'mustRunAfter' of vs-code-pluggin
 
 include(':plugin-vscode')
-// include(':ballerina-intellij-idea-plugin')
 include(':benchmarks')
 include(':ballerina-activemq-artemis')
 include(':ballerina-rabbitmq')
@@ -202,7 +201,6 @@ project(':jballerina-integration-test').projectDir = file('tests/jballerina-inte
 // project(':ballerina-tools-integration-test').projectDir = file('tests/ballerina-tools-integration-test')
 // project(':examples-test').projectDir = file('tests/ballerina-examples-test')
 project(':plugin-vscode').projectDir = file('tool-plugins/vscode')
-//project(':ballerina-intellij-idea-plugin').projectDir = file('tool-plugins/intellij')
 project(':ballerina-activemq-artemis').projectDir = file('stdlib/messaging/activemq-artemis')
 project(':ballerina-rabbitmq').projectDir = file('stdlib/messaging/rabbitmq')
 project(':ballerina-nats').projectDir = file('stdlib/nats')

--- a/tool-plugins/intellij/build.gradle
+++ b/tool-plugins/intellij/build.gradle
@@ -21,7 +21,6 @@ plugins {
     id "org.sonarqube" version "2.6"
 }
 
-apply from: "$rootDir/gradle/javaProject.gradle"
 version = ballerinaPluginVersion
 
 repositories {
@@ -81,7 +80,9 @@ task copyPsiViewerPluginToSandBox(type: Copy) {
 copyPsiViewerPluginToSandBox.mustRunAfter prepareSandbox
 runIde.dependsOn copyPsiViewerPluginToSandBox
 
+apply plugin: 'checkstyle'
 checkstyle {
+    configFile rootProject.file("src/main/resources/checkstyle/checkstyle.xml")
     checkstyleMain {
         source = fileTree("src/main/java")
         include '**/*.java'
@@ -91,26 +92,26 @@ checkstyle {
     }
 }
 
-createJavadoc {
-    source = fileTree("src/main/java")
-    failOnError false
-    options.addStringOption('-quiet')
-    exclude 'src/main/gen/**'
-}
-
-spotbugsMain {
-    it.effort "min"
-    it.reportLevel "low"
-    it.reports {
-        xml.enabled false
-        html.enabled true
-    }
-    def excludeFile = file('spotbugs-exclude.xml')
-    if (excludeFile.exists()) {
-        it.excludeFilter = excludeFile
-    }
-    ignoreFailures = true
-}
+//createJavadoc {
+//    source = fileTree("src/main/java")
+//    failOnError false
+//    options.addStringOption('-quiet')
+//    exclude 'src/main/gen/**'
+//}
+//
+//spotbugsMain {
+//    it.effort "min"
+//    it.reportLevel "low"
+//    it.reports {
+//        xml.enabled false
+//        html.enabled true
+//    }
+//    def excludeFile = file('spotbugs-exclude.xml')
+//    if (excludeFile.exists()) {
+//        it.excludeFilter = excludeFile
+//    }
+//    ignoreFailures = true
+//}
 
 runIde.dependsOn check
 buildPlugin.dependsOn check

--- a/tool-plugins/intellij/build.gradle
+++ b/tool-plugins/intellij/build.gradle
@@ -92,26 +92,5 @@ checkstyle {
     }
 }
 
-//createJavadoc {
-//    source = fileTree("src/main/java")
-//    failOnError false
-//    options.addStringOption('-quiet')
-//    exclude 'src/main/gen/**'
-//}
-//
-//spotbugsMain {
-//    it.effort "min"
-//    it.reportLevel "low"
-//    it.reports {
-//        xml.enabled false
-//        html.enabled true
-//    }
-//    def excludeFile = file('spotbugs-exclude.xml')
-//    if (excludeFile.exists()) {
-//        it.excludeFilter = excludeFile
-//    }
-//    ignoreFailures = true
-//}
-
 runIde.dependsOn check
 buildPlugin.dependsOn check

--- a/tool-plugins/intellij/settings.gradle
+++ b/tool-plugins/intellij/settings.gradle
@@ -1,0 +1,18 @@
+/*	
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.	
+ *	
+ * Licensed under the Apache License, Version 2.0 (the "License");	
+ * you may not use this file except in compliance with the License.	
+ * You may obtain a copy of the License at	
+ *	
+ * http://www.apache.org/licenses/LICENSE-2.0	
+ *	
+ * Unless required by applicable law or agreed to in writing, software	
+ * distributed under the License is distributed on an "AS IS" BASIS,	
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.	
+ * See the License for the specific language governing permissions and	
+ * limitations under the License.	
+ *	
+ */
+
+rootProject.name = 'ballerina-intellij-idea-plugin'

--- a/tool-plugins/intellij/src/main/resources/checkstyle/checkstyle.xml
+++ b/tool-plugins/intellij/src/main/resources/checkstyle/checkstyle.xml
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    # Copyright 2015 WSO2 Inc. (http://wso2.org)
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    # http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+-->
+
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<module name="Checker">
+
+    <property name="charset" value="UTF-8"/>
+
+    <module name="FileTabCharacter">
+        <property name="severity" value="error" />
+        <!-- Checks that there are no tab characters in the file.
+        -->
+    </module>
+
+    <!--
+
+    LENGTH CHECKS FOR FILES
+
+    -->
+
+    <module name="FileLength">
+        <property name="max" value="3000" />
+        <property name="severity" value="warning" />
+    </module>
+
+
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
+
+    <module name="RegexpSingleline">
+        <!-- Checks that FIXME is not used in comments.  TODO is preferred.
+        -->
+        <property name="format" value="((//.*)|(\*.*))FIXME" />
+        <property name="message" value='TODO is preferred to FIXME.  e.g. "TODO: (ENG-123) -  Refactor when v2 is released."' />
+    </module>
+
+    <module name="RegexpSingleline">
+        <!-- Checks that TODOs are named with some basic formatting. Checks for the following pattern  TODO: (
+        -->
+        <property name="format" value="((//.*)|(\*.*))TODO[^: (]" />
+        <property name="message" value='All TODOs should be named.  e.g. "TODO: (ENG-123) - Refactor when v2 is released."' />
+    </module>
+
+    <!--<module name="JavadocPackage">-->
+        <!--&lt;!&ndash; Checks that each Java package has a Javadoc file used for commenting.-->
+          <!--Only allows a package-info.java, not package.html. &ndash;&gt;-->
+        <!--<property name="severity" value="warning"/>-->
+    <!--</module>-->
+
+    <!-- All Java AST specific tests live under TreeWalker module. -->
+    <module name="TreeWalker">
+
+        <!--
+
+        IMPORT CHECKS
+
+        -->
+
+        <module name="AvoidStarImport">
+            <property name="allowClassImports" value="false" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="RedundantImport">
+            <!-- Checks for redundant import statements. -->
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="ImportOrder">
+            <property name="groups" value="*,java,javax"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="bottom"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+        </module>
+
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="junit.framework" />
+        </module>
+
+        <module name="UnusedImports" />
+
+        <!--
+
+        METHOD LENGTH CHECKS
+
+        -->
+
+        <module name="MethodLength">
+            <property name="tokens" value="METHOD_DEF" />
+            <property name="max" value="300" />
+            <property name="countEmpty" value="false" />
+            <property name="severity" value="warning" />
+        </module>
+
+        <!--
+
+        JAVADOC CHECKS
+
+        -->
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <module name="JavadocMethod">
+            <property name="scope" value="protected" />
+            <property name="severity" value="error" />
+            <property name="allowMissingJavadoc" value="true" />
+            <property name="allowMissingParamTags" value="true" />
+            <property name="allowMissingReturnTag" value="true" />
+            <property name="allowMissingThrowsTags" value="true" />
+            <property name="allowThrowsTagsForSubclasses" value="true" />
+            <property name="allowUndeclaredRTE" value="true" />
+        </module>
+
+        <module name="JavadocType">
+            <property name="scope" value="protected" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="JavadocStyle">
+            <property name="severity" value="error" />
+        </module>
+
+        <!--
+
+        NAMING CHECKS
+
+        -->
+
+        <!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+        <module name="PackageName">
+            <!-- Validates identifiers for package names against the
+              supplied expression. -->
+            <!-- Here the default checkstyle rule restricts package name parts to
+              seven characters, this is not in line with common practice at Google.
+            -->
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="TypeNameCheck">
+            <!-- Validates static, final fields against the
+            expression "^[A-Z][a-zA-Z0-9]*$". -->
+            <metadata name="altname" value="TypeName" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="ConstantNameCheck">
+            <!-- Validates non-private, static, final fields against the supplied
+            public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+            <metadata name="altname" value="ConstantName" />
+            <property name="applyToPublic" value="true" />
+            <property name="applyToProtected" value="true" />
+            <property name="applyToPackage" value="true" />
+            <property name="applyToPrivate" value="false" />
+            <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$" />
+            <message key="name.invalidPattern"
+                value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)." />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="StaticVariableNameCheck">
+            <!-- Validates static, non-final fields against the supplied
+            expression "^[a-z][a-zA-Z0-9]*_?$". -->
+            <metadata name="altname" value="StaticVariableName" />
+            <property name="applyToPublic" value="true" />
+            <property name="applyToProtected" value="true" />
+            <property name="applyToPackage" value="true" />
+            <property name="applyToPrivate" value="true" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*_?$" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="MemberNameCheck">
+            <!-- Validates non-static members against the supplied expression. -->
+            <metadata name="altname" value="MemberName" />
+            <property name="applyToPublic" value="true" />
+            <property name="applyToProtected" value="true" />
+            <property name="applyToPackage" value="true" />
+            <property name="applyToPrivate" value="true" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="MethodNameCheck">
+            <!-- Validates identifiers for method names. -->
+            <metadata name="altname" value="MethodName" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="ParameterName">
+            <!-- Validates identifiers for method parameters against the
+              expression "^[a-z][a-zA-Z0-9]*$". -->
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="LocalFinalVariableName">
+            <!-- Validates identifiers for local final variables against the
+              expression "^[a-z][a-zA-Z0-9]*$". -->
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="LocalVariableName">
+            <!-- Validates identifiers for local variables against the
+              expression "^[a-z][a-zA-Z0-9]*$". -->
+            <property name="severity" value="error" />
+        </module>
+
+
+        <!--
+
+        LENGTH and CODING CHECKS
+
+        -->
+
+        <module name="LineLength">
+            <!-- Checks if a line is too long. -->
+            <property name="max" value="120" default="120" />
+            <property name="severity" value="error" />
+
+            <!--
+              The default ignore pattern exempts the following elements:
+                - import statements
+                - long URLs inside comments
+            -->
+
+            <property name="ignorePattern" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
+                default="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$" />
+        </module>
+
+        <module name="LeftCurly">
+            <!-- Checks for placement of the left curly brace ('{'). -->
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="RightCurly">
+            <!-- Checks right curlies on CATCH, ELSE, and TRY blocks are on
+            the same line. e.g., the following example is fine:
+            <pre>
+              if {
+                ...
+              } else
+            </pre>
+            -->
+            <!-- This next example is not fine:
+            <pre>
+              if {
+                ...
+              }
+              else
+            </pre>
+            -->
+            <property name="option" value="same" />
+            <property name="severity" value="error" />
+        </module>
+
+        <!-- Checks for braces around if and else blocks -->
+        <module name="NeedBraces">
+            <property name="severity" value="error" />
+            <property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO" />
+        </module>
+
+        <module name="UpperEll">
+            <!-- Checks that long constants are defined with an upper ell.-->
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="FallThrough">
+            <!-- Warn about falling through to the next case statement.  Similar to
+            javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+            on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+            some other variants which we don't publicized to promote consistency).
+            -->
+            <property name="reliefPattern"
+                value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on" />
+            <property name="severity" value="error" />
+        </module>
+
+
+        <!--
+
+        MODIFIERS CHECKS
+
+        -->
+
+        <module name="ModifierOrder">
+            <!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+                 8.4.3.  The prescribed order is:
+                 public, protected, private, abstract, static, final, transient, volatile,
+                 synchronized, native, strictfp
+              -->
+        </module>
+
+
+        <!--
+
+        WHITESPACE CHECKS
+
+        -->
+        <module name="GenericWhitespace" />
+
+        <module name="WhitespaceAround">
+            <!-- Checks that various tokens are surrounded by whitespace.
+                 This includes most binary operators and keywords followed
+                 by regular or curly braces.
+            -->
+            <property name="tokens"
+                value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SLIST, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN" />
+            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyMethods" value="true" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="WhitespaceAfter">
+            <!-- Checks that commas, semicolons and typecasts are followed by
+                 whitespace.
+            -->
+            <property name="tokens" value="COMMA, SEMI, TYPECAST" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="NoWhitespaceAfter">
+            <!-- Checks that there is no whitespace after various unary operators.
+                 Linebreaks are allowed.
+            -->
+            <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS" />
+            <property name="allowLineBreaks" value="true" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="NoWhitespaceBefore">
+            <!-- Checks that there is no whitespace before various unary operators.
+                 Linebreaks are allowed.
+            -->
+            <property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC" />
+            <property name="allowLineBreaks" value="true" />
+            <property name="severity" value="error" />
+        </module>
+
+        <module name="ParenPad">
+            <!-- Checks that there is no whitespace before close parens or after
+                 open parens.
+            -->
+            <property name="severity" value="error" />
+        </module>
+
+        <!-- No System.out -->
+        <module name="Regexp">
+            <property name="format" value="System\.out\.println" />
+            <property name="illegalPattern" value="true" />
+        </module>
+
+        <!-- No System.err -->
+        <module name="Regexp">
+            <!-- . matches any character, so we need to escape it and use \. to match dots. -->
+            <property name="format" value="System\.err\.println" />
+            <property name="illegalPattern" value="true" />
+        </module>
+
+        <!-- No printStackTrace -->
+        <module name="Regexp">
+            <!-- . matches any character, so we need to escape it and use \. to match dots. -->
+            <property name="format" value="e\.printStackTrace\(\)" />
+            <property name="illegalPattern" value="true" />
+        </module>
+
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE OFF: (.+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE ON"/>
+            <property name="checkFormat" value="Javadoc.*"/>
+            <property name="messageFormat" value="$1"/>
+        </module>
+
+    </module>
+
+</module>

--- a/tool-plugins/intellij/src/main/resources/checkstyle/checkstyle.xml
+++ b/tool-plugins/intellij/src/main/resources/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    # Copyright 2015 WSO2 Inc. (http://wso2.org)
+    # Copyright 2019 WSO2 Inc. (http://wso2.org)
     #
     # Licensed under the Apache License, Version 2.0 (the "License");
     # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Purpose
This PR proposes to detach the ballerina intelliJ plugin build from the ballerina gradle build due to the following reasons.

- With the diagram support, intellij plugin is using javafx libraries which are not available in the openJDK and so the plugin is now compilable only with the oracle JDK (Please note that this won't affect the plugin runtime since the IDEA runtime environment comes with the required javafx libraries)
- Eventually ballerina tooling components will have separate repositories in the ballerina platform organization, hence this decoupling will be required eventually.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
