### PR TITLE
Migrate table XML utils, enable table->xml conversion 

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/DataIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/DataIterator.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.jvm;
 
 import org.ballerinalang.jvm.types.BStructureType;
+import org.ballerinalang.jvm.values.DecimalValue;
 
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,8 @@ public interface DataIterator {
     Boolean getBoolean(int columnIndex);
 
     String getBlob(int columnIndex);
+
+    DecimalValue getDecimal(int columnIndex);
 
     Object[] getStruct(int columnIndex);
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONGenerator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONGenerator.java
@@ -19,6 +19,7 @@ package org.ballerinalang.jvm;
 
 import org.ballerinalang.jvm.types.TypeTags;
 import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.DecimalValue;
 import org.ballerinalang.jvm.values.MapValueImpl;
 import org.ballerinalang.jvm.values.RefValue;
 import org.ballerinalang.jvm.values.StreamingJsonValue;
@@ -297,7 +298,7 @@ public class JSONGenerator {
                 this.writeNumber(((Number) json).doubleValue());
                 break;
             case TypeTags.DECIMAL_TAG:
-                this.writeNumber((BigDecimal) json);
+                this.writeNumber(((DecimalValue) json).value());
                 break;
             case TypeTags.INT_TAG:
                 this.writeNumber(((Number) json).longValue());

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableOMDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableOMDataSource.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.jvm;
+
+import org.apache.axiom.om.ds.AbstractPushOMDataSource;
+import org.ballerinalang.jvm.types.BField;
+import org.ballerinalang.jvm.types.BStructureType;
+import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.types.TypeTags;
+import org.ballerinalang.jvm.values.TableValue;
+
+import java.sql.SQLException;
+import java.sql.Struct;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * This will provide custom OMDataSource implementation by wrapping BTable.
+ * This will use to convert result set into XML stream.
+ *
+ * @since 0.8.0
+ */
+public class TableOMDataSource extends AbstractPushOMDataSource {
+
+    private static final String XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final String XSI_PREFIX = "xsi";
+    private static final String ARRAY_ELEMENT_NAME = "element";
+    private static final String DEFAULT_ROOT_WRAPPER = "results";
+    private static final String DEFAULT_ROW_WRAPPER = "result";
+
+    private TableValue table;
+    private String rootWrapper;
+    private String rowWrapper;
+
+    public TableOMDataSource(TableValue table, String rootWrapper, String rowWrapper) {
+        this.table = table;
+        this.rootWrapper = rootWrapper != null ? rootWrapper : DEFAULT_ROOT_WRAPPER;
+        this.rowWrapper = rowWrapper != null ? rowWrapper : DEFAULT_ROW_WRAPPER;
+    }
+
+    @Override
+    public void serialize(XMLStreamWriter xmlStreamWriter) throws XMLStreamException {
+        xmlStreamWriter.writeStartElement("", this.rootWrapper, "");
+        while (table.hasNext()) {
+            table.moveToNext();
+            xmlStreamWriter.writeStartElement("", this.rowWrapper, "");
+            BStructureType structType = table.getStructType();
+            BField[] structFields = null;
+            if (structType != null) {
+                structFields = structType.getFields().values().toArray(new BField[0]);
+            }
+            int index = 1;
+            for (ColumnDefinition col : table.getColumnDefs()) {
+                String name;
+                if (structFields != null) {
+                    name = structFields[index - 1].getFieldName();
+                } else {
+                    name = col.getName();
+                }
+                writeElement(xmlStreamWriter, name, col.getTypeTag(), index, structFields);
+                ++index;
+            }
+            xmlStreamWriter.writeEndElement();
+        }
+        xmlStreamWriter.writeEndElement();
+        xmlStreamWriter.flush();
+    }
+
+   private void writeElement(XMLStreamWriter xmlStreamWriter, String name, int typeTag, int index,
+           BField[] structFields) throws XMLStreamException {
+        boolean isArray = false;
+        xmlStreamWriter.writeStartElement("", name, "");
+        String value = null;
+        switch (typeTag) {
+        case TypeTags.BOOLEAN_TAG:
+            value = String.valueOf(table.getBoolean(index));
+            break;
+        case TypeTags.STRING_TAG:
+            value = table.getString(index);
+            break;
+        case TypeTags.INT_TAG:
+            value = String.valueOf(table.getInt(index));
+            break;
+        case TypeTags.FLOAT_TAG:
+            value = String.valueOf(table.getFloat(index));
+            break;
+        case TypeTags.DECIMAL_TAG:
+            value = String.valueOf(table.getDecimal(index));
+            break;
+        case TypeTags.BYTE_ARRAY_TAG:
+            value = table.getBlob(index);
+            break;
+        case TypeTags.ARRAY_TAG:
+            isArray = true;
+            Object[] array = table.getArray(index);
+            processArray(xmlStreamWriter, array);
+            break;
+        case TypeTags.OBJECT_TYPE_TAG:
+        case TypeTags.RECORD_TYPE_TAG:
+            isArray = true;
+            Object[] structData = table.getStruct(index);
+            if (structFields == null) {
+                processArray(xmlStreamWriter, structData);
+            } else {
+                processStruct(xmlStreamWriter, structData, structFields, index);
+            }
+            break;
+        default:
+            value = table.getString(index);
+            break;
+        }
+        if (!isArray) {
+            if (value == null) {
+                xmlStreamWriter.writeNamespace(XSI_PREFIX, XSI_NAMESPACE);
+                xmlStreamWriter.writeAttribute(XSI_PREFIX, XSI_NAMESPACE, "nil", "true");
+            } else {
+                xmlStreamWriter.writeCharacters(value);
+            }
+        }
+        xmlStreamWriter.writeEndElement();
+    }
+
+    private void processArray(XMLStreamWriter xmlStreamWriter, Object[] array) throws XMLStreamException {
+        if (array != null) {
+            for (Object value  : array) {
+                xmlStreamWriter.writeStartElement("", ARRAY_ELEMENT_NAME, "");
+                xmlStreamWriter.writeCharacters(String.valueOf(value));
+                xmlStreamWriter.writeEndElement();
+            }
+        }
+    }
+
+    private void processStruct(XMLStreamWriter xmlStreamWriter, Object[] structData,
+            BField[] structFields, int index) throws XMLStreamException {
+        try {
+            int i = 0;
+            boolean structError = true;
+            BType internaltType = structFields[index - 1].getFieldType();
+            if (internaltType.getTag() == TypeTags.OBJECT_TYPE_TAG
+                    || internaltType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                BField[] internalStructFields = ((BStructureType) internaltType).getFields()
+                                                                                .values().toArray(new BField[0]);
+                if (internalStructFields != null) {
+                    for (Object val : structData) {
+                        xmlStreamWriter.writeStartElement("", internalStructFields[i].getFieldName(), "");
+                        if (val instanceof Struct) {
+                            processStruct(xmlStreamWriter, ((Struct) val).getAttributes(), internalStructFields, i + 1);
+                        } else {
+                            xmlStreamWriter.writeCharacters(val.toString());
+                        }
+                        xmlStreamWriter.writeEndElement();
+                        ++i;
+                    }
+                    structError = false;
+                }
+            }
+            if (structError) {
+                throw BallerinaErrors.createError("error in constructing the xml element from struct type data");
+            }
+        } catch (SQLException e) {
+            throw BallerinaErrors.createError(
+                    "error in retrieving struct data to construct the inner xml element:" + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isDestructiveWrite() {
+        return true;
+    }
+}

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
@@ -35,6 +35,7 @@ import org.apache.axiom.om.OMProcessingInstruction;
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.om.impl.dom.TextImpl;
+import org.apache.axiom.om.impl.llom.OMSourcedElementImpl;
 import org.apache.axiom.om.util.StAXParserConfiguration;
 import org.ballerinalang.jvm.types.BArrayType;
 import org.ballerinalang.jvm.types.BMapType;
@@ -45,6 +46,7 @@ import org.ballerinalang.jvm.types.TypeConstants;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.MapValueImpl;
+import org.ballerinalang.jvm.values.TableValue;
 import org.ballerinalang.jvm.values.XMLItem;
 import org.ballerinalang.jvm.values.XMLQName;
 import org.ballerinalang.jvm.values.XMLSequence;
@@ -270,17 +272,17 @@ public class XMLFactory {
     }
 
     /**
-     * Converts a {@link BTable} to {@link XMLValue}.
+     * Converts a {@link org.ballerinalang.jvm.values.TableValue} to {@link XMLValue}.
      *
-     * @param table {@link BTable} to convert
+     * @param table {@link org.ballerinalang.jvm.values.TableValue} to convert
      * @return converted {@link XMLValue}
      */
-    // @SuppressWarnings("rawtypes")
-    // public static XMLValue tableToXML(BTable table) {
-    // OMSourcedElementImpl omSourcedElement = new OMSourcedElementImpl();
-    // omSourcedElement.init(new TableOMDataSource(table, null, null));
-    // return new XMLItem(omSourcedElement);
-    // }
+    @SuppressWarnings("rawtypes")
+    public static XMLValue tableToXML(TableValue table) {
+        OMSourcedElementImpl omSourcedElement = new OMSourcedElementImpl();
+        omSourcedElement.init(new TableOMDataSource(table, null, null));
+        return new XMLItem(omSourcedElement);
+    }
 
     /**
      * Create an element type XMLValue.

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableIterator.java
@@ -147,6 +147,16 @@ public class TableIterator implements DataIterator {
     }
 
     @Override
+    public DecimalValue getDecimal(int columnIndex) {
+        try {
+            BigDecimal val = rs.getBigDecimal(columnIndex);
+            return rs.wasNull() ? null : new DecimalValue(val);
+        } catch (SQLException e) {
+            throw new BallerinaException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public Object[] getStruct(int columnIndex) {
         Object[] objArray = null;
         try {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/TableValue.java
@@ -284,7 +284,7 @@ public class TableValue implements RefValue, CollectionValue {
     }
 
     public DecimalValue getDecimal(int columnIndex) {
-        throw new UnsupportedOperationException();
+        return iterator.getDecimal(columnIndex);
     }
 
     public List<ColumnDefinition> getColumnDefs() {

--- a/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/ConstructFrom.java
+++ b/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/ConstructFrom.java
@@ -22,6 +22,7 @@ import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.JSONUtils;
 import org.ballerinalang.jvm.Strand;
 import org.ballerinalang.jvm.TypeChecker;
+import org.ballerinalang.jvm.XMLFactory;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.types.BTypedescType;
 import org.ballerinalang.jvm.values.RefValue;
@@ -120,7 +121,7 @@ public class ConstructFrom {
                 case TypeTags.JSON_TAG:
                     return JSONUtils.toJSON((TableValue) inputValue);
                 case TypeTags.XML_TAG:
-                    // TODO:
+                    return XMLFactory.tableToXML((TableValue) inputValue);
                 default:
                     break;
             }

--- a/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
+++ b/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/table/TableTest.java
@@ -115,8 +115,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to JSON conversion.")
     public void testToJsonComplexTypesNil() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplexTypesNil");
         Assert.assertEquals(returns.length, 1);
@@ -125,8 +124,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
     public void testToXml() {
         BValue[] returns = BRunUtil.invoke(result, "testToXml");
         Assert.assertEquals(returns.length, 1);
@@ -137,8 +135,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
     public void testToXmlComplexTypes() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexTypes");
         Assert.assertEquals(returns.length, 1);
@@ -149,8 +146,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion.")
     public void testToXmlComplexTypesNil() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexTypesNil");
         Assert.assertEquals(returns.length, 1);
@@ -166,8 +162,7 @@ public class TableTest {
         Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check xml streaming when result set consumed once.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check xml streaming when result set consumed once.")
     public void testToXmlMultipleConsume() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlMultipleConsume");
         Assert.assertEquals(returns.length, 1);
@@ -179,8 +174,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check table to XML conversion with concat operation.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check table to XML conversion with concat operation.")
     public void testToXmlWithAdd() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlWithAdd");
         Assert.assertEquals(returns.length, 1);
@@ -200,8 +194,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.", enabled = false)
+    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.")
     public void testToXmlComplex() {
         BValue[] returns = BRunUtil.invoke(result, "toXmlComplex");
         Assert.assertEquals(returns.length, 1);
@@ -222,8 +215,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.", enabled = false)
+    @Test(groups = {TABLE_TEST}, description = "Check xml conversion with complex element.")
     public void testToXmlComplexWithStructDef () {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlComplexWithStructDef");
         Assert.assertEquals(returns.length, 1);
@@ -240,6 +232,8 @@ public class TableTest {
     }
 
     // TODO: #16033
+    // When try to debug, int and long values seem to be in refvalues. When we get stringvalue,
+    // int/long value arrays are shown as empty arrays
     @Test(groups = {TABLE_TEST}, description = "Check json conversion with complex element.", enabled = false)
     public void testToJsonComplex() {
         BValue[] returns = BRunUtil.invokeFunction(result, "testToJsonComplex");
@@ -449,8 +443,7 @@ public class TableTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check xml conversion with null values.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check xml conversion with null values.")
     public void testXmlWithNull() {
         BValue[] returns = BRunUtil.invoke(result, "testXmlWithNull");
         Assert.assertEquals(returns.length, 1);
@@ -466,8 +459,7 @@ public class TableTest {
         Assert.assertTrue(expected1.equals(returns[0].stringValue()) || expected2.equals(returns[0].stringValue()));
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check xml conversion within transaction.")
     public void testToXmlWithinTransaction() {
         BValue[] returns = BRunUtil.invoke(result, "testToXmlWithinTransaction");
         Assert.assertEquals(returns.length, 2);
@@ -477,8 +469,7 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 0);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check JSON conversion within transaction.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check JSON conversion within transaction.")
     public void testToJsonWithinTransaction() {
         BValue[] returns = BRunUtil.invoke(result,  "testToJsonWithinTransaction");
         Assert.assertEquals(returns.length, 2);
@@ -605,8 +596,7 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[5]).intValue(), 2);
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check get float and double min and max types.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check get float and double min and max types.")
     public void testSignedIntMaxMinValues() {
         BValue[] returns = BRunUtil.invoke(result, "testSignedIntMaxMinValues");
         Assert.assertEquals(returns.length, 6);
@@ -632,8 +622,7 @@ public class TableTest {
                 + "-2147483648|-9223372036854775808#3|-1|-1|-1|-1#");
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST, description = "Check blob binary and clob types types.", enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check blob binary and clob types types.")
     public void testComplexTypeInsertAndRetrieval() {
         BValue[] returns = BRunUtil.invoke(result, "testComplexTypeInsertAndRetrieval");
         Assert.assertEquals(returns.length, 6);
@@ -665,10 +654,7 @@ public class TableTest {
         Assert.assertEquals((returns[4]).stringValue(), "100|nonNil|Sample Text|200|nil|nil|");
     }
 
-    // TODO: #16033
-    @Test(groups = TABLE_TEST,
-          description = "Check result sets with same column name or complex name.",
-          enabled = false)
+    @Test(groups = TABLE_TEST, description = "Check result sets with same column name or complex name.")
     public void testJsonXMLConversionwithDuplicateColumnNames() {
         BValue[] returns = BRunUtil.invoke(result, "testJsonXMLConversionwithDuplicateColumnNames");
         Assert.assertEquals(returns.length, 2);
@@ -1284,7 +1270,8 @@ public class TableTest {
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 2);
     }
 
-    @Test
+    // #16033 TODO: Enable once table SQL features are working
+    @Test(enabled = false)
     public void testSelectQueryWithCursorTable() {
         BValue[] retVal = BRunUtil.invoke(result, "testSelectQueryWithCursorTable");
         Assert.assertTrue(retVal[0] instanceof BError);
@@ -1292,7 +1279,8 @@ public class TableTest {
                 .contains("Table query over a cursor table not supported"));
     }
 
-    @Test
+    // #16033 TODO: Enable once table SQL features are working
+    @Test(enabled = false)
     public void testJoinQueryWithCursorTable() {
         BValue[] retVal = BRunUtil.invoke(result, "testJoinQueryWithCursorTable");
         Assert.assertTrue(retVal[0] instanceof BError);
@@ -1404,12 +1392,5 @@ public class TableTest {
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(), "Hello");
-    }
-
-    // TODO: #16033
-    @Test(description = "Test removing data from a table using a given lambda as a filter", enabled = false)
-    public void testRemoveOp() {
-        BValue[] returns = BRunUtil.invoke(result, "testRemoveOp");
-        Assert.assertEquals(returns[0].stringValue(), "table<Order> {index: [], primaryKey: [], data: []}");
     }
 }

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping.bal
@@ -189,7 +189,7 @@ function testMappingToNillableTypeFieldsBlob() returns @tainted byte[]? {
     return blob_type;
 }
 
-function testMappingDatesToNillableTimeType() returns [int, int, int, int, int, int, int, int]|error {
+function testMappingDatesToNillableTimeType() returns @tainted [int, int, int, int, int, int, int, int]|error {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -234,16 +234,23 @@ function testMappingDatesToNillableTimeType() returns [int, int, int, int, int, 
         while (dt.hasNext()) {
             var rs = dt.getNext();
             if (rs is ResultDatesWithNillableTimeType) {
-                dateRetrieved = rs.DATE_TYPE.time ?: -1;
-                timeRetrieved = rs.TIME_TYPE.time ?: -1;
-                timestampRetrieved = rs.TIMESTAMP_TYPE.time ?: -1;
-                datetimeRetrieved = rs.DATETIME_TYPE.time ?: -1;
+                dateRetrieved = getTimeIntFromTimeRecord(rs.DATE_TYPE);
+                timeRetrieved = getTimeIntFromTimeRecord(rs.TIME_TYPE);
+                timestampRetrieved = getTimeIntFromTimeRecord(rs.TIMESTAMP_TYPE);
+                datetimeRetrieved = getTimeIntFromTimeRecord(rs.DATETIME_TYPE);
             }
         }
     }
     checkpanic testDB.stop();
     return [dateInserted, dateRetrieved, timeInserted, timeRetrieved, timestampInserted, timestampRetrieved,
     datetimeInserted, datetimeRetrieved];
+}
+
+function getTimeIntFromTimeRecord(time:Time? timeRec) returns int {
+    if (timeRec is time:Time) {
+        return timeRec.time;
+    }
+    return -1;
 }
 
 function testMappingDatesToNillableIntType(int datein, int timein, int timestampin) returns @tainted

--- a/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping_negative.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/sql/table/table_nillable_mapping_negative.bal
@@ -209,7 +209,7 @@ function testAssignNilToNonNillableTimeStamp() returns @tainted string {
     return testAssignNilToNonNillableField("timestamp_type", NonNillableTimeStamp);
 }
 
-function testAssignNilToNonNillableField(string field, typedesc recordType) returns @tainted string {
+function testAssignNilToNonNillableField(string field, typedesc<record{}> recordType) returns @tainted string {
     jdbc:Client testDB = new({
         url: "jdbc:h2:file:./target/tempdb/TEST_DATA_TABLE_H2",
         username: "SA",
@@ -231,7 +231,7 @@ function testAssignNilToNonNillableField(string field, typedesc recordType) retu
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -326,7 +326,7 @@ function testAssignNullArrayToNonNillableWithNonNillableElements() returns @tain
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -349,7 +349,7 @@ function testAssignNullArrayToNonNillableTypeWithNillableElements() returns @tai
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -372,7 +372,7 @@ function testAssignNullElementArrayToNonNillableTypeWithNonNillableElements() re
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -395,7 +395,7 @@ function testAssignNullElementArrayToNillableTypeWithNonNillableElements() retur
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }
@@ -416,7 +416,7 @@ function testAssignInvalidUnionArray() returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.detail().message;
+                message = <string>ret.detail()["message"];
             }
         }
     }
@@ -437,7 +437,7 @@ function testAssignInvalidUnionArrayElement() returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.detail().message;
+                message = <string>ret.detail()["message"];
             }
         }
     }
@@ -458,7 +458,7 @@ function testAssignInvalidUnionArray2() returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap dt.getNext();
             if (ret is error) {
-                message = <string>ret.detail().message;
+                message = <string>ret.detail()["message"];
             }
         }
     }
@@ -491,7 +491,7 @@ function testAssignToInvalidUnionField(string field) returns @tainted string {
         while (dt.hasNext()) {
             var ret = trap <InvalidUnion>dt.getNext();
             if (ret is error) {
-                errorMessage = <string> ret.detail().message;
+                errorMessage = <string> ret.detail()["message"];
             }
         }
     }

--- a/stdlib/jdbc/src/test/resources/testng.xml
+++ b/stdlib/jdbc/src/test/resources/testng.xml
@@ -37,7 +37,7 @@ under the License.
             <class name="org.ballerinax.jdbc.SQLConnectionPoolTest"/>
             <class name="org.ballerinax.jdbc.SQLConnectorInitTest"/>
 
-<!--            <class name="org.ballerinax.jdbc.table.TableTest"/>-->
+            <class name="org.ballerinax.jdbc.table.TableTest"/>
 <!--            <class name="org.ballerinax.jdbc.table.TableIterationTest"/>-->
         </classes>
     </test>

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralTest.java
@@ -344,6 +344,13 @@ public class TableLiteralTest {
                         + "table with type:Person");
     }
 
+    @Test(priority = 1,
+          description = "Test removing data from a table using a given lambda as a filter")
+    public void testRemoveOpAnonymousFilter() {
+        BValue[] returns = BRunUtil.invoke(result, "testRemoveOpAnonymousFilter");
+        Assert.assertEquals(returns[0].stringValue(), "table<Order> {index: [], primaryKey: [], data: []}");
+    }
+
     @Test(priority = 3,
           enabled = false) //Issue #5106
     public void testSessionCount() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_literal.bal
@@ -59,6 +59,11 @@ type ResultCount record {
     int COUNTVAL;
 };
 
+type Order record {
+    int id;
+    string name;
+};
+
 table<Person> dt1 = table{};
 table<Company> dt2 = table{};
 
@@ -590,6 +595,21 @@ function testRemoveWithInvalidParamType() returns string {
     return returnStr;
 }
 
+function testRemoveOpAnonymousFilter() returns table<Order> {
+    table<Order> orderTable = table {
+        { id, name },
+        [
+            {1, "BTC"},
+            {2, "LTC"}
+        ]
+    };
+
+    int invalid = 0;
+    var s = orderTable.remove(function (Order ord) returns boolean {
+                        return ord.id > invalid;
+                    });
+    return orderTable;
+}
 
 function getPersonId(Person p) returns (int) {
     return p.id;


### PR DESCRIPTION
## Purpose

1. Migrate TableOMDatasource class and enable table->xml conversion.
2. Enable table->xml conversion tests in TableTest
3. Add decimal retrieval logic in DataIterator back. I added this sometime back but this change has been dropped when merging previous jballerina branch with the master.
4. Moves a table literal related test to TableLiteralTest from TableTest

Fixes #16006