### PR TITLE
[WIP] Allow type names as typedesc for langlib.typedesc

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -732,14 +732,11 @@ public class SymbolResolver extends BLangNodeVisitor {
             case TypeTags.TABLE:
                 bSymbol = lookupLangLibMethodInModule(symTable.langTableModuleSymbol, name);
                 break;
-            case TypeTags.TYPEDESC:
-                bSymbol = lookupLangLibMethodInModule(symTable.langTypedescModuleSymbol, name);
-                break;
             case TypeTags.XML:
                 bSymbol = lookupLangLibMethodInModule(symTable.langXmlModuleSymbol, name);
                 break;
             default:
-                bSymbol = symTable.notFoundSymbol;
+                bSymbol = lookupLangLibMethodInModule(symTable.langTypedescModuleSymbol, name);
         }
         if (bSymbol == symTable.notFoundSymbol) {
             bSymbol = lookupLangLibMethodInModule(symTable.langValueModuleSymbol, name);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2977,11 +2977,27 @@ public class TypeChecker extends BLangNodeVisitor {
         iExpr.langLibInvocation = true;
         SymbolEnv enclEnv = this.env;
         this.env = SymbolEnv.createInvocationEnv(iExpr, this.env);
-        iExpr.argExprs.add(0, iExpr.expr);
+        addLangLibExpressionArg(iExpr);
         checkInvocationParamAndReturnType(iExpr);
         this.env = enclEnv;
 
         return true;
+    }
+
+    private void addLangLibExpressionArg(BLangInvocation iExpr) {
+        if (iExpr.symbol.owner.pkgID.orgName.value.equals("ballerina")
+            && iExpr.symbol.owner.pkgID.name.value.equals("lang.typedesc")
+            && iExpr.expr.type.tag != TypeTags.TYPEDESC) {
+            BLangTypedescExpr typedescExpr = (BLangTypedescExpr) TreeBuilder.createTypeAccessNode();
+            BTypedescType bTypedescType = new BTypedescType(TypeTags.TYPEDESC, iExpr.expr.type, null);
+            typedescExpr.resolvedType = bTypedescType;
+            typedescExpr.type = bTypedescType;
+            typedescExpr.typeChecked = true;
+            // skip setting typedescExpr.typeNode
+            iExpr.argExprs.add(0, typedescExpr);
+            return;
+        }
+        iExpr.argExprs.add(0, iExpr.expr);
     }
 
     private void checkInvocationParamAndReturnType(BLangInvocation iExpr) {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTypedescTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTypedescTest.java
@@ -47,4 +47,11 @@ public class LangLibTypedescTest {
         Assert.assertEquals(returns[0].getType().toString(), "map<json>");
         Assert.assertEquals(returns[0].stringValue(), "{\"name\":\"N\", \"age\":3}");
     }
+
+    @Test
+    public void testRecToJsonOnJsonDotConstructFrom() {
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testRecToJsonDirect");
+        Assert.assertEquals(returns[0].getType().toString(), "map<json>");
+        Assert.assertEquals(returns[0].stringValue(), "{\"name\":\"N\", \"age\":3}");
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/typedesclib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/typedesclib_test.bal
@@ -24,3 +24,9 @@ function testRecToJson() returns json|error {
     json|error j = typedesc<json>.constructFrom(p);
     return j;
 }
+
+function testRecToJsonDirect() returns json|error {
+    Person  p = {name: "N", age: 3};
+    json|error j = json.constructFrom(p);
+    return j;
+}


### PR DESCRIPTION
This allows json in json.constructFrom to be considered as typedesc<json>.

```ballerina
Person  p = {name: "N", age: 3};
json|error j = json.constructFrom(p);
```