### PR TITLE
Remove error return from Client creation functions

### DIFF
--- a/stdlib/http/src/main/ballerina/http/caching/http_caching_client.bal
+++ b/stdlib/http/src/main/ballerina/http/caching/http_caching_client.bal
@@ -91,12 +91,7 @@ public type HttpCachingClient client object {
     # + config - The configurations for the client endpoint associated with the caching client
     # + cacheConfig - The configurations for the HTTP cache to be used with the caching client
     public function __init(string url, ClientEndpointConfig config, CacheConfig cacheConfig) {
-        var httpSecureClient = createHttpSecureClient(url, config);
-        if (httpSecureClient is HttpClient) {
-            self.httpClient = httpSecureClient;
-        } else {
-            panic httpSecureClient;
-        }
+        self.httpClient = createHttpSecureClient(url, config);
         self.cache = createHttpCache("http-cache", cacheConfig);
     }
 
@@ -228,7 +223,7 @@ public type HttpCachingClient client object {
 # + cacheConfig - The configurations for the HTTP cache to be used with the caching client
 # + return - An `HttpCachingClient` instance which wraps the base `Client` with a caching layer
 public function createHttpCachingClient(string url, ClientEndpointConfig config, CacheConfig cacheConfig)
-                                                                                      returns HttpClient|error {
+                                                                                      returns HttpClient {
     HttpCachingClient httpCachingClient = new(url, config, cacheConfig);
     log:printDebug(function() returns string {
         return "Created HTTP caching client: " + io:sprintf("%s", httpCachingClient);

--- a/stdlib/http/src/main/ballerina/http/http_client.bal
+++ b/stdlib/http/src/main/ballerina/http/http_client.bal
@@ -200,7 +200,7 @@ public type HttpTimeoutError record {|
     int statusCode = 0;
 |};
 
-function createClient(string url, ClientEndpointConfig config) returns HttpClient|error {
+function createClient(string url, ClientEndpointConfig config) returns HttpClient {
     HttpClient simpleClient = new(url, config = config);
     return simpleClient;
 }

--- a/stdlib/http/src/main/ballerina/http/http_secure_client.bal
+++ b/stdlib/http/src/main/ballerina/http/http_secure_client.bal
@@ -34,12 +34,7 @@ public type HttpSecureClient client object {
     public function __init(string url, ClientEndpointConfig config) {
         self.url = url;
         self.config = config;
-        var simpleClient = createClient(url, self.config);
-        if (simpleClient is HttpClient) {
-            self.httpClient = simpleClient;
-        } else {
-            panic simpleClient;
-        }
+        self.httpClient = createClient(url, self.config);
     }
 
     # This wraps the `post()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -263,7 +258,7 @@ public type HttpSecureClient client object {
 # + url - Base URL
 # + config - Client endpoint configurations
 # + return - Created secure HTTP client
-public function createHttpSecureClient(string url, ClientEndpointConfig config) returns HttpClient|error {
+public function createHttpSecureClient(string url, ClientEndpointConfig config) returns HttpClient {
     HttpSecureClient httpSecureClient;
     if (config.auth is OutboundAuthConfig) {
         httpSecureClient = new(url, config);

--- a/stdlib/http/src/main/ballerina/http/redirect/redirect_client.bal
+++ b/stdlib/http/src/main/ballerina/http/redirect/redirect_client.bal
@@ -331,16 +331,12 @@ function redirect(Response response, HttpOperation httpVerb, Request request,
 function performRedirection(string location, RedirectClient redirectClient, HttpOperation redirectMethod,
                             Request request, Response response) returns @untainted HttpResponse|error {
     var retryClient = createRetryClient(location, createNewEndpointConfig(redirectClient.config));
-    if (retryClient is HttpClient) {
-        log:printDebug(function() returns string {
-                return "Redirect using new clientEP : " + location;
-            });
-        HttpResponse|error result = invokeEndpoint("", createRedirectRequest(response.statusCode, request),
-            redirectMethod, retryClient);
-        return checkRedirectEligibility(result, location, redirectMethod, request, redirectClient);
-    } else {
-        return retryClient;
-    }
+    log:printDebug(function() returns string {
+            return "Redirect using new clientEP : " + location;
+        });
+    HttpResponse|error result = invokeEndpoint("", createRedirectRequest(response.statusCode, request),
+        redirectMethod, retryClient);
+    return checkRedirectEligibility(result, location, redirectMethod, request, redirectClient);
 }
 
 //Create a new HTTP client endpoint configuration with a given location as the url.


### PR DESCRIPTION
## Purpose
> Client creation functions are returning errors, but they do not need to return error. This will reduce unnecessary logic.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
