### PR TITLE
Fix a typo in the TCP socket example listener

### DIFF
--- a/examples/tcp-socket-listener-client/tcp_socket_listener.bal
+++ b/examples/tcp-socket-listener-client/tcp_socket_listener.bal
@@ -39,7 +39,7 @@ service echoServer on new  socket:Listener(61598) {
                         err = str);
                 }
             } else {
-                log:printInfo("Client leaved: " + caller.remotePort);
+                log:printInfo("Client left: " + caller.remotePort);
             }
         } else {
             io:println(result);

--- a/examples/tcp-socket-listener-client/tcp_socket_listener.out
+++ b/examples/tcp-socket-listener-client/tcp_socket_listener.out
@@ -8,4 +8,4 @@ $ ballerina run tcp_socket_listener.bal
 
 2019-02-18 11:24:32,429 INFO  [] - Client connected: 504372137
 2019-02-18 11:24:32,467 INFO  [] - Number of bytes written: 20
-2019-02-18 11:24:32,487 INFO  [] - Client leaved: 504372137
+2019-02-18 11:24:32,487 INFO  [] - Client left: 504372137


### PR DESCRIPTION
## Purpose
Fix a typo in the <ballerina-lang-repo>/examples/tcp-socket-listener-client/tcp_socket_listener.bal file.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/15733

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
