### PR TITLE
Exit early when wrong error detail type detected

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1721,7 +1721,10 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             }
         }
 
-        // reason is a record
+        // Wrong error detail type in error type def, error already emitted  to dlog.
+        if (rhsErrorType.detailType.tag != TypeTags.RECORD) {
+            return;
+        }
         BRecordType rhsDetailType = (BRecordType) rhsErrorType.detailType;
         Map<String, BField> fields = rhsDetailType.fields.stream()
                 .collect(Collectors.toMap(field -> field.name.value, field -> field));


### PR DESCRIPTION
For invalid error type def SMS, when the error ref statement is also available somewhere in the program. Compiler crashes with typecast exception. This PR fixes it.

```ballerina
type SMS error <string, map<string>>;
```

```ballerina
string reason11;
map<string> detail11;
error (reason11, ... detail11) = err1;
```