### PR TITLE
Change ports used in the WebSocket tests

### DIFF
--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CancelWebSocketUpgradeTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CancelWebSocketUpgradeTest.java
@@ -36,7 +36,7 @@ public class CancelWebSocketUpgradeTest extends WebSocketTestCommons {
             expectedExceptions = WebSocketHandshakeException.class,
             expectedExceptionsMessageRegExp = "Invalid handshake response getStatus: 404 Not Found")
     public void testCancelUpgrade() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9090/simple/cancel");
+        client = new WebSocketTestClient("ws://localhost:21009/simple/cancel");
         client.handshake();
         client.shutDown();
     }
@@ -45,7 +45,7 @@ public class CancelWebSocketUpgradeTest extends WebSocketTestCommons {
             expectedExceptions = WebSocketHandshakeException.class,
             expectedExceptionsMessageRegExp = "Invalid handshake response getStatus: 400 Bad Request")
     public void testCancelUpgradeSuccessStatusCode() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9090/cannotcancel/cannot/cancel");
+        client = new WebSocketTestClient("ws://localhost:21009/cannotcancel/cannot/cancel");
         client.handshake();
         client.shutDown();
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientCloseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientCloseTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class ClientCloseTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9085";
+    private static final String URL = "ws://localhost:21004";
     private LogLeecher logLeecher;
 
     @Test(description = "Test client closing the connection without a close frame")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientInitializationFailureTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientInitializationFailureTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class ClientInitializationFailureTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9091/client/failure";
+    private static final String URL = "ws://localhost:21010/client/failure";
 
     @BeforeClass(description = "Initializes the Ballerina server with the client_failure.bal file")
     public void setup() throws URISyntaxException {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ClientServiceTest.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 public class ClientServiceTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9200/client/service";
+    private static final String URL = "ws://localhost:21020/client/service";
     private WebSocketRemoteServer remoteServer;
 
     @BeforeClass(description = "Initializes the Ballerina server with the client_service.bal file")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderClientSupportTest.java
@@ -38,7 +38,7 @@ public class CustomHeaderClientSupportTest extends WebSocketTestCommons {
 
     private WebSocketRemoteServer remoteServer;
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9092/pingpong/ws";
+    private static final String URL = "ws://localhost:21011/pingpong/ws";
     private static final String RECEIVED_TEXT = "some-header-value";
 
     @BeforeClass(description = "Initializes the Ballerina server with the custom_header_client.bal file")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderServerSupportTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/CustomHeaderServerSupportTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 public class CustomHeaderServerSupportTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9093/simple3/custom/header/server";
+    private static final String URL = "ws://localhost:21012/simple3/custom/header/server";
     private static final String RECEIVED_TEXT = "some-header-value";
 
     @BeforeClass(description = "Initializes the Ballerina server with the custom_header_server.bal file")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/IsOpenTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/IsOpenTest.java
@@ -34,7 +34,7 @@ import java.net.URISyntaxException;
 public class IsOpenTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9078";
+    private static final String URL = "ws://localhost:21001";
     private LogLeecher logLeecher;
 
     @Test(description = "Test isOpen when close is called")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/MissingResourcesTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/MissingResourcesTest.java
@@ -41,7 +41,7 @@ public class MissingResourcesTest extends WebSocketTestCommons {
 
     @Test(description = "Tests behavior when onText resource is missing and a text message is received")
     public void testMissingOnText() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9086/onlyOnBinary");
+        client = new WebSocketTestClient("ws://localhost:21005/onlyOnBinary");
         client.handshake();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);
@@ -55,7 +55,7 @@ public class MissingResourcesTest extends WebSocketTestCommons {
 
     @Test(description = "Tests behavior when onPong resource is missing and a pong is received")
     public void testMissingOnPong() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9086/onlyOnBinary");
+        client = new WebSocketTestClient("ws://localhost:21005/onlyOnBinary");
         client.handshake();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);
@@ -68,7 +68,7 @@ public class MissingResourcesTest extends WebSocketTestCommons {
 
     @Test(description = "Tests behavior when onBinary resource is missing and binary message is received")
     public void testMissingOnBinary() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9087/onlyOnText");
+        client = new WebSocketTestClient("ws://localhost:21006/onlyOnText");
         client.handshake();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);
@@ -82,7 +82,7 @@ public class MissingResourcesTest extends WebSocketTestCommons {
 
     @Test(description = "Tests behavior when onBinary resource is missing and binary message is received")
     public void testMissingOnIdleTimeout() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9087/onlyOnText");
+        client = new WebSocketTestClient("ws://localhost:21006/onlyOnText");
         client.handshake();
         CountDownLatch countDownLatch = new CountDownLatch(2);
         client.setCountDownLatch(countDownLatch);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/OnBinaryContinuationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/OnBinaryContinuationTest.java
@@ -39,7 +39,7 @@ public class OnBinaryContinuationTest extends WebSocketTestCommons {
 
     @Test(description = "Tests XML support for pushText and onText")
     public void testBinaryContinuation() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9088/onBinaryContinuation";
+        String url = "http://localhost:21007/onBinaryContinuation";
         client = new WebSocketTestClient(url);
         client.handshake();
         String msg = "<note><to>Tove</to></note>";

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/OnErrorWebSocketTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 public class OnErrorWebSocketTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9094/error/ws";
+    private static final String URL = "ws://localhost:21013/error/ws";
     private LogLeecher logLeecher;
 
     @BeforeClass(description = "Initializes the Ballerina server with the error_log_service.bal file")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PingPongSupportTestCase.java
@@ -40,7 +40,7 @@ public class PingPongSupportTestCase extends WebSocketTestCommons {
 
     private WebSocketRemoteServer remoteServer;
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9095/pingpong/ws";
+    private static final String URL = "ws://localhost:21014/pingpong/ws";
     private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
     private static final ByteBuffer RECEIVING_BYTE_BUFFER = ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8));
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PushAndOnTextResourceTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PushAndOnTextResourceTest.java
@@ -37,7 +37,7 @@ public class PushAndOnTextResourceTest extends WebSocketTestCommons {
 
     @Test(description = "Tests string support for pushText and onText")
     public void testString() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9080/onTextString";
+        String url = "http://localhost:21003/onTextString";
         client = new WebSocketTestClient(url);
         client.handshake();
         String msg = "Hello";
@@ -47,13 +47,13 @@ public class PushAndOnTextResourceTest extends WebSocketTestCommons {
 
     @Test(description = "Tests JSON support for pushText and onText")
     public void testJson() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9081/onTextJSON";
+        String url = "http://localhost:21023/onTextJSON";
         testJsonAndRecord(url);
     }
 
     @Test(description = "Tests XML support for pushText and onText")
     public void testXml() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9082/onTextXML";
+        String url = "http://localhost:21024/onTextXML";
         client = new WebSocketTestClient(url);
         client.handshake();
         String msg = "<note><to>Tove</to></note>";
@@ -70,13 +70,13 @@ public class PushAndOnTextResourceTest extends WebSocketTestCommons {
 
     @Test(description = "Tests Record support for pushText and onText")
     public void testRecord() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9083/onTextRecord";
+        String url = "http://localhost:21025/onTextRecord";
         testJsonAndRecord(url);
     }
 
     @Test(description = "Tests byte array support for pushText and onText")
     public void testByteArray() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9084/onTextByteArray";
+        String url = "http://localhost:21026/onTextByteArray";
         client = new WebSocketTestClient(url);
         client.handshake();
         String msg = "Hello";

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PushTextFailureTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/PushTextFailureTest.java
@@ -35,7 +35,7 @@ import java.net.URISyntaxException;
 @Test(groups = {"websocket-test"})
 public class PushTextFailureTest extends WebSocketTestCommons {
 
-    private static final String URL = "ws://localhost:9089/pushTextFailure";
+    private static final String URL = "ws://localhost:21008/pushTextFailure";
     private LogLeecher logLeecher;
 
     // Related file 07_pushText_failure.bal

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ResourceFailureTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/ResourceFailureTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 public class ResourceFailureTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9097/simple7?q1=name";
+    private static final String URL = "ws://localhost:21016/simple7?q1=name";
     private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
     private CountDownLatch countDownLatch;
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/SslEchoTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/SslEchoTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 @Test(groups = {"websocket-test"})
 public class SslEchoTest extends WebSocketTestCommons {
 
-    private static final String URL = "wss://localhost:9076/sslEcho";
+    private static final String URL = "wss://localhost:21022/sslEcho";
     private WebSocketTestClient client;
 
     // Related file 21_ssl_echo.bal

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/UpgradeResourceFailureTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/UpgradeResourceFailureTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class UpgradeResourceFailureTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9097/simple7";
+    private static final String URL = "ws://localhost:21016/simple7";
 
     @BeforeClass(description = "Initializes the Ballerina server with the resource_failure.bal file")
     public void setup() throws URISyntaxException {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/UpgradeResourceWithoutHandshakeTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/UpgradeResourceWithoutHandshakeTest.java
@@ -36,7 +36,7 @@ public class UpgradeResourceWithoutHandshakeTest extends WebSocketTestCommons {
 
     @Test
     public void testUpgradeResourceWithoutHandshake() throws URISyntaxException, InterruptedException {
-        WebSocketTestClient client = new WebSocketTestClient("ws://localhost:9079/UpgradeWithoutHandshake");
+        WebSocketTestClient client = new WebSocketTestClient("ws://localhost:21002/UpgradeWithoutHandshake");
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);
         client.handshake();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketAutoPingPongTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketAutoPingPongTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class WebSocketAutoPingPongTest extends WebSocketTestCommons {
 
     private WebSocketTestClient client;
-    private static final String URL = "ws://localhost:9100";
+    private static final String URL = "ws://localhost:21019";
     private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
 
     @BeforeClass(description = "Initializes Ballerina with the simple_server_without_ping_resource.bal file")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketContinuationAndAggregationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketContinuationAndAggregationTest.java
@@ -35,7 +35,7 @@ public class WebSocketContinuationAndAggregationTest extends WebSocketTestCommon
 
     @Test(description = "Tests string support for pushText and onText")
     public void testString() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9080/onTextString";
+        String url = "http://localhost:21003/onTextString";
         WebSocketTestClient client = new WebSocketTestClient(url);
         client.handshake();
         String msg = "Hello";
@@ -45,7 +45,7 @@ public class WebSocketContinuationAndAggregationTest extends WebSocketTestCommon
 
     @Test(description = "Tests JSON support for pushText and onText")
     public void testJson() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9081/onTextJSON";
+        String url = "http://localhost:21023/onTextJSON";
         WebSocketTestClient client = new WebSocketTestClient(url);
         client.handshake();
         assertSuccess(client, "{'id':1234, 'name':'Riyafa'}", "{\"id\":1234, \"name\":\"Riyafa\"}");
@@ -55,7 +55,7 @@ public class WebSocketContinuationAndAggregationTest extends WebSocketTestCommon
 
     @Test(description = "Tests string support for pushText and onText")
     public void testXml() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9082/onTextXML";
+        String url = "http://localhost:21024/onTextXML";
         WebSocketTestClient client = new WebSocketTestClient(url);
         client.handshake();
         String msg = "<note><to>Tove</to></note>";
@@ -68,7 +68,7 @@ public class WebSocketContinuationAndAggregationTest extends WebSocketTestCommon
 
     @Test(description = "Tests string support for pushText and onText")
     public void testRecord() throws URISyntaxException, InterruptedException {
-        String url = "http://localhost:9083/onTextRecord";
+        String url = "http://localhost:21025/onTextRecord";
         WebSocketTestClient client = new WebSocketTestClient(url);
         client.handshake();
         assertSuccess(client, "{'id':1234, 'name':'Riyafa'}", "{\"id\":1234, \"name\":\"Riyafa\"}");

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketQueryAndPathParamSupportTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketQueryAndPathParamSupportTestCase.java
@@ -38,7 +38,7 @@ public class WebSocketQueryAndPathParamSupportTestCase extends WebSocketTestComm
         String path2 = "path2";
         String query1 = "query1";
         String query2 = "query2";
-        String url = String.format("ws://localhost:9096/simple6/%s/%s?q1=%s&q2=%s", path1, path2, query1, query2);
+        String url = String.format("ws://localhost:21015/simple6/%s/%s?q1=%s&q2=%s", path1, path2, query1, query2);
         WebSocketTestClient client = new WebSocketTestClient(url);
         CountDownLatch countDownLatch = new CountDownLatch(1);
         client.setCountDownLatch(countDownLatch);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketServiceNotFoundTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketServiceNotFoundTest.java
@@ -36,7 +36,7 @@ public class WebSocketServiceNotFoundTest extends WebSocketTestCommons {
             expectedExceptions = WebSocketHandshakeException.class,
             expectedExceptionsMessageRegExp = "Invalid handshake response getStatus: 404 Not Found")
     public void testServiceNotFound() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9098/prox");
+        client = new WebSocketTestClient("ws://localhost:21017/prox");
         client.handshake();
         client.shutDown();
     }
@@ -45,7 +45,7 @@ public class WebSocketServiceNotFoundTest extends WebSocketTestCommons {
             expectedExceptions = WebSocketHandshakeException.class,
             expectedExceptionsMessageRegExp = "Invalid handshake response getStatus: 404 Not Found")
     public void testResourceNotFound() throws InterruptedException, URISyntaxException {
-        client = new WebSocketTestClient("ws://localhost:9090/proxy/cancell");
+        client = new WebSocketTestClient("ws://localhost:21009/proxy/cancell");
         client.handshake();
         client.shutDown();
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSimpleProxyTest.java
@@ -28,6 +28,6 @@ import org.testng.annotations.Test;
 @Test(groups = {"websocket-test"})
 public class WebSocketSimpleProxyTest extends WebSocketSimpleProxyTestCommons {
     public WebSocketSimpleProxyTest() {
-        super(15300, false, "ws://localhost:9099");
+        super(15300, false, "ws://localhost:21018");
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSslProxyTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketSslProxyTest.java
@@ -29,6 +29,6 @@ import org.testng.annotations.Test;
 public class WebSocketSslProxyTest extends WebSocketSimpleProxyTestCommons {
 
     public WebSocketSslProxyTest() {
-        super(15400, true, "ws://localhost:9077");
+        super(15400, true, "ws://localhost:21021");
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/websocket/WebSocketTestCommons.java
@@ -41,11 +41,11 @@ public class WebSocketTestCommons extends BaseTest {
      */
     @BeforeGroups(value = "websocket-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
-        int[] requiredPorts = new int[]{
-                9076, 9077, 9078, 9079, 9080, 9081, 9082, 9083, 9084, 9085, 9086, 9087, 9088, 9089, 9090, 9091, 9092,
-                9093, 9094, 9095, 9096, 9097, 9098, 9099, 9100, 9200};
+        int[] requiredPorts =
+                new int[]{21001, 21002, 21003, 21004, 21005, 21006, 21007, 21008, 21009, 21010, 21011, 21022, 21021,
+                        21012, 21013, 21014, 21015, 21016, 21017, 21018, 21019, 21020, 21023, 21024, 21025, 21026};
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
-                "websocket").getAbsolutePath();
+                                          "websocket").getAbsolutePath();
         serverInstance = new BServerInstance(balServer);
         serverInstance.startServer(balFile, "wsservices", requiredPorts);
     }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/01_isOpen.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/01_isOpen.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/io;
 
-listener http:WebSocketListener socketListener = new(9078);
+listener http:WebSocketListener socketListener = new(21001);
 
 @http:WebSocketServiceConfig {
     path: "/"

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/02_upgrade_resource_without_handshake.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/02_upgrade_resource_without_handshake.bal
@@ -28,7 +28,7 @@ service upgradeService = @http:WebSocketServiceConfig {} service {
     }
 };
 
-service UpgradeWithoutHandshake on new http:Listener(9079) {
+service UpgradeWithoutHandshake on new http:Listener(21002) {
 
     @http:ResourceConfig {
         webSocketUpgrade: {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/03_push_and_onText.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/03_push_and_onText.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/io;
 import ballerina/log;
 
-service onTextString on new http:WebSocketListener(9080) {
+service onTextString on new http:WebSocketListener(21003) {
 
     resource function onText(http:WebSocketCaller caller, string data, boolean finalFrame) {
         var returnVal = caller->pushText(data);
@@ -28,7 +28,7 @@ service onTextString on new http:WebSocketListener(9080) {
     }
 }
 
-service onTextJSON on new http:WebSocketListener(9081) {
+service onTextJSON on new http:WebSocketListener(21023) {
 
 resource function onText(http:WebSocketCaller caller, json data) {
         var returnVal = caller->pushText(data);
@@ -38,7 +38,7 @@ resource function onText(http:WebSocketCaller caller, json data) {
     }
 }
 
-service onTextXML on new http:WebSocketListener(9082) {
+service onTextXML on new http:WebSocketListener(21024) {
 
     resource function onText(http:WebSocketCaller caller, xml data) {
         var returnVal = caller->pushText(data);
@@ -52,7 +52,7 @@ type Person record {|
     int id;
     string name;
 |};
-service onTextRecord on new http:WebSocketListener(9083) {
+service onTextRecord on new http:WebSocketListener(21025) {
 
     resource function onText(http:WebSocketCaller caller, Person data) {
         var personData = json.constructFrom(data);
@@ -67,7 +67,7 @@ service onTextRecord on new http:WebSocketListener(9083) {
     }
 }
 
-service onTextByteArray on new http:WebSocketListener(9084){
+service onTextByteArray on new http:WebSocketListener(21026){
 
     resource function onText(http:WebSocketCaller caller, byte[] data) {
         var returnVal = caller->pushText(data);

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/04_client_close.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/04_client_close.bal
@@ -20,7 +20,7 @@ import ballerina/io;
 @http:WebSocketServiceConfig {
     path: "/"
 }
-service clientClose on new http:WebSocketListener(9085) {
+service clientClose on new http:WebSocketListener(21004) {
     resource function onClose(http:WebSocketCaller wsEp, int statusCode, string reason) {
         io:println("Status code: " + statusCode.toString());
     }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/05_missing_resources.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/05_missing_resources.bal
@@ -19,7 +19,7 @@ import ballerina/http;
 @http:WebSocketServiceConfig {
     idleTimeoutInSeconds: 10
 }
-service onlyOnBinary on new http:WebSocketListener(9086) {
+service onlyOnBinary on new http:WebSocketListener(21005) {
     resource function onBinary(http:WebSocketCaller caller, byte[] data) {
         var returnVal = caller->pushBinary(data);
         if (returnVal is http:WebSocketError) {
@@ -28,7 +28,7 @@ service onlyOnBinary on new http:WebSocketListener(9086) {
     }
 }
 
-service onlyOnText on new http:WebSocketListener(9087) {
+service onlyOnText on new http:WebSocketListener(21006) {
     resource function onText(http:WebSocketCaller caller, string data) {
         var returnVal = caller->pushText(data);
         if (returnVal is http:WebSocketError) {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/06_on_binary_continuation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/06_on_binary_continuation.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/io;
 
 byte[] content = [];
-service onBinaryContinuation on new http:WebSocketListener(9088) {
+service onBinaryContinuation on new http:WebSocketListener(21007) {
     resource function onBinary(http:WebSocketCaller caller, byte[] data, boolean finalFrame) {
         if (finalFrame) {
             appendToArray(<@untainted> data, content);

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/07_pushText_failure.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/07_pushText_failure.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/io;
 
-service pushTextFailure on new http:WebSocketListener(9089) {
+service pushTextFailure on new http:WebSocketListener(21008) {
     resource function onOpen(http:WebSocketCaller caller) {
         http:WebSocketError? err1 = caller->close(timeoutInSecs = 0);
         var err = caller->pushText("hey");

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/08_cancel_websocket_upgrade.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/08_cancel_websocket_upgrade.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerina/http;
 
-listener http:Listener ep1 = new(9090);
+listener http:Listener ep1 = new(21009);
 
 service simpleProxy1 = @http:WebSocketServiceConfig {} service {
 

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/09_client_failure.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/09_client_failure.bal
@@ -23,7 +23,7 @@ http:WebSocketCaller? globalServerCaller = ();
 @http:WebSocketServiceConfig {
     path: "/client/failure"
 }
-service clientFailure on new http:WebSocketListener(9091) {
+service clientFailure on new http:WebSocketListener(21010) {
 
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp;

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/10_custom_header_client.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/10_custom_header_client.bal
@@ -23,7 +23,7 @@ final byte[] APPLICATION_DATA = strData1.toBytes();
 @http:WebSocketServiceConfig {
     path: "/pingpong/ws"
 }
-service PingPongTestService1 on new http:WebSocketListener(9092) {
+service PingPongTestService1 on new http:WebSocketListener(21011) {
 
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new("ws://localhost:15100/websocket", { callbackService:

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/11_custom_header_server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/11_custom_header_server.bal
@@ -31,7 +31,7 @@ service simpleProxy3 = @http:WebSocketServiceConfig {} service {
     }
 };
 
-service simple3 on new http:Listener(9093) {
+service simple3 on new http:Listener(21012) {
 
     @http:ResourceConfig {
         webSocketUpgrade: {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/12_error_log_service.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/12_error_log_service.bal
@@ -21,7 +21,7 @@ import ballerina/http;
 @http:WebSocketServiceConfig {
     path: "/error/ws"
 }
-service errorService on new http:WebSocketListener(9094) {
+service errorService on new http:WebSocketListener(21013) {
     resource function onOpen(http:WebSocketCaller ep) {
         log:printInfo("connection open");
     }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/13_ping_pong.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/13_ping_pong.bal
@@ -50,7 +50,7 @@ service clientCallbackService2 = @http:WebSocketServiceConfig {} service {
 @http:WebSocketServiceConfig {
     path: "/pingpong/ws"
 }
-service PingPongTestService2 on new http:WebSocketListener(9095) {
+service PingPongTestService2 on new http:WebSocketListener(21014) {
 
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new("ws://localhost:15200/websocket", { callbackService:

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/14_query_and_path_param_support.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/14_query_and_path_param_support.bal
@@ -22,7 +22,7 @@ final string PATH2 = "PATH2";
 final string QUERY1 = "QUERY1";
 final string QUERY2 = "QUERY2";
 
-service simple6 on new http:Listener(9096) {
+service simple6 on new http:Listener(21015) {
 
     @http:ResourceConfig {
         webSocketUpgrade: {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/15_resource_failure.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/15_resource_failure.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 
-service simple7 on new http:Listener(9097) {
+service simple7 on new http:Listener(21016) {
 
     @http:ResourceConfig {
         webSocketUpgrade: {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/16_service_not_found.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/16_service_not_found.bal
@@ -26,7 +26,7 @@ service simpleProxy8 = @http:WebSocketServiceConfig {} service {
 @http:ServiceConfig {
     basePath: "/proxy"
 }
-service simple8 on new http:Listener(9098) {
+service simple8 on new http:Listener(21017) {
 
     @http:ResourceConfig {
         webSocketUpgrade: {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/17_simple_proxy_server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/17_simple_proxy_server.bal
@@ -21,7 +21,7 @@ final string ASSOCIATED_CONNECTION = "ASSOCIATED_CONNECTION";
 
 @http:WebSocketServiceConfig {
 }
-service on new http:WebSocketListener(9099) {
+service on new http:WebSocketListener(21018) {
 
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new("ws://localhost:15300/websocket", { callbackService:

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/18_simple_server_without_ping_resource.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/18_simple_server_without_ping_resource.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/io;
 
-service on new http:WebSocketListener(9100) {
+service on new http:WebSocketListener(21019) {
     resource function onOpen(http:WebSocketCaller wsEp) {
         io:println("New Client Connected");
     }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/19_client_service.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/19_client_service.bal
@@ -22,7 +22,7 @@ final string REMOTE_BACKEND_URL200 = "ws://localhost:15000/websocket";
 @http:WebSocketServiceConfig {
     path: "/client/service"
 }
-service clientFailure200 on new http:WebSocketListener(9200) {
+service clientFailure200 on new http:WebSocketListener(21020) {
 
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new(

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/20_ssl_proxy.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/20_ssl_proxy.bal
@@ -19,7 +19,7 @@ import ballerina/log;
 
 @http:WebSocketServiceConfig {
 }
-service on new http:WebSocketListener(9077) {
+service on new http:WebSocketListener(21021) {
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new("wss://localhost:15400/websocket", { callbackService:
             sslClientService, secureSocket: { trustStore: {

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/21_ssl_echo.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/21_ssl_echo.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 
-service sslEcho on new http:WebSocketListener(9076, { secureSocket: {
+service sslEcho on new http:WebSocketListener(21022, { secureSocket: {
         keyStore: {
             path: "${ballerina.home}/bre/security/ballerinaKeystore.p12",
             password: "ballerina"


### PR DESCRIPTION
## Purpose
> Change ports used in the WebSocket tests

## Approach
> Change the port range to 21000+

## Samples
> N/A

## Remarks
> N/A
## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
