### PR TITLE
Fix function default expression non visiting issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3032,7 +3032,6 @@ public class TypeChecker extends BLangNodeVisitor {
                         // can not provide a named arg, if the arg is not public and the caller is not from same package
                         dlog.error(expr.pos, DiagnosticCode.NON_PUBLIC_ARG_ACCESSED_WITH_NAMED_ARG,
                                 ((BLangNamedArgsExpression) expr).name.value, iExpr.toString());
-                        return symTable.semanticError;
                     }
                     foundNamedArg = true;
                     if (i < parameterCount) {
@@ -3040,7 +3039,6 @@ public class TypeChecker extends BLangNodeVisitor {
                     } else {
                         // can not provide a rest parameters as named args
                         dlog.error(expr.pos, DiagnosticCode.TOO_MANY_ARGS_FUNC_CALL, iExpr.name.value);
-                        return symTable.semanticError;
                     }
                     i++;
                     break;
@@ -3054,7 +3052,6 @@ public class TypeChecker extends BLangNodeVisitor {
                 default: // positional args
                     if (foundNamedArg) {
                         dlog.error(expr.pos, DiagnosticCode.POSITIONAL_ARG_DEFINED_AFTER_NAMED_ARG);
-                        return symTable.semanticError;
                     }
                     if (i < parameterCount) {
                         iExpr.requiredArgs.add(expr);
@@ -3066,11 +3063,10 @@ public class TypeChecker extends BLangNodeVisitor {
             }
         }
 
-        return checkInvocationArgs(iExpr, paramTypes, parameterCount, vararg);
+        return checkInvocationArgs(iExpr, paramTypes, vararg);
     }
 
-    private BType checkInvocationArgs(BLangInvocation iExpr, List<BType> paramTypes, int requiredParamsCount,
-                                      BLangExpression vararg) {
+    private BType checkInvocationArgs(BLangInvocation iExpr, List<BType> paramTypes, BLangExpression vararg) {
         BType actualType = symTable.semanticError;
         BInvokableSymbol invokableSymbol = (BInvokableSymbol) iExpr.symbol;
         List<BVarSymbol> nonRestParams = new ArrayList<>(invokableSymbol.params);
@@ -3082,8 +3078,6 @@ public class TypeChecker extends BLangNodeVisitor {
             return actualType;
         }
 
-        // checkRequiredArgs(iExpr.requiredArgs, paramTypes);
-        // checkNamedArgs(iExpr.namedArgs, invokableSymbol.defaultableParams);
         checkRestArgs(iExpr.restArgs, vararg, invokableSymbol.restParam);
         BType retType = typeParamAnalyzer.getReturnTypeParams(env, invokableSymbol.type.getReturnType());
 
@@ -3100,42 +3094,6 @@ public class TypeChecker extends BLangNodeVisitor {
         return new BFutureType(TypeTags.FUTURE, retType, null, isWorkerStart);
     }
 
-    private void checkRequiredArgs(List<BLangExpression> requiredArgExprs, List<BType> requiredParamTypes) {
-        for (int i = 0; i < requiredArgExprs.size(); i++) {
-            BType expectedType = requiredParamTypes.get(i);
-            // Special case handling for the first param because for parameterized invocations, we have added the
-            // value on which the function is invoked as the first param of the function call. If we run checkExpr()
-            // on it, it will recursively add the first param to argExprs again, resulting in a too many args in
-            // function call error.
-            if (i == 0 && requiredArgExprs.get(i).typeChecked) {
-                types.checkType(requiredArgExprs.get(i).pos, requiredArgExprs.get(i).type, expectedType,
-                        DiagnosticCode.INCOMPATIBLE_TYPES);
-                BLangExpression expr = requiredArgExprs.get(i);
-                types.setImplicitCastExpr(expr, expr.type, expectedType);
-            } else {
-                checkExpr(requiredArgExprs.get(i), this.env, expectedType);
-            }
-            typeParamAnalyzer.checkForTypeParamsInArg(requiredArgExprs.get(i).type, env, expectedType);
-        }
-    }
-
-    private void checkNamedArgs(List<BLangExpression> namedArgExprs, List<BVarSymbol> defaultableParams) {
-        for (BLangExpression expr : namedArgExprs) {
-            BLangIdentifier argName = ((NamedArgNode) expr).getName();
-            BVarSymbol varSym = defaultableParams.stream()
-                    .filter(param -> param.getName().value.equals(argName.value))
-                    .findAny()
-                    .orElse(null);
-            if (varSym == null) {
-                dlog.error(expr.pos, DiagnosticCode.UNDEFINED_PARAMETER, argName);
-                break;
-            }
-
-            checkExpr(expr, this.env, varSym.type);
-            typeParamAnalyzer.checkForTypeParamsInArg(expr.type, env, varSym.type);
-        }
-    }
-
     private void checkNonRestArgs(List<BVarSymbol> nonRestParams, BLangInvocation iExpr, List<BType> paramTypes) {
         List<BLangExpression> nonRestArgs = iExpr.requiredArgs;
         List<BVarSymbol> requiredParams = nonRestParams.stream()
@@ -3145,7 +3103,6 @@ public class TypeChecker extends BLangNodeVisitor {
         if (nonRestArgs.size() < requiredParams.size()) {
             // make sure all the required parameters are given.
             dlog.error(iExpr.pos, DiagnosticCode.NOT_ENOUGH_ARGS_FUNC_CALL, iExpr.name.value);
-            return;
         }
 
         List<BVarSymbol> valueProvidedParams = new ArrayList<>();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureNegativeTest.java
@@ -43,27 +43,74 @@ public class FunctionSignatureNegativeTest {
         BAssertUtil.validateError(result, i++, "invalid rest arguments", 33, 23);
         BAssertUtil.validateError(result, i++, "incompatible types: expected 'json', found 'xml'", 40, 61);
         BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithOnlyPositionalParams()'", 57, 9);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'a' in call to " +
+                "'functionWithOnlyPositionalParams'()", 57, 9);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'b' in call to " +
+                "'functionWithOnlyPositionalParams'()", 57, 9);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'c' in call to " +
+                "'functionWithOnlyPositionalParams'()", 57, 9);
         BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithOnlyPositionalParams()'", 58, 9);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'c' in call to " +
+                "'functionWithOnlyPositionalParams'()", 58, 9);
         BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithOnlyPositionalParams()'", 59, 9);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'boolean', found 'string'", 59, 45);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'c' in call to " +
+                "'functionWithOnlyPositionalParams'()", 59, 9);
         BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithOnlyPositionalParams()'", 60, 9);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'b' in call to " +
+                "'functionWithOnlyPositionalParams'()", 60, 9);
         BAssertUtil.validateError(result, i++, tooManyArguments + "'functionWithOnlyPositionalParams()'", 61, 9);
         BAssertUtil.validateError(result, i++, tooManyArguments + "'functionWithOnlyPositionalParams()'", 62, 56);
         BAssertUtil.validateError(result, i++, tooManyArguments + "'functionWithOnlyPositionalParams()'", 63, 62);
+        BAssertUtil.validateError(result, i++, "redeclared argument 'a'", 63, 45);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'c' in call to " +
+                "'functionWithOnlyPositionalParams'()", 63, 9);
         BAssertUtil.validateError(result, i++, "incompatible types: expected 'boolean', found 'string'", 68, 46);
         BAssertUtil.validateError(result, i++, tooManyArguments + "'functionWithOnlyDefaultableParams()'", 70, 9);
         BAssertUtil.validateError(result, i++, tooManyArguments + "'functionWithOnlyDefaultableParams()'", 71, 57);
         BAssertUtil.validateError(result, i++, tooManyArguments + "'functionWithOnlyDefaultableParams()'", 72, 63);
+        BAssertUtil.validateError(result, i++, "redeclared argument 'a'", 72, 46);
         BAssertUtil.validateError(result, i++, "required parameter not allowed after defaultable parameters", 75, 60);
         BAssertUtil.validateError(result, i++, "incompatible types: expected 'boolean', found 'boolean[]'", 85, 33);
         BAssertUtil.validateError(result, i++, "incompatible types: expected 'float', found 'boolean[]'", 87, 28);
         BAssertUtil.validateError(result, i++, "positional argument not allowed after named arguments", 89, 45);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'boolean', found 'boolean[]'", 89, 45);
         BAssertUtil.validateError(result, i++, "rest argument not allowed after named arguments", 90, 45);
         BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithNoRestParam()'", 98, 5);
-        BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithNoRestParam()'", 99, 5);
-        BAssertUtil.validateError(result, i++, "missing required parameter 'x' in call to " +
-                "'functionWithNoRestParam'()", 100, 5);
         BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
-                "'functionWithNoRestParam'()", 100, 5);
+                "'functionWithNoRestParam'()", 98, 5);
+        BAssertUtil.validateError(result, i++, notEnoughArguments + "'functionWithNoRestParam()'", 99, 5);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'int', found 'string'", 99, 29);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
+                "'functionWithNoRestParam'()", 99, 5);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'int', found 'string'", 100, 29);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'string', found 'int'", 100, 39);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'float', found 'boolean'", 103, 44);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'float', found 'boolean'", 105, 44);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'boolean', found 'float'", 105, 51);
+        BAssertUtil.validateError(result, i++, "not enough arguments in call to " +
+                "'functionWithNoRestParam()'", 106, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'x' in call to " +
+                "'functionWithNoRestParam'()", 106, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
+                "'functionWithNoRestParam'()", 106, 5);
+        BAssertUtil.validateError(result, i++, "not enough arguments in call to " +
+                "'functionWithNoRestParam()'", 107, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'x' in call to " +
+                "'functionWithNoRestParam'()", 107, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
+                "'functionWithNoRestParam'()", 107, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'x' in call to " +
+                "'functionWithNoRestParam'()", 108, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
+                "'functionWithNoRestParam'()", 108, 5);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
+                "'functionWithNoRestParam'()", 114, 5);
+        BAssertUtil.validateError(result, i++, "too many arguments in call to 'getFloat()'", 115, 36);
+        BAssertUtil.validateError(result, i++, "missing required parameter 'y' in call to " +
+                "'functionWithNoRestParam'()", 115, 5);
+
+        Assert.assertEquals(i, result.getErrorCount());
     }
 
     @Test
@@ -74,7 +121,6 @@ public class FunctionSignatureNegativeTest {
 
     @Test
     public void testOutsideObjectMethodDefinition() {
-
         CompileResult result = BCompileUtil.compile("test-src/functions" +
                 "/function_with_outside_object_method_definition.bal");
         BAssertUtil.validateError(result, 0, "outside object method definitions are not allowed", 5, 1);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures-negative.bal
@@ -95,8 +95,26 @@ function functionWithNoRestParam(int x, string y, float f = 1.1, boolean b = tru
 }
 
 function requiredParamTest() {
+    functionWithNoRestParam(100); // not enough arguments in call to 'functionWithNoRestParam()'
+    functionWithNoRestParam("string"); // not enough arguments in call to 'functionWithNoRestParam()'
+    functionWithNoRestParam("string", 100); // incompatible types
+    functionWithNoRestParam(100, "string");
+    functionWithNoRestParam(100, "string", 2.2);
+    functionWithNoRestParam(100, "string", false); // incompatible types: expected 'float', found 'boolean'
+    functionWithNoRestParam(100, "string", 2.2, false);
+    functionWithNoRestParam(100, "string", false, 2.2); // incompatible types:
     functionWithNoRestParam(); // not enough arguments in call to 'functionWithNoRestParam()'
     functionWithNoRestParam(f = 1.2); // not enough arguments in call to 'functionWithNoRestParam()'
     functionWithNoRestParam(b = false, f = 1.2); // missing required parameter 'x' in call to 'functionWithNoRestParam'()
     // missing required parameter 'y' in call to 'functionWithNoRestParam'()
+}
+
+function testDefaultExprEvaluation() {
+    functionWithNoRestParam(1, "2", f = getFloat());
+    functionWithNoRestParam(1, f = getFloat()); // missing required parameter 'y' in call to 'functionWithNoRestParam'()
+    functionWithNoRestParam(1, f = getFloat(2.2)); // too many arguments in call to 'getFloat()'
+}
+
+function getFloat() returns float {
+    return 25.0;
 }


### PR DESCRIPTION
## Purpose
Default value expressions used in function parameters were not visited if a semantic error was encountered in the type checking phase. This PR will address this issue
