### PR TITLE
Opt-out compiler added vars while adding debug symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -129,7 +129,7 @@ public abstract class BIRNode {
             this.name = name;
             this.scope = scope;
             this.kind = kind;
-            this.metaVarName = metaVarName != null ? metaVarName : "ttttt";
+            this.metaVarName = metaVarName;
         }
 
         public BIRVariableDcl(BType type, Name name, VarScope scope, VarKind kind) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRParameter;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.ConstValue;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.TaintTable;
+import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.ByteCPEntry;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.FloatCPEntry;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.IntegerCPEntry;
@@ -241,7 +242,10 @@ public class BIRBinaryWriter {
             birbuf.writeByte(localVar.kind.getValue());
             writeType(birbuf, localVar.type);
             birbuf.writeInt(addStringCPEntry(localVar.name.value));
-            birbuf.writeInt(addStringCPEntry(localVar.metaVarName));
+            // skip compiler added vars and only write metaVarName for user added vars
+            if (!localVar.kind.equals(VarKind.TEMP)) {
+                birbuf.writeInt(addStringCPEntry(localVar.metaVarName));
+            }
         }
 
         // Write basic blocks related to parameter default values

--- a/stdlib/bir/src/main/ballerina/bir/bir_emitter.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_emitter.bal
@@ -143,7 +143,10 @@ public type BirEmitter object {
             } else {
                 print(varDecl.name.value);
                 print(" ");
-                print(varDecl.metaVarName);
+                if (!(varDecl.kind is TempVarKind)) {
+                    print("%meta ");
+                    print(varDecl.metaVarName);
+                }
             }
             println("\t// ", varDecl.kind);
         }

--- a/stdlib/bir/src/main/ballerina/bir/bir_pkg_parser.bal
+++ b/stdlib/bir/src/main/ballerina/bir/bir_pkg_parser.bal
@@ -197,7 +197,9 @@ public type PackageParser object {
         var numLocalVars = self.reader.readInt32();
         while (count < numLocalVars) {
             var dcl = self.parseVariableDcl();
-            dcl.metaVarName = self.reader.readStringCpRef();
+            if (!(dcl.kind is TempVarKind)) {
+                dcl.metaVarName = self.reader.readStringCpRef();
+            }
             dcls[dcls.length()] = dcl;
             localVarMap[dcl.name.value] = dcl;
             count += 1;


### PR DESCRIPTION
## Purpose
Avoid adding debug symbols into bytecode for the temp variables added by compiler.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
