### PR TITLE
include kid in JWT Header

### DIFF
--- a/stdlib/jwt/src/main/ballerina/jwt/jwt_issuer.bal
+++ b/stdlib/jwt/src/main/ballerina/jwt/jwt_issuer.bal
@@ -95,6 +95,9 @@ function buildHeaderString(JwtHeader header) returns (string|error) {
         return prepareError("Unsupported JWS algorithm.");
     }
     headerJson[TYP] = "JWT";
+    if (header.kid != ()) {
+        headerJson[kid] = header.kid;
+    }
     string headerValInString = headerJson.toString();
     string encodedPayload = encoding:encodeBase64Url(headerValInString.toByteArray("UTF-8"));
     return encodedPayload;

--- a/stdlib/jwt/src/main/ballerina/jwt/jwt_issuer.bal
+++ b/stdlib/jwt/src/main/ballerina/jwt/jwt_issuer.bal
@@ -95,7 +95,7 @@ function buildHeaderString(JwtHeader header) returns (string|error) {
         return prepareError("Unsupported JWS algorithm.");
     }
     headerJson[TYP] = "JWT";
-    if (header.kid is string) {
+    if (header["kid"] is string) {
         headerJson[KID] = header.kid;
     }
     string headerValInString = headerJson.toString();

--- a/stdlib/jwt/src/main/ballerina/jwt/jwt_issuer.bal
+++ b/stdlib/jwt/src/main/ballerina/jwt/jwt_issuer.bal
@@ -95,8 +95,8 @@ function buildHeaderString(JwtHeader header) returns (string|error) {
         return prepareError("Unsupported JWS algorithm.");
     }
     headerJson[TYP] = "JWT";
-    if (header.kid != ()) {
-        headerJson[kid] = header.kid;
+    if (header.kid is string) {
+        headerJson[KID] = header.kid;
     }
     string headerValInString = headerJson.toString();
     string encodedPayload = encoding:encodeBase64Url(headerValInString.toByteArray("UTF-8"));


### PR DESCRIPTION
## Purpose
In the current implementation of issuing a JWT, the key id (`kid`) is supported through the JwtHeader type, but it is not rendered into the resulting JWT.

## Approach
Just adding the `kid` to the header, if a value is present.

## Samples
modified from the "issue JWT test case"
```
jwt:JwtHeader header = {};
header.alg = jwt:RS256;
header.typ = "JWT";
header.kid = "custom-key-1";

```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
