### PR TITLE
Improve taint propagation into const/final vars

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -464,6 +464,16 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                     ((BInvokableSymbol) varNode.symbol).taintTable = taintTable;
                 }
             }
+            // blocker found while analyzing module level variable, reset stopAnalysis flag
+            if (stopAnalysis && isModuleVariable(varNode.symbol)) {
+                stopAnalysis = false;
+            }
+
+            if (isModuleVariable(varNode.symbol)
+                    && getCurrentAnalysisState().taintedStatus == TaintedStatus.TAINTED) {
+                dlogSet.add(new TaintRecord.TaintError(varNode.pos, varNode.name.value,
+                        DiagnosticCode.TAINTED_VALUE_PASSED_TO_GLOBAL_VARIABLE));
+            }
             setTaintedStatus(varNode, getCurrentAnalysisState().taintedStatus);
         }
 
@@ -486,6 +496,10 @@ public class TaintAnalyzer extends BLangNodeVisitor {
                 ((BVarSymbol) varNode.symbol).taintabilityAllowance = BVarSymbol.TaintabilityAllowance.UNTAINTED;
             }
         }
+    }
+
+    private boolean isModuleVariable(BSymbol symbol) {
+        return symbol.owner.getKind() == SymbolKind.PACKAGE;
     }
 
     @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -354,9 +354,10 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testGlobalVariablesNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/global-variables-negative.bal");
-        Assert.assertEquals(result.getDiagnostics().length, 2);
-        BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'pa'", 6, 9);
-        BAssertUtil.validateError(result, 1, "tainted value passed to global variable 'globalVariable'", 14, 5);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
+        BAssertUtil.validateError(result, 0, "tainted value passed to global variable 'KK'", 3, 1);
+        BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'pa'", 7, 9);
+        BAssertUtil.validateError(result, 2, "tainted value passed to global variable 'globalVariable'", 15, 5);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/global-variables-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/global-variables-negative.bal
@@ -1,5 +1,6 @@
 string globalVariable = "";
 @tainted string taintedGlobalVariable = "";
+final string KK = taintedVal();
 
 public function main (string... args) {
     normalFunction(args[0]);
@@ -16,4 +17,8 @@ public function anotherNormalFunction (string anotherNormalInput) {
 
 public function sen(@untainted string pa) {
 
+}
+
+function taintedVal() returns @tainted string {
+    return "val";
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables.bal
@@ -3,11 +3,14 @@ import ballerina/http;
 listener http:Listener helloWorldEP = new (19090);
 const JOB = "job";
 final string SS = "job2";
+const EMPTY_STRING = "";
+const FORWARD_SLASH = "/";
 
 any globalLevelVariable = "";
 service sample on helloWorldEP {
     any serviceLevelVariable = "";
     @tainted any taintedServiceVar = "";
+    http:Client cl = new("http://postman-echo.com");
 
     resource function params (http:Caller caller, http:Request req) {
         var bar = req.getQueryParamValue("bar");
@@ -16,6 +19,7 @@ service sample on helloWorldEP {
         self.serviceLevelVariable = "static";
         globalLevelVariable = "static";
         modifyParamVar([JOB, SS], taintedVal());
+        var response = self.cl->get(prepareUrl([<@untainted> JOB]));
     }
 }
 
@@ -25,4 +29,18 @@ function modifyParamVar(string[] s, string tainted) {
 
 function taintedVal() returns @tainted string {
     return "val";
+}
+
+function prepareUrl(string[] paths) returns string {
+    string url = EMPTY_STRING;
+
+    if (paths.length() > 0) {
+        foreach var path in paths {
+            if (!path.startsWith(FORWARD_SLASH)) {
+                url = url + FORWARD_SLASH;
+            }
+            url = url + path;
+        }
+    }
+    return url;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables.bal
@@ -1,6 +1,8 @@
 import ballerina/http;
 
 listener http:Listener helloWorldEP = new (19090);
+const JOB = "job";
+final string SS = "job2";
 
 any globalLevelVariable = "";
 service sample on helloWorldEP {
@@ -13,6 +15,14 @@ service sample on helloWorldEP {
 
         self.serviceLevelVariable = "static";
         globalLevelVariable = "static";
+        modifyParamVar([JOB, SS], taintedVal());
     }
 }
 
+function modifyParamVar(string[] s, string tainted) {
+    s[0] = tainted;
+}
+
+function taintedVal() returns @tainted string {
+    return "val";
+}


### PR DESCRIPTION
## Purpose
This PR prevent wrong taint error message being generated when global variables are passed as arguments to functions.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/16974

