### PR TITLE
Remove the need to have the obj directory and support other orgs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BootstrapRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BootstrapRunner.java
@@ -89,7 +89,9 @@ public class BootstrapRunner {
             throws IOException {
         for (BPackageSymbol pkg : imports) {
             PackageID id = pkg.pkgID;
-            if (!"ballerina".equals(id.orgName.value)) {
+            //Todo: ballerinax check shouldn't be here. This should be fixed by having a proper package hierarchy.
+            //Todo: Remove ballerinax check after fixing it by the packerina team
+            if (!"ballerina".equals(id.orgName.value) && !"ballerinax".equals(id.orgName.value)) {
                 writeNonEntryPkgs(pkg.imports, birCache, importsBirCache, jarTargetDir, dumpBir);
 
                 byte[] bytes = PackageFileWriter.writePackage(pkg.birPackageFile);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -44,6 +44,7 @@ public class ProjectDirConstants {
     public static final String CACHES_DIR_NAME = "caches";
     public static final String BALLERINA_CENTRAL_DIR_NAME = "central.ballerina.io";
     public static final String USER_REPO_OBJ_DIRNAME = "obj";
+    public static final String USER_REPO_BIR_DIRNAME = "bir";
 
     public static final String HOME_REPO_ENV_KEY = "BALLERINA_HOME_DIR";
     public static final String HOME_REPO_DEFAULT_DIRNAME = ".ballerina";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -24,10 +24,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 1;
-    public static final short MIN_SUPPORTED_VERSION = 50;
-    public static final short MAX_SUPPORTED_VERSION = 50;
-    public static final int VERSION_BYTE = 6;
+    public static final int BIR_VERSION_NUMBER = 51;
+    public static final short MIN_SUPPORTED_VERSION = 51;
+    public static final short MAX_SUPPORTED_VERSION = 51;
 
     // int, float, string, boolean, reference type
     public static final int NO_OF_VAR_TYPE_CATEGORIES = 5;

--- a/gradle/balNativeLibProject.gradle
+++ b/gradle/balNativeLibProject.gradle
@@ -22,6 +22,7 @@ configurations {
         transitive false
     }
 }
+project.ext.orgName = file('src/main/ballerina/Ballerina.toml').text.split("\n")[1].split("=")[1].split("\"")[1]
 
 class CreateBaloTask extends JavaExec {
     def isBuiltin = 'false'
@@ -40,7 +41,7 @@ class CreateBaloTask extends JavaExec {
         def args = []
         args << isBuiltin
         args << "src/main/ballerina/"
-        args << "${project.buildDir}/generated-balo/repo/ballerina"
+        args << "${project.buildDir}/generated-balo/repo/" + project.ext.orgName
         args << "${project.buildDir}/ballerina-home/main"
         args << skipWarnings
         args << jvmTarget

--- a/gradle/birProject.gradle
+++ b/gradle/birProject.gradle
@@ -6,7 +6,7 @@ project.ext.moduleName = files(file('src/main/ballerina').listFiles()).filter { 
     f.isDirectory() && f.name != 'target' && f.name != '.ballerina'
 }.singleFile.name
 
-def generatedBirDir = "$buildDir/generated-bir/ballerina/" + project.ext.moduleName + "/0.0.0/"
+def generatedBirDir = "$buildDir/generated-bir/" + project.ext.orgName + "/" + project.ext.moduleName + "/0.0.0/"
 
 
 task copyExternalMappingNextToBir(type: Copy) {
@@ -21,7 +21,7 @@ task createBir {
 
     doLast {
         copy {
-            def zipFile = zipTree("$buildDir/generated-balo/repo/ballerina/" + project.ext.moduleName + "/0.0.0/" + project.ext.moduleName + ".zip").matching {
+            def zipFile = zipTree("$buildDir/generated-balo/repo/" + project.ext.orgName + "/" + project.ext.moduleName + "/0.0.0/" + project.ext.moduleName + ".zip").matching {
                 include "**/*.bir"
             }.files
             from zipFile
@@ -29,7 +29,7 @@ task createBir {
         }
     }
 
-    inputs.file "$buildDir/generated-balo/repo/ballerina/" + project.ext.moduleName + "/0.0.0/" + project.ext.moduleName + ".zip"
+    inputs.file "$buildDir/generated-balo/repo/" + project.ext.orgName + "/" + project.ext.moduleName + "/0.0.0/" + project.ext.moduleName + ".zip"
     outputs.dir "$buildDir/generated-bir"
 }
 

--- a/stdlib/bir/src/main/ballerina/bir/bir_context.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_context.bal
@@ -59,8 +59,8 @@ function checkMagic(ChannelReader reader) {
 
 function checkVersion(ChannelReader reader) {
     var birVersion = reader.readInt32();
-    var supportedBirVersion = 1;
-    if (birVersion != 1){
+    var supportedBirVersion = 51;
+    if (birVersion != supportedBirVersion){
         error err = error( "Unsupported BIR version " + birVersion + ", supports version " + supportedBirVersion);
         panic err;
     }


### PR DESCRIPTION
## Purpose
> The obj the directory which has the balos was needed to run any module. This change removes that requirement.
Also the gradle files have been changed to use the org name from the Ballerina.toml file to properly copy the files if the org name is different from ballerina. In this case the toml file (in /src/main/ballerina/Ballerina.toml folder) should have the org name.
Moreover there's is an issue with the project hierarchy not being properly implemented which causes ballerinax to be not recognized. It is now hardcoded in the BootstrapRunner class. This has to be removed and fixed.

## Approach
> Change gradle and other necessary files

## Samples
> N/A

## Remarks
> https://github.com/ballerina-platform/ballerina-lang/issues/16235

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
