### PR TITLE
Add type guard code action for the function invocations

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandUtil.java
@@ -467,14 +467,14 @@ public class CommandUtil {
                     });
         } else {
             CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
-            String varName = CommonUtil.generateName(1, bLangNode, compilerContext);
+            String varName = CommonUtil.generateVariableName(1, bLangNode, compilerContext);
             List<BType> members = new ArrayList<>((unionType).getMemberTypes());
             String typeDef = CommonUtil.getBTypeName(unionType, context);
-            String newText = String.format("%s %s = %s%s", typeDef, varName, content, LINE_SEPARATOR);
-            newText += IntStream.range(0, members.size() - 1)
+            String newText = String.format("%s %s = %s;%s", typeDef, varName, content, LINE_SEPARATOR);
+            newText += spaces + IntStream.range(0, members.size() - 1)
                     .mapToObj(value -> {
                         String bTypeName = CommonUtil.getBTypeName(members.get(value), context);
-                        return String.format("if(%s is %s) {%s}", varName, bTypeName, padding);
+                        return String.format("if (%s is %s) {%s}", varName, bTypeName, padding);
                     })
                     .collect(Collectors.joining(" else "));
             newText += String.format(" else {%s}", padding);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandUtil.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.command;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.langserver.command.executors.AddAllDocumentationExecutor;
@@ -44,7 +45,9 @@ import org.ballerinalang.langserver.compiler.common.LSDocument;
 import org.ballerinalang.langserver.compiler.common.modal.BallerinaPackage;
 import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.compiler.workspace.WorkspaceDocumentManager;
+import org.ballerinalang.langserver.definition.LSReferencesException;
 import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
+import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.Node;
 import org.ballerinalang.model.tree.TopLevelNode;
@@ -69,6 +72,12 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -80,6 +89,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangStatement;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.io.BufferedReader;
@@ -96,10 +106,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.StringJoiner;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.ballerinalang.langserver.common.utils.CommonUtil.LINE_SEPARATOR;
 import static org.ballerinalang.langserver.common.utils.FunctionGenerator.generateTypeDefinition;
 import static org.ballerinalang.langserver.compiler.LSCompilerUtil.getUntitledFilePath;
+import static org.ballerinalang.langserver.util.references.ReferencesUtil.getReferenceAtCursor;
 
 /**
  * Utilities for the command related operations.
@@ -251,13 +265,41 @@ public class CommandUtil {
             action.setCommand(new Command(commandTitle, CreateVariableExecutor.COMMAND, args));
             action.setDiagnostics(diagnostics);
             actions.add(action);
-
-            commandTitle = CommandConstants.IGNORE_RETURN_TITLE;
-            action = new CodeAction(commandTitle);
-            action.setKind(CodeActionKind.QuickFix);
-            action.setCommand(new Command(commandTitle, IgnoreReturnExecutor.COMMAND, args));
-            action.setDiagnostics(diagnostics);
-            actions.add(action);
+            try {
+                SymbolReferencesModel.Reference referenceAtCursor = getReferenceAtCursor(context, uri, position);
+                BSymbol symbolAtCursor = referenceAtCursor.getSymbol();
+                if (symbolAtCursor instanceof BInvokableSymbol) {
+                    BType returnType = ((BInvokableSymbol) symbolAtCursor).retType;
+                    boolean hasError = false;
+                    if (returnType instanceof BErrorType) {
+                        hasError = true;
+                    } else if (returnType instanceof BUnionType) {
+                        BUnionType unionType = (BUnionType) returnType;
+                        hasError = unionType.getMemberTypes().stream().anyMatch(s -> s instanceof BErrorType);
+                        // Add type guard code action
+                        List<TextEdit> edits = getTypeGuardCodeActionEdits(context, uri, referenceAtCursor, unionType);
+                        commandTitle = String.format(CommandConstants.TYPE_GUARD_TITLE,
+                                                     symbolAtCursor.name);
+                        action = new CodeAction(commandTitle);
+                        action.setKind(CodeActionKind.QuickFix);
+                        action.setEdit(new WorkspaceEdit(Collections.singletonList(Either.forLeft(
+                                new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, null), edits)))));
+                        action.setDiagnostics(diagnostics);
+                        actions.add(action);
+                    }
+                    // Add ignore return value code action
+                    if (!hasError) {
+                        commandTitle = CommandConstants.IGNORE_RETURN_TITLE;
+                        action = new CodeAction(commandTitle);
+                        action.setKind(CodeActionKind.QuickFix);
+                        action.setCommand(new Command(commandTitle, IgnoreReturnExecutor.COMMAND, args));
+                        action.setDiagnostics(diagnostics);
+                        actions.add(action);
+                    }
+                }
+            } catch (LSReferencesException | WorkspaceDocumentException | IOException e) {
+                // ignore
+            }
         } else if (isUnresolvedPackage(diagnosticMessage)) {
             Matcher matcher = CommandConstants.UNRESOLVED_MODULE_PATTERN.matcher(
                     diagnosticMessage.toLowerCase(Locale.ROOT)
@@ -388,6 +430,59 @@ public class CommandUtil {
         return actions;
     }
 
+    private static List<TextEdit> getTypeGuardCodeActionEdits(LSContext context, String uri,
+                                                              SymbolReferencesModel.Reference referenceAtCursor,
+                                                              BUnionType unionType)
+            throws WorkspaceDocumentException, IOException {
+        WorkspaceDocumentManager docManager = context.get(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY);
+        BLangNode bLangNode = referenceAtCursor.getbLangNode();
+        Position startPos = new Position(bLangNode.pos.sLine - 1, bLangNode.pos.sCol - 1);
+        Position endPosWithSemiColon = new Position(bLangNode.pos.eLine - 1, bLangNode.pos.eCol);
+        Position endPos = new Position(bLangNode.pos.eLine - 1, bLangNode.pos.eCol - 1);
+        Range newTextRange = new Range(startPos, endPosWithSemiColon);
+
+        List<TextEdit> edits = new ArrayList<>();
+        String spaces = StringUtils.repeat(' ', bLangNode.pos.sCol - 1);
+        String padding = LINE_SEPARATOR + LINE_SEPARATOR + spaces;
+        String content = getContentOfRange(docManager, uri, new Range(startPos, endPos));
+        boolean hasError = unionType.getMemberTypes().stream().anyMatch(s -> s instanceof BErrorType);
+
+        // Check is binary union type with error type
+        if (unionType.getMemberTypes().size() == 2 && hasError) {
+            unionType.getMemberTypes().stream()
+                    .filter(s -> !(s instanceof BErrorType))
+                    .findFirst()
+                    .ifPresent(bType -> {
+                        if (bType instanceof BNilType) {
+                            // if (foo() is error) {...}
+                            String newText = String.format("if (%s is error) {%s}", content, padding);
+                            edits.add(new TextEdit(newTextRange, newText));
+                        } else {
+                            // if (foo() is int) {...} else {...}
+                            String type = CommonUtil.getBTypeName(bType, context);
+                            String newText = String.format("if (%s is %s) {%s} else {%s}",
+                                                           content, type, padding, padding);
+                            edits.add(new TextEdit(newTextRange, newText));
+                        }
+                    });
+        } else {
+            CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
+            String varName = CommonUtil.generateName(1, bLangNode, compilerContext);
+            List<BType> members = new ArrayList<>((unionType).getMemberTypes());
+            String typeDef = CommonUtil.getBTypeName(unionType, context);
+            String newText = String.format("%s %s = %s%s", typeDef, varName, content, LINE_SEPARATOR);
+            newText += IntStream.range(0, members.size() - 1)
+                    .mapToObj(value -> {
+                        String bTypeName = CommonUtil.getBTypeName(members.get(value), context);
+                        return String.format("if(%s is %s) {%s}", varName, bTypeName, padding);
+                    })
+                    .collect(Collectors.joining(" else "));
+            newText += String.format(" else {%s}", padding);
+            edits.add(new TextEdit(newTextRange, newText));
+        }
+        return edits;
+    }
+
     private static String extractTypeName(LSContext context, Matcher matcher, String foundType, List<TextEdit> edits) {
         if (matcher.find() && matcher.groupCount() > 2) {
             String orgName = matcher.group(1);
@@ -416,7 +511,7 @@ public class CommandUtil {
      */
     public static String getObjectConstructorSnippet(List<BLangSimpleVariable> fields, int baseOffset) {
         StringJoiner funcFields = new StringJoiner(", ");
-        StringJoiner funcBody = new StringJoiner(CommonUtil.LINE_SEPARATOR);
+        StringJoiner funcBody = new StringJoiner(LINE_SEPARATOR);
         String offsetStr = String.join("", Collections.nCopies(baseOffset, " "));
         fields.stream()
                 .filter(bField -> ((bField.symbol.flags & Flags.PUBLIC) != Flags.PUBLIC))
@@ -425,8 +520,8 @@ public class CommandUtil {
                     funcBody.add(offsetStr + "    self." + var.name.value + " = " + var.name.value + ";");
                 });
 
-        return offsetStr + "public function __init(" + funcFields.toString() + ") {" + CommonUtil.LINE_SEPARATOR +
-                funcBody.toString() + CommonUtil.LINE_SEPARATOR + offsetStr + "}" + CommonUtil.LINE_SEPARATOR;
+        return offsetStr + "public function __init(" + funcFields.toString() + ") {" + LINE_SEPARATOR +
+                funcBody.toString() + LINE_SEPARATOR + offsetStr + "}" + LINE_SEPARATOR;
     }
 
     /**
@@ -568,10 +663,11 @@ public class CommandUtil {
         Node result = null;
         TopLevelNode next = (nodeIterator.hasNext()) ? nodeIterator.next() : null;
         while (next != null) {
-            int sLine = next.getPosition().getStartLine();
-            int eLine = next.getPosition().getEndLine();
-            int sCol = next.getPosition().getStartColumn();
-            int eCol = next.getPosition().getEndColumn();
+            org.ballerinalang.util.diagnostic.Diagnostic.DiagnosticPosition nextPosition = next.getPosition();
+            int sLine = nextPosition.getStartLine();
+            int eLine = nextPosition.getEndLine();
+            int sCol = nextPosition.getStartColumn();
+            int eCol = nextPosition.getEndColumn();
             if ((line > sLine || (line == sLine && column >= sCol)) &&
                     (line < eLine || (line == eLine && column <= eCol))) {
                 result = next;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateVariableExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateVariableExecutor.java
@@ -108,7 +108,7 @@ public class CreateVariableExecutor implements LSCommandExecutor {
         }
         CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
         BLangPackage packageNode = CommonUtil.getPackageNode(functionNode);
-        String variableName = CommonUtil.generateName(1, functionNode, compilerContext);
+        String variableName = CommonUtil.generateVariableName(1, functionNode, compilerContext);
 
         if (packageNode == null) {
             throw new LSCommandExecutorException("Package node cannot be null");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateVariableExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateVariableExecutor.java
@@ -36,26 +36,15 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolResolver;
-import org.wso2.ballerinalang.compiler.semantics.model.Scope;
-import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
-import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
-import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
-import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 
 import static org.ballerinalang.langserver.command.CommandUtil.applyWorkspaceEdit;
@@ -71,45 +60,6 @@ import static org.ballerinalang.langserver.common.utils.CommonUtil.createVariabl
 public class CreateVariableExecutor implements LSCommandExecutor {
 
     public static final String COMMAND = "CREATE_VAR";
-
-    private static Set<String> getAllEntries(BLangInvocation functionNode, CompilerContext context) {
-        Set<String> strings = new HashSet<>();
-        BLangPackage packageNode = null;
-        BLangNode parent = functionNode.parent;
-        while (parent != null) {
-            if (parent instanceof BLangPackage) {
-                packageNode = (BLangPackage) parent;
-                break;
-            }
-            if (parent instanceof BLangFunction) {
-                BLangFunction bLangFunction = (BLangFunction) parent;
-                bLangFunction.requiredParams.forEach(var -> strings.add(var.name.value));
-                bLangFunction.defaultableParams.forEach(def -> strings.add(def.var.name.value));
-            }
-            parent = parent.parent;
-        }
-
-        if (packageNode != null) {
-            packageNode.getGlobalVariables().forEach(globalVar -> strings.add(globalVar.name.value));
-            packageNode.getGlobalEndpoints().forEach(endpoint -> strings.add(endpoint.getName().getValue()));
-            packageNode.getServices().forEach(service -> strings.add(service.name.value));
-            packageNode.getFunctions().forEach(func -> strings.add(func.name.value));
-        }
-        BLangNode bLangNode = functionNode.parent;
-        while (bLangNode != null && !(bLangNode instanceof BLangBlockStmt)) {
-            bLangNode = bLangNode.parent;
-        }
-        if (bLangNode != null && packageNode != null) {
-            SymbolResolver symbolResolver = SymbolResolver.getInstance(context);
-            SymbolTable symbolTable = SymbolTable.getInstance(context);
-            BLangBlockStmt blockStmt = (BLangBlockStmt) bLangNode;
-            SymbolEnv symbolEnv = symbolTable.pkgEnvMap.get(packageNode.symbol);
-            SymbolEnv blockEnv = SymbolEnv.createBlockEnv(blockStmt, symbolEnv);
-            Map<Name, Scope.ScopeEntry> entries = symbolResolver.getAllVisibleInScopeSymbols(blockEnv);
-            entries.forEach((name, scopeEntry) -> strings.add(name.value));
-        }
-        return strings;
-    }
 
     /**
      * {@inheritDoc}
@@ -158,7 +108,7 @@ public class CreateVariableExecutor implements LSCommandExecutor {
         }
         CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
         BLangPackage packageNode = CommonUtil.getPackageNode(functionNode);
-        String variableName = CommonUtil.generateName(1, getAllEntries(functionNode, compilerContext));
+        String variableName = CommonUtil.generateName(1, functionNode, compilerContext);
 
         if (packageNode == null) {
             throw new LSCommandExecutorException("Package node cannot be null");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -90,4 +90,6 @@ public class CommandConstants {
     public static final String MAKE_OBJ_ABSTRACT_TITLE = "Make '%s' an Abstract Object";
 
     public static final String MAKE_OBJ_NON_ABSTRACT_TITLE = "Make '%s' an Non-Abstract Object";
+
+    public static final String TYPE_GUARD_TITLE = "Type Guard '%s'";
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -104,6 +104,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -114,6 +115,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
 
 import static org.ballerinalang.langserver.compiler.LSCompilerUtil.getUntitledFilePath;
@@ -1289,12 +1291,27 @@ public class CommonUtil {
             // Lower first letter
             newName = newName.substring(0, 1).toLowerCase(Locale.getDefault()) + newName.substring(1);
             // if already available, try appending 'Result'
-            if (allNameEntries.contains(newName)) {
-                newName = newName + "Result";
+            Iterator<String> iterator = allNameEntries.iterator();
+            boolean alreadyExists = false;
+            boolean appendResult = true;
+            boolean appendOut = true;
+            String suffixResult = "Result";
+            String suffixOut = "Out";
+            while (iterator.hasNext()) {
+                String next = iterator.next();
+                if (next.equals(newName)) {
+                    alreadyExists = true;
+                } else if (next.equals(newName + suffixResult)) {
+                    appendResult = false;
+                } else if (next.equals(newName + suffixOut)) {
+                    appendOut = false;
+                }
             }
-            // if already available, try appending 'Out'
-            if (allNameEntries.contains(newName)) {
-                newName = newName + "Out";
+            // if already available, try appending 'Result' or 'Out'
+            if (alreadyExists && appendResult) {
+                newName = newName + suffixResult;
+            } else if (alreadyExists && appendOut) {
+                newName = newName + suffixOut;
             }
             // if still already available, try a random letter
             while (allNameEntries.contains(newName)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -114,7 +114,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 
 import static org.ballerinalang.langserver.compiler.LSCompilerUtil.getUntitledFilePath;
@@ -1287,17 +1286,22 @@ public class CommonUtil {
                 List<String> restParts = Arrays.stream(parts, 1, parts.length).collect(Collectors.toList());
                 newName = parts[0] + StringUtils.capitalize(String.join("", restParts));
             }
+            // Lower first letter
+            newName = newName.substring(0, 1).toLowerCase(Locale.getDefault()) + newName.substring(1);
             // if already available, try appending 'Result'
             if (allNameEntries.contains(newName)) {
                 newName = newName + "Result";
+            }
+            // if already available, try appending 'Out'
+            if (allNameEntries.contains(newName)) {
+                newName = newName + "Out";
             }
             // if still already available, try a random letter
             while (allNameEntries.contains(newName)) {
                 newName = generateVariableName(++value, bLangNode, context);
             }
         }
-        // Lower first letter
-        return newName.substring(0, 1).toLowerCase(Locale.getDefault()) + newName.substring(1);
+        return newName;
     }
 
     public static BLangPackage getPackageNode(BLangNode bLangNode) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -1289,6 +1289,10 @@ public class CommonUtil {
                 List<String> restParts = Arrays.stream(parts, 1, parts.length).collect(Collectors.toList());
                 newName = parts[0] + StringUtils.capitalize(String.join("", restParts));
             }
+            // If empty, revert back to original name
+            if (newName.isEmpty()) {
+                newName = ((BLangInvocation) bLangNode).name.value;
+            }
             // Lower first letter
             newName = newName.substring(0, 1).toLowerCase(Locale.getDefault()) + newName.substring(1);
             // if already available, try appending 'Result'

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -1282,6 +1282,7 @@ public class CommonUtil {
             newName = replacer.apply("update", newName);
             newName = replacer.apply("set", newName);
             newName = replacer.apply("add", newName);
+            newName = replacer.apply("create", newName);
             // Remove '_' underscores
             while (newName.contains("_")) {
                 String[] parts = newName.split("_");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BFunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BFunctionCompletionItemBuilder.java
@@ -179,14 +179,16 @@ public final class BFunctionCompletionItemBuilder {
                 insertText.append("${1}");
             }
         } else {
-            for (int itr = 0; itr < parameterDefs.size(); itr++) {
-                signature.append(getParameterSignature(parameterDefs.get(itr), false));
+            if (!parameterDefs.isEmpty()) {
+                for (int itr = 0; itr < parameterDefs.size(); itr++) {
+                    signature.append(getParameterSignature(parameterDefs.get(itr), false));
 
-                if (itr != parameterDefs.size() - 1) {
-                    signature.append(", ");
+                    if (itr != parameterDefs.size() - 1) {
+                        signature.append(", ");
+                    }
                 }
+                insertText.append("${1}");
             }
-            insertText.append("${1}");
         }
         signature.append(")");
         insertText.append(")");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferenceFindingVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferenceFindingVisitor.java
@@ -148,7 +148,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
                     + napespaceUriWsList.get(0).getPrevious().length() + napespaceUriWsList.get(0).getWs().length();
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(xmlNsPos.src, xmlNsPos.sLine, xmlNsPos.sLine, sCol, eCol);
-            this.addSymbol(xmlnsNode.symbol, true, pos);
+            this.addSymbol(xmlnsNode, xmlnsNode.symbol, true, pos);
         }
     }
 
@@ -161,7 +161,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
                     + this.getTypeLengthWithWS(constant.typeNode, true);
             int eCol = sSol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(varPos.src, varPos.sLine, varPos.eLine, sSol, eCol);
-            this.addSymbol(constant.symbol, true, pos);
+            this.addSymbol(constant, constant.symbol, true, pos);
         }
     }
 
@@ -173,7 +173,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             int sCol = servicePos.sCol + wsList.get(1).toString().length();
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(servicePos.src, servicePos.sLine, servicePos.eLine, sCol, eCol);
-            this.addSymbol(serviceNode.symbol, true, pos);
+            this.addSymbol(serviceNode, serviceNode.symbol, true, pos);
         }
         if (serviceNode.attachedExprs != null) {
             serviceNode.attachedExprs.forEach(this::acceptNode);
@@ -190,7 +190,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             int sCol = funcPos.sCol + this.getCharLengthBeforeToken(this.tokenName, wsList);
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(funcPos.src, funcPos.sLine, funcPos.sLine, sCol, eCol);
-            this.addSymbol(funcNode.symbol, isDefinition, pos);
+            this.addSymbol(funcNode, funcNode.symbol, isDefinition, pos);
         }
 
         funcNode.defaultableParams.forEach(this::acceptNode);
@@ -211,7 +211,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             int sCol = typeDefPos.sCol + this.getCharLengthBeforeToken(this.tokenName, wsList);
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(typeDefPos.src, typeDefPos.sLine, typeDefPos.sLine, sCol, eCol);
-            this.addSymbol(typeDefinition.symbol, true, pos);
+            this.addSymbol(typeDefinition, typeDefinition.symbol, true, pos);
         }
 
         // Visit the type node
@@ -311,7 +311,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             } else {
                 pos = varPos;
             }
-            this.addSymbol(varNode.symbol, true, pos);
+            this.addSymbol(varNode, varNode.symbol, true, pos);
         } else {
             this.acceptNode(typeNode);
         }
@@ -347,7 +347,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             }
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(varPos.src, varPos.sLine, varPos.eLine, sCol, eCol);
-            this.addSymbol(variable.symbol, true, pos);
+            this.addSymbol(variable, variable.symbol, true, pos);
         } else {
             // In the foreach's variable definition node, type becomes null and will be handled by the acceptNode
             this.acceptNode(typeNode);
@@ -412,12 +412,12 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             int sCol = varRefPos.getStartColumn() + this.getCharLengthBeforeToken(this.tokenName, wsList);
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(varRefPos.src, varRefPos.sLine, varRefPos.sLine, sCol, eCol);
-            this.addSymbol(varRefExpr.symbol, false, pos);
+            this.addSymbol(varRefExpr, varRefExpr.symbol, false, pos);
         } else if (varRefExpr.pkgAlias.value.equals(this.tokenName)) {
             int sCol = varRefPos.getStartColumn();
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos pos = new DiagnosticPos(varRefPos.src, varRefPos.sLine, varRefPos.sLine, sCol, eCol);
-            this.addSymbol(varRefExpr.pkgSymbol, false, pos);
+            this.addSymbol(varRefExpr, varRefExpr.pkgSymbol, false, pos);
         }
     }
 
@@ -444,7 +444,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             wsList.remove(0);
             int eCol = sCol + this.getCharLengthBeforeToken(this.tokenName, wsList);
             DiagnosticPos symbolPos = new DiagnosticPos(pos.src, pos.sLine, pos.sLine, sCol, eCol);
-            this.addSymbol(fieldAccessExpr.symbol, false, symbolPos);
+            this.addSymbol(fieldAccessExpr, fieldAccessExpr.symbol, false, symbolPos);
         }
     }
 
@@ -494,7 +494,8 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
         if (!this.isMatchingUserDefinedType(userDefinedType)) {
             return;
         }
-        this.addSymbol(userDefinedType.type.tsymbol, false, this.getTypeNamePosition(userDefinedType, this.tokenName));
+        this.addSymbol(userDefinedType, userDefinedType.type.tsymbol, false,
+                       this.getTypeNamePosition(userDefinedType, this.tokenName));
     }
 
     @Override
@@ -581,7 +582,7 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
             sCol += this.getCharLengthBeforeToken(this.tokenName, wsList);
             int eCol = sCol + this.tokenName.length();
             DiagnosticPos symbolPos = new DiagnosticPos(pos.src, pos.sLine, pos.eLine, sCol, eCol);
-            this.addSymbol(invocationExpr.symbol, false, symbolPos);
+            this.addSymbol(invocationExpr, invocationExpr.symbol, false, symbolPos);
         }
         invocationExpr.argExprs.forEach(this::acceptNode);
     }
@@ -658,12 +659,14 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
         return bType.typeName.value.equals(this.tokenName);
     }
 
-    private SymbolReferencesModel.Reference getSymbolReference(BSymbol symbol, DiagnosticPos position) {
-        return new SymbolReferencesModel.Reference(position, symbol);
+    private SymbolReferencesModel.Reference getSymbolReference(DiagnosticPos position, BSymbol symbol,
+                                                               BLangNode bLangNode) {
+        return new SymbolReferencesModel.Reference(position, symbol, bLangNode);
     }
 
-    private void addSymbol(BSymbol bSymbol, boolean isDefinition, DiagnosticPos position) {
-        Optional<SymbolReferencesModel.Reference> symbolAtCursor = this.symbolReferences.getSymbolAtCursor();
+    private void addSymbol(BLangNode bLangNode, BSymbol bSymbol,
+                           boolean isDefinition, DiagnosticPos position) {
+        Optional<SymbolReferencesModel.Reference> symbolAtCursor = this.symbolReferences.getReferenceAtCursor();
         // Here, tsymbol check has been added in order to support the finite types
         // TODO: Handle finite type. After the fix check if it falsely capture symbols in other files with same name
         if (!this.currentCUnitMode && symbolAtCursor.isPresent() && (symbolAtCursor.get().getSymbol() != bSymbol
@@ -675,11 +678,11 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
         BSymbol originalSymbol = (bSymbol instanceof BVarSymbol && ((BVarSymbol) bSymbol).originalSymbol != null)
                 ? ((BVarSymbol) bSymbol).originalSymbol
                 : bSymbol;
-        SymbolReferencesModel.Reference ref = this.getSymbolReference(originalSymbol, zeroBasedPos);
+        SymbolReferencesModel.Reference ref = this.getSymbolReference(zeroBasedPos, originalSymbol, bLangNode);
         if (this.currentCUnitMode && this.cursorLine == zeroBasedPos.sLine && this.cursorCol >= zeroBasedPos.sCol
                 && this.cursorCol <= zeroBasedPos.eCol) {
             // This is the symbol at current cursor position
-            this.symbolReferences.setSymbolAtCursor(ref);
+            this.symbolReferences.setReferenceAtCursor(ref);
             return;
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferencesModel.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferencesModel.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.util.references;
 
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
@@ -32,7 +33,7 @@ import java.util.stream.Collectors;
 public class SymbolReferencesModel {
     private List<Reference> references = new ArrayList<>();
     private List<Reference> definitions = new ArrayList<>();
-    private Reference symbolAtCursor = null;
+    private Reference referenceAtCursor = null;
 
     public List<Reference> getReferences() {
         return references;
@@ -50,12 +51,12 @@ public class SymbolReferencesModel {
         this.definitions.add(definition);
     }
 
-    public Optional<Reference> getSymbolAtCursor() {
-        return Optional.ofNullable(symbolAtCursor);
+    public Optional<Reference> getReferenceAtCursor() {
+        return Optional.ofNullable(referenceAtCursor);
     }
 
-    public void setSymbolAtCursor(Reference symbol) {
-        this.symbolAtCursor = symbol;
+    public void setReferenceAtCursor(Reference symbol) {
+        this.referenceAtCursor = symbol;
     }
 
     /**
@@ -64,13 +65,15 @@ public class SymbolReferencesModel {
     public static class Reference {
         private DiagnosticPos position;
         private BSymbol symbol;
+        private BLangNode bLangNode;
         private String compilationUnit;
         private String symbolPkgName;
         private String sourcePkgName;
 
-        public Reference(DiagnosticPos position, BSymbol symbol) {
+        public Reference(DiagnosticPos position, BSymbol symbol, BLangNode bLangNode) {
             this.position = position;
             this.symbol = symbol;
+            this.bLangNode = bLangNode;
             this.symbolPkgName = symbol.pkgID.nameComps.stream().map(Name::getValue).collect(Collectors.joining("."));
             this.compilationUnit = position.src.cUnitName;
             this.sourcePkgName = position.src.pkgID.name.value;
@@ -94,6 +97,10 @@ public class SymbolReferencesModel {
 
         public BSymbol getSymbol() {
             return symbol;
+        }
+
+        public BLangNode getbLangNode() {
+            return bLangNode;
         }
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CodeActionTest.java
@@ -216,8 +216,11 @@ public class CodeActionTest {
         JsonObject responseJson = this.getResponseJson(res);
         for (JsonElement jsonElement : responseJson.getAsJsonArray("result")) {
             JsonElement right = jsonElement.getAsJsonObject().get("right");
-
-            JsonObject edit = right.getAsJsonObject().get("edit").getAsJsonObject().get("documentChanges")
+            JsonElement editText = right.getAsJsonObject().get("edit");
+            if (editText == null) {
+                continue;
+            }
+            JsonObject edit = editText.getAsJsonObject().get("documentChanges")
                     .getAsJsonArray().get(0).getAsJsonObject().get("edits").getAsJsonArray().get(0)
                     .getAsJsonObject();
             if (right.getAsJsonObject().get("title").toString().equals(title) && edit.equals(
@@ -240,7 +243,11 @@ public class CodeActionTest {
 //                {"fixReturnType2.json", "fixReturnType.bal"}, //Re-Enable once Tuple error msg is fixed in TypeChecker
                 {"fixReturnType3.json", "fixReturnType.bal"},
 //                {"markUntaintedCodeAction1.json", "taintedVariable.bal"},
-//                {"markUntaintedCodeAction2.json", "taintedVariable.bal"}
+//                {"markUntaintedCodeAction2.json", "taintedVariable.bal"},
+//                {"typeGuardCodeAction1.json", "typeGuard.bal"},
+//                {"typeGuardCodeAction2.json", "typeGuard.bal"},
+//                {"typeGuardCodeAction3.json", "typeGuard.bal"},
+                {"typeGuardCodeAction4.json", "typeGuard.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/source/typeGuard.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/source/typeGuard.bal
@@ -1,0 +1,28 @@
+import ballerina/io;
+
+public function main(string... args) {
+    foo();
+    getBar();
+    update_apple();
+    get_orange();
+}
+
+function foo() returns (int | string | error) {
+    error e = error("incompatible reason");
+    return e;
+}
+
+function getBar() returns (error?) {
+    error e = error("incompatible reason");
+    return e;
+}
+
+function update_apple() returns (int|error) {
+    error e = error("incompatible reason");
+    return e;
+}
+
+function get_orange() returns (int | string | boolean) {
+    error e = error("incompatible reason");
+    return true;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction1.json
@@ -1,0 +1,20 @@
+{
+    "line": 3,
+    "character": 6,
+    "expected": {
+        "title": "Type Guard 'foo'",
+        "edit": {
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 4
+                },
+                "end": {
+                    "line": 3,
+                    "character": 10
+                }
+            },
+            "newText": "(int|string|error) fooResult = foo();\n    if (fooResult is int) {\n\n    } else if (fooResult is string) {\n\n    } else {\n\n    }"
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction2.json
@@ -1,0 +1,20 @@
+{
+    "line": 4,
+    "character": 6,
+    "expected": {
+        "title": "Type Guard 'getBar'",
+        "edit": {
+            "range": {
+                "start": {
+                    "line": 4,
+                    "character": 4
+                },
+                "end": {
+                    "line": 4,
+                    "character": 13
+                }
+            },
+            "newText": "if (getBar() is error) {\n\n    }"
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction3.json
@@ -1,0 +1,20 @@
+{
+    "line": 5,
+    "character": 6,
+    "expected": {
+        "title": "Type Guard 'update_apple'",
+        "edit": {
+            "range": {
+                "start": {
+                    "line": 5,
+                    "character": 4
+                },
+                "end": {
+                    "line": 5,
+                    "character": 19
+                }
+            },
+            "newText": "if (update_apple() is int) {\n\n    } else {\n\n    }"
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/typeGuardCodeAction4.json
@@ -1,0 +1,20 @@
+{
+    "line": 6,
+    "character": 6,
+    "expected": {
+        "title": "Type Guard 'get_orange'",
+        "edit": {
+            "range": {
+                "start": {
+                    "line": 6,
+                    "character": 4
+                },
+                "end": {
+                    "line": 6,
+                    "character": 17
+                }
+            },
+            "newText": "(int|string|boolean) orange = get_orange();\n    if (orange is int) {\n\n    } else if (orange is string) {\n\n    } else {\n\n    }"
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> Add type guard code action for the function invocations.

Fixes #15718 
Fixes #16404


**Before code action:**
```ballerina
public function main(string... args) {
    foo();
}

function foo() returns (int | string | error) {
    error e = error("incompatible reason");
    return e;
}
```

**After code action:**
```ballerina
public function main(string... args) {
    (int|string|error) fooResult = foo();
    if (fooResult is int) {

    } else if (fooResult is string) {

    } else {

    }
}

function foo() returns (int | string | error) {
    error e = error("incompatible reason");
    return e;
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
