### PR TITLE
Disable JBallerina ArgumentParserPositiveTest

### DIFF
--- a/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
+++ b/tests/ballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
@@ -36,7 +36,6 @@ import java.nio.file.Paths;
  *
  * @since 0.990.4
  */
-@Test(groups = "brokenOnJBallerina")
 public class ArgumentParserPositiveTest {
 
     private static final String MAIN_FUNCTION_TEST_SRC_DIR = "src/test/resources/test-src/main.function";

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
@@ -34,6 +34,7 @@ import java.io.PrintStream;
  *
  * @since 0.990.4
  */
+@Test(groups = { "brokenOnJBallerina" })
 public class ArgumentParserPositiveTest {
 
     private static final String MAIN_FUNCTION_TEST_SRC_DIR = "test-src/main.function/";


### PR DESCRIPTION
## Purpose
Fix disabling of Ballerina ArgumentParserPositiveTest instead of JBallerina ArgumentParserPositiveTest.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
