### PR TITLE
Revert orgName to org-name in toml

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/parser/ManifestProcessor.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/parser/ManifestProcessor.java
@@ -98,7 +98,9 @@ public class ManifestProcessor {
      */
     public static Manifest parseTomlContentAsStream(InputStream inputStream) {
         try {
-            Manifest manifest = new Toml().read(inputStream).to(Manifest.class);
+            Toml toml = new Toml().read(inputStream);
+            Manifest manifest = toml.to(Manifest.class);
+            manifest.getProject().setOrgName(toml.getString("project.org-name"));
             validateManifestDependencies(manifest);
             return manifest;
         } catch (IllegalStateException ise) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/ZipConverter.java
@@ -5,11 +5,9 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
-import org.wso2.ballerinalang.programfile.ProgramFileConstants;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystemAlreadyExistsException;
@@ -95,8 +93,6 @@ public class ZipConverter extends PathConverter {
                 pathList = Files.list(path)
                                 .map(SortablePath::new)
                                 .filter(SortablePath::valid)
-                                // todo need to remove the following line.
-                                // .filter(sortablePath -> validBaloPath(pkgName, sortablePath))
                                 .sorted(Comparator.reverseOrder())
                                 .limit(1)
                                 .map(SortablePath::getPath)
@@ -120,42 +116,6 @@ public class ZipConverter extends PathConverter {
             // return an empty stream.
         }
         return Stream.of();
-    }
-
-    /**
-     * Validates the package with compiler version.
-     *
-     * @param pkgName      package name
-     * @param sortablePath sortable path
-     * @return if the package is compatible with the compiler version
-     */
-    private boolean validBaloPath(String pkgName, SortablePath sortablePath) {
-        Path zipPath = resolveIntoArchive(sortablePath.getPath()
-                                                      .resolve(pkgName + ProjectDirConstants.BLANG_COMPILED_PKG_EXT));
-        return filterByBaloVersion(zipPath.resolve(ProjectDirConstants.USER_REPO_OBJ_DIRNAME)
-                                          .resolve(pkgName + ProjectDirConstants.BLANG_COMPILED_PKG_BINARY_EXT));
-    }
-
-    /**
-     * Filter by balo version.
-     *
-     * @param path package path
-     * @return if the balo version of the package is compatible with compiler version
-     */
-    private boolean filterByBaloVersion(Path path) {
-        try (InputStream stream = Files.newInputStream(path)) {
-            byte[] data = new byte[ProgramFileConstants.VERSION_BYTE];
-            if (stream.read(data) != -1) {
-                short version = data[data.length - 1];
-                return (version >= ProgramFileConstants.MIN_SUPPORTED_VERSION) &&
-                        (version <= ProgramFileConstants.MAX_SUPPORTED_VERSION);
-            }
-        } catch (IOException ignore) {
-            // An I/O exception can occur when opening the balo file which will return an input stream to read the balo
-            // version. Since this is done during dependency resolution, we don't throw an exception instead we return
-            // false
-        }
-        return false;
     }
 
     /**

--- a/compiler/ballerina-lang/src/test/resources/Ballerina.toml
+++ b/compiler/ballerina-lang/src/test/resources/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 # Name of the module
-orgName = "foo"
+org-name = "foo"
 
 #The current version, obeying semver
 version = "1.0.0"

--- a/compiler/ballerina-lang/src/test/resources/src/ballerina/multi-package/Ballerina.toml
+++ b/compiler/ballerina-lang/src/test/resources/src/ballerina/multi-package/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "abc"
+org-name = "abc"
 version = "0.0.1"
 

--- a/examples/Ballerina.toml
+++ b/examples/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "ballerina-examples"
+org-name = "ballerina-examples"
 version = "0.0.1"
 

--- a/language-server/modules/langserver-compiler/samples/source/packagecache/Ballerina.toml
+++ b/language-server/modules/langserver-compiler/samples/source/packagecache/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "demo"
+org-name = "demo"
 version = "0.0.1"
 

--- a/language-server/modules/langserver-compiler/src/test/resources/source/multipackages/Ballerina.toml
+++ b/language-server/modules/langserver-compiler/src/test/resources/source/multipackages/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "demo"
+org-name = "demo"
 version = "0.0.1"
 

--- a/language-server/modules/langserver-compiler/src/test/resources/source/singlepackage/Ballerina.toml
+++ b/language-server/modules/langserver-compiler/src/test/resources/source/singlepackage/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "demo"
+org-name = "demo"
 version = "0.0.1"
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/source/testgen/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/source/testgen/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "abc"
+org-name = "abc"
 version = "0.0.1"

--- a/language-server/modules/langserver-core/src/test/resources/command/source/testgen/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/command/source/testgen/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "abc"
+org-name = "abc"
 version = "0.0.1"

--- a/language-server/modules/langserver-core/src/test/resources/implementation/source/gotoImplProject/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/implementation/source/gotoImplProject/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "testorg"
+org-name = "testorg"
 version = "0.0.1"
 

--- a/language-server/modules/langserver-core/src/test/resources/referencesProject/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/referencesProject/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "reftest"
+org-name = "reftest"
 version = "0.0.1"
 

--- a/language-server/modules/langserver-core/src/test/resources/workspace/project/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/workspace/project/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "foo"
+org-name = "foo"
 version = "0.0.1"
 

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/test/resources/compilationnegative/multi-module-project/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "testerina_test"
+org-name = "testerina_test"
 version = "0.0.1"
 

--- a/stdlib/auth/src/main/ballerina/Ballerina.toml
+++ b/stdlib/auth/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/builtin/src/main/ballerina/Ballerina.toml
+++ b/stdlib/builtin/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/cache/src/main/ballerina/Ballerina.toml
+++ b/stdlib/cache/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/config-api/src/main/ballerina/Ballerina.toml
+++ b/stdlib/config-api/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/crypto/src/main/ballerina/Ballerina.toml
+++ b/stdlib/crypto/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/database/h2/src/main/ballerina/Ballerina.toml
+++ b/stdlib/database/h2/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/database/mysql/src/main/ballerina/Ballerina.toml
+++ b/stdlib/database/mysql/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/database/sql/src/main/ballerina/Ballerina.toml
+++ b/stdlib/database/sql/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/encoding/src/main/ballerina/Ballerina.toml
+++ b/stdlib/encoding/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/file/src/main/ballerina/Ballerina.toml
+++ b/stdlib/file/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/filepath/src/main/ballerina/Ballerina.toml
+++ b/stdlib/filepath/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/http/src/main/ballerina/Ballerina.toml
+++ b/stdlib/http/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/http/src/test/resources/test-src/services/dispatching/versioning/test/Ballerina.toml
+++ b/stdlib/http/src/test/resources/test-src/services/dispatching/versioning/test/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
 # Name of the package
-orgName = "versioning.test"
+org-name = "versioning.test"
 version = "1.0.0"

--- a/stdlib/internal/src/main/ballerina/Ballerina.toml
+++ b/stdlib/internal/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/internal/src/test/resources/datafiles/compression/my.app/Ballerina.toml
+++ b/stdlib/internal/src/test/resources/datafiles/compression/my.app/Ballerina.toml
@@ -1,5 +1,5 @@
 [project]
 # Name of the package
-orgName = "natasha"
+org-name = "natasha"
 #The current version of foo bar
 version = "1.0.0"

--- a/stdlib/io/src/main/ballerina/Ballerina.toml
+++ b/stdlib/io/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/jms/src/main/ballerina/Ballerina.toml
+++ b/stdlib/jms/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/jwt/src/main/ballerina/Ballerina.toml
+++ b/stdlib/jwt/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/ldap/src/main/ballerina/Ballerina.toml
+++ b/stdlib/ldap/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/log-api/src/main/ballerina/Ballerina.toml
+++ b/stdlib/log-api/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/math/src/main/ballerina/Ballerina.toml
+++ b/stdlib/math/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/messaging/activemq-artemis/src/main/ballerina/Ballerina.toml
+++ b/stdlib/messaging/activemq-artemis/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/messaging/rabbitmq/src/main/ballerina/Ballerina.toml
+++ b/stdlib/messaging/rabbitmq/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/mime/src/main/ballerina/Ballerina.toml
+++ b/stdlib/mime/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/nats/src/main/ballerina/Ballerina.toml
+++ b/stdlib/nats/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/oauth2/src/main/ballerina/Ballerina.toml
+++ b/stdlib/oauth2/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/observability/src/main/ballerina/Ballerina.toml
+++ b/stdlib/observability/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/openapi/src/main/ballerina/Ballerina.toml
+++ b/stdlib/openapi/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/privacy/src/main/ballerina/Ballerina.toml
+++ b/stdlib/privacy/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/reflect/src/main/ballerina/Ballerina.toml
+++ b/stdlib/reflect/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/runtime-api/src/main/ballerina/Ballerina.toml
+++ b/stdlib/runtime-api/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/socket/src/main/ballerina/Ballerina.toml
+++ b/stdlib/socket/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/streams/src/main/ballerina/Ballerina.toml
+++ b/stdlib/streams/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/system/src/main/ballerina/Ballerina.toml
+++ b/stdlib/system/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/task/src/main/ballerina/Ballerina.toml
+++ b/stdlib/task/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/time/src/main/ballerina/Ballerina.toml
+++ b/stdlib/time/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/transactions/src/main/ballerina/Ballerina.toml
+++ b/stdlib/transactions/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/utils/src/main/ballerina/Ballerina.toml
+++ b/stdlib/utils/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/stdlib/websub/src/main/ballerina/Ballerina.toml
+++ b/stdlib/websub/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/tests/ballerina-tools-integration-test/src/test/resources/import-in-both/Ballerina.toml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/import-in-both/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "manny"
+org-name = "manny"
 version = "1.0.0"
 

--- a/tests/ballerina-tools-integration-test/src/test/resources/import-module/Ballerina.toml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/import-module/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "bcintegrationtest"
+org-name = "bcintegrationtest"
 version = "0.0.1"
 

--- a/tests/ballerina-tools-integration-test/src/test/resources/import-test-in-cache/Ballerina.toml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/import-test-in-cache/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "fanny"
+org-name = "fanny"
 version = "1.0.0"
 

--- a/tests/ballerina-tools-integration-test/src/test/resources/import-test-in-project/Ballerina.toml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/import-test-in-project/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "fanny"
+org-name = "fanny"
 version = "1.0.0"
 

--- a/tests/ballerina-tools-integration-test/src/test/resources/list/Ballerina.toml
+++ b/tests/ballerina-tools-integration-test/src/test/resources/list/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "myorg"
+org-name = "myorg"
 version = "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/finite_type_project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/finite_type_project/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
 # Name of the package
-orgName = "finiteTypeTest"
+org-name = "finiteTypeTest"
 version = "v1"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_documentation/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_documentation/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
 # Name of the package
-orgName = "testDocOrg"
+org-name = "testDocOrg"
 version = "v1"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
 # Name of the package
-orgName = "testorg"
+org-name = "testorg"
 version = "v1"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_negative/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_negative/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
 # Name of the package
-orgName = "testorg"
+org-name = "testorg"
 version = "v1"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/debugger/multi-package/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/debugger/multi-package/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "abc"
+org-name = "abc"
 version = "0.0.1"
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "a.b"
+org-name = "a.b"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "a.b"
+org-name = "a.b"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "testorg"
+org-name = "testorg"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "testorg"
+org-name = "testorg"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lang/annotations/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lang/annotations/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "lang.annotations.foo"
+org-name = "lang.annotations.foo"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "testorg"
+org-name = "testorg"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
 # Name of the package
-orgName = "globalvar.pkg.main"
+org-name = "globalvar.pkg.main"

--- a/tests/observability-test-utils/src/main/ballerina/Ballerina.toml
+++ b/tests/observability-test-utils/src/main/ballerina/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-orgName = "ballerina"
+org-name = "ballerina"
 version = "0.0.0"

--- a/tool-plugins/vscode/test/data/helloPackage/Ballerina.toml
+++ b/tool-plugins/vscode/test/data/helloPackage/Ballerina.toml
@@ -1,4 +1,4 @@
 [project]
-orgName = "pahan"
+org-name = "pahan"
 version = "0.0.1"
 


### PR DESCRIPTION
## Purpose
Revert orgName to org-name in toml which was initially renamed with the TOML parser library addition.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
