### PR TITLE
Implement the `mergeJson` function

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/util/exceptions/BallerinaErrorReasons.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/util/exceptions/BallerinaErrorReasons.java
@@ -39,6 +39,7 @@ public class BallerinaErrorReasons {
 
     public static final String JSON_OPERATION_ERROR = BALLERINA_PREFIX.concat("JSONOperationError");
     public static final String JSON_CONVERSION_ERROR = BALLERINA_PREFIX.concat("JSONConversionError");
+    public static final String MERGE_JSON_ERROR = BALLERINA_PREFIX.concat("MergeJsonError");
 
     public static final String STRING_OPERATION_ERROR = BALLERINA_PREFIX.concat("StringOperationError");
 

--- a/langlib/lang.value/src/main/ballerina/src/lang.value/value.bal
+++ b/langlib/lang.value/src/main/ballerina/src/lang.value/value.bal
@@ -73,3 +73,16 @@ public function toJsonString(json v) returns string = external;
 # All numbers in the JSON will be represented as float values.
 # Returns an error if the string cannot be parsed.
 public function fromJsonString(string str) returns json|error = external;
+
+# Return the result of merging json value `j1` with `j2`.
+# If the merge fails, then return an error.
+# The merge of j1 with j2 is defined as follows:
+# - if j1 is (), then the result is j2
+# - if j2 is nil, then the result is j1
+# - if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,
+#   set j1[k] to the merge of j1[k] with j
+#     - if j1[k] is undefined, then set j1[k] to j
+#     - if any merge fails, then the merge of j1 with j2 fails
+#     - otherwise, the result is j1.
+# - otherwise, the merge fails
+public function mergeJson(json j1, json j2) returns json|error = external;

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/MergeJson.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/MergeJson.java
@@ -1,0 +1,96 @@
+/*
+ *   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.value;
+
+import org.ballerinalang.jvm.BallerinaErrors;
+import org.ballerinalang.jvm.Strand;
+import org.ballerinalang.jvm.TypeChecker;
+import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.types.BTypes;
+import org.ballerinalang.jvm.types.TypeConstants;
+import org.ballerinalang.jvm.types.TypeTags;
+import org.ballerinalang.jvm.util.exceptions.BallerinaErrorReasons;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.jvm.values.MapValueImpl;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+import java.util.Map;
+
+/**
+ * Merge two JSON values.
+ *
+ * @since 1.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.value",
+        functionName = "mergeJson",
+        args = {@Argument(name = "j1", type = TypeKind.JSON), @Argument(name = "j2", type = TypeKind.JSON)},
+        returnType = {@ReturnType(type = TypeKind.JSON), @ReturnType(type = TypeKind.ERROR)},
+        isPublic = true
+)
+public class MergeJson {
+
+    public static Object mergeJson(Strand strand, Object j1, Object j2) {
+
+        if (j1 == null) {
+            return j2;
+        }
+
+        if (j2 == null) {
+            return j1;
+        }
+
+        BType j1Type = TypeChecker.getType(j1);
+        BType j2Type = TypeChecker.getType(j2);
+
+        if (j1Type.getTag() != TypeTags.MAP_TAG || j2Type.getTag() != TypeTags.MAP_TAG) {
+            return BallerinaErrors.createError(BallerinaErrorReasons.MERGE_JSON_ERROR,
+                                               "Cannot merge JSON values of types " + j1Type + " and " + j2Type);
+        }
+
+        MapValue<String, Object> m1 = (MapValue<String, Object>) j1;
+        MapValue<String, Object> m2 = (MapValue<String, Object>) j2;
+
+        for (Map.Entry<String, Object> entry : m2.entrySet()) {
+            String key = entry.getKey();
+
+            if (!m1.containsKey(key)) {
+                m1.put(key, entry.getValue());
+                continue;
+            }
+
+            Object elementMergeResult = mergeJson(strand, m1.get(key), entry.getValue());
+            BType elementMergeResultType = TypeChecker.getType(elementMergeResult);
+
+            if (elementMergeResultType.getTag() == TypeTags.ERROR_TAG) {
+                MapValueImpl<String, Object> detailMap = new MapValueImpl<>(BTypes.typeErrorDetail);
+                detailMap.put(TypeConstants.DETAIL_MESSAGE, "JSON Merge failed for key '" + key + "'");
+                detailMap.put(TypeConstants.DETAIL_CAUSE, elementMergeResult);
+                return BallerinaErrors.createError(BallerinaErrorReasons.MERGE_JSON_ERROR, detailMap);
+            }
+
+            m1.put(key, elementMergeResult);
+        }
+        return m1;
+    }
+
+}

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/MergeJson.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/MergeJson.java
@@ -64,7 +64,8 @@ public class MergeJson {
 
         if (j1Type.getTag() != TypeTags.MAP_TAG || j2Type.getTag() != TypeTags.MAP_TAG) {
             return BallerinaErrors.createError(BallerinaErrorReasons.MERGE_JSON_ERROR,
-                                               "Cannot merge JSON values of types " + j1Type + " and " + j2Type);
+                                               "Cannot merge JSON values of types '" + j1Type + "' and '" +
+                                                       j2Type + "'");
         }
 
         MapValue<String, Object> m1 = (MapValue<String, Object>) j1;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.langlib.test;
 
 import org.ballerinalang.model.types.TypeTags;
+import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
@@ -27,6 +28,7 @@ import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -99,4 +101,23 @@ public class LangLibValueTest {
         assertEquals(array.getRefValue(3).stringValue(), "4");
     }
 
+    @Test(dataProvider = "mergeJsonFunctions")
+    public void testMergeJson(String function) {
+        BValue[] returns = BRunUtil.invoke(compileResult, function);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @DataProvider(name = "mergeJsonFunctions")
+    public Object[][] mergeJsonFunctions() {
+        return new Object[][] {
+            { "testNilAndNonNilJsonMerge" },
+            { "testNonNilNonMappingJsonMerge" },
+            { "testMappingJsonAndNonMappingJsonMerge1" },
+            { "testMappingJsonAndNonMappingJsonMerge2" },
+            { "testMappingJsonNoIntersectionMergeSuccess" },
+            { "testMappingJsonWithIntersectionMergeFailure1" },
+            { "testMappingJsonWithIntersectionMergeFailure2" },
+            { "testMappingJsonWithIntersectionMergeSuccess" }
+        };
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -47,3 +47,112 @@ function testToStringMethod() returns [string, string, string, string] {
     return [a.toString(), b.toString(), c.toString(), d];
 }
 
+/////////////////////////// Tests for `mergeJson()` ///////////////////////////
+const MERGE_JSON_ERROR_REASON = "{ballerina}MergeJsonError";
+const MESSAGE = "message";
+
+function testNilAndNonNilJsonMerge() returns boolean {
+    json j1 = ();
+    json j2 = { one: "hello", two: 2 };
+    json j3 = 5;
+
+    json|error mj1 = j1.mergeJson(j2);
+    json|error mj2 = j2.mergeJson(j1);
+
+    json|error mj3 = j1.mergeJson(j3);
+    json|error mj4 = j3.mergeJson(j1);
+
+    return mj1 is json && mj1 === j2 && mj2 is json && mj2 === j2 && mj3 is json && mj3 == j3 &&
+        mj4 is json && mj4 == j3;
+}
+
+function testNonNilNonMappingJsonMerge() returns boolean {
+    json j1 = 34.5;
+    json j2 = ["hello", "world"];
+
+    json|error mj = j1.mergeJson(j2);
+    return mj is error && mj.reason() == MERGE_JSON_ERROR_REASON &&
+        mj.detail()[MESSAGE] == "Cannot merge JSON values of types 'float' and 'json[]'";
+}
+
+function testMappingJsonAndNonMappingJsonMerge1() returns boolean {
+    json j1 = { one: "hello", two: "world", three: 1 };
+    json j2 = "string value";
+
+    json|error mj = j1.mergeJson(j2);
+    return mj is error && mj.reason() == MERGE_JSON_ERROR_REASON &&
+        mj.detail()[MESSAGE] == "Cannot merge JSON values of types 'map<json>' and 'string'";
+}
+
+function testMappingJsonAndNonMappingJsonMerge2() returns boolean {
+    json j1 = { one: "hello", two: "world", three: 1 };
+    json[] j2 = [1, 2];
+
+    json|error mj = j1.mergeJson(j2);
+    return mj is error && mj.reason() == MERGE_JSON_ERROR_REASON &&
+        mj.detail()[MESSAGE] == "Cannot merge JSON values of types 'map<json>' and 'json[]'";
+}
+
+function testMappingJsonNoIntersectionMergeSuccess() returns boolean {
+    json j1 = { one: "hello", two: "world", three: 1 };
+    map<json> j2 = { x: 12.0, y: "test value" };
+
+    json|error mje = j1.mergeJson(j2);
+
+    if (!(mje is map<json>) || mje.length() != 5) {
+        return false;
+    }
+
+    json mj = <json> mje;
+    return mj.one == "hello" && mj.two == "world" && mj.three == 1 && mj.x == 12.0 && mj.y == "test value";
+}
+
+function testMappingJsonWithIntersectionMergeFailure1() returns boolean {
+    json j1 = { one: "hello", two: "world", three: 1 };
+    json j2 = { two: 1, y: "test value" };
+
+    json|error mj = j1.mergeJson(j2);
+
+    if (!(mj is error) || mj.reason() != MERGE_JSON_ERROR_REASON ||
+            mj.detail()[MESSAGE] != "JSON Merge failed for key 'two'") {
+        return false;
+    }
+
+    error err = <error> mj;
+    error cause = <error> err.detail()?.cause;
+    return cause.reason() == MERGE_JSON_ERROR_REASON &&
+            cause.detail()[MESSAGE] == "Cannot merge JSON values of types 'string' and 'int'";
+}
+
+function testMappingJsonWithIntersectionMergeFailure2() returns boolean {
+    json j1 = { one: { a: "one", b: 2 }, three: 1 };
+    json j2 = { two: "test value", one: true };
+
+    json|error mj = j1.mergeJson(j2);
+
+    if (!(mj is error) || mj.reason() != MERGE_JSON_ERROR_REASON ||
+            mj.detail()[MESSAGE] != "JSON Merge failed for key 'one'") {
+        return false;
+    }
+
+    error err = <error> mj;
+    error cause = <error> err.detail()?.cause;
+    return cause.reason() == MERGE_JSON_ERROR_REASON &&
+            cause.detail()[MESSAGE] == "Cannot merge JSON values of types 'map<json>' and 'boolean'";
+}
+
+function testMappingJsonWithIntersectionMergeSuccess() returns boolean {
+    json j1 = { one: "hello", two: (), three: 1, four: { a: (), b: "test", c: "value" } };
+    json j2 = { four: { a: "strings", b: () }, one: (), two: "world", five: 5  };
+
+    json|error mj = j1.mergeJson(j2);
+
+    if (mj is error) {
+        return false;
+    } else {
+        map<json> expMap = { a: "strings", b: "test", c: "value" };
+        map<json> mj4 = <map<json>> mj.four;
+        return mj === j1 && mj.one == "hello" && mj.two == "world" && mj.three == 1 &&
+            mj4 == expMap && mj.five == 5;
+    }
+}


### PR DESCRIPTION
## Purpose
$title.

Extract from the spec
```
# Return the result of merging json value `j1` with `j2`.
# If the merge fails, the return an error.
# The merge of j1 with j2 is defined as follows:
# - if j1 is (), then the result is j2
# - if j2 is nil, then the result is j1
# - if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,
#   set j1[k] to the merge of j1[k] with j
#     - if j1[k] is undefined, then set j1[k] to j
#     - if any merge fails, then the merge of j1 with j2 fails
#     - otherwise, the result is j1.
# - otherwise, the merge fails
public function mergeJson(json j1, json j2) returns json|error = external;
```

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
