### PR TITLE
 Enable TableTest, fixes issues, disables some /  Fix issues in migration logic 

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValue.java
@@ -43,7 +43,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,7 +77,6 @@ public class ArrayValue implements RefValue, CollectionValue {
     private byte[] byteValues;
     private double[] floatValues;
     private String[] stringValues;
-    private BigDecimal[] decimalValues;
 
     public BType elementType;
 
@@ -118,12 +116,6 @@ public class ArrayValue implements RefValue, CollectionValue {
         this.stringValues = values;
         this.size = values.length;
         setArrayElementType(BTypes.typeString);
-    }
-
-    public ArrayValue(BigDecimal[] values) {
-        this.decimalValues = values;
-        this.size = values.length;
-        setArrayElementType(BTypes.typeDecimal);
     }
 
     public ArrayValue(BType type) {
@@ -265,11 +257,6 @@ public class ArrayValue implements RefValue, CollectionValue {
     public String getString(long index) {
         rangeCheckForGet(index, size);
         return stringValues[(int) index];
-    }
-
-    public BigDecimal getDecimal(long index) {
-        rangeCheckForGet(index, size);
-        return decimalValues[(int) index];
     }
 
     public Object get(long index) {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableIterator.java
@@ -268,45 +268,45 @@ public class TableIterator implements DataIterator {
     private ArrayValue createAndPopulatePrimitiveValueArray(Object firstNonNullElement, Object[] dataArray) {
         int length = dataArray.length;
         if (firstNonNullElement instanceof String) {
-            ArrayValue stringDataArray = new ArrayValue(BTypes.typeString);
+            ArrayValue stringDataArray = new ArrayValue(new BArrayType(BTypes.typeString));
             for (int i = 0; i < length; i++) {
                 stringDataArray.add(i, (String) dataArray[i]);
             }
             return stringDataArray;
         } else if (firstNonNullElement instanceof Boolean) {
-            ArrayValue boolDataArray = new ArrayValue(BTypes.typeBoolean);
+            ArrayValue boolDataArray = new ArrayValue(new BArrayType(BTypes.typeBoolean));
             for (int i = 0; i < length; i++) {
-                boolDataArray.add(i, ((Boolean) dataArray[i]) ? 1 : 0);
+                boolDataArray.add(i, ((Boolean) dataArray[i]).booleanValue());
             }
             return boolDataArray;
         } else if (firstNonNullElement instanceof Integer) {
-            ArrayValue intDataArray = new ArrayValue(BTypes.typeInt);
+            ArrayValue intDataArray = new ArrayValue(new BArrayType(BTypes.typeInt));
             for (int i = 0; i < length; i++) {
-                intDataArray.add(i, dataArray[i]);
+                intDataArray.add(i, ((Integer) dataArray[i]).intValue());
             }
             return intDataArray;
         } else if (firstNonNullElement instanceof Long) {
-            ArrayValue longDataArray = new ArrayValue(BTypes.typeInt);
+            ArrayValue longDataArray = new ArrayValue(new BArrayType(BTypes.typeInt));
             for (int i = 0; i < length; i++) {
-                longDataArray.add(i, dataArray[i]);
+                longDataArray.add(i, ((Long) dataArray[i]).longValue());
             }
             return longDataArray;
         } else if (firstNonNullElement instanceof Float) {
-            ArrayValue floatDataArray = new ArrayValue(BTypes.typeFloat);
+            ArrayValue floatDataArray = new ArrayValue(new BArrayType(BTypes.typeFloat));
             for (int i = 0; i < length; i++) {
-                floatDataArray.add(i, dataArray[i]);
+                floatDataArray.add(i, ((Float) dataArray[i]).floatValue());
             }
             return floatDataArray;
         } else if (firstNonNullElement instanceof Double) {
-            ArrayValue doubleDataArray = new ArrayValue(BTypes.typeFloat);
+            ArrayValue doubleDataArray = new ArrayValue(new BArrayType(BTypes.typeFloat));
             for (int i = 0; i < dataArray.length; i++) {
-                doubleDataArray.add(i, dataArray[i]);
+                doubleDataArray.add(i, ((Double) dataArray[i]).doubleValue());
             }
             return doubleDataArray;
         } else if ((firstNonNullElement instanceof BigDecimal)) {
-            ArrayValue decimalDataArray = new ArrayValue(BTypes.typeDecimal);
+            ArrayValue decimalDataArray = new ArrayValue(new BArrayType(BTypes.typeDecimal));
             for (int i = 0; i < dataArray.length; i++) {
-                decimalDataArray.add(i, dataArray[i]);
+                decimalDataArray.add(i, new DecimalValue((BigDecimal) dataArray[i]));
             }
             return decimalDataArray;
         } else {
@@ -320,37 +320,37 @@ public class TableIterator implements DataIterator {
         if (firstNonNullElement instanceof String) {
             refValueArray = createEmptyRefValueArray(BTypes.typeString, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (String) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i]);
             }
         } else if (firstNonNullElement instanceof Boolean) {
             refValueArray = createEmptyRefValueArray(BTypes.typeBoolean, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (Boolean) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i]);
             }
         } else if (firstNonNullElement instanceof Integer) {
             refValueArray = createEmptyRefValueArray(BTypes.typeInt, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (Long) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i]);
             }
         } else if (firstNonNullElement instanceof Long) {
             refValueArray = createEmptyRefValueArray(BTypes.typeInt, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (Long) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i]);
             }
         } else if (firstNonNullElement instanceof Float) {
             refValueArray = createEmptyRefValueArray(BTypes.typeFloat, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (Double) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i]);
             }
         } else if (firstNonNullElement instanceof Double) {
             refValueArray = createEmptyRefValueArray(BTypes.typeFloat, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (Double) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i]);
             }
         } else if (firstNonNullElement instanceof BigDecimal) {
             refValueArray = createEmptyRefValueArray(BTypes.typeDecimal, length);
             for (int i = 0; i < length; i++) {
-                refValueArray.add(i, dataArray[i] != null ? (BigDecimal) dataArray[i] : null);
+                refValueArray.add(i, dataArray[i] != null ? new DecimalValue((BigDecimal) dataArray[i]) : null);
             }
         }
         return refValueArray;

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableValue.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.jvm.values;
 
+import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.ColumnDefinition;
 import org.ballerinalang.jvm.DataIterator;
 import org.ballerinalang.jvm.TableProvider;
@@ -27,7 +28,6 @@ import org.ballerinalang.jvm.types.BTableType;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.types.BTypes;
 import org.ballerinalang.jvm.util.exceptions.BallerinaErrorReasons;
-import org.ballerinalang.jvm.util.exceptions.BallerinaException;
 import org.ballerinalang.jvm.values.freeze.FreezeUtils;
 import org.ballerinalang.jvm.values.freeze.State;
 import org.ballerinalang.jvm.values.freeze.Status;
@@ -80,13 +80,13 @@ public class TableValue implements RefValue, CollectionValue {
                       BStructureType constraintType, ArrayValue params) {
         this.tableProvider = TableProvider.getInstance();
         if (!fromTable.isInMemoryTable()) {
-            throw new BallerinaException(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
-                                         "Table query over a cursor table not supported");
+            throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                    "Table query over a cursor table not supported");
         }
         if (joinTable != null) {
             if (!joinTable.isInMemoryTable()) {
-                throw new BallerinaException(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
-                                             "Table query over a cursor table not supported");
+                throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                        "Table query over a cursor table not supported");
             }
             this.tableName = tableProvider.createTable(fromTable.tableName, joinTable.tableName, query,
                                                        constraintType, params);
@@ -161,7 +161,8 @@ public class TableValue implements RefValue, CollectionValue {
 
     public boolean hasNext() {
         if (tableClosed) {
-            throw new BallerinaException("Trying to perform hasNext operation over a closed table");
+            throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                    "Trying to perform hasNext operation over a closed table");
         }
         if (isIteratorGenerationConditionMet()) {
             generateIterator();
@@ -178,8 +179,8 @@ public class TableValue implements RefValue, CollectionValue {
 
     public void moveToNext() {
         if (tableClosed) {
-            throw new BallerinaException(BallerinaErrorReasons.TABLE_CLOSED_ERROR,
-                                         "Trying to perform an operation over a closed table");
+            throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_CLOSED_ERROR,
+                    "Trying to perform an operation over a closed table");
         }
         if (isIteratorGenerationConditionMet()) {
             generateIterator();
@@ -236,8 +237,9 @@ public class TableValue implements RefValue, CollectionValue {
 
     public void addData(MapValueImpl<String, Object> data) {
         if (data.getType() != this.constraintType) {
-            throw new BallerinaException("incompatible types: record of type:" + data.getType().getName()
-                                         + " cannot be added to a table with type:" + this.constraintType.getName());
+            throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                    "incompatible types: record of type:" + data.getType().getName()
+                            + " cannot be added to a table with type:" + this.constraintType.getName());
         }
         tableProvider.insertData(tableName, data);
         reset();
@@ -296,7 +298,8 @@ public class TableValue implements RefValue, CollectionValue {
     @Override
     public Object copy(Map<Object, Object> refs) {
         if (tableClosed) {
-            throw new BallerinaException("Trying to invoke clone built-in method over a closed table");
+            throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                    "Trying to invoke clone built-in method over a closed table");
         }
 
         if (isFrozen()) {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/PoolOptionsWrapper.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/PoolOptionsWrapper.java
@@ -19,7 +19,6 @@
 package org.ballerinax.jdbc;
 
 import org.ballerinalang.jvm.values.MapValue;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -74,7 +73,7 @@ public class PoolOptionsWrapper {
         try {
             sqlDatasource.acquireMutex();
         } catch (InterruptedException e) {
-            throw new BallerinaException("error in obtaining a connection pool");
+            throw SQLDatasourceUtils.getSQLApplicationError("error in obtaining a connection pool");
         }
     }
 

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/SQLDataIterator.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/SQLDataIterator.java
@@ -34,7 +34,7 @@ import org.ballerinalang.jvm.values.MapValueImpl;
 import org.ballerinalang.jvm.values.RefValue;
 import org.ballerinalang.jvm.values.TableIterator;
 import org.ballerinalang.stdlib.time.util.TimeUtils;
-import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinax.jdbc.exceptions.PanickingApplicationException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -62,8 +62,8 @@ import javax.sql.rowset.CachedRowSet;
 public class SQLDataIterator extends TableIterator {
 
     private Calendar utcCalendar;
-    private static final String UNASSIGNABLE_UNIONTYPE_EXCEPTION =
-            "Corresponding Union type in the record is not an assignable nillable type";
+    private static final String UNASSIGNABLE_UNIONTYPE_EXCEPTION = "Corresponding Union type in the record is not "
+            + "an assignable nillable type";
     private static final String MISMATCHING_FIELD_ASSIGNMENT = "Trying to assign to a mismatching type";
     private String sourceDatabase;
     private static final String POSTGRES_OID_COLUMN_TYPE_NAME = "oid";
@@ -84,7 +84,7 @@ public class SQLDataIterator extends TableIterator {
             resourceManager.gracefullyReleaseResources();
             rs = null;
         } catch (SQLException e) {
-            throw new BallerinaException(e.getMessage(), e);
+            throw SQLDatasourceUtils.getSQLDatabaseError(e);
         }
     }
 
@@ -96,7 +96,7 @@ public class SQLDataIterator extends TableIterator {
                 close();
             }
         } catch (SQLException e) {
-            throw new BallerinaException(e.getMessage(), e);
+            throw SQLDatasourceUtils.getSQLDatabaseError(e);
         }
     }
 
@@ -106,14 +106,15 @@ public class SQLDataIterator extends TableIterator {
             Blob bValue = rs.getBlob(columnIndex);
             return rs.wasNull() ? null : SQLDatasourceUtils.getString(bValue);
         } catch (SQLException e) {
-            throw new BallerinaException(e.getMessage(), e);
+            throw SQLDatasourceUtils.getSQLDatabaseError(e);
         }
     }
 
     @Override
     public MapValue<String, Object> generateNext() {
         if (this.type == null) {
-            throw new BallerinaException("the expected record type is not specified in the remote function");
+            throw SQLDatasourceUtils
+                    .getSQLApplicationError("the expected record type is not specified in the remote function");
         }
         MapValue<String, Object> bStruct = new MapValueImpl<>(this.type);
         int index = 0;
@@ -122,9 +123,10 @@ public class SQLDataIterator extends TableIterator {
         try {
             BField[] structFields = this.type.getFields().values().toArray(new BField[0]);
             if (columnDefs.size() != structFields.length) {
-                throw new BallerinaException(
-                        "Number of fields in the constraint type is " + (structFields.length > columnDefs.size() ?
-                                "greater" : "lower") + " than column count of the result set");
+                throw SQLDatasourceUtils.getSQLApplicationError("Number of fields in the constraint type is " + (
+                        structFields.length > columnDefs.size() ?
+                                "greater" :
+                                "lower") + " than column count of the result set");
             }
             for (ColumnDefinition columnDef : columnDefs) {
                 if (columnDef instanceof SQLColumnDefinition) {
@@ -231,62 +233,67 @@ public class SQLDataIterator extends TableIterator {
                             handleStructValue(bStruct, fieldName, structData, fieldType);
                             break;
                         default:
-                            throw new BallerinaException("unsupported sql type "
-                                    + sqlType + " found for the column " + columnName + " index:" + index);
+                            throw SQLDatasourceUtils.getSQLApplicationError(
+                                    "unsupported sql type " + sqlType + " found for the column " + columnName
+                                            + " index:" + index);
                     }
                 }
             }
         } catch (IOException | SQLException e) {
-            throw new BallerinaException(
+            throw SQLDatasourceUtils.getSQLApplicationError(
                     "error in retrieving next value for column: " + columnName + ": of SQL Type: " + sqlType + ": "
                             + "at " + "index:" + index + ":" + e.getMessage());
+        } catch (PanickingApplicationException e) {
+            throw SQLDatasourceUtils.getSQLApplicationError(e);
         }
         return bStruct;
     }
 
     private void validateAndSetRefRecordField(MapValue<String, Object> bStruct, String fieldName, int expectedTypeTag,
-            int actualTypeTag, Object value, String exceptionMessage) {
+            int actualTypeTag, Object value, String exceptionMessage) throws PanickingApplicationException {
         setMatchingRefRecordField(bStruct, fieldName, value, expectedTypeTag == actualTypeTag, exceptionMessage);
     }
 
     private void validateAndSetRefRecordField(MapValue<String, Object> bStruct, String fieldName,
-           int expectedTypeTags[], int actualTypeTag, Object value, String exceptionMessage) {
+            int expectedTypeTags[], int actualTypeTag, Object value, String exceptionMessage)
+            throws PanickingApplicationException {
         boolean typeMatches = Arrays.stream(expectedTypeTags).anyMatch(tag -> actualTypeTag == tag);
         setMatchingRefRecordField(bStruct, fieldName, value, typeMatches, exceptionMessage);
     }
 
     private void setMatchingRefRecordField(MapValue<String, Object> bStruct, String fieldName, Object value,
-            boolean typeMatches, String exceptionMessage) {
+            boolean typeMatches, String exceptionMessage) throws PanickingApplicationException {
         if (typeMatches) {
             bStruct.put(fieldName, value);
         } else {
-            throw new BallerinaException(exceptionMessage);
+            throw new PanickingApplicationException(exceptionMessage);
         }
     }
 
-    private void handleNilToNonNillableFieldAssignment() {
-        throw new BallerinaException("Trying to assign a Nil value to a non-nillable field");
+    private void handleNilToNonNillableFieldAssignment() throws PanickingApplicationException {
+        throw new PanickingApplicationException("Trying to assign a Nil value to a non-nillable field");
     }
 
-    private void handleMismatchingFieldAssignment() {
-        throw new BallerinaException("Trying to assign to a mismatching type");
+    private void handleMismatchingFieldAssignment() throws PanickingApplicationException {
+        throw new PanickingApplicationException("Trying to assign to a mismatching type");
     }
 
-    private void handleUnAssignableUnionTypeAssignment() {
-        throw new BallerinaException(UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+    private void handleUnAssignableUnionTypeAssignment() throws PanickingApplicationException {
+        throw new PanickingApplicationException(UNASSIGNABLE_UNIONTYPE_EXCEPTION);
     }
 
-    private int retrieveNonNilTypeTag(BType fieldType) {
+    private int retrieveNonNilTypeTag(BType fieldType) throws PanickingApplicationException {
         List<BType> members = ((BUnionType) fieldType).getMemberTypes();
         return retrieveNonNilType(members).getTag();
     }
 
     private MapValue<String, Object> createTimeStruct(long millis) {
-        return TimeUtils.createTimeRecord(TimeUtils.getTimeZoneRecord(), TimeUtils.getTimeRecord(),
-                millis, Constants.TIMEZONE_UTC);
+        return TimeUtils.createTimeRecord(TimeUtils.getTimeZoneRecord(), TimeUtils.getTimeRecord(), millis,
+                Constants.TIMEZONE_UTC);
     }
 
-    private MapValue<String, Object> createUserDefinedType(Struct structValue, BStructureType structType) {
+    private MapValue<String, Object> createUserDefinedType(Struct structValue, BStructureType structType)
+            throws PanickingApplicationException {
         if (structValue == null) {
             return null;
         }
@@ -296,7 +303,7 @@ public class SQLDataIterator extends TableIterator {
             Object[] dataArray = structValue.getAttributes();
             if (dataArray != null) {
                 if (dataArray.length != internalStructFields.length) {
-                    throw new BallerinaException("specified struct and returned struct are not compatible");
+                    throw new PanickingApplicationException("specified struct and returned struct are not compatible");
                 }
                 int index = 0;
                 for (BField internalField : internalStructFields) {
@@ -322,7 +329,7 @@ public class SQLDataIterator extends TableIterator {
                         if (value instanceof BigDecimal) {
                             struct.put(fieldName, value);
                         } else {
-                            struct.put(fieldName, new BigDecimal((double) value));
+                            struct.put(fieldName, new DecimalValue((BigDecimal) value));
                         }
                         break;
                     case TypeTags.STRING_TAG:
@@ -337,19 +344,20 @@ public class SQLDataIterator extends TableIterator {
                                 createUserDefinedType((Struct) value, (BStructureType) internalField.getFieldType()));
                         break;
                     default:
-                        throw new BallerinaException("error in retrieving UDT data for unsupported type:" + type);
+                        throw new PanickingApplicationException(
+                                "error in retrieving UDT data for unsupported type:" + type);
                     }
                     ++index;
                 }
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in retrieving UDT data:" + e.getMessage());
+            throw new PanickingApplicationException("error in retrieving UDT data:" + e.getMessage());
         }
         return struct;
     }
 
     private void handleArrayValue(MapValue<String, Object> bStruct, String fieldName, Array data, BType fieldType)
-            throws SQLException {
+            throws SQLException, PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         ArrayValue dataArray = getDataArray(data);
         if (dataArray != null) {
@@ -372,7 +380,7 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void handleMappingArrayValue(BType nonNilType, MapValue<String, Object> bStruct, ArrayValue dataArray,
-                                         String fieldName, boolean containsNull) {
+            String fieldName, boolean containsNull) throws PanickingApplicationException {
         if (nonNilType.getTag() == TypeTags.ARRAY_TAG) {
             BArrayType expectedArrayType = (BArrayType) nonNilType;
             if (((BArrayType) nonNilType).getElementType().getTag() == TypeTags.UNION_TAG) {
@@ -386,9 +394,9 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void handleMappingArrayElementToNonUnionType(boolean containsNull, BType nonNilType, ArrayValue newArray,
-                                                         MapValue<String, Object> bStruct, String fieldName) {
+            MapValue<String, Object> bStruct, String fieldName) throws PanickingApplicationException {
         if (containsNull) {
-            throw new BallerinaException(
+            throw new PanickingApplicationException(
                     "Trying to assign an array containing NULL values to an array of a non-nillable element type");
         } else {
             int expectedTypeTag = ((BArrayType) nonNilType).getElementType().getTag();
@@ -404,7 +412,7 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void handleMappingArrayElementToUnionType(BArrayType expectedArrayType, ArrayValue arrayTobeSet,
-                                                      String fieldName, MapValue<String, Object> bStruct) {
+            String fieldName, MapValue<String, Object> bStruct) throws PanickingApplicationException {
         BType arrayType;
         if (arrayTobeSet.getType().getTag() == TypeTags.DECIMAL_TAG) {
             arrayType = BTypes.typeDecimal;
@@ -430,21 +438,21 @@ public class SQLDataIterator extends TableIterator {
         }
     }
 
-    private BType retrieveNonNilType(List<BType> members) {
+    private BType retrieveNonNilType(List<BType> members) throws PanickingApplicationException {
         if (members.size() != 2) {
-            throw new BallerinaException(UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            throw new PanickingApplicationException(UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         }
         if (members.get(0).getTag() == TypeTags.NULL_TAG) {
             return members.get(1);
         } else if (members.get(1).getTag() == TypeTags.NULL_TAG) {
             return members.get(0);
         } else {
-            throw new BallerinaException(UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            throw new PanickingApplicationException(UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         }
     }
 
     private void handleStructValue(MapValue<String, Object> bStruct, String fieldName, Struct structData,
-                                   BType fieldType) {
+            BType fieldType) throws PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             BType structFieldType = retrieveNonNilType(((BUnionType) fieldType).getMemberTypes());
@@ -464,26 +472,25 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void handleBooleanValue(MapValue<String, Object> bStruct, String fieldName, boolean boolValue,
-                                    BType fieldType)
-            throws SQLException {
+            BType fieldType) throws SQLException, PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         boolean isOriginalValueNull = rs.wasNull();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             Boolean booleanValue = isOriginalValueNull ? null : boolValue;
-            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.BOOLEAN_TAG,
-                    retrieveNonNilTypeTag(fieldType), booleanValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.BOOLEAN_TAG, retrieveNonNilTypeTag(fieldType),
+                    booleanValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         } else {
             if (isOriginalValueNull) {
                 handleNilToNonNillableFieldAssignment();
             } else {
-                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.BOOLEAN_TAG, fieldTypeTag,
-                       boolValue, MISMATCHING_FIELD_ASSIGNMENT);
+                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.BOOLEAN_TAG, fieldTypeTag, boolValue,
+                        MISMATCHING_FIELD_ASSIGNMENT);
             }
         }
     }
 
     private void handleDateValue(MapValue<String, Object> record, String fieldName, java.util.Date date,
-                                 BType fieldType) {
+            BType fieldType) throws PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             handleMappingDateValueToUnionType(fieldType, record, fieldName, date);
@@ -492,7 +499,8 @@ public class SQLDataIterator extends TableIterator {
         }
     }
 
-    private void handleBinaryValue(MapValue<String, Object> bStruct, String fieldName, byte[] bytes, BType fieldType) {
+    private void handleBinaryValue(MapValue<String, Object> bStruct, String fieldName, byte[] bytes, BType fieldType)
+            throws PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             BType nonNillType = retrieveNonNilType(((BUnionType) fieldType).getMemberTypes());
@@ -514,10 +522,10 @@ public class SQLDataIterator extends TableIterator {
                     if (elementTypeTag == TypeTags.BYTE_TAG) {
                         bStruct.put(fieldName, new ArrayValue(bytes));
                     } else {
-                        throw new BallerinaException(MISMATCHING_FIELD_ASSIGNMENT);
+                        throw new PanickingApplicationException(MISMATCHING_FIELD_ASSIGNMENT);
                     }
                 } else {
-                    throw new BallerinaException(MISMATCHING_FIELD_ASSIGNMENT);
+                    throw new PanickingApplicationException(MISMATCHING_FIELD_ASSIGNMENT);
                 }
             } else {
                 handleNilToNonNillableFieldAssignment();
@@ -525,18 +533,18 @@ public class SQLDataIterator extends TableIterator {
         }
     }
 
-    private void handleStringValue(String stringValue, String fieldName,
-                                   MapValue<String, Object> bStruct, BType fieldType) {
+    private void handleStringValue(String stringValue, String fieldName, MapValue<String, Object> bStruct,
+            BType fieldType) throws PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             int[] expectedTypeTags = { TypeTags.STRING_TAG, TypeTags.JSON_TAG };
-            validateAndSetRefRecordField(bStruct, fieldName, expectedTypeTags,
-                    retrieveNonNilTypeTag(fieldType), stringValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            validateAndSetRefRecordField(bStruct, fieldName, expectedTypeTags, retrieveNonNilTypeTag(fieldType),
+                    stringValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         } else {
             if (stringValue != null) {
                 int[] expectedTypeTags = { TypeTags.STRING_TAG, TypeTags.JSON_TAG };
-                validateAndSetRefRecordField(bStruct, fieldName, expectedTypeTags, fieldTypeTag,
-                        stringValue, MISMATCHING_FIELD_ASSIGNMENT);
+                validateAndSetRefRecordField(bStruct, fieldName, expectedTypeTags, fieldTypeTag, stringValue,
+                        MISMATCHING_FIELD_ASSIGNMENT);
             } else {
                 handleNilToNonNillableFieldAssignment();
             }
@@ -545,14 +553,14 @@ public class SQLDataIterator extends TableIterator {
 
     @FunctionalInterface
     private interface ErrorHandlerFunction {
-        void apply();
+        void apply() throws PanickingApplicationException;
     }
 
     private ErrorHandlerFunction mismatchingFieldAssignmentHandler = this::handleMismatchingFieldAssignment;
     private ErrorHandlerFunction unassignableUnionTypeAssignmentHandler = this::handleUnAssignableUnionTypeAssignment;
 
     private void handleOIDValue(int index, MapValue<String, Object> bStruct, String fieldName, BType fieldType)
-            throws SQLException {
+            throws SQLException, PanickingApplicationException {
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             BType nonNilType = retrieveNonNilType(((BUnionType) fieldType).getMemberTypes());
@@ -571,7 +579,8 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void assignOIDValue(int fieldTypeTag, BType fieldType, String fieldName, int index,
-            MapValue<String, Object> bStruct, ErrorHandlerFunction errorHandlerFunction) throws SQLException {
+            MapValue<String, Object> bStruct, ErrorHandlerFunction errorHandlerFunction)
+            throws SQLException, PanickingApplicationException {
         if (fieldTypeTag == TypeTags.ARRAY_TAG) {
             int elementTypeTag = ((BArrayType) fieldType).getElementType().getTag();
             if (elementTypeTag == TypeTags.BYTE_TAG) {
@@ -589,50 +598,49 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void handleLongValue(long longValue, MapValue<String, Object> bStruct, String fieldName, BType fieldType)
-            throws SQLException {
+            throws SQLException, PanickingApplicationException {
         boolean isOriginalValueNull = rs.wasNull();
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             Long refValue = isOriginalValueNull ? null : longValue;
-            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.INT_TAG,
-                    retrieveNonNilTypeTag(fieldType), refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.INT_TAG, retrieveNonNilTypeTag(fieldType),
+                    refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         } else {
             if (isOriginalValueNull) {
                 handleNilToNonNillableFieldAssignment();
             } else {
-                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.INT_TAG, fieldTypeTag,
-                        longValue, MISMATCHING_FIELD_ASSIGNMENT);
+                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.INT_TAG, fieldTypeTag, longValue,
+                        MISMATCHING_FIELD_ASSIGNMENT);
             }
         }
     }
 
     private void handleDoubleValue(double fValue, MapValue<String, Object> bStruct, String fieldName, BType fieldType)
-            throws SQLException {
+            throws SQLException, PanickingApplicationException {
         boolean isOriginalValueNull = rs.wasNull();
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             Double refValue = isOriginalValueNull ? null : fValue;
-            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.FLOAT_TAG,
-                    retrieveNonNilTypeTag(fieldType), refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.FLOAT_TAG, retrieveNonNilTypeTag(fieldType),
+                    refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         } else {
             if (isOriginalValueNull) {
                 handleNilToNonNillableFieldAssignment();
             } else {
-                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.FLOAT_TAG, fieldTypeTag,
-                        fValue, MISMATCHING_FIELD_ASSIGNMENT);
+                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.FLOAT_TAG, fieldTypeTag, fValue,
+                        MISMATCHING_FIELD_ASSIGNMENT);
             }
         }
     }
 
     private void handleDecimalValue(BigDecimal fValue, MapValue<String, Object> bStruct, String fieldName,
-                                    BType fieldType)
-            throws SQLException {
+            BType fieldType) throws SQLException, PanickingApplicationException {
         boolean isOriginalValueNull = rs.wasNull();
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             DecimalValue refValue = isOriginalValueNull ? null : new DecimalValue(fValue);
-            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.DECIMAL_TAG,
-                    retrieveNonNilTypeTag(fieldType), refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.DECIMAL_TAG, retrieveNonNilTypeTag(fieldType),
+                    refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         } else {
             if (isOriginalValueNull) {
                 handleNilToNonNillableFieldAssignment();
@@ -643,8 +651,8 @@ public class SQLDataIterator extends TableIterator {
         }
     }
 
-    private void handleMappingDateValueToUnionType(BType fieldType, MapValue<String, Object> record,
-                                                   String fieldName, java.util.Date date) {
+    private void handleMappingDateValueToUnionType(BType fieldType, MapValue<String, Object> record, String fieldName,
+            java.util.Date date) throws PanickingApplicationException {
         int type = retrieveNonNilTypeTag(fieldType);
         switch (type) {
         case TypeTags.STRING_TAG:
@@ -664,7 +672,7 @@ public class SQLDataIterator extends TableIterator {
     }
 
     private void handleMappingDateValueToNonUnionType(java.util.Date date, int fieldTypeTag,
-                                                      MapValue<String, Object> record, String fieldName) {
+            MapValue<String, Object> record, String fieldName) throws PanickingApplicationException {
         if (date != null) {
             switch (fieldTypeTag) {
             case TypeTags.STRING_TAG:

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/SQLDatasourceUtils.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/SQLDatasourceUtils.java
@@ -212,12 +212,20 @@ public class SQLDatasourceUtils {
         return getSQLDatabaseError(messagePrefix + sqlErrorMessage, vendorCode, sqlState);
     }
 
+    public static ErrorValue getSQLDatabaseError(SQLException exception) {
+        return getSQLDatabaseError(exception, "");
+    }
+
     public static ErrorValue getSQLDatabaseError(DatabaseException exception, String messagePrefix) {
         String message = exception.getMessage() != null ? exception.getMessage() : Constants.DATABASE_ERROR_MESSAGE;
         int vendorCode = exception.getSqlErrorCode();
         String sqlState = exception.getSqlState();
         String sqlErrorMessage = exception.getSqlErrorMessage();
         return getSQLDatabaseError(messagePrefix + message + sqlErrorMessage, vendorCode, sqlState);
+    }
+
+    public static ErrorValue getSQLDatabaseError(DatabaseException exception) {
+        return getSQLDatabaseError(exception, "");
     }
 
     private static ErrorValue getSQLDatabaseError(String message, int vendorCode, String sqlState) {
@@ -236,6 +244,10 @@ public class SQLDatasourceUtils {
             detailedErrorMessage += exception.getDetailedErrorMessage();
         }
         return getSQLApplicationError(detailedErrorMessage);
+    }
+
+    public static ErrorValue getSQLApplicationError(ApplicationException exception) {
+        return getSQLApplicationError(exception, "");
     }
 
     public static ErrorValue getSQLApplicationError(String detailedErrorMessage) {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/SQLTransactionContext.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/SQLTransactionContext.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinax.jdbc;
 
-import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.util.transactions.BallerinaTransactionContext;
 
 import java.sql.Connection;
@@ -52,7 +52,7 @@ public class SQLTransactionContext implements BallerinaTransactionContext {
         try {
             conn.commit();
         } catch (SQLException e) {
-            throw new BallerinaException("transaction commit failed:" + e.getMessage());
+            throw BallerinaErrors.createError("transaction commit failed:" + e.getMessage());
         }
     }
 
@@ -63,7 +63,7 @@ public class SQLTransactionContext implements BallerinaTransactionContext {
                 conn.rollback();
             }
         } catch (SQLException e) {
-            throw new BallerinaException("transaction rollback failed:" + e.getMessage());
+            throw BallerinaErrors.createError("transaction rollback failed:" + e.getMessage());
         }
     }
 
@@ -74,7 +74,7 @@ public class SQLTransactionContext implements BallerinaTransactionContext {
                 conn.close();
             }
         } catch (SQLException e) {
-            throw new BallerinaException("connection close failed:" + e.getMessage());
+            throw BallerinaErrors.createError("connection close failed:" + e.getMessage());
         }
     }
 

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/exceptions/PanickingApplicationException.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/exceptions/PanickingApplicationException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinax.jdbc.exceptions;
+
+/**
+ * Represents an exception caused by application related errors which should cause panic at Ballerina level.
+ *
+ * @since 1.0.0
+ */
+public class PanickingApplicationException extends ApplicationException {
+    /**
+     * Constructs a new {@link PanickingApplicationException} with the specified error message.
+     *
+     * @param message Error Reason
+     */
+    public PanickingApplicationException(String message) {
+        super(message);
+    }
+}

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/exceptions/PanickingDatabaseException.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/exceptions/PanickingDatabaseException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinax.jdbc.exceptions;
+
+import java.sql.SQLException;
+
+/**
+ * Represents an exception caused by database related errors which should cause panic at Ballerina level.
+ *
+ * @since 1.0.0
+ */
+public class PanickingDatabaseException extends DatabaseException {
+
+    /**
+     * Constructs a new {@link PanickingDatabaseException} with the specified error message.
+     *
+     * @param message Error Reason
+     * @param cause The SQL Exception root cause
+     */
+    public PanickingDatabaseException(String message, SQLException cause) {
+        super(message, cause);
+    }
+}

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/AbstractSQLStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/AbstractSQLStatement.java
@@ -34,10 +34,10 @@ import org.ballerinalang.jvm.values.DecimalValue;
 import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.TableValue;
-import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinax.jdbc.Constants;
 import org.ballerinax.jdbc.SQLDataIterator;
 import org.ballerinax.jdbc.SQLDatasource;
+import org.ballerinax.jdbc.SQLDatasourceUtils;
 import org.ballerinax.jdbc.exceptions.ApplicationException;
 import org.ballerinax.jdbc.exceptions.DatabaseException;
 import org.ballerinax.jdbc.table.BCursorTable;
@@ -406,7 +406,7 @@ public abstract class AbstractSQLStatement implements SQLStatement {
                 conn.close();
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in cleaning sql resources: " + e.getMessage(), e);
+            throw SQLDatasourceUtils.getSQLDatabaseError(e, "error in cleaning sql resources: ");
         }
     }
 
@@ -427,7 +427,8 @@ public abstract class AbstractSQLStatement implements SQLStatement {
             }
             cleanupResources(stmt, conn, connectionClosable);
         } catch (SQLException e) {
-            throw new BallerinaException("error in cleaning sql resources: " + e.getMessage(), e);
+            throw SQLDatasourceUtils.getSQLDatabaseError(e, "error in cleaning sql resources: ");
+
         }
     }
 
@@ -1246,8 +1247,8 @@ public abstract class AbstractSQLStatement implements SQLStatement {
                 Object timeVal = (((MapValue<String, Object>) value).get(Constants.STRUCT_TIME_FIELD));
                 long time = (Long) timeVal;
                 val = new Time(time);
-            } else if (value instanceof Integer) {
-                val = new Time((Integer) value);
+            } else if (value instanceof Long) {
+                val = new Time((Long) value);
             } else if (value instanceof String) {
                 val = convertToTime((String) value);
             }
@@ -1563,7 +1564,7 @@ public abstract class AbstractSQLStatement implements SQLStatement {
             arrayLength = ((ArrayValue) value).size();
             arrayData = new BigDecimal[arrayLength];
             for (int i = 0; i < arrayLength; i++) {
-                arrayData[i] = ((ArrayValue) value).getDecimal(i);
+                arrayData[i] = ((DecimalValue) ((ArrayValue) value).getRefValue(i)).value();
             }
             return new Object[] { arrayData, Constants.SQLDataTypes.DECIMAL };
         case TypeTags.STRING_TAG:

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/CallStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/CallStatement.java
@@ -28,7 +28,6 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.TableValue;
 import org.ballerinalang.jvm.values.TypedescValue;
-import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinax.jdbc.Constants;
 import org.ballerinax.jdbc.SQLDatasource;
 import org.ballerinax.jdbc.SQLDatasourceUtils;
@@ -443,7 +442,7 @@ public class CallStatement extends AbstractSQLStatement {
             }
             cleanupResources(stmt, conn, connectionClosable);
         } catch (SQLException e) {
-            throw new BallerinaException("error in cleaning sql resources: " + e.getMessage(), e);
+            throw SQLDatasourceUtils.getSQLDatabaseError(e, "error in cleaning sql resources: ");
         }
     }
 }

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/table/BCursorTable.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/table/BCursorTable.java
@@ -17,10 +17,12 @@
  */
 package org.ballerinax.jdbc.table;
 
+import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.DataIterator;
 import org.ballerinalang.jvm.types.BStructureType;
+import org.ballerinalang.jvm.util.exceptions.BallerinaErrorReasons;
+import org.ballerinalang.jvm.values.MapValueImpl;
 import org.ballerinalang.jvm.values.TableValue;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.util.Map;
 
@@ -46,7 +48,8 @@ public class BCursorTable extends TableValue {
     }
 
     public int length() {
-        throw new BallerinaException("The row count of a table returned from a database cannot be provided");
+        throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                "The row count of a table returned from a database cannot be provided");
     }
 
     protected boolean isIteratorGenerationConditionMet() {
@@ -58,8 +61,19 @@ public class BCursorTable extends TableValue {
         return false;
     }
 
+    public Object performAddOperation(MapValueImpl<String, Object> data) {
+        throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                "data cannot be added to a table returned from a database");
+    }
+
+    public Object performRemoveOperation() {
+        throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                "data cannot be deleted from a table returned from a database");
+    }
+
     @Override
     public Object copy(Map<Object, Object> refs) {
-        throw new BallerinaException("A table returned from a database can not be cloned");
+        throw BallerinaErrors.createError(BallerinaErrorReasons.TABLE_OPERATION_ERROR,
+                "A table returned from a database can not be cloned");
     }
 }

--- a/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
+++ b/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
@@ -71,6 +71,7 @@ public class TableTest {
 
     @BeforeClass
     public void setup() {
+        System.setProperty("enableJBallerinaTests", "true");
         testDatabase = new FileBasedTestDatabase(DBType.H2, "datafiles/sql/TableTest_H2_Data.sql",
                 SQLDBUtils.DB_DIRECTORY, DB_NAME_H2);
 
@@ -114,7 +115,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.", enabled = false)
     public void testToJsonComplexTypesNil() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplexTypesNil");
         Assert.assertEquals(returns.length, 1);
@@ -123,7 +125,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
     public void testToXml() {
         BValue[] returns = BRunUtil.invoke(result, "testToXml");
         Assert.assertEquals(returns.length, 1);
@@ -134,7 +137,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
     public void testToXmlComplexTypes() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexTypes");
         Assert.assertEquals(returns.length, 1);
@@ -145,7 +149,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
     public void testToXmlComplexTypesNil() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexTypesNil");
         Assert.assertEquals(returns.length, 1);
@@ -161,7 +166,8 @@ public class TableTest {
         Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
-    @Test(groups = TABLE_TEST, description = "Check xml streaming when result set consumed once.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check xml streaming when result set consumed once.", enabled = false)
     public void testToXmlMultipleConsume() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlMultipleConsume");
         Assert.assertEquals(returns.length, 1);
@@ -173,7 +179,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion with concat operation.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion with concat operation.", enabled = false)
     public void testToXmlWithAdd() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlWithAdd");
         Assert.assertEquals(returns.length, 1);
@@ -193,7 +200,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.")
+    // TODO: #16033
+    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.", enabled = false)
     public void testToXmlComplex() {
         BValue[] returns = BRunUtil.invoke(result, "toXmlComplex");
         Assert.assertEquals(returns.length, 1);
@@ -214,8 +222,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // Disabling for MySQL as array types are not supported.
-    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.")
+    // TODO: #16033
+    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.", enabled = false)
     public void testToXmlComplexWithStructDef () {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexWithStructDef");
         Assert.assertEquals(returns.length, 1);
@@ -231,7 +239,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = {TABLE_TEST}, description = "Check json conversion with complex element.")
+    // TODO: #16033
+    @Test(groups = {TABLE_TEST}, description = "Check json conversion with complex element.", enabled = false)
     public void testToJsonComplex() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplex");
         Assert.assertEquals(returns.length, 1);
@@ -246,7 +255,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = {TABLE_TEST}, description = "Check json conversion with complex element.")
+    // TODO: #16033
+    @Test(groups = {TABLE_TEST}, description = "Check json conversion with complex element.", enabled = false)
     public void testToJsonComplexWithStructDef() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplexWithStructDef");
         Assert.assertEquals(returns.length, 1);
@@ -439,7 +449,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check xml conversion with null values.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check xml conversion with null values.", enabled = false)
     public void testXmlWithNull() {
         BValue[] returns = BRunUtil.invoke(result, "testXmlWithNull");
         Assert.assertEquals(returns.length, 1);
@@ -455,7 +466,8 @@ public class TableTest {
         Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
-    @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.", enabled = false)
     public void testToXmlWithinTransaction() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlWithinTransaction");
         Assert.assertEquals(returns.length, 2);
@@ -465,7 +477,8 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 0);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check JSON conversion within transaction.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check JSON conversion within transaction.", enabled = false)
     public void testToJsonWithinTransaction() {
         BValue[] returns = BRunUtil.invoke(result,  "testToJsonWithinTransaction");
         Assert.assertEquals(returns.length, 2);
@@ -592,7 +605,8 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[5]).intValue(), 2);
     }
 
-    @Test(groups = TABLE_TEST, description = "Check get float and double min and max types.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check get float and double min and max types.", enabled = false)
     public void testSignedIntMaxMinValues() {
         BValue[] returns = BRunUtil.invoke(result, "testSignedIntMaxMinValues");
         Assert.assertEquals(returns.length, 6);
@@ -618,7 +632,8 @@ public class TableTest {
                 + "-2147483648|-9223372036854775808#3|-1|-1|-1|-1#");
     }
 
-    @Test(groups = TABLE_TEST, description = "Check blob binary and clob types types.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST, description = "Check blob binary and clob types types.", enabled = false)
     public void testComplexTypeInsertAndRetrieval() {
         BValue[] returns = BRunUtil.invoke(result, "testComplexTypeInsertAndRetrieval");
         Assert.assertEquals(returns.length, 6);
@@ -650,7 +665,10 @@ public class TableTest {
         Assert.assertEquals((returns[4]).stringValue(), "100|nonNil|Sample Text|200|nil|nil|");
     }
 
-    @Test(groups = TABLE_TEST, description = "Check result sets with same column name or complex name.")
+    // TODO: #16033
+    @Test(groups = TABLE_TEST,
+          description = "Check result sets with same column name or complex name.",
+          enabled = false)
     public void testJsonXMLConversionwithDuplicateColumnNames() {
         BValue[] returns = BRunUtil.invoke(result, "testJsonXMLConversionwithDuplicateColumnNames");
         Assert.assertEquals(returns.length, 2);
@@ -1189,14 +1207,14 @@ public class TableTest {
         Assert.assertTrue(returns[0] instanceof BValueArray);
         BValueArray intArray = (BValueArray) returns[0];
         Assert.assertNull(intArray.getRefValue(0));
-        Assert.assertEquals(((BInteger) intArray.getRefValue(1)).intValue(), 2);
-        Assert.assertEquals(((BInteger) intArray.getRefValue(2)).intValue(), 3);
+        Assert.assertEquals(intArray.getRefValue(1).value(), 2L);
+        Assert.assertEquals(intArray.getRefValue(2).value(), 3L);
 
         Assert.assertTrue(returns[1] instanceof BValueArray);
         BValueArray longArray = (BValueArray) returns[1];
-        Assert.assertEquals(((BInteger) longArray.getRefValue(0)).intValue(), 100000000);
+        Assert.assertEquals(longArray.getRefValue(0).value(), 100000000L);
         Assert.assertNull(longArray.getRefValue(1));
-        Assert.assertEquals(((BInteger) longArray.getRefValue(2)).intValue(), 300000000);
+        Assert.assertEquals(longArray.getRefValue(2).value(), 300000000L);
 
         Assert.assertTrue(returns[2] instanceof BValueArray);
         BValueArray doubleArray = (BValueArray) returns[2];
@@ -1388,7 +1406,8 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), "Hello");
     }
 
-    @Test(description = "Test removing data from a table using a given lambda as a filter")
+    // TODO: #16033
+    @Test(description = "Test removing data from a table using a given lambda as a filter", enabled = false)
     public void testRemoveOp() {
         BValue[] returns = BRunUtil.invoke(result, "testRemoveOp");
         Assert.assertEquals(returns[0].stringValue(), "table<Order> {index: [], primaryKey: [], data: []}");

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping_negative.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping_negative.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/jdbc;
+import ballerinax/jdbc;
 import ballerina/time;
 
 type NonNillableInt record {
@@ -137,79 +137,79 @@ type ResultMapNillableTypeNonNillableElements record {
     string[]? STRING_ARRAY;
 };
 
-function testAssignNilToNonNillableInt() returns string {
+function testAssignNilToNonNillableInt() returns @tainted string {
     return testAssignNilToNonNillableField("int_type", NonNillableInt);
 }
 
-function testAssignNilToNonNillableLong() returns string {
+function testAssignNilToNonNillableLong() returns @tainted string {
     return testAssignNilToNonNillableField("long_type", NonNillableLong);
 }
 
-function testAssignNilToNonNillableFloat() returns string {
+function testAssignNilToNonNillableFloat() returns @tainted string {
     return testAssignNilToNonNillableField("float_type", NonNillableFloat);
 }
 
-function testAssignNilToNonNillableDouble() returns string {
+function testAssignNilToNonNillableDouble() returns @tainted string {
     return testAssignNilToNonNillableField("double_type", NonNillableDouble);
 }
 
-function testAssignNilToNonNillableBoolean() returns string {
+function testAssignNilToNonNillableBoolean() returns @tainted string {
     return testAssignNilToNonNillableField("boolean_type", NonNillableBoolean);
 }
 
-function testAssignNilToNonNillableString() returns string {
+function testAssignNilToNonNillableString() returns @tainted string {
     return testAssignNilToNonNillableField("string_type", NonNillableString);
 }
 
-function testAssignNilToNonNillableNumeric() returns string {
+function testAssignNilToNonNillableNumeric() returns @tainted string {
     return testAssignNilToNonNillableField("numeric_type", NonNillableNumeric);
 }
 
-function testAssignNilToNonNillableTinyInt() returns string {
+function testAssignNilToNonNillableTinyInt() returns @tainted string {
     return testAssignNilToNonNillableField("tinyint_type", NonNillableTinyInt);
 }
 
-function testAssignNilToNonNillableSmallint() returns string {
+function testAssignNilToNonNillableSmallint() returns @tainted string {
     return testAssignNilToNonNillableField("smallint_type", NonNillableSmallInt);
 }
 
-function testAssignNilToNonNillableDecimal() returns string {
+function testAssignNilToNonNillableDecimal() returns @tainted string {
     return testAssignNilToNonNillableField("decimal_type", NonNillableDecimal);
 }
 
-function testAssignNilToNonNillableReal() returns string {
+function testAssignNilToNonNillableReal() returns @tainted string {
     return testAssignNilToNonNillableField("real_type", NonNillableReal);
 }
 
-function testAssignNilToNonNillableClob() returns string {
+function testAssignNilToNonNillableClob() returns @tainted string {
     return testAssignNilToNonNillableField("clob_type", NonNillableClob);
 }
 
-function testAssignNilToNonNillableBlob() returns string {
+function testAssignNilToNonNillableBlob() returns @tainted string {
     return testAssignNilToNonNillableField("blob_type", NonNillableBlob);
 }
 
-function testAssignNilToNonNillableBinary() returns string {
+function testAssignNilToNonNillableBinary() returns @tainted string {
     return testAssignNilToNonNillableField("binary_type", NonNillableBinary);
 }
 
-function testAssignNilToNonNillableDate() returns string {
+function testAssignNilToNonNillableDate() returns @tainted string {
     return testAssignNilToNonNillableField("date_type", NonNillableDate);
 }
 
-function testAssignNilToNonNillableTime() returns string {
+function testAssignNilToNonNillableTime() returns @tainted string {
     return testAssignNilToNonNillableField("time_type", NonNillableTime);
 }
 
-function testAssignNilToNonNillableDateTime() returns string {
+function testAssignNilToNonNillableDateTime() returns @tainted string {
     return testAssignNilToNonNillableField("datetime_type", NonNillableDateTime);
 }
 
-function testAssignNilToNonNillableTimeStamp() returns string {
+function testAssignNilToNonNillableTimeStamp() returns @tainted string {
     return testAssignNilToNonNillableField("timestamp_type", NonNillableTimeStamp);
 }
 
-function testAssignNilToNonNillableField(string field, typedesc recordType) returns string {
+function testAssignNilToNonNillableField(string field, typedesc recordType) returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -231,7 +231,7 @@ function testAssignNilToNonNillableField(string field, typedesc recordType) retu
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string>ret.reason();
+                errorMessage = <string> ret.detail().message;
             }
         }
     }
@@ -239,79 +239,79 @@ function testAssignNilToNonNillableField(string field, typedesc recordType) retu
     return errorMessage;
 }
 
-function testAssignToInvalidUnionInt() returns string {
+function testAssignToInvalidUnionInt() returns @tainted string {
     return testAssignToInvalidUnionField("int_type");
 }
 
-function testAssignToInvalidUnionLong() returns string {
+function testAssignToInvalidUnionLong() returns @tainted string {
     return testAssignToInvalidUnionField("long_type");
 }
 
-function testAssignToInvalidUnionFloat() returns string {
+function testAssignToInvalidUnionFloat() returns @tainted string {
     return testAssignToInvalidUnionField("float_type");
 }
 
-function testAssignToInvalidUnionDouble() returns string {
+function testAssignToInvalidUnionDouble() returns @tainted string {
     return testAssignToInvalidUnionField("double_type");
 }
 
-function testAssignToInvalidUnionBoolean() returns string {
+function testAssignToInvalidUnionBoolean() returns @tainted string {
     return testAssignToInvalidUnionField("boolean_type");
 }
 
-function testAssignToInvalidUnionString() returns string {
+function testAssignToInvalidUnionString() returns @tainted string {
     return testAssignToInvalidUnionField("string_type");
 }
 
-function testAssignToInvalidUnionNumeric() returns string {
+function testAssignToInvalidUnionNumeric() returns @tainted string {
     return testAssignToInvalidUnionField("numeric_type");
 }
 
-function testAssignToInvalidUnionTinyInt() returns string {
+function testAssignToInvalidUnionTinyInt() returns @tainted string {
     return testAssignToInvalidUnionField("tinyint_type");
 }
 
-function testAssignToInvalidUnionSmallint() returns string {
+function testAssignToInvalidUnionSmallint() returns @tainted string {
     return testAssignToInvalidUnionField("smallint_type");
 }
 
-function testAssignToInvalidUnionDecimal() returns string {
+function testAssignToInvalidUnionDecimal() returns @tainted string {
     return testAssignToInvalidUnionField("decimal_type");
 }
 
-function testAssignToInvalidUnionReal() returns string {
+function testAssignToInvalidUnionReal() returns @tainted string {
     return testAssignToInvalidUnionField("real_type");
 }
 
-function testAssignToInvalidUnionClob() returns string {
+function testAssignToInvalidUnionClob() returns @tainted string {
     return testAssignToInvalidUnionField("clob_type");
 }
 
-function testAssignToInvalidUnionBlob() returns string {
+function testAssignToInvalidUnionBlob() returns @tainted string {
     return testAssignToInvalidUnionField("blob_type");
 }
 
-function testAssignToInvalidUnionBinary() returns string {
+function testAssignToInvalidUnionBinary() returns @tainted string {
     return testAssignToInvalidUnionField("binary_type");
 }
 
-function testAssignToInvalidUnionDate() returns string {
+function testAssignToInvalidUnionDate() returns @tainted string {
     return testAssignToInvalidUnionField("date_type");
 }
 
-function testAssignToInvalidUnionTime() returns string {
+function testAssignToInvalidUnionTime() returns @tainted string {
     return testAssignToInvalidUnionField("time_type");
 }
 
-function testAssignToInvalidUnionDateTime() returns string {
+function testAssignToInvalidUnionDateTime() returns @tainted string {
     return testAssignToInvalidUnionField("datetime_type");
 }
 
-function testAssignToInvalidUnionTimeStamp() returns string {
+function testAssignToInvalidUnionTimeStamp() returns @tainted string {
     return testAssignToInvalidUnionField("timestamp_type");
 }
 
-function testAssignNullArrayToNonNillableWithNonNillableElements() returns string {
+function testAssignNullArrayToNonNillableWithNonNillableElements() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -326,7 +326,7 @@ function testAssignNullArrayToNonNillableWithNonNillableElements() returns strin
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = ret.reason();
+                errorMessage = <string> ret.detail().message;
             }
         }
     }
@@ -334,7 +334,7 @@ function testAssignNullArrayToNonNillableWithNonNillableElements() returns strin
     return errorMessage;
 }
 
-function testAssignNullArrayToNonNillableTypeWithNillableElements() returns string {
+function testAssignNullArrayToNonNillableTypeWithNillableElements() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -349,7 +349,7 @@ function testAssignNullArrayToNonNillableTypeWithNillableElements() returns stri
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = ret.reason();
+                errorMessage = <string> ret.detail().message;
             }
         }
     }
@@ -357,7 +357,7 @@ function testAssignNullArrayToNonNillableTypeWithNillableElements() returns stri
     return errorMessage;
 }
 
-function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() returns string {
+function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -372,7 +372,7 @@ function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() re
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = ret.reason();
+                errorMessage = <string> ret.detail().message;
             }
         }
     }
@@ -380,7 +380,7 @@ function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() re
     return errorMessage;
 }
 
-function testAssignNullElementArrayToNillableTypeWithNonNillableElements() returns string {
+function testAssignNullElementArrayToNillableTypeWithNonNillableElements() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -395,7 +395,7 @@ function testAssignNullElementArrayToNillableTypeWithNonNillableElements() retur
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = ret.reason();
+                errorMessage = <string> ret.detail().message;
             }
         }
     }
@@ -403,7 +403,7 @@ function testAssignNullElementArrayToNillableTypeWithNonNillableElements() retur
     return errorMessage;
 }
 
-function testAssignInvalidUnionArray() returns string {
+function testAssignInvalidUnionArray() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -416,7 +416,7 @@ function testAssignInvalidUnionArray() returns string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.reason();
+                message = <string>ret.detail().message;
             }
         }
     }
@@ -424,7 +424,7 @@ function testAssignInvalidUnionArray() returns string {
     return message;
 }
 
-function testAssignInvalidUnionArrayElement() returns string {
+function testAssignInvalidUnionArrayElement() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -437,7 +437,7 @@ function testAssignInvalidUnionArrayElement() returns string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.reason();
+                message = <string>ret.detail().message;
             }
         }
     }
@@ -445,7 +445,7 @@ function testAssignInvalidUnionArrayElement() returns string {
     return message;
 }
 
-function testAssignInvalidUnionArray2() returns string {
+function testAssignInvalidUnionArray2() returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -458,7 +458,7 @@ function testAssignInvalidUnionArray2() returns string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.reason();
+                message = <string>ret.detail().message;
             }
         }
     }
@@ -466,7 +466,7 @@ function testAssignInvalidUnionArray2() returns string {
     return message;
 }
 
-function testAssignToInvalidUnionField(string field) returns string {
+function testAssignToInvalidUnionField(string field) returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -491,7 +491,7 @@ function testAssignToInvalidUnionField(string field) returns string {
         while (dt.hasNext()) {
             var ret = trap <InvalidUnion>dt.getNext();
             if (ret is error) {
-                errorMessage = ret.reason();
+                errorMessage = <string> ret.detail().message;
             }
         }
     }

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_type.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_type.bal
@@ -560,12 +560,15 @@ function testArrayDataInsertAndPrint() returns [int, int, int, int, int, int] {
     int updatedCount = -1;
     if (updateRet is jdbc:UpdateResult) {
         updatedCount = updateRet.updatedRowCount;
+    } else {
+       error e = updateRet;
+       io:println(<string> e.detail().message);
     }
     var dtRet = testDB->select("SELECT int_array, long_array, float_array, boolean_array, string_array
                                  from ArrayTypes where row_id = 4", ResultMap);
     if (dtRet is table<ResultMap>) {
         while (dtRet.hasNext()) {
-            var rs =dtRet.getNext();
+            var rs = dtRet.getNext();
             if (rs is ResultMap) {
                 io:println(rs.INT_ARRAY);
                 intArrLen = rs.INT_ARRAY.length();

--- a/stdlib/jdbc/src/test/resources/testng.xml
+++ b/stdlib/jdbc/src/test/resources/testng.xml
@@ -38,7 +38,7 @@ under the License.
             <class name="org.ballerinax.jdbc.SQLConnectionPoolTest"/>
             <class name="org.ballerinax.jdbc.SQLConnectorInitTest"/>
 
-<!--            <class name="org.ballerinax.jdbc.table.TableTest"/>-->
+            <class name="org.ballerinax.jdbc.table.TableTest"/>
             <class name="org.ballerinax.jdbc.table.TableIterationTest"/>
         </classes>
     </test>

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BRunUtil.java
@@ -286,6 +286,8 @@ public class BRunUtil {
                 paramTypes[i] = String.class;
             } else if (arg instanceof ArrayValue) {
                 paramTypes[i] = ArrayValue.class;
+            } else if (arg instanceof Long) {
+                paramTypes[i] = Long.class;
             } else {
                 // This is done temporarily, until blocks are added here for all possible cases.
                 throw new RuntimeException("unknown param type: " + arg.getClass());


### PR DESCRIPTION
## Purpose

Here two exceptions for application/database kind panic scenarios have been introduced as well. Numerous migration issues also have been fixed.

TableTest has been enabled. 17 tests have been disabled temporarily which are mostly related to XML/JSON conversion scenarios. A missing logic snippet to BRunUtil also has been added.