### PR TITLE
Add type narrowing support for while

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1918,7 +1918,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             dlog.error(whileNode.expr.pos, DiagnosticCode.INCOMPATIBLE_TYPES, symTable.booleanType, actualType);
         }
 
-        analyzeStmt(whileNode.body, env);
+        SymbolEnv whileEnv = typeNarrower.evaluateTruth(whileNode.expr, whileNode.body, env);
+        analyzeStmt(whileNode.body, whileEnv);
     }
 
     @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
@@ -174,4 +174,16 @@ public class WhileStmtTest {
         String expected = "level2level3level1";
         Assert.assertEquals(actual, expected);
     }
+
+    @Test(description = "Test type narrowing inside the while body")
+    public void testTypeNarrowingInWhileBody() {
+        BValue[] returns = BRunUtil.invoke(positiveCompileResult, "testTypeNarrowingInWhileBody");
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BString.class);
+
+        String actual = returns[0].stringValue();
+        String expected = "foo1foo2foo3";
+        Assert.assertEquals(actual, expected);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt.bal
@@ -159,3 +159,19 @@ function testNestedWhileWithContinue() returns string {
     }
     return result;
 }
+
+function testTypeNarrowingInWhileBody() returns string {
+    record {| string val; |}?[] arr = [{val: "foo1"}, {val: "foo2"}, {val: "foo3"}, (), {val: "foo5"}];
+
+    record {| string val; |}|() rec = arr[0];
+    int i = 0;
+    string result = "";
+
+    while (rec is record {| string val; |}) {
+        result += rec.val;
+        i += 1;
+        rec = arr[i];
+    }
+
+    return result;
+}


### PR DESCRIPTION
## Purpose
> This PR adds support for narrowing the type of a var when a type test is used in the while condition.

Fixes #16136 

## Samples
```ballerina
record {| string val; |}?[] arr = [{val: "foo1"}, {val: "foo2"}, {val: "foo3"}, (), {val: "foo5"}];

    record {| string val; |}|() rec = arr[0];
    int i = 0;

    while (rec is record {| string val; |}) {
        string s = rec.val;
        io:println(s);
        i += 1;
        rec = arr[i];
    }
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
