### PR TITLE
Fix issue with union of multi-dimension objects arrays

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -766,6 +766,10 @@ public class TypeChecker extends BLangNodeVisitor {
                                         ? listConstructorExpr.exprs.size() : ((BArrayType) type).size,
                                 ((BArrayType) type).state);
                     } else {
+                        if (type.tag == TypeTags.ARRAY
+                                && types.isAssignable(arrayLiteralType, ((BArrayType) type).eType)) {
+                            arrayLiteralType = ((BArrayType) type).eType;
+                        }
                         actualType = new BArrayType(arrayLiteralType);
                     }
                     listCompatibleTypes.addAll(getListCompatibleTypes(type, actualType));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/arraysofarrays/ArraysOfArraysTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/arraysofarrays/ArraysOfArraysTest.java
@@ -160,6 +160,14 @@ public class ArraysOfArraysTest {
         Assert.assertEquals(((BValueArray) (((BValueArray) returns[1]).getRefValue(0))).getString(0), "scope1");
     }
 
+    @Test(description = "Test multi-dimension array unions with objects")
+    public void testObjectArrayUnion() {
+        BValue[] args = new BValue[0];
+        BValue[] returns = BRunUtil.invoke(result, "testObjectArrayUnion", args);
+        Assert.assertEquals(((BMap) (((BValueArray) returns[0]).getRefValue(0))).get("fooId1").stringValue(), "Foo1");
+        Assert.assertEquals(((BMap) (((BValueArray) returns[0]).getRefValue(0))).get("fooId2").stringValue(), "Foo2");
+    }
+
     private static byte[] hexStringToByteArray(String str) {
         int len = str.length();
         byte[] data = new byte[len / 2];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/arraysofarrays/arrays-of-arrays.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/arraysofarrays/arrays-of-arrays.bal
@@ -204,3 +204,43 @@ function testArrayUnion() returns [boolean[][], string[][]] {
     (string[]|string[][]) x2 = [["scope1"]];
     return [<boolean[][]>x1, <string[][]>x2];
 }
+
+type Foo1 abstract object {
+    string fooId1 = "";
+};
+
+type Foo2 abstract object {
+    string fooId2 = "";
+};
+
+type Bar object {
+    *Foo1;
+    *Foo2;
+
+    public function __init() {
+        self.fooId1 = "Foo1";
+        self.fooId2 = "Foo2";
+    }
+};
+
+function testObjectArrayUnion() returns Foo1[][] {
+    Bar b = new;
+    Foo1[]|Foo1[][] arr1 = [[b]];
+    Foo1[]|Foo2[][] arr2 = [[b]];
+    Foo1[]|Bar[][] arr3 = [[b]];
+    Bar[]|Bar[][] arr4 = [[b]];
+    Bar[]|Foo1[][] arr5 = [[b]];
+
+    Foo1 f = new Bar();
+    Foo1[]|Foo1[][] arr6 = [[f]];
+    Foo1[]|Bar[][] arr7 = [[b]];
+    Bar[]|Bar[][] arr8 = [[b]];
+    Bar[]|Foo1[][] arr9 = [[b]];
+
+    Foo1[]|Foo1[][]|Foo2[][] arr10 = [[f]];
+    if (arr3 is Bar[][]) {
+        Foo1[][] f1 = arr3;
+        Foo2[][] f2 = arr3;
+    }
+    return <Foo1[][]>arr1;
+}


### PR DESCRIPTION
## Purpose
$subject, and will allow;

```ballerina
type Foo1 abstract object {
    string fooId1 = "";
};

type Foo2 abstract object {
    string fooId2 = "";
};

type Bar object {
    *Foo1;
    *Foo2;

    public function __init() {
        self.fooId1 = "Foo1";
        self.fooId2 = "Foo2";
    }
};

function testObjectArrayUnion() returns Foo1[][] {
    Bar b = new;
    Foo1[]|Foo1[][] arr1 = [[b]];
    return <Foo1[][]>arr1;
}
```