### PR TITLE
Fix docs for optional array types

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -137,11 +137,10 @@ public class Type {
             typeModel.memberTypes = memberTypeNodes.stream()
                                     .map(Type::fromTypeNode)
                                     .collect(Collectors.toList());
-        } else if (type.nullable && type.type instanceof BUnionType) {
-            BUnionType unionType = (BUnionType) type.type;
-            if (unionType.getMemberTypes().size() == 2) {
-                typeModel = new Type((BType) unionType.getMemberTypes().toArray()[0]);
-            }
+        } else if (type.nullable && type instanceof BLangUnionTypeNode
+                && ((BLangUnionTypeNode) type).getMemberTypeNodes().size() == 2) {
+            BLangUnionTypeNode unionType = (BLangUnionTypeNode) type;
+            typeModel = fromTypeNode((BLangType) unionType.getMemberTypeNodes().toArray()[0]);
         }
         if (typeModel == null) {
             typeModel = new Type(type);

--- a/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
+++ b/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
@@ -66,6 +66,21 @@ public class HtmlDocTest {
         Assert.assertTrue(module.records.isEmpty());
     }
 
+    @Test(description = "Optional Array Type args should be captured correctly")
+    public void testOptionalArrayTypes() {
+        BLangPackage bLangPackage = createPackage("public function find(string[]? names, string name) returns (boolean)" +
+                "{return true;}");
+        Module module = generateModule(bLangPackage);
+        Assert.assertEquals(module.functions.size(), 1);
+        Assert.assertEquals(module.functions.get(0).name, "find");
+        Function function = module.functions.get(0);
+        Assert.assertEquals(function.parameters.get(0).type.name, "string", "Invalid parameter type");
+        Assert.assertTrue(function.parameters.get(0).type.isArrayType, "Invalid parameter type");
+        Assert.assertTrue(function.parameters.get(0).type.isNullable, "Invalid parameter type");
+        Assert.assertEquals(function.parameters.get(0).name, "names", "Invalid parameter name");
+        Assert.assertEquals(function.returnParameters.get(0).type.name, "boolean", "Invalid return type");
+    }
+
     @Test(description = "Functions in a module should be shown in the constructs")
     public void testFunctions() {
         BLangPackage bLangPackage = createPackage("public function hello(string name) returns (string)" +

--- a/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
+++ b/misc/docerina/src/test/java/org/ballerinalang/docgen/docs/HtmlDocTest.java
@@ -68,8 +68,8 @@ public class HtmlDocTest {
 
     @Test(description = "Optional Array Type args should be captured correctly")
     public void testOptionalArrayTypes() {
-        BLangPackage bLangPackage = createPackage("public function find(string[]? names, string name) returns (boolean)" +
-                "{return true;}");
+        BLangPackage bLangPackage = createPackage("public function find(string[]? names, string name)" +
+                " returns (boolean) { return true; }");
         Module module = generateModule(bLangPackage);
         Assert.assertEquals(module.functions.size(), 1);
         Assert.assertEquals(module.functions.get(0).name, "find");


### PR DESCRIPTION
## Purpose
This will fix the type label for optional array type arguments in api docs.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
