### PR TITLE
Refactor jdbc update method

### DIFF
--- a/stdlib/jdbc/src/main/ballerina/jdbc/Module.md
+++ b/stdlib/jdbc/src/main/ballerina/jdbc/Module.md
@@ -24,7 +24,7 @@ jdbc:Client testDB = new({
 });
 ```
 
-2. Client owned, unshareable connection pool
+2. Client owned, unsharable connection pool
 If you define the `poolOptions` field inline, an unshareable connection pool will be created.
 
 ```ballerina

--- a/stdlib/jdbc/src/main/ballerina/jdbc/client_endpoint.bal
+++ b/stdlib/jdbc/src/main/ballerina/jdbc/client_endpoint.bal
@@ -49,7 +49,8 @@ public type Client client object {
     # + parameters - The parameters to be passed to the select query. The number of parameters is variable
     # + return - A `table` returned by the sql query statement else `Error` will be returned if there
     # is any error
-    public remote function select(@untainted string sqlQuery, typedesc<record{}>? recordType, Param... parameters) returns @tainted table<record {}>|Error {
+    public remote function select(@untainted string sqlQuery, typedesc<record{}>? recordType, Param... parameters)
+                                  returns @tainted table<record {}>|Error {
         if (!self.clientActive) {
             return self.handleStoppedClientInvocation();
         }
@@ -59,16 +60,15 @@ public type Client client object {
     # The update remote function implementation for JDBC Client to update data and schema of the database.
     #
     # + sqlQuery - SQL statement to execute
-    # + keyColumns - Names of auto generated columns for which the auto generated key values are returned
     # + parameters - The parameters to be passed to the update query. The number of parameters is variable
     # + return - `UpdateResult` with the updated row count and key column values,
     #             else  `Error` will be returned if there is any error
-    public remote function update(@untainted string sqlQuery, string[]? keyColumns = (), Param... parameters)
+    public remote function update(@untainted string sqlQuery, Param... parameters)
                                   returns UpdateResult|Error {
         if (!self.clientActive) {
             return self.handleStoppedClientInvocation();
         }
-        return self.jdbcClient->update(sqlQuery, keyColumns, ...parameters);
+        return self.jdbcClient->update(sqlQuery, ...parameters);
     }
 
     # The batchUpdate remote function implementation for JDBC Client to batch data insert.

--- a/stdlib/jdbc/src/main/ballerina/jdbc/jdbc_client.bal
+++ b/stdlib/jdbc/src/main/ballerina/jdbc/jdbc_client.bal
@@ -37,20 +37,18 @@ public type JdbcClient client object {
     # + return - A `table` returned by the sql query statement else `Error` will be returned if there
     # is any error
     public remote function select(@untainted string sqlQuery, typedesc<record{}>? recordType,
-    Param... parameters) returns @tainted table<record {}>|Error {
+                                  Param... parameters) returns @tainted table<record {}>|Error {
         return nativeSelect(self, sqlQuery, recordType, ...parameters);
     }
 
     # The update remote function implementation for JDBC Client to update data and schema of the database.
     #
     # + sqlQuery - SQL statement to execute
-    # + keyColumns - Names of auto generated columns for which the auto generated key values are returned
     # + parameters - The parameters to be passed to the update query. The number of parameters is variable
     # + return - A `UpdateResult` with the updated row count and key column values,
     #            else `Error` will be returned if there is any error
-    public remote function update(@untainted string sqlQuery, string[]? keyColumns = (), Param... parameters)
-                                  returns UpdateResult|Error {
-        return nativeUpdate(self, sqlQuery, keyColumns, ...parameters);
+    public remote function update(@untainted string sqlQuery, Param... parameters) returns UpdateResult|Error {
+        return nativeUpdate(self, sqlQuery, ...parameters);
     }
 
     # The batchUpdate remote function implementation for JDBC Client to batch data insert.
@@ -80,7 +78,7 @@ function nativeSelect(JdbcClient sqlClient, @untainted string sqlQuery, typedesc
 function nativeCall(JdbcClient sqlClient, @untainted string sqlQuery, typedesc<record{}>[]? recordType, Param... parameters)
    returns @tainted table<record {}>[]|()|Error = external;
 
-function nativeUpdate(JdbcClient sqlClient, @untainted string sqlQuery, string[]? keyColumns = (), Param... parameters)
+function nativeUpdate(JdbcClient sqlClient, @untainted string sqlQuery, Param... parameters)
     returns UpdateResult|Error = external;
 
 function nativeBatchUpdate(JdbcClient sqlClient, @untainted string sqlQuery, boolean rollbackAllInFailure,

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/actions/Update.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/actions/Update.java
@@ -44,11 +44,9 @@ public class Update extends BlockingNativeCallableUnit {
         //TODO: #16033
     }
 
-    public static Object nativeUpdate(Strand strand, ObjectValue client, String query, Object keyColumns,
-            ArrayValue parameters) {
+    public static Object nativeUpdate(Strand strand, ObjectValue client, String query, ArrayValue parameters) {
         SQLDatasource sqlDatasource = (SQLDatasource) client.getNativeData(Constants.JDBC_CLIENT);
-        SQLStatement updateStatement = new UpdateStatement(client, sqlDatasource, query, (ArrayValue) keyColumns,
-                parameters, strand);
+        SQLStatement updateStatement = new UpdateStatement(client, sqlDatasource, query, parameters, strand);
         return updateStatement.execute();
     }
 }

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/UpdateStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/UpdateStatement.java
@@ -51,16 +51,14 @@ public class UpdateStatement extends AbstractSQLStatement {
     private final ObjectValue client;
     private final SQLDatasource datasource;
     private final String query;
-    private final ArrayValue keyColumns;
     private final ArrayValue parameters;
 
-    public UpdateStatement(ObjectValue client, SQLDatasource datasource, String query,
-                           ArrayValue keyColumns, ArrayValue parameters, Strand strand) {
+    public UpdateStatement(ObjectValue client, SQLDatasource datasource, String query, ArrayValue parameters,
+                           Strand strand) {
         super(strand);
         this.client = client;
         this.datasource = datasource;
         this.query = query;
-        this.keyColumns = keyColumns;
         this.parameters = parameters;
     }
 
@@ -79,18 +77,7 @@ public class UpdateStatement extends AbstractSQLStatement {
             conn = getDatabaseConnection(strand, client, datasource, false);
             String processedQuery = createProcessedQueryString(query, generatedParams);
             int keyColumnCount = 0;
-            if (keyColumns != null) {
-                keyColumnCount = keyColumns.size();
-            }
-            if (keyColumnCount > 0) {
-                String[] columnArray = new String[keyColumnCount];
-                for (int i = 0; i < keyColumnCount; i++) {
-                    columnArray[i] = keyColumns.getString(i);
-                }
-                stmt = conn.prepareStatement(processedQuery, columnArray);
-            } else {
-                stmt = conn.prepareStatement(processedQuery, Statement.RETURN_GENERATED_KEYS);
-            }
+            stmt = conn.prepareStatement(processedQuery, Statement.RETURN_GENERATED_KEYS);
             createProcessedStatement(conn, stmt, generatedParams, datasource.getDatabaseProductName());
             int count = stmt.executeUpdate();
             rs = stmt.getGeneratedKeys();

--- a/stdlib/jdbc/src/test/resources/test-src/sql/sql_actions_test.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/sql_actions_test.bal
@@ -184,12 +184,11 @@ function testGeneratedKeyWithColumn() returns int {
             poolOptions: { maximumPoolSize: 1 }
         });
 
-    string[] keyColumnNames = ["CUSTOMERID"];
     string firstName = "Kathy";
     string lastName = "Williams";
     string queryString = "insert into Customers (firstName,lastName,registrationID,creditLimit,country) values (?,
         ?, 4, 5000.75, 'USA')";
-    var x = testDB->update(queryString, keyColumnNames, firstName, lastName);
+    var x = testDB->update(queryString, firstName, lastName);
 
     int generatedID = 0;
     if (x is jdbc:UpdateResult) {
@@ -287,7 +286,7 @@ function testInsertTableDataWithParameters() returns int {
     jdbc:Parameter para5 = { sqlType: jdbc:TYPE_VARCHAR, value: "UK", direction: jdbc:DIRECTION_IN };
 
     var result = testDB->update("Insert into Customers (firstName,lastName,registrationID,creditLimit,country)
-                                     values (?,?,?,?,?)", (), para1, para2, para3, para4, para5);
+                                     values (?,?,?,?,?)", para1, para2, para3, para4, para5);
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
         insertCount = result.updatedRowCount;
@@ -305,7 +304,7 @@ function testInsertTableDataWithParameters2() returns int {
         });
 
     var result = testDB->update("Insert into Customers (firstName,lastName,registrationID,creditLimit,country)
-                                     values (?,?,?,?,?)", (), "Anne", "James", 3, 5000.75, "UK");
+                                     values (?,?,?,?,?)", "Anne", "James", 3, 5000.75, "UK");
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
         insertCount = result.updatedRowCount;
@@ -324,7 +323,7 @@ function testInsertTableDataWithParameters3() returns int {
 
     string s1 = "Anne";
     var result = testDB->update("Insert into Customers (firstName,lastName,registrationID,creditLimit,country)
-                                     values (?,?,?,?,?)", (), s1, "James", 3, 5000.75, "UK");
+                                     values (?,?,?,?,?)", s1, "James", 3, 5000.75, "UK");
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
         insertCount = result.updatedRowCount;
@@ -454,7 +453,7 @@ function testINParameters() returns int {
 
     var result = testDB->update("INSERT INTO DataTypeTable (row_id,int_type, long_type,
             float_type, double_type, boolean_type, string_type, numeric_type, decimal_type, real_type, tinyint_type,
-            smallint_type, clob_type, binary_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (),
+            smallint_type, clob_type, binary_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         paraID, paraInt, paraLong, paraFloat, paraDouble, paraBool, paraString, paraNumeric,
         paraDecimal, paraReal, paraTinyInt, paraSmallInt, paraClob, paraBinary);
     int insertCount = 0;
@@ -478,8 +477,7 @@ function testBlobInParameter() returns @tainted [int, byte[]] {
 
     byte[] blobVal = [];
 
-    var result = testDB->update("INSERT INTO BlobTable (row_id,blob_type) VALUES (?,?)", (),
-        paraID, paraBlob);
+    var result = testDB->update("INSERT INTO BlobTable (row_id,blob_type) VALUES (?,?)", paraID, paraBlob);
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
         insertCount = result.updatedRowCount;
@@ -507,7 +505,7 @@ function testINParametersWithDirectValues() returns @tainted [int, int, float, f
 
     var result = testDB->update("INSERT INTO DataTypeTable (row_id, int_type, long_type, float_type,
         double_type, boolean_type, string_type, numeric_type, decimal_type, real_type,
-        bit_type) VALUES (?,?,?,?,?,?,?,?,?,?,?)", (), 25, 1, 9223372036854774807, 123.34, 2139095039.1, true, "Hello",
+        bit_type) VALUES (?,?,?,?,?,?,?,?,?,?,?)", 25, 1, 9223372036854774807, 123.34, 2139095039.1, true, "Hello",
         1234.567, 1234.567, 1234.567, [1, 2]);
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
@@ -567,7 +565,7 @@ function testINParametersWithDirectVariables() returns @tainted [int, int, float
 
     var result = testDB->update("INSERT INTO DataTypeTable (row_id, int_type, long_type,
             float_type, double_type, boolean_type, string_type, numeric_type, decimal_type, real_type, bit_type)
-            VALUES (?,?,?,?,?,?,?,?,?,?,?)", (), rowid, intType, longType, floatType, doubleType, boolType,
+            VALUES (?,?,?,?,?,?,?,?,?,?,?)", rowid, intType, longType, floatType, doubleType, boolType,
             stringType, numericType, decimalType, realType, byteArray);
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
@@ -630,7 +628,7 @@ function testNullINParameterValues() returns int {
 
     var result = testDB->update("INSERT INTO DataTypeTable (row_id, int_type, long_type,
             float_type, double_type, boolean_type, string_type, numeric_type, decimal_type, real_type, tinyint_type,
-            smallint_type, clob_type, binary_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (),
+            smallint_type, clob_type, binary_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         paraID, paraInt, paraLong, paraFloat, paraDouble, paraBool, paraString, paraNumeric,
         paraDecimal, paraReal, paraTinyInt, paraSmallInt, paraClob, paraBinary);
     int insertCount = 0;
@@ -652,8 +650,7 @@ function testNullINParameterBlobValue() returns int {
     jdbc:Parameter paraID = { sqlType: jdbc:TYPE_INTEGER, value: 4 };
     jdbc:Parameter paraBlob = { sqlType: jdbc:TYPE_BLOB, value: () };
 
-    var result = testDB->update("INSERT INTO BlobTable (row_id, blob_type) VALUES (?,?)", (),
-        paraID, paraBlob);
+    var result = testDB->update("INSERT INTO BlobTable (row_id, blob_type) VALUES (?,?)", paraID, paraBlob);
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
         insertCount = result.updatedRowCount;
@@ -669,7 +666,7 @@ function testEmptySQLType() returns int {
             password: "",
             poolOptions: { maximumPoolSize: 1 }
         });
-    var result = testDB->update("Insert into Customers (firstName) values (?)", (), "Anne");
+    var result = testDB->update("Insert into Customers (firstName) values (?)", "Anne");
     int insertCount = 0;
     if (result is jdbc:UpdateResult) {
         insertCount = result.updatedRowCount;
@@ -862,7 +859,7 @@ function testDateTimeInParameters() returns int[] {
     jdbc:Parameter para4 = { sqlType: jdbc:TYPE_TIMESTAMP, value: "2017-01-30T13:27:01.999-08:00" };
     jdbc:Parameter para5 = { sqlType: jdbc:TYPE_DATETIME, value: "2017-01-30T13:27:01.999999Z" };
 
-    var result1 = testDB->update(stmt, (), para1, para2, para3, para4, para5);
+    var result1 = testDB->update(stmt, para1, para2, para3, para4, para5);
     int insertCount1 = 0;
     if (result1 is jdbc:UpdateResult) {
         insertCount1 = result1.updatedRowCount;
@@ -876,7 +873,7 @@ function testDateTimeInParameters() returns int[] {
     para4 = { sqlType: jdbc:TYPE_TIMESTAMP, value: "2017-01-30T13:27:01.999" };
     para5 = { sqlType: jdbc:TYPE_DATETIME, value: "-2017-01-30T13:27:01.999999-08:30" };
 
-    var result2 = testDB->update(stmt, (), para1, para2, para3, para4, para5);
+    var result2 = testDB->update(stmt, para1, para2, para3, para4, para5);
     int insertCount2 = 0;
     if (result2 is jdbc:UpdateResult) {
         insertCount2 = result2.updatedRowCount;
@@ -891,7 +888,7 @@ function testDateTimeInParameters() returns int[] {
     para4 = { sqlType: jdbc:TYPE_TIMESTAMP, value: timeNow };
     para5 = { sqlType: jdbc:TYPE_DATETIME, value: timeNow };
 
-    var result3 = testDB->update(stmt, (), para1, para2, para3, para4, para5);
+    var result3 = testDB->update(stmt, para1, para2, para3, para4, para5);
     int insertCount3 = 0;
     if (result3 is jdbc:UpdateResult) {
         insertCount3 = result3.updatedRowCount;
@@ -918,7 +915,7 @@ function testDateTimeNullInValues() returns string {
     jdbc:Parameter?[] parameters = [para0, para1, para2, para3, para4];
 
     _ = checkpanic testDB->update("Insert into DateTimeTypes
-        (row_id, date_type, time_type, timestamp_type, datetime_type) values (?,?,?,?,?)", (),
+        (row_id, date_type, time_type, timestamp_type, datetime_type) values (?,?,?,?,?)",
         para0, para1, para2, para3, para4);
     var dt = testDB->select("SELECT date_type, time_type, timestamp_type, datetime_type
                 from DateTimeTypes where row_id = 33", ResultDates);


### PR DESCRIPTION
## Purpose

Current jdbc update method has defaultable keyColumns array parameter. But now we can't have both defaultable and rest params in an invocation. So we have decided to remove the keyColumns support.  But still the auto generated keys will be available in the returned record. 

Some databases( ex, Oracle) supports additional auto updated columns via triggers etc. To retrieve those keys, need to issue a select statement soon after the udpate function call within the same transaction to get those values.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
```ballerina
function testGeneratedKeyWithColumn() returns int {
    jdbc:Client testDB = new({
            url: "jdbc:h2:file:./target/tempdb/TEST_SQL_CONNECTOR_H2",
            username: "SA",
            password: "",
            poolOptions: { maximumPoolSize: 1 }
        });

    string firstName = "Kathy";
    string lastName = "Williams";
    string queryString = "insert into Customers (firstName,lastName,registrationID,creditLimit,country) values (?,
        ?, 4, 5000.75, 'USA')";
    var x = testDB->update(queryString, firstName, lastName);

    int generatedID = 0;
    if (x is jdbc:UpdateResult) {
        generatedID = <int>x.generatedKeys["CUSTOMERID"];
    }
    checkpanic testDB.stop();
    return generatedID;
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [x] API documentation 
  - [x] Module documentation in Module.md files
  - [ ] Ballerina By Examples
