### PR TITLE
Avoid NoSuchMethodError when Ballerina.toml exist with .bal file

### DIFF
--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/compiler_backend_jvm/jvm_method_gen.bal
@@ -1208,7 +1208,9 @@ function generateMainMethod(bir:Function? userMainFunc, jvm:ClassWriter cw, bir:
         }
     }
 
-    scheduleStartMethod(mv, pkg, initClass, serviceEPAvailable, errorGen);
+    if (hasInitFunction(pkg)) {
+       scheduleStartMethod(mv, pkg, initClass, serviceEPAvailable, errorGen);
+    }
 
     // stop all listeners
     stopListeners(mv, serviceEPAvailable);

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/compiler_backend_jvm/jvm_package_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/compiler_backend_jvm/jvm_package_gen.bal
@@ -375,10 +375,8 @@ function generateClassNameMappings(bir:Package module, string pkgName, string in
         bir:Function startFunc = <bir:Function>functions[1];
         functionName = startFunc.name.value;
 
-        if (functionName == getModuleStartFuncName(module)) {
-            class.functions[1] = startFunc;
-            count += 1;
-        }
+        class.functions[1] = startFunc;
+        count += 1;
 
         // Generate classes for other functions.
         while (count < funcSize) {

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -1208,7 +1208,9 @@ function generateMainMethod(bir:Function? userMainFunc, jvm:ClassWriter cw, bir:
         }
     }
 
-    scheduleStartMethod(mv, pkg, initClass, serviceEPAvailable, errorGen);
+    if (hasInitFunction(pkg)) {
+        scheduleStartMethod(mv, pkg, initClass, serviceEPAvailable, errorGen);
+    }
 
     // stop all listeners
     stopListeners(mv, serviceEPAvailable);

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_package_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_package_gen.bal
@@ -374,10 +374,8 @@ function generateClassNameMappings(bir:Package module, string pkgName, string in
         bir:Function startFunc = <bir:Function>functions[1];
         functionName = startFunc.name.value;
 
-        if (functionName == getModuleStartFuncName(module)) {
-            class.functions[1] = startFunc;
-            count += 1;
-        }
+        class.functions[1] = startFunc;
+        count += 1;
 
         // Generate classes for other functions.
         while (count < funcSize) {


### PR DESCRIPTION
## Purpose
> This will avoid NoSuchMethodError, when there is a Ballerina.toml file along with a .bal file. But init and start methods will not be invoked untill the issue https://github.com/ballerina-platform/ballerina-lang/issues/16322 is fixed.
Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
