### PR TITLE
Migrate table XML utils, enable table->xml conversion

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/DataIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/DataIterator.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.jvm;
 
 import org.ballerinalang.jvm.types.BStructureType;
+import org.ballerinalang.jvm.values.DecimalValue;
 
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,8 @@ public interface DataIterator {
     Boolean getBoolean(int columnIndex);
 
     String getBlob(int columnIndex);
+
+    DecimalValue getDecimal(int columnIndex);
 
     Object[] getStruct(int columnIndex);
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONGenerator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONGenerator.java
@@ -19,6 +19,7 @@ package org.ballerinalang.jvm;
 
 import org.ballerinalang.jvm.types.TypeTags;
 import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.DecimalValue;
 import org.ballerinalang.jvm.values.MapValueImpl;
 import org.ballerinalang.jvm.values.RefValue;
 import org.ballerinalang.jvm.values.StreamingJsonValue;
@@ -297,7 +298,7 @@ public class JSONGenerator {
                 this.writeNumber(((Number) json).doubleValue());
                 break;
             case TypeTags.DECIMAL_TAG:
-                this.writeNumber((BigDecimal) json);
+                this.writeNumber(((DecimalValue) json).value());
                 break;
             case TypeTags.INT_TAG:
                 this.writeNumber(((Number) json).longValue());

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableOMDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableOMDataSource.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.jvm;
+
+import org.apache.axiom.om.ds.AbstractPushOMDataSource;
+import org.ballerinalang.jvm.types.BField;
+import org.ballerinalang.jvm.types.BStructureType;
+import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.types.TypeTags;
+import org.ballerinalang.jvm.values.TableValue;
+
+import java.sql.SQLException;
+import java.sql.Struct;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * This will provide custom OMDataSource implementation by wrapping BTable.
+ * This will use to convert result set into XML stream.
+ *
+ * @since 0.8.0
+ */
+public class TableOMDataSource extends AbstractPushOMDataSource {
+
+    private static final String XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final String XSI_PREFIX = "xsi";
+    private static final String ARRAY_ELEMENT_NAME = "element";
+    private static final String DEFAULT_ROOT_WRAPPER = "results";
+    private static final String DEFAULT_ROW_WRAPPER = "result";
+
+    private TableValue table;
+    private String rootWrapper;
+    private String rowWrapper;
+
+    public TableOMDataSource(TableValue table, String rootWrapper, String rowWrapper) {
+        this.table = table;
+        this.rootWrapper = rootWrapper != null ? rootWrapper : DEFAULT_ROOT_WRAPPER;
+        this.rowWrapper = rowWrapper != null ? rowWrapper : DEFAULT_ROW_WRAPPER;
+    }
+
+    @Override
+    public void serialize(XMLStreamWriter xmlStreamWriter) throws XMLStreamException {
+        xmlStreamWriter.writeStartElement("", this.rootWrapper, "");
+        while (table.hasNext()) {
+            table.moveToNext();
+            xmlStreamWriter.writeStartElement("", this.rowWrapper, "");
+            BStructureType structType = table.getStructType();
+            BField[] structFields = null;
+            if (structType != null) {
+                structFields = structType.getFields().values().toArray(new BField[0]);
+            }
+            int index = 1;
+            for (ColumnDefinition col : table.getColumnDefs()) {
+                String name;
+                if (structFields != null) {
+                    name = structFields[index - 1].getFieldName();
+                } else {
+                    name = col.getName();
+                }
+                writeElement(xmlStreamWriter, name, col.getTypeTag(), index, structFields);
+                ++index;
+            }
+            xmlStreamWriter.writeEndElement();
+        }
+        xmlStreamWriter.writeEndElement();
+        xmlStreamWriter.flush();
+    }
+
+   private void writeElement(XMLStreamWriter xmlStreamWriter, String name, int typeTag, int index,
+           BField[] structFields) throws XMLStreamException {
+        boolean isArray = false;
+        xmlStreamWriter.writeStartElement("", name, "");
+        String value = null;
+        switch (typeTag) {
+        case TypeTags.BOOLEAN_TAG:
+            value = String.valueOf(table.getBoolean(index));
+            break;
+        case TypeTags.STRING_TAG:
+            value = table.getString(index);
+            break;
+        case TypeTags.INT_TAG:
+            value = String.valueOf(table.getInt(index));
+            break;
+        case TypeTags.FLOAT_TAG:
+            value = String.valueOf(table.getFloat(index));
+            break;
+        case TypeTags.DECIMAL_TAG:
+            value = String.valueOf(table.getDecimal(index));
+            break;
+        case TypeTags.BYTE_TAG:
+            value = table.getBlob(index);
+            break;
+        case TypeTags.ARRAY_TAG:
+            isArray = true;
+            Object[] array = table.getArray(index);
+            processArray(xmlStreamWriter, array);
+            break;
+        case TypeTags.OBJECT_TYPE_TAG:
+        case TypeTags.RECORD_TYPE_TAG:
+            isArray = true;
+            Object[] structData = table.getStruct(index);
+            if (structFields == null) {
+                processArray(xmlStreamWriter, structData);
+            } else {
+                processStruct(xmlStreamWriter, structData, structFields, index);
+            }
+            break;
+        default:
+            value = table.getString(index);
+            break;
+        }
+        if (!isArray) {
+            if (value == null) {
+                xmlStreamWriter.writeNamespace(XSI_PREFIX, XSI_NAMESPACE);
+                xmlStreamWriter.writeAttribute(XSI_PREFIX, XSI_NAMESPACE, "nil", "true");
+            } else {
+                xmlStreamWriter.writeCharacters(value);
+            }
+        }
+        xmlStreamWriter.writeEndElement();
+    }
+
+    private void processArray(XMLStreamWriter xmlStreamWriter, Object[] array) throws XMLStreamException {
+        if (array != null) {
+            for (Object value  : array) {
+                xmlStreamWriter.writeStartElement("", ARRAY_ELEMENT_NAME, "");
+                xmlStreamWriter.writeCharacters(String.valueOf(value));
+                xmlStreamWriter.writeEndElement();
+            }
+        }
+    }
+
+    private void processStruct(XMLStreamWriter xmlStreamWriter, Object[] structData,
+            BField[] structFields, int index) throws XMLStreamException {
+        try {
+            int i = 0;
+            boolean structError = true;
+            BType internaltType = structFields[index - 1].getFieldType();
+            if (internaltType.getTag() == TypeTags.OBJECT_TYPE_TAG
+                    || internaltType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                BField[] internalStructFields = ((BStructureType) internaltType).getFields()
+                                                                                .values().toArray(new BField[0]);
+                if (internalStructFields != null) {
+                    for (Object val : structData) {
+                        xmlStreamWriter.writeStartElement("", internalStructFields[i].getFieldName(), "");
+                        if (val instanceof Struct) {
+                            processStruct(xmlStreamWriter, ((Struct) val).getAttributes(), internalStructFields, i + 1);
+                        } else {
+                            xmlStreamWriter.writeCharacters(val.toString());
+                        }
+                        xmlStreamWriter.writeEndElement();
+                        ++i;
+                    }
+                    structError = false;
+                }
+            }
+            if (structError) {
+                throw BallerinaErrors.createError("error in constructing the xml element from struct type data");
+            }
+        } catch (SQLException e) {
+            throw BallerinaErrors.createError(
+                    "error in retrieving struct data to construct the inner xml element:" + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isDestructiveWrite() {
+        return true;
+    }
+}

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableOMDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableOMDataSource.java
@@ -103,7 +103,7 @@ public class TableOMDataSource extends AbstractPushOMDataSource {
         case TypeTags.DECIMAL_TAG:
             value = String.valueOf(table.getDecimal(index));
             break;
-        case TypeTags.BYTE_TAG:
+        case TypeTags.BYTE_ARRAY_TAG:
             value = table.getBlob(index);
             break;
         case TypeTags.ARRAY_TAG:

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
@@ -35,6 +35,7 @@ import org.apache.axiom.om.OMProcessingInstruction;
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.om.impl.dom.TextImpl;
+import org.apache.axiom.om.impl.llom.OMSourcedElementImpl;
 import org.apache.axiom.om.util.StAXParserConfiguration;
 import org.ballerinalang.jvm.types.BArrayType;
 import org.ballerinalang.jvm.types.BMapType;
@@ -45,6 +46,7 @@ import org.ballerinalang.jvm.types.TypeConstants;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.MapValueImpl;
+import org.ballerinalang.jvm.values.TableValue;
 import org.ballerinalang.jvm.values.XMLItem;
 import org.ballerinalang.jvm.values.XMLQName;
 import org.ballerinalang.jvm.values.XMLSequence;
@@ -270,17 +272,17 @@ public class XMLFactory {
     }
 
     /**
-     * Converts a {@link BTable} to {@link XMLValue}.
+     * Converts a {@link org.ballerinalang.jvm.values.TableValue} to {@link XMLValue}.
      *
-     * @param table {@link BTable} to convert
+     * @param table {@link org.ballerinalang.jvm.values.TableValue} to convert
      * @return converted {@link XMLValue}
      */
-    // @SuppressWarnings("rawtypes")
-    // public static XMLValue tableToXML(BTable table) {
-    // OMSourcedElementImpl omSourcedElement = new OMSourcedElementImpl();
-    // omSourcedElement.init(new TableOMDataSource(table, null, null));
-    // return new XMLItem(omSourcedElement);
-    // }
+    @SuppressWarnings("rawtypes")
+    public static XMLValue tableToXML(TableValue table) {
+        OMSourcedElementImpl omSourcedElement = new OMSourcedElementImpl();
+        omSourcedElement.init(new TableOMDataSource(table, null, null));
+        return new XMLItem(omSourcedElement);
+    }
 
     /**
      * Create an element type XMLValue.

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableIterator.java
@@ -147,6 +147,16 @@ public class TableIterator implements DataIterator {
     }
 
     @Override
+    public DecimalValue getDecimal(int columnIndex) {
+        try {
+            BigDecimal val = rs.getBigDecimal(columnIndex);
+            return rs.wasNull() ? null : new DecimalValue(val);
+        } catch (SQLException e) {
+            throw new BallerinaException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public Object[] getStruct(int columnIndex) {
         Object[] objArray = null;
         try {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableValue.java
@@ -284,7 +284,7 @@ public class TableValue implements RefValue, CollectionValue {
     }
 
     public DecimalValue getDecimal(int columnIndex) {
-        throw new UnsupportedOperationException();
+        return iterator.getDecimal(columnIndex);
     }
 
     public List<ColumnDefinition> getColumnDefs() {

--- a/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/ConstructFrom.java
+++ b/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/ConstructFrom.java
@@ -22,6 +22,7 @@ import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.JSONUtils;
 import org.ballerinalang.jvm.Strand;
 import org.ballerinalang.jvm.TypeChecker;
+import org.ballerinalang.jvm.XMLFactory;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.types.BTypedescType;
 import org.ballerinalang.jvm.values.RefValue;
@@ -120,7 +121,7 @@ public class ConstructFrom {
                 case TypeTags.JSON_TAG:
                     return JSONUtils.toJSON((TableValue) inputValue);
                 case TypeTags.XML_TAG:
-                    // TODO:
+                    return XMLFactory.tableToXML((TableValue) inputValue);
                 default:
                     break;
             }

--- a/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
+++ b/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
@@ -1393,11 +1393,4 @@ public class TableTest {
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(), "Hello");
     }
-
-    // TODO: #16033
-    @Test(description = "Test removing data from a table using a given lambda as a filter", enabled = false)
-    public void testRemoveOp() {
-        BValue[] returns = BRunUtil.invoke(result, "testRemoveOp");
-        Assert.assertEquals(returns[0].stringValue(), "table<Order> {index: [], primaryKey: [], data: []}");
-    }
 }

--- a/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
+++ b/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
@@ -115,8 +115,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.")
     public void testToJsonComplexTypesNil() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplexTypesNil");
         Assert.assertEquals(returns.length, 1);
@@ -125,8 +124,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
     public void testToXml() {
         BValue[] returns = BRunUtil.invoke(result, "testToXml");
         Assert.assertEquals(returns.length, 1);
@@ -149,8 +147,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
     public void testToXmlComplexTypesNil() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexTypesNil");
         Assert.assertEquals(returns.length, 1);
@@ -166,8 +163,7 @@ public class TableTest {
         Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check xml streaming when result set consumed once.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check xml streaming when result set consumed once.")
     public void testToXmlMultipleConsume() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlMultipleConsume");
         Assert.assertEquals(returns.length, 1);
@@ -179,8 +175,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion with concat operation.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion with concat operation.")
     public void testToXmlWithAdd() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlWithAdd");
         Assert.assertEquals(returns.length, 1);
@@ -200,8 +195,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.", enabled = false)
+    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.")
     public void testToXmlComplex() {
         BValue[] returns = BRunUtil.invoke(result, "toXmlComplex");
         Assert.assertEquals(returns.length, 1);
@@ -222,8 +216,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.", enabled = false)
+    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.")
     public void testToXmlComplexWithStructDef () {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexWithStructDef");
         Assert.assertEquals(returns.length, 1);
@@ -240,6 +233,8 @@ public class TableTest {
     }
 
     // TODO: #16033
+    // When try to debug, int and long values seem to be in refvalues. When we get stringvalue,
+    // int/long value arrays are shown as empty arrays
     @Test(groups = {TABLE_TEST}, description = "Check json conversion with complex element.", enabled = false)
     public void testToJsonComplex() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplex");
@@ -449,8 +444,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check xml conversion with null values.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check xml conversion with null values.")
     public void testXmlWithNull() {
         BValue[] returns = BRunUtil.invoke(result, "testXmlWithNull");
         Assert.assertEquals(returns.length, 1);
@@ -466,8 +460,7 @@ public class TableTest {
         Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.")
     public void testToXmlWithinTransaction() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlWithinTransaction");
         Assert.assertEquals(returns.length, 2);
@@ -477,8 +470,7 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 0);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check JSON conversion within transaction.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check JSON conversion within transaction.")
     public void testToJsonWithinTransaction() {
         BValue[] returns = BRunUtil.invoke(result,  "testToJsonWithinTransaction");
         Assert.assertEquals(returns.length, 2);
@@ -605,8 +597,7 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[5]).intValue(), 2);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check get float and double min and max types.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check get float and double min and max types.")
     public void testSignedIntMaxMinValues() {
         BValue[] returns = BRunUtil.invoke(result, "testSignedIntMaxMinValues");
         Assert.assertEquals(returns.length, 6);
@@ -665,10 +656,7 @@ public class TableTest {
         Assert.assertEquals((returns[4]).stringValue(), "100|nonNil|Sample Text|200|nil|nil|");
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST,
-          description = "Check result sets with same column name or complex name.",
-          enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check result sets with same column name or complex name.")
     public void testJsonXMLConversionwithDuplicateColumnNames() {
         BValue[] returns = BRunUtil.invoke(result, "testJsonXMLConversionwithDuplicateColumnNames");
         Assert.assertEquals(returns.length, 2);
@@ -1284,7 +1272,8 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 2);
     }
 
-    @Test
+    // #16033 TODO: Enable once table SQL features are working
+    @Test(enabled = false)
     public void testSelectQueryWithCursorTable() {
         BValue[] retVal = BRunUtil.invoke(result, "testSelectQueryWithCursorTable");
         Assert.assertTrue(retVal[0] instanceof BError);
@@ -1292,7 +1281,8 @@ public class TableTest {
                 .contains("Table query over a cursor table not supported"));
     }
 
-    @Test
+    // #16033 TODO: Enable once table SQL features are working
+    @Test(enabled = false)
     public void testJoinQueryWithCursorTable() {
         BValue[] retVal = BRunUtil.invoke(result, "testJoinQueryWithCursorTable");
         Assert.assertTrue(retVal[0] instanceof BError);

--- a/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
+++ b/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
@@ -135,8 +135,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
     public void testToXmlComplexTypes() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexTypes");
         Assert.assertEquals(returns.length, 1);
@@ -623,8 +622,7 @@ public class TableTest {
                 + "-2147483648|-9223372036854775808#3|-1|-1|-1|-1#");
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check blob binary and clob types types.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check blob binary and clob types types.")
     public void testComplexTypeInsertAndRetrieval() {
         BValue[] returns = BRunUtil.invoke(result, "testComplexTypeInsertAndRetrieval");
         Assert.assertEquals(returns.length, 6);

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping.bal
@@ -189,7 +189,7 @@ function testMappingToNillableTypeFieldsBlob() returns @tainted byte[]? {
     return blob_type;
 }
 
-function testMappingDatesToNillableTimeType() returns [int, int, int, int, int, int, int, int]|error {
+function testMappingDatesToNillableTimeType() returns @tainted [int, int, int, int, int, int, int, int]|error {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -234,16 +234,23 @@ function testMappingDatesToNillableTimeType() returns [int, int, int, int, int, 
         while (dt.hasNext()) {
             var rs = dt.getNext();
             if (rs is ResultDatesWithNillableTimeType) {
-                dateRetrieved = rs.DATE_TYPE.time ?: -1;
-                timeRetrieved = rs.TIME_TYPE.time ?: -1;
-                timestampRetrieved = rs.TIMESTAMP_TYPE.time ?: -1;
-                datetimeRetrieved = rs.DATETIME_TYPE.time ?: -1;
+                dateRetrieved = getTimeIntFromTimeRecord(rs.DATE_TYPE);
+                timeRetrieved = getTimeIntFromTimeRecord(rs.TIME_TYPE);
+                timestampRetrieved = getTimeIntFromTimeRecord(rs.TIMESTAMP_TYPE);
+                datetimeRetrieved = getTimeIntFromTimeRecord(rs.DATETIME_TYPE);
             }
         }
     }
     checkpanic testDB.stop();
     return [dateInserted, dateRetrieved, timeInserted, timeRetrieved, timestampInserted, timestampRetrieved,
     datetimeInserted, datetimeRetrieved];
+}
+
+function getTimeIntFromTimeRecord(time:Time? timeRec) returns int {
+    if (timeRec is time:Time) {
+        return timeRec.time;
+    }
+    return -1;
 }
 
 function testMappingDatesToNillableIntType(int datein, int timein, int timestampin) returns @tainted

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping_negative.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping_negative.bal
@@ -209,7 +209,7 @@ function testAssignNilToNonNillableTimeStamp() returns @tainted string {
     return testAssignNilToNonNillableField("timestamp_type", NonNillableTimeStamp);
 }
 
-function testAssignNilToNonNillableField(string field, typedesc recordType) returns @tainted string {
+function testAssignNilToNonNillableField(string field, typedesc<record{}> recordType) returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -231,7 +231,7 @@ function testAssignNilToNonNillableField(string field, typedesc recordType) retu
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -326,7 +326,7 @@ function testAssignNullArrayToNonNillableWithNonNillableElements() returns @tain
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -349,7 +349,7 @@ function testAssignNullArrayToNonNillableTypeWithNillableElements() returns @tai
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -372,7 +372,7 @@ function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() re
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -395,7 +395,7 @@ function testAssignNullElementArrayToNillableTypeWithNonNillableElements() retur
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -416,7 +416,7 @@ function testAssignInvalidUnionArray() returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.detail().message;
+                message = <string>ret.detail()["message"];
             }
         }
     }
@@ -437,7 +437,7 @@ function testAssignInvalidUnionArrayElement() returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.detail().message;
+                message = <string>ret.detail()["message"];
             }
         }
     }
@@ -458,7 +458,7 @@ function testAssignInvalidUnionArray2() returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.detail().message;
+                message = <string>ret.detail()["message"];
             }
         }
     }
@@ -491,7 +491,7 @@ function testAssignToInvalidUnionField(string field) returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap <InvalidUnion>dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_type.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_type.bal
@@ -383,60 +383,58 @@ function testXmlWithNull() returns xml {
     checkpanic testDB.stop();
     return ret;
 }
+
+function testToXmlWithinTransaction() returns [string, int] {
+    jdbc:Client testDB = new({
+        url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
+        username: "SA",
+        password: "",
+        poolOptions: { maximumPoolSize: 1 }
+    });
+
+    int returnValue = -1;
+    string resultXml = "";
+    transaction {
+        var dt = testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
+        if (dt is table<record {}>) {
+            var result = typedesc<xml>.constructFrom(dt);
+            if (result is xml) {
+                resultXml = io:sprintf("%s", result);
+                returnValue = 0;
+            } else {
+                resultXml = "<fail>error</fail>";
+            }
+        }
+    }
+    checkpanic testDB.stop();
+    return [resultXml, returnValue];
+}
 // TODO: #16033
-//function testToXmlWithinTransaction() returns [string, int] {
-//    jdbc:Client testDB = new({
-//        path: "./target/tempdb/",
-//        name: "TEST_DATA_TABLE_H2",
-//        username: "SA",
-//        password: "",
-//        poolOptions: { maximumPoolSize: 1 }
-//    });
-//
-//    int returnValue = -1;
-//    string resultXml = "";
-//    transaction {
-//        var dt = testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
-//        if (dt is table<record {}>) {
-//            var result = xml.convert(dt);
-//            if (result is xml) {
-//                resultXml = io:sprintf("%s", result);
-//                returnValue = 0;
-//            } else {
-//                resultXml = "<fail>error</fail>";
-//            }
-//        }
-//    }
-//    checkpanic testDB.stop();
-//    return [resultXml, returnValue];
-//}
-// TODO: #16033
-//function testToJsonWithinTransaction() returns [string, int] {
-//    jdbc:Client testDB = new({
-//        path: "./target/tempdb/",
-//        name: "TEST_DATA_TABLE_H2",
-//        username: "SA",
-//        password: "",
-//        poolOptions: { maximumPoolSize: 1 }
-//    });
-//
-//    int returnValue = -1;
-//    string result = "";
-//    transaction {
-//        var dt = testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
-//        if (dt is table<record {}>) {
-//            var j = json.convert(dt);
-//            if (j is json) {
-//                result = io:sprintf("%s", j);
-//                returnValue = 0;
-//            } else {
-//                result = "<fail>error</fail>";
-//            }
-//        }
-//    }
-//    checkpanic testDB.stop();
-//    return [result, returnValue];
-//}
+function testToJsonWithinTransaction() returns [string, int] {
+    jdbc:Client testDB = new({
+        url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
+        username: "SA",
+        password: "",
+        poolOptions: { maximumPoolSize: 1 }
+    });
+
+    int returnValue = -1;
+    string result = "";
+    transaction {
+        var dt = testDB->select("SELECT int_type, long_type from DataTable WHERE row_id = 1", ());
+        if (dt is table<record {}>) {
+            var j = typedesc<json>.constructFrom(dt);
+            if (j is json) {
+                result = io:sprintf("%s", j);
+                returnValue = 0;
+            } else {
+                result = "<fail>error</fail>";
+            }
+        }
+    }
+    checkpanic testDB.stop();
+    return [result, returnValue];
+}
 
 function testGetPrimitiveTypes() returns @tainted [int, int, float, float, boolean, string, decimal] {
     jdbc:Client testDB = new({
@@ -528,7 +526,7 @@ function testArrayData() returns @tainted [int[], int[], decimal[], string[], bo
     return [int_arr, long_arr, float_arr, string_arr, boolean_arr];
 }
 
-function testArrayDataInsertAndPrint() returns [int, int, int, int, int, int] {
+function testArrayDataInsertAndPrint() returns @tainted [int, int, int, int, int, int] {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -562,6 +560,7 @@ function testArrayDataInsertAndPrint() returns [int, int, int, int, int, int] {
         updatedCount = updateRet.updatedRowCount;
     } else {
        error e = updateRet;
+       io:println(<string> e.detail()["message"]);
     }
     var dtRet = testDB->select("SELECT int_array, long_array, float_array, boolean_array, string_array
                                  from ArrayTypes where row_id = 4", ResultMap);
@@ -1235,7 +1234,7 @@ function testComplexTypeInsertAndRetrieval() returns @tainted [int, int, string,
     string selectSQL =
     "SELECT row_id, blob_type, clob_type, binary_type FROM ComplexTypes where row_id = 100 or row_id = 200";
     string text = "Sample Text";
-    byte[] content = text.toByteArray("UTF-8");
+    byte[] content = text.toBytes();
 
     int retDataInsert;
     int retNullInsert;
@@ -1426,7 +1425,7 @@ function testTableAddInvalid() returns @tainted string {
     if (selectRet is table<ResultPrimitiveInt>) {
         var ret = trap selectRet.add(row);
         if (ret is error) {
-            s = <string>ret.detail().message;
+            s = <string>ret.detail()["message"];
         } else {
             s = "nil";
         }
@@ -1449,10 +1448,10 @@ function testTableRemoveInvalid() returns @tainted string {
     if (selectRet is table<ResultPrimitiveInt>) {
         var ret = trap selectRet.remove(isDelete);
         if (ret is int) {
-            s = string.convert(ret);
+            s = checkpanic string.constructFrom(ret);
         } else {
             error e = ret;
-            s = <string> e.detail().message;
+            s = <string> e.detail()["message"];
         }
         selectRet.close();
     }
@@ -1473,7 +1472,7 @@ function tableGetNextInvalid() returns @tainted string {
         selectRet.close();
         var ret = trap selectRet.getNext();
         if (ret is error) {
-            retVal = <string> ret.detail().message;
+            retVal = <string> ret.detail()["message"];
         }
     }
     checkpanic testDB.stop();
@@ -1494,10 +1493,10 @@ function testToJsonAndAccessFromMiddle() returns @tainted [json, int] {
     var selectRet = testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable", ());
     json result = getJsonConversionResult(selectRet);
-
-    json j = result[1];
+    json[] jArray = <json[]>result;
+    json j = jArray[1];
     checkpanic testDB.stop();
-    return [result, result.length()];
+    return [result, jArray.length()];
 }
 
 function testToJsonAndIterate() returns @tainted [json, int]|error {
@@ -1510,12 +1509,7 @@ function testToJsonAndIterate() returns @tainted [json, int]|error {
     var selectRet = testDB->select("SELECT int_type, long_type, float_type, double_type,
                   boolean_type, string_type from DataTable", ());
     json result = getJsonConversionResult(selectRet);
-    json j = [];
-    int i = 0;
-    foreach var row in check json[].convert(result) {
-        j[i] = row;
-        i += 1;
-    }
+    json[] j = <json[]> result;
     checkpanic testDB.stop();
     return [j, j.length()];
 }
@@ -1547,12 +1541,14 @@ function testToJsonAndLengthof() returns [int, int] {
 
     json result = getJsonConversionResult(selectRet);
 
+    json[] jArray = checkpanic json[].constructFrom(result);
+
     // get the length before accessing
-    int beforeLen = result.length();
+    int beforeLen = jArray.length();
 
     // get the length after accessing
-    json j = result[0];
-    int afterLen = result.length();
+    json j = jArray[0];
+    int afterLen = jArray.length();
     checkpanic testDB.stop();
     return [beforeLen, afterLen];
 }
@@ -1560,16 +1556,16 @@ function testToJsonAndLengthof() returns [int, int] {
 function getJsonConversionResult(table<record {}>|error tableOrError) returns json {
     json retVal = {};
     if (tableOrError is table<record {}>) {
-        var jsonConversionResult = json.convert(tableOrError);
+        var jsonConversionResult = typedesc<json>.constructFrom(tableOrError);
         if (jsonConversionResult is json) {
             // Converting to string to make sure the json is built before returning.
-            _ = jsonConversionResult.toString();
+            string data = io:sprintf("%s", jsonConversionResult);
             retVal = jsonConversionResult;
         } else {
-            retVal = {"Error" : <string>jsonConversionResult.detail().message};
+            retVal = {"Error" : <string>jsonConversionResult.detail()["message"]};
         }
     } else {
-        retVal = {"Error" : <string>tableOrError.detail().message};
+        retVal = {"Error" : <string>tableOrError.detail()["message"]};
     }
     return retVal;
 }
@@ -1577,58 +1573,59 @@ function getJsonConversionResult(table<record {}>|error tableOrError) returns js
 function getXMLConversionResult(table<record {}>|error tableOrError) returns xml {
     xml retVal = xml `<Error/>`;
     if (tableOrError is table<record {}>) {
-        var xmlConversionResult = xml.convert(tableOrError);
+        var xmlConversionResult = typedesc<xml>.constructFrom(tableOrError);
+        io:println(xmlConversionResult);
         if (xmlConversionResult is xml) {
             // Converting to string to make sure the xml is built before returning.
             _ = io:sprintf("%s", xmlConversionResult);
             retVal = xmlConversionResult;
         } else {
-            string errorXML = <string>xmlConversionResult.detail().message;
+            string errorXML = <string>xmlConversionResult.detail()["message"];
             retVal = xml `<Error>{{errorXML}}</Error>`;
         }
     } else {
-        string errorXML = <string>tableOrError.detail().message;
+        string errorXML = <string>tableOrError.detail()["message"];
         retVal = xml `<Error>{{errorXML}}</Error>`;
     }
     return retVal;
 }
 
-function testSelectQueryWithCursorTable() returns error? {
-    jdbc:Client testDB = new({
-        url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
-        username: "SA",
-        password: "",
-        poolOptions: { maximumPoolSize: 1 }
-    });
+//function testSelectQueryWithCursorTable() returns error? {
+//    jdbc:Client testDB = new({
+//        url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
+//        username: "SA",
+//        password: "",
+//        poolOptions: { maximumPoolSize: 1 }
+//    });
+//
+//    table<IntData> t1 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", IntData);
+//    error? e = trap testSelectQueryWithCursorTableHelper(t1);
+//    t1.close();
+//    checkpanic testDB.stop();
+//    return e;
+//}
 
-    table<IntData> t1 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", IntData);
-    error? e = trap testSelectQueryWithCursorTableHelper(t1);
-    t1.close();
-    checkpanic testDB.stop();
-    return e;
-}
+//function testSelectQueryWithCursorTableHelper(table<IntData> t1) {
+//    table<IntData> t1Copy = from t1 select *;
+//}
 
-function testSelectQueryWithCursorTableHelper(table<IntData> t1) {
-    table<IntData> t1Copy = from t1 select *;
-}
-
-function testJoinQueryWithCursorTable() returns error? {
-    jdbc:Client testDB = new({
-        url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
-        username: "SA",
-        password: "",
-        poolOptions: { maximumPoolSize: 2 }
-    });
-
-    table<IntData> t1 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", IntData);
-    table<IntData> t2 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", IntData);
-
-    error? e = trap testJoinQueryWithCursorTableHelper(t1, t2);
-    t1.close();
-    t2.close();
-    checkpanic testDB.stop();
-    return e;
-}
+//function testJoinQueryWithCursorTable() returns error? {
+//    jdbc:Client testDB = new({
+//        url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
+//        username: "SA",
+//        password: "",
+//        poolOptions: { maximumPoolSize: 2 }
+//    });
+//
+//    table<IntData> t1 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", IntData);
+//    table<IntData> t2 = check testDB->select("SELECT int_type from DataTable WHERE row_id = 1", IntData);
+//
+//    error? e = trap testJoinQueryWithCursorTableHelper(t1, t2);
+//    t1.close();
+//    t2.close();
+//    checkpanic testDB.stop();
+//    return e;
+//}
 
 function testTypeCheckingConstrainedCursorTableWithClosedConstraint() returns @tainted [int, int, float, float, boolean,
      string] {
@@ -1664,10 +1661,10 @@ function testTypeCheckingConstrainedCursorTableWithClosedConstraint() returns @t
      return [i, l, f, d, b, s];
 }
 
-function testJoinQueryWithCursorTableHelper(table<IntData> t1, table<IntData> t2) {
-    table<IntData> joinedTable = from t1 as table1 join t2 as table2 on
-    table1.int_type == table2.int_type select table1.int_type as int_type;
-}
+//function testJoinQueryWithCursorTableHelper(table<IntData> t1, table<IntData> t2) {
+//    table<IntData> joinedTable = from t1 as table1 join t2 as table2 on
+//    table1.int_type == table2.int_type select table1.int_type as int_type;
+//}
 
 function testAssignStringValueToJsonField() returns @tainted json {
     jdbc:Client testDB = new({

--- a/stdlib/jdbc/src/test/resources/testng.xml
+++ b/stdlib/jdbc/src/test/resources/testng.xml
@@ -37,7 +37,7 @@ under the License.
             <class name="org.ballerinax.jdbc.SQLConnectionPoolTest"/>
             <class name="org.ballerinax.jdbc.SQLConnectorInitTest"/>
 
-<!--            <class name="org.ballerinax.jdbc.table.TableTest"/>-->
+            <class name="org.ballerinax.jdbc.table.TableTest"/>
 <!--            <class name="org.ballerinax.jdbc.table.TableIterationTest"/>-->
         </classes>
     </test>

--- a/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/artemis_errors.bal
+++ b/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/artemis_errors.bal
@@ -19,5 +19,5 @@ type Detail record {
     error cause?;
 };
 
-public const ARTEMIS_ERROR = "{ballerina/artemis}ArtemisError";
-public type ArtemisError error<ARTEMIS_ERROR, Detail>;
+public const ARTEMIS_ERROR = "{ballerina/artemis}Error";
+public type Error error<ARTEMIS_ERROR, Detail>;

--- a/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/message.bal
+++ b/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/message.bal
@@ -57,7 +57,7 @@ public type Message client object {
     # Acknowledges reception of this message.
     #
     # + return - If an error occurred while acknowledging the message
-    public remote function acknowledge() returns ArtemisError? = external;
+    public remote function acknowledge() returns Error? = external;
 
     # Returns the size (in bytes) of this message's body.
     #
@@ -75,7 +75,7 @@ public type Message client object {
     # + key - The name of the property
     # + return - The value of the property or nil if not found
     public function getProperty(string key) returns @tainted string | int | float | boolean | byte | byte[] | () |
-                                                        ArtemisError = external;
+                                                        Error = external;
 
     # The type of the message.
     #
@@ -87,13 +87,13 @@ public type Message client object {
     # + return - The message payload or error on failure to retrieve payload or if the type is unsupported.
     #  A map payload can contain an error if the type is unsupported.
     public function getPayload() returns @tainted string | byte[] | map<string | int | float | byte | boolean | byte[]> |
-                                            ArtemisError | () = external;
+                                            Error | () = external;
 
     # Call this function to save to a WritableByteChannel if the message is `STREAM` type.
     #
     # + ch - The byte channel to save to
     # + return - will return an `error` if the message is not of type `STREAM` or on failure
-    public function saveToWritableByteChannel(@untainted io:WritableByteChannel ch) returns ArtemisError? = external;
+    public function saveToWritableByteChannel(@untainted io:WritableByteChannel ch) returns Error? = external;
 
     # Get the message configuration.
     #

--- a/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/producer.bal
+++ b/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/producer.bal
@@ -50,7 +50,7 @@ public type Producer client object {
     #
     # + data - the `Message` or data to send 
     # + return - `error` on failure
-    public remote function send(MessageContent | Message data) returns ArtemisError? {
+    public remote function send(MessageContent | Message data) returns Error? {
         return self.externSend(data is Message ? data : new(self.session, data));
     }
 
@@ -62,9 +62,9 @@ public type Producer client object {
     # Closes the ClientProducer. If already closed nothing is done.
     # 
     # + return - `error` on failure to close.
-    public remote function close() returns ArtemisError? = external;
+    public remote function close() returns Error? = external;
 
-    function externSend(Message data) returns ArtemisError? = external;
+    function externSend(Message data) returns Error? = external;
 };
 
 # The ActiveMQ Artemis address related configuration.

--- a/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/session.bal
+++ b/stdlib/messaging/activemq-artemis/src/main/ballerina/artemis/session.bal
@@ -36,7 +36,7 @@ public type Session client object {
     # Closes the connection and release all its resources
     #
     # + return - `error` if an error occurs closing the connection or nil
-    public remote function close() returns ArtemisError? = external;
+    public remote function close() returns Error? = external;
 };
 
 # Configurations related to a Artemis Session.

--- a/stdlib/messaging/activemq-artemis/src/main/java/org/ballerinalang/messaging/artemis/ArtemisConstants.java
+++ b/stdlib/messaging/activemq-artemis/src/main/java/org/ballerinalang/messaging/artemis/ArtemisConstants.java
@@ -34,7 +34,7 @@ public class ArtemisConstants {
     public static final String PROTOCOL_PACKAGE_ARTEMIS = BALLERINA_PACKAGE_PREFIX + ARTEMIS;
 
     // Error related constants
-    static final String ARTEMIS_ERROR_CODE = "{" + PROTOCOL_PACKAGE_ARTEMIS + "}ArtemisError";
+    static final String ARTEMIS_ERROR_CODE = "{" + PROTOCOL_PACKAGE_ARTEMIS + "}Error";
     static final String ARTEMIS_ERROR_RECORD = "ArtemisError";
     static final String ARTEMIS_ERROR_DETAILS = "Detail";
     static final String ARTEMIS_ERROR_MESSAGE = "message";

--- a/stdlib/messaging/activemq-artemis/src/main/java/org/ballerinalang/messaging/artemis/ArtemisResourceValidator.java
+++ b/stdlib/messaging/activemq-artemis/src/main/java/org/ballerinalang/messaging/artemis/ArtemisResourceValidator.java
@@ -80,10 +80,10 @@ public class ArtemisResourceValidator {
                         + resource.getName().getValue() +
                         " resource: The first parameter should be an artemis:Message");
             }
-            if (!"ballerina/artemis:ArtemisError".equals(paramDetails.get(1).type.toString())) {
+            if (!"ballerina/artemis:Error".equals(paramDetails.get(1).type.toString())) {
                 dlog.logDiagnostic(ERROR, resource.pos, String.format(
                         "Invalid resource signature for %s resource in service : The second parameter should be " +
-                                "artemis:ArtemisError",
+                                "artemis:Error",
                         resource.getName().getValue()));
             }
         }
@@ -146,7 +146,7 @@ public class ArtemisResourceValidator {
         boolean flag = true;
         if (paramDetails == null || paramDetails.size() != expectedSize) {
             dlog.logDiagnostic(ERROR, resource.pos, "onError resource only accepts the " +
-                    "parameters artemis:Message and artemis:ArtemisError");
+                    "parameters artemis:Message and artemis:Error");
             flag = false;
         }
         return flag;

--- a/stdlib/messaging/activemq-artemis/src/test/java/org/ballerinalang/messaging/artemis/ArtemisCompilationTest.java
+++ b/stdlib/messaging/activemq-artemis/src/test/java/org/ballerinalang/messaging/artemis/ArtemisCompilationTest.java
@@ -116,7 +116,7 @@ public class ArtemisCompilationTest {
         BAssertUtil.validateError(
                 compileResult, 0,
                 "Invalid resource signature for onError resource in service : The second parameter should be " +
-                        "artemis:ArtemisError", 28, 5);
+                        "artemis:Error", 28, 5);
     }
 
     @Test(description = "Invalid resource names")

--- a/stdlib/messaging/activemq-artemis/src/test/resources/test-src/artemis_mandatory_on_message_resource.bal
+++ b/stdlib/messaging/activemq-artemis/src/test/resources/test-src/artemis_mandatory_on_message_resource.bal
@@ -22,6 +22,6 @@ import ballerina/artemis;
     }
 }
 service artemisConsumer on new artemis:Listener({host:"localhost", port:61616}) {
-    resource function onError(artemis:Message message, artemis:ArtemisError err) returns error? {
+    resource function onError(artemis:Message message, artemis:Error err) returns error? {
     }
 }

--- a/stdlib/messaging/activemq-artemis/src/test/resources/test-src/artemis_mandatory_service_annotation.bal
+++ b/stdlib/messaging/activemq-artemis/src/test/resources/test-src/artemis_mandatory_service_annotation.bal
@@ -20,6 +20,6 @@ service artemisConsumer on new artemis:Listener({host:"localhost", port:61616}) 
     resource function onMessage(artemis:Message message) returns error? {
     }
 
-    resource function onError(artemis:Message message, artemis:ArtemisError err) returns error? {
+    resource function onError(artemis:Message message, artemis:Error err) returns error? {
     }
 }

--- a/stdlib/messaging/activemq-artemis/src/test/resources/test-src/artemis_more_resources.bal
+++ b/stdlib/messaging/activemq-artemis/src/test/resources/test-src/artemis_more_resources.bal
@@ -25,7 +25,7 @@ service artemisConsumer on new artemis:Listener({host:"localhost", port:61616}) 
     resource function onMessage(artemis:Message message) returns error? {
     }
 
-    resource function onError(artemis:Message message, artemis:ArtemisError err) returns error? {
+    resource function onError(artemis:Message message, artemis:Error err) returns error? {
     }
 
     resource function xyz(artemis:Message message) returns error? {

--- a/stdlib/messaging/activemq-artemis/src/test/resources/test-src/data-binding/unsupported_map_type.bal
+++ b/stdlib/messaging/activemq-artemis/src/test/resources/test-src/data-binding/unsupported_map_type.bal
@@ -27,6 +27,6 @@ service artemisConsumer on artemisListener {
     resource function onMessage(artemis:Message message, map<xml> data) returns error? {
     }
 
-    resource function onError(artemis:Message message, artemis:ArtemisError err) returns error? {
+    resource function onError(artemis:Message message, artemis:Error err) returns error? {
     }
 }

--- a/stdlib/messaging/activemq-artemis/src/test/resources/test-src/data-binding/unsupported_type.bal
+++ b/stdlib/messaging/activemq-artemis/src/test/resources/test-src/data-binding/unsupported_type.bal
@@ -27,6 +27,6 @@ service artemisConsumer on artemisListener {
     resource function onMessage(artemis:Message message, int[] data) returns error? {
     }
 
-    resource function onError(artemis:Message message, artemis:ArtemisError err) returns error? {
+    resource function onError(artemis:Message message, artemis:Error err) returns error? {
     }
 }

--- a/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
+++ b/tests/ballerina-unit-test/src/test/resources/test-src/types/table/table_type.bal
@@ -1738,24 +1738,3 @@ function testAssignStringValueToJsonField() returns json {
     checkpanic testDB.stop();
     return val;
 }
-
-type Order record {
-    int id;
-    string name;
-};
-
-function testRemoveOp() returns table<Order> {
-    table<Order> orderTable = table {
-        { id, name },
-        [
-            {1, "BTC"},
-            {2, "LTC"}
-        ]
-    };
-
-    int invalid = 0;
-    var s = orderTable.remove(function (Order ord) returns boolean {
-                        return ord.id > invalid;
-                    });
-    return orderTable;
-}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralTest.java
@@ -344,6 +344,13 @@ public class TableLiteralTest {
                         + "table with type:Person");
     }
 
+    @Test(priority = 1,
+          description = "Test removing data from a table using a given lambda as a filter")
+    public void testRemoveOpAnonymousFilter() {
+        BValue[] returns = BRunUtil.invoke(result, "testRemoveOpAnonymousFilter");
+        Assert.assertEquals(returns[0].stringValue(), "table<Order> {index: [], primaryKey: [], data: []}");
+    }
+
     @Test(priority = 3,
           enabled = false) //Issue #5106
     public void testSessionCount() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_literal.bal
@@ -59,6 +59,11 @@ type ResultCount record {
     int COUNTVAL;
 };
 
+type Order record {
+    int id;
+    string name;
+};
+
 table<Person> dt1 = table{};
 table<Company> dt2 = table{};
 
@@ -590,6 +595,21 @@ function testRemoveWithInvalidParamType() returns string {
     return returnStr;
 }
 
+function testRemoveOpAnonymousFilter() returns table<Order> {
+    table<Order> orderTable = table {
+        { id, name },
+        [
+            {1, "BTC"},
+            {2, "LTC"}
+        ]
+    };
+
+    int invalid = 0;
+    var s = orderTable.remove(function (Order ord) returns boolean {
+                        return ord.id > invalid;
+                    });
+    return orderTable;
+}
 
 function getPersonId(Person p) returns (int) {
     return p.id;


### PR DESCRIPTION
## Purpose
1. Migrate TableOMDatasource class and enable table->xml conversion.
2. Enable table->xml conversion tests in TableTest
3. Add decimal retrieval logic in DataIterator back. I added this sometime back but this change has been dropped when merging previous jballerina branch with the master.
4. Moves a table literal related test to TableLiteralTest from TableTest

Fixes #16006

