### PR TITLE
Move Scanner as a class variable

### DIFF
--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ReadlnAny.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ReadlnAny.java
@@ -38,11 +38,12 @@ import java.util.Scanner;
 )
 public class ReadlnAny {
 
+    private static Scanner sc = new Scanner(System.in, Charset.defaultCharset().displayName());
+
     public static String readln(Strand strand, Object result) {
         if (result != null) {
             System.out.print(result.toString());
         }
-        Scanner sc = new Scanner(System.in, Charset.defaultCharset().displayName());
         return sc.nextLine();
     }
 }


### PR DESCRIPTION
## Purpose
> System.in input stream close after the first read. So subsequence read attempt failed. 

Fixes #15788

## Approach
> Move Scanner variable to an instance variable to prevent getting close. Since these native impl are singleton type, this will prevent recycling the scanner.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
