### PR TITLE
Fix var index in LocalVariableTable

### DIFF
--- a/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
@@ -421,13 +421,11 @@ function generateMethod(bir:Function func, jvm:ClassWriter cw, bir:Package modul
 
     // Create Local Variable Table
     k = localVarOffset;
-    int lVarIndex = 0;
     while (k < localVars.length()) {
         bir:VariableDcl localVar = getVariableDcl(localVars[k]);
         if (localVar.kind is bir:LocalVarKind && localVar.metaVarName != "") {
             mv.visitLocalVariable(localVar.metaVarName, getJVMTypeSign(localVar.typeValue), 
-                methodStartLabel, methodEndLabel, lVarIndex);
-            lVarIndex = lVarIndex + 1;
+                methodStartLabel, methodEndLabel, k);
         }
         k = k + 1;
     }


### PR DESCRIPTION
Previously we have added a custom index
for user added variables. However according
to jvm spec at https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.13,
index should be the actual index of the var
in local variable array in JVM. This will fix
getting incorrect values as the value of a
visible local var inside a stack frame.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
