### PR TITLE
Change default values of the RequestLimit config

### DIFF
--- a/stdlib/http/src/main/ballerina/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/http/service_endpoint.bal
@@ -127,8 +127,8 @@ public type Local record {|
 # + maxEntityBodySize - Maximum allowed size for the entity body. Exceeding this limit will result in a
 #                       `413 - Payload Too Large` response.
 public type RequestLimits record {|
-    int maxUriLength = -1;
-    int maxHeaderSize = -1;
+    int maxUriLength = 4096;
+    int maxHeaderSize = 8192;
     int maxEntityBodySize = -1;
 |};
 


### PR DESCRIPTION
## Purpose
Improve documentation of RequestLimit[1] with proper default values as follows:
int maxUriLength = 4096;
int maxHeaderSize = 8192;

[1] ballerina-lang/stdlib/http/src/main/ballerina/http/service_endpoint.bal

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9668.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
