### PR TITLE
Enable JSON to Record conversion data binding tests

### DIFF
--- a/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/ConstructFrom.java
+++ b/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/ConstructFrom.java
@@ -62,13 +62,13 @@ public class ConstructFrom {
         BType describingType = t.getDescribingType();
         // typedesc<json>.constructFrom like usage
         if (describingType.getTag() == org.ballerinalang.jvm.types.TypeTags.TYPEDESC_TAG) {
-            return convert(strand, ((BTypedescType) t.getDescribingType()).getConstraint(), v);
+            return convert(((BTypedescType) t.getDescribingType()).getConstraint(), v);
         }
         // json.constructFrom like usage
-        return convert(strand, describingType, v);
+        return convert(describingType, v);
     }
 
-    public static Object convert(Strand strand, BType convertType, Object inputValue) {
+    public static Object convert(BType convertType, Object inputValue) {
         RefValue convertedValue;
         org.ballerinalang.jvm.types.BType targetType;
         if (convertType.getTag() == org.ballerinalang.jvm.types.TypeTags.UNION_TAG) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
@@ -19,21 +19,21 @@ package org.ballerinalang.net.http;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.jvm.BallerinaValues;
-import org.ballerinalang.jvm.JSONUtils;
 import org.ballerinalang.jvm.types.BArrayType;
-import org.ballerinalang.jvm.types.BStructureType;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.types.TypeTags;
 import org.ballerinalang.jvm.util.exceptions.BallerinaConnectorException;
-import org.ballerinalang.jvm.util.exceptions.BallerinaException;
 import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.XMLValue;
+import org.ballerinalang.langlib.typedesc.ConstructFrom;
 import org.ballerinalang.mime.util.EntityBodyHandler;
 import org.ballerinalang.net.uri.URIUtil;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
@@ -210,7 +210,7 @@ public class HttpDispatcher {
             paramValues[paramValues.length - 2] = populateAndGetEntityBody(inRequest, inRequestEntity,
                                                                    signatureParams.getEntityBody());
             paramValues[paramValues.length - 1] = true;
-        } catch (BallerinaException ex) {
+        } catch (Exception ex) {
             httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
             throw new BallerinaConnectorException("data binding failed: " + ex.getMessage());
         }
@@ -218,7 +218,8 @@ public class HttpDispatcher {
     }
 
     private static Object populateAndGetEntityBody(ObjectValue inRequest, ObjectValue inRequestEntity,
-                                                   org.ballerinalang.jvm.types.BType entityBodyType) {
+                                                   org.ballerinalang.jvm.types.BType entityBodyType)
+            throws IOException {
         HttpUtil.populateEntityBody(inRequest, inRequestEntity, true, true);
         try {
             switch (entityBodyType.getTag()) {
@@ -240,22 +241,28 @@ public class HttpDispatcher {
                         EntityBodyHandler.addMessageDataSource(inRequestEntity, blobDataSource);
                         return blobDataSource;
                     } else if (((BArrayType) entityBodyType).getElementType().getTag() == TypeTags.RECORD_TYPE_TAG) {
-                        bjson = getBJsonValue(inRequestEntity);
-                        return getRecordArray(entityBodyType, bjson);
+                        return getRecordEntity(inRequestEntity, entityBodyType);
                     } else {
                         throw new BallerinaConnectorException("Incompatible Element type found inside an array " +
                                 ((BArrayType) entityBodyType).getElementType().getName());
                     }
                 case TypeTags.RECORD_TYPE_TAG:
-                    bjson = getBJsonValue(inRequestEntity);
-                    return getRecord(entityBodyType, bjson);
+                    return getRecordEntity(inRequestEntity, entityBodyType);
                 default:
                         //Do nothing
             }
-        } catch (Exception ex) {
-            throw new BallerinaConnectorException("Error in reading payload : " + ex.getMessage());
+        } catch (ErrorValue ex) {
+            throw new BallerinaConnectorException(ex.toString());
         }
         return null;
+    }
+
+    private static Object getRecordEntity(ObjectValue inRequestEntity, BType entityBodyType) {
+        Object result = getRecord(entityBodyType, getBJsonValue(inRequestEntity));
+        if (result instanceof ErrorValue) {
+            throw (ErrorValue) result;
+        }
+        return result;
     }
 
     /**
@@ -267,25 +274,9 @@ public class HttpDispatcher {
      */
     private static Object getRecord(BType entityBodyType, Object bjson) {
         try {
-            return JSONUtils.convertJSONToRecord(bjson, (BStructureType) entityBodyType);
+            return ConstructFrom.convert(entityBodyType, bjson);
         } catch (NullPointerException ex) {
             throw new BallerinaConnectorException("cannot convert payload to record type: " +
-                    entityBodyType.getName());
-        }
-    }
-
-    /**
-     * Convert a json array to the relevant record array.
-     *
-     * @param entityBodyType Represents entity body type
-     * @param bjson          Represents the json array that needs to be converted
-     * @return the relevant ballerina record or object array
-     */
-    private static Object getRecordArray(BType entityBodyType, Object bjson) {
-        try {
-            return JSONUtils.convertJSONToBArray(bjson, (BArrayType) entityBodyType);
-        } catch (NullPointerException ex) {
-            throw new BallerinaConnectorException("cannot convert payload to an array of type: " +
                     entityBodyType.getName());
         }
     }

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/DataBindingTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/DataBindingTest.java
@@ -139,7 +139,7 @@ public class DataBindingTest {
                 , "Age variable not set properly.");
     }
 
-    @Test(description = "Test data binding with an array of records", enabled = false)
+    @Test(description = "Test data binding with an array of records")
     public void testDataBindingWithRecordArray() {
         HTTPTestRequest requestMsg = MessageUtils.generateHTTPMessage("/echo/body8", "POST",
                 "[{'name':'wso2','age':12}, {'name':'ballerina','age':3}]");
@@ -192,7 +192,7 @@ public class DataBindingTest {
     }
 
     @Test(description = "Test data binding without a payload", expectedExceptions = BallerinaConnectorException.class,
-            expectedExceptionsMessageRegExp = ".*Error in reading payload : String payload is null*")
+          expectedExceptionsMessageRegExp = ".*data binding failed: String payload is null*")
     public void testDataBindingWithoutPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body1", "GET");
@@ -203,7 +203,7 @@ public class DataBindingTest {
     }
 
     @Test(expectedExceptions = BallerinaConnectorException.class,
-            expectedExceptionsMessageRegExp = ".*data binding failed: Error in reading payload.*")
+            expectedExceptionsMessageRegExp = ".*data binding failed: error Unexpected character 'n'.*")
     public void testDataBindingIncompatibleXMLPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body4", "POST", "name':'WSO2', 'team':'ballerina");
@@ -212,7 +212,7 @@ public class DataBindingTest {
     }
 
     @Test(expectedExceptions = BallerinaConnectorException.class,
-            expectedExceptionsMessageRegExp = ".*Error in reading payload : unrecognized token 'ballerina'.*")
+            expectedExceptionsMessageRegExp = ".*data binding failed: unrecognized token 'ballerina'.*")
     public void testDataBindingIncompatibleStructPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body6", "POST", "ballerina");
@@ -231,11 +231,9 @@ public class DataBindingTest {
         Assert.assertNull(((MapValue<String, Object>) bJson).get("Team"), "Team variable not set properly.");
     }
 
-    //TODO following two test cases doesn't throw error anymore. json to struct conversion doesn't do field validation.
-    //It returns then required struct with default values when matching fields are not present.
     @Test(expectedExceptions = BallerinaConnectorException.class,
-            expectedExceptionsMessageRegExp = ".*error while mapping 'age': no such field found in json",
-            enabled = false)
+          expectedExceptionsMessageRegExp = "data binding failed: error \\{ballerina\\}ConversionError " +
+                  "message='map<json>' value cannot be converted to 'Person'")
     public void testDataBindingStructWithNoMatchingContent() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body6", "POST", "{'name':'WSO2', 'team':8}");
@@ -244,11 +242,21 @@ public class DataBindingTest {
     }
 
     @Test(expectedExceptions = BallerinaConnectorException.class,
-            expectedExceptionsMessageRegExp = ".* error while mapping 'message': no such field found in json",
-            enabled = false)
+            expectedExceptionsMessageRegExp = "data binding failed: error \\{ballerina\\}ConversionError " +
+                    "message='map<json>' value cannot be converted to 'Stock'")
     public void testDataBindingStructWithInvalidTypes() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body7", "POST", "{'name':'WSO2', 'team':8}");
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
+        Services.invoke(TEST_EP_PORT, requestMsg);
+    }
+
+    @Test(expectedExceptions = BallerinaConnectorException.class,
+          expectedExceptionsMessageRegExp = ".*data binding failed: error \\{ballerina\\}ConversionError " +
+                  "message='json\\[\\]' value cannot be converted to 'Person\\[\\]'.*")
+    public void testDataBindingWithRecordArrayNegative() {
+        HTTPTestRequest requestMsg = MessageUtils.generateHTTPMessage("/echo/body8", "POST",
+                  "[{'name':'wso2','team':12}, " + "{'lang':'ballerina','age':3}]");
         requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
         Services.invoke(TEST_EP_PORT, requestMsg);
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPVerbsPassthruTestCases.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPVerbsPassthruTestCases.java
@@ -126,7 +126,6 @@ public class HTTPVerbsPassthruTestCases extends HttpBaseTest {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 400, "Response code mismatched");
         Assert.assertTrue(response.getData()
-                .contains("data binding failed: Error in reading payload : unrecognized " +
-                        "token 'name:WSO2,team:ballerina'"));
+                .contains("data binding failed: unrecognized token 'name:WSO2,team:ballerina'"));
     }
 }


### PR DESCRIPTION
## Purpose
> $Title

Fixes #7859

## Approach
> Use constructFrom native function for the implementation. If the incoming json does not have fields for a given record, then binding fails resulting a bad request.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
