### PR TITLE
Decouple OpenAPI Designer from Ballerina File change

### DIFF
--- a/composer/packages/api-designer/src/api-designer/components/utils/inline-edit/inline-edit.tsx
+++ b/composer/packages/api-designer/src/api-designer/components/utils/inline-edit/inline-edit.tsx
@@ -326,7 +326,7 @@ class OpenApiInlineEdit extends React.Component<OpenApiInlineEditProps, OpenApiI
                 break;
         }
 
-        this.props.onValueChange(model);
+        // this.props.onValueChange(model);
     }
 
     private isContactObj(arg: any): arg is Swagger.ContactObject {

--- a/composer/packages/api-designer/src/api-designer/index.tsx
+++ b/composer/packages/api-designer/src/api-designer/index.tsx
@@ -24,8 +24,6 @@ import { Button, Divider } from "semantic-ui-react";
 
 import { ExpandMode, OpenApiContext, OpenApiContextProvider } from "./components/context/open-api-context";
 
-import { EVENTS } from "./components/utils/constants";
-
 import OpenApiInfo from "./components/info/info";
 import AddOpenApiPath from "./paths/add-path";
 import OpenApiPathList from "./paths/paths-list";
@@ -95,8 +93,7 @@ class OpenApiVisualizer extends React.Component<OpenApiProps, OpenApiState> {
     }
 
     public render() {
-        const { openApiJson } = this.props;
-        const { showOpenApiAddPath, expandMode } = this.state;
+        const { showOpenApiAddPath, expandMode, openApiJson } = this.state;
 
         const appContext: OpenApiContext = {
             expandMode,
@@ -214,7 +211,7 @@ class OpenApiVisualizer extends React.Component<OpenApiProps, OpenApiState> {
             }
 
             if (onDidChange) {
-                onDidChange(EVENTS.ADD_RESOURCE, this.state.openApiJson);
+                // onDidChange(EVENTS.ADD_RESOURCE, this.state.openApiJson);
             }
 
         } else {
@@ -272,11 +269,11 @@ class OpenApiVisualizer extends React.Component<OpenApiProps, OpenApiState> {
         }), () => {
 
             if (onDidAddOperation) {
-                onDidAddOperation(operation, this.state.openApiJson);
+                // onDidAddOperation(operation, this.state.openApiJson);
             }
 
             if (onDidChange) {
-                onDidChange(EVENTS.ADD_OPERATION, this.state.openApiJson);
+                // onDidChange(EVENTS.ADD_OPERATION, this.state.openApiJson);
             }
 
         });
@@ -355,11 +352,11 @@ class OpenApiVisualizer extends React.Component<OpenApiProps, OpenApiState> {
             }), () => {
 
                 if (onDidAddParameter) {
-                    onDidAddParameter(parameter, this.state.openApiJson);
+                    // onDidAddParameter(parameter, this.state.openApiJson);
                 }
 
                 if (onDidChange) {
-                    onDidChange(EVENTS.ADD_PARAMETER, this.state.openApiJson);
+                    // onDidChange(EVENTS.ADD_PARAMETER, this.state.openApiJson);
                 }
 
             });
@@ -393,11 +390,11 @@ class OpenApiVisualizer extends React.Component<OpenApiProps, OpenApiState> {
             }), () => {
 
                 if (onDidAddParameter) {
-                    onDidAddParameter(parameter, this.state.openApiJson);
+                    // onDidAddParameter(parameter, this.state.openApiJson);
                 }
 
                 if (onDidChange) {
-                    onDidChange(EVENTS.ADD_PARAMETER, this.state.openApiJson);
+                    // onDidChange(EVENTS.ADD_PARAMETER, this.state.openApiJson);
                 }
 
             });
@@ -420,7 +417,7 @@ class OpenApiVisualizer extends React.Component<OpenApiProps, OpenApiState> {
             openApiJson,
         }), () => {
             if (onDidChange) {
-                onDidChange(EVENTS.ON_INLINE_CHANGE, this.state.openApiJson);
+                // onDidChange(EVENTS.ON_INLINE_CHANGE, this.state.openApiJson);
             }
         });
 

--- a/composer/packages/api-designer/src/api-designer/operations/operations-list.tsx
+++ b/composer/packages/api-designer/src/api-designer/operations/operations-list.tsx
@@ -85,7 +85,7 @@ class OpenApiOperation extends React.Component<OpenApiOperationProp, OpenApiOper
             <Accordion>
                 {Object.keys(pathItem).sort().map((openApiOperation, index) => {
                     return(
-                        <React.Fragment>
+                        <React.Fragment key={openApiOperation}>
                             <Accordion.Title
                                 active={activeOpIndex.includes(index)}
                                 index={index}

--- a/composer/packages/api-designer/src/api-designer/parameter/parameter-list.tsx
+++ b/composer/packages/api-designer/src/api-designer/parameter/parameter-list.tsx
@@ -45,7 +45,7 @@ class OpenApiParameterList extends React.Component<OpenApiParameterListProps, an
                 <Table.Body>
                     {parameterList.map((param: Swagger.ParameterObject, index: number) => {
                         return (
-                            <Table.Row>
+                            <Table.Row key={param.name}>
                                 <Table.Cell className="parameter-name-cell">
                                     <div className="parameter__name required">
                                         {param.name}

--- a/composer/packages/api-designer/src/api-designer/paths/paths-list.tsx
+++ b/composer/packages/api-designer/src/api-designer/paths/paths-list.tsx
@@ -91,7 +91,7 @@ class OpenApiPathList extends React.Component<OpenApiPathProps, OpenApiPathState
                         <Accordion fluid styled>
                             {Object.keys(paths).sort().map((openApiResource, index) => {
                                 return(
-                                    <React.Fragment>
+                                    <React.Fragment key={openApiResource}>
                                         <Accordion.Title
                                             active={activeIndex.includes(index)}
                                             index={index}

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/SchemaParser.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/SchemaParser.java
@@ -23,7 +23,7 @@ public class SchemaParser {
     }
 
     public void parseObjectSchema(Object string,  OpenApiPropertyType openApiPropertyType) {
-        //TODO Implement object scehema 
+        //TODO Implement object scehema
     }
 
     public void parseArraySchema(Object array, OpenApiPropertyType openApiPropertyType) {

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeMatchingUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeMatchingUtil.java
@@ -84,7 +84,7 @@ public class TypeMatchingUtil {
             final Schema schemaValue = schema.getValue();
             final String schemaName = schema.getKey();
 
-            schemaType.setSchemaName(StringUtils.capitalize(schemaName));
+            schemaType.setSchemaName(delimeterizeUnescapedIdentifires(StringUtils.capitalize(schemaName)));
 
             if (schemaValue instanceof ObjectSchema) {
                 if (schemaValue.getProperties() != null) {
@@ -161,7 +161,7 @@ public class TypeMatchingUtil {
                     | NoSuchMethodException | InstantiationException e) {
                 outStream.println(e.getLocalizedMessage());
             }
-            propertyType.setPropertyName(propName);
+            propertyType.setPropertyName(delimeterizeUnescapedIdentifires(propName));
             propertyTypes.add(propertyType);
         }
 
@@ -340,6 +340,20 @@ public class TypeMatchingUtil {
         }
 
         return requestBodyType;
+    }
+
+    public static String delimeterizeUnescapedIdentifires(String identifier) {
+
+        //check if identifier starts with a number or contains spaces in between
+        if (Character.isDigit(identifier.charAt(0))) {
+            identifier = "'" + identifier;
+        }
+
+        if (StringUtils.split(identifier).length > 0) {
+            //TODO escape spaces
+        }
+
+        return identifier;
     }
 
 }

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/resources/templates/service/schema.mustache
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/resources/templates/service/schema.mustache
@@ -1,5 +1,5 @@
-{{#component}}{{#schemaTypes}}public type {{schemaName}} record { {{#if isArray}}
+{{#component}}{{#schemaTypes}}public type {{{schemaName}}} record { {{#if isArray}}
     {{itemType}}[] {{itemName}};{{/if}}{{#if schemaProperties}}{{#schemaProperties}}
-    {{propertyType}}{{#if isArray}}[]{{/if}} {{propertyName}};{{/schemaProperties}}{{/if}}
+    {{propertyType}}{{#if isArray}}[]{{/if}} {{{propertyName}}};{{/schemaProperties}}{{/if}}
 };
 {{/schemaTypes}}{{/component}}

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/resources/templates/service/serviceMock.mustache
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/resources/templates/service/serviceMock.mustache
@@ -7,7 +7,7 @@ listener http:Listener ep{{@index}} = new({{port}}{{#host}}, config = {host: "{{
 {{/servers}}
 @openapi:ServiceInfo {{=<% %>=}}{<%={{ }}=%>
     contract: "{{definitionPath}}"{{#if tags}},
-    tags: [ {{#tags}}{{name}}{{/tags}} ]{{/if}}{{#if operations}},
+    tags: [ ]{{/if}}{{#if operations}},
     operations: [ {{#operations}}{{name}}{{/operations}} ]{{/if}}
 }
 @http:ServiceConfig {

--- a/tool-plugins/vscode/src/api-editor/activator.ts
+++ b/tool-plugins/vscode/src/api-editor/activator.ts
@@ -163,7 +163,7 @@ function createAPIEditorPanel(selectedService: string, renderHtml: string,
         oasEditorPanel = window.createWebviewPanel(
             'ballerinaOASEditor',
             'Ballerina API Designer - ' + selectedService,
-            { viewColumn: ViewColumn.Two, preserveFocus: true } ,
+            { viewColumn: ViewColumn.One, preserveFocus: true } ,
             getCommonWebViewOptions()
         );
     }


### PR DESCRIPTION
## Purpose
> This PR will decouple the OpenApi designer from ballerina file changes which happen every time the design is updated. Furthermore this PR will escape numeric identifiers by adding a `'` on the begening of the identifier.
