### PR TITLE
Improve ballerina task performance by using single scheduler

### DIFF
--- a/stdlib/task/spotbugs-exclude.xml
+++ b/stdlib/task/spotbugs-exclude.xml
@@ -16,9 +16,4 @@
   ~ under the License.
   -->
 <FindBugsFilter>
-    <Match>
-        <Class name="org.ballerinalang.stdlib.task.utils.Utils" />
-        <Method name="getCronExpressionFromAppointmentRecord" />
-        <Bug pattern="BC_UNCONFIRMED_CAST" />
-    </Match>
 </FindBugsFilter>

--- a/stdlib/task/src/main/ballerina/src/task/scheduler.bal
+++ b/stdlib/task/src/main/ballerina/src/task/scheduler.bal
@@ -27,7 +27,7 @@ public type Scheduler object {
     # + serviceToAttach - Service which needs to be attached to the task.
     # + attachment - An optional parameter which needs to passed inside the resources.
     # + return - Returns `SchedulerError` if the process failed due to any reason, nil otherwise.
-    public function attach(service serviceToAttach, any attachment = ()) returns SchedulerError? {
+    public function attach(service serviceToAttach, public any attachment = ()) returns SchedulerError? {
         string message = "Failed to attach the service to the scheduler";
         if (attachment != ()) {
             map<any> attachments = { attachment: attachment };

--- a/stdlib/task/src/main/java/org/ballerinalang/stdlib/task/objects/TaskManager.java
+++ b/stdlib/task/src/main/java/org/ballerinalang/stdlib/task/objects/TaskManager.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.task.objects;
+
+import org.ballerinalang.stdlib.task.exceptions.SchedulingException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.StdSchedulerFactory;
+
+/**
+ * Task manager to handle schedulers in ballerina tasks.
+ */
+public class TaskManager {
+    private Scheduler scheduler;
+
+    private static class TaskManagerHelper {
+        private static final TaskManager INSTANCE = new TaskManager();
+    }
+
+    private TaskManager() {}
+
+    public static TaskManager getInstance() {
+        return TaskManagerHelper.INSTANCE;
+    }
+
+    public Scheduler getScheduler() throws SchedulingException {
+        try {
+            if (this.scheduler != null && this.scheduler.isStarted()) {
+                return this.scheduler;
+            }
+            this.scheduler = StdSchedulerFactory.getDefaultScheduler();
+            this.scheduler.start();
+        } catch (SchedulerException e) {
+            throw new SchedulingException("Cannot start the Task Listener/Scheduler.", e);
+        }
+        return this.scheduler;
+    }
+}

--- a/stdlib/task/src/main/java/org/ballerinalang/stdlib/task/objects/Timer.java
+++ b/stdlib/task/src/main/java/org/ballerinalang/stdlib/task/objects/Timer.java
@@ -78,7 +78,7 @@ public class Timer extends AbstractTask {
         try {
             scheduleTimer(jobDataMap);
         } catch (SchedulerException e) {
-            throw new SchedulingException("Failed to schedule Task.", e);
+            throw new SchedulingException("Failed to schedule task.", e);
         }
     }
 

--- a/stdlib/task/src/test/java/org/ballerinalang/stdlib/task/scheduler/TimerSchedulerTest.java
+++ b/stdlib/task/src/test/java/org/ballerinalang/stdlib/task/scheduler/TimerSchedulerTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.stdlib.task.scheduler;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
@@ -56,12 +57,19 @@ public class TimerSchedulerTest {
         CompileResult compileResult = BCompileUtil.compile("scheduler/timer/service_parameter.bal");
         BRunUtil.invoke(compileResult, "attachTimer");
         String expectedResult = "Sam is 10 years old";
-        await().atMost(5000, TimeUnit.MILLISECONDS).until(() -> {
+        try {
+            await().atMost(10000, TimeUnit.MILLISECONDS).until(() -> {
+                BValue[] result = BRunUtil.invoke(compileResult, "getResult");
+                Assert.assertEquals(result.length, 1);
+                Assert.assertTrue(result[0] instanceof BString);
+                return (expectedResult.equals(result[0].stringValue()));
+            });
+        } catch (ConditionTimeoutException e) {
             BValue[] result = BRunUtil.invoke(compileResult, "getResult");
             Assert.assertEquals(result.length, 1);
             Assert.assertTrue(result[0] instanceof BString);
-            return (expectedResult.equals(result[0].stringValue()));
-        });
+            Assert.assertEquals(result[0].stringValue(), expectedResult, "Result did not match");
+        }
     }
 
     @Test(description = "Tests for pause and resume functions of the timer")

--- a/stdlib/task/src/test/java/org/ballerinalang/stdlib/task/scheduler/TimerSchedulerTest.java
+++ b/stdlib/task/src/test/java/org/ballerinalang/stdlib/task/scheduler/TimerSchedulerTest.java
@@ -51,7 +51,7 @@ public class TimerSchedulerTest {
         });
     }
 
-    @Test(description = "Test service parameter passing", groups = {"brokenOnLangLibChange"})
+    @Test(description = "Test service parameter passing")
     public void testTimerAttachment() {
         CompileResult compileResult = BCompileUtil.compile("scheduler/timer/service_parameter.bal");
         BRunUtil.invoke(compileResult, "attachTimer");

--- a/stdlib/task/src/test/resources/scheduler/timer/service_parameter.bal
+++ b/stdlib/task/src/test/resources/scheduler/timer/service_parameter.bal
@@ -28,8 +28,14 @@ function attachTimer() {
     };
 
     task:Scheduler timer = new({ interval: 100, initialDelay: 1000 });
-    checkpanic timer.attach(timerService, person);
-    checkpanic timer.start();
+    var attachResult = timer.attach(timerService, person);
+    if (attachResult is error) {
+        panic attachResult;
+    }
+    var startResult = timer.start();
+    if (startResult is error) {
+        panic startResult;
+    }
 }
 
 string result = "";


### PR DESCRIPTION
## Purpose
> `ballerina/task` module had performance issues when creating many tasks in smaller intervals. This will reduce the overhead of a task by removing the creation of a `SchedulerFactory` and a `Scheduler` instances for each and every task. Instead now we have a single `scheduler` instance, and we submit all the tasks as jobs. 

Fixes #15954
Fixes #16861 
Fixes #15670

## Approach
> Create a singleton `TaskManager` object, where we keep a `scheduler` object, and submit every task as a `job` for the `scheduler`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples