### PR TITLE
Fix lang.annotation pkg prefix added into native BTypes

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -1344,7 +1344,7 @@ public class CommonUtil {
                                           PackageID typePkgId) {
         String pkgPrefix = "";
         if (!typePkgId.equals(currentPkgId) &&
-                !(typePkgId.orgName.value.equals("ballerina") && typePkgId.name.value.equals("builtin"))) {
+                !(typePkgId.orgName.value.equals("ballerina") && typePkgId.name.value.startsWith("lang."))) {
             pkgPrefix = typePkgId.name.value + ":";
             if (importsAcceptor != null) {
                 importsAcceptor.accept(typePkgId.orgName.value, typePkgId.name.value);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/FunctionDefinitionCompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/FunctionDefinitionCompletionTest.java
@@ -55,7 +55,7 @@ public class FunctionDefinitionCompletionTest extends CompletionTest {
                 {"recordVarDef1.json", "function"},
                 {"recordVarDef2.json", "function"},
                 // Enable the following later
-//                {"functionPointerAsParameter.json", "function"}, //TODO: Fix this
+                {"functionPointerAsParameter.json", "function"},
                 {"matchStatementSuggestions1.json", "function"},
                 {"matchStatementSuggestions3.json", "function"},
                 {"matchStatementSuggestions4.json", "function"},
@@ -85,7 +85,7 @@ public class FunctionDefinitionCompletionTest extends CompletionTest {
                 {"completionWithinTransactionOnRetry.json", "function"},
                 {"objectAttachFunctionImpl1.json", "function"},
                 {"objectAttachFunctionImpl2.json", "function"},
-//                {"objectAttachFunctionImpl3.json", "function"}, //TODO: Fix this
+                {"objectAttachFunctionImpl3.json", "function"},
                 {"completionAfterReturn.json", "function"},
                 {"functionCompletionWithMissingImport.json", "function"},
                 {"completionWithinRecord1.json", "function"},

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/functionPointerAsParameter.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/functionPointerAsParameter.json
@@ -118,7 +118,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "bar(lang.annotations:int a, lang.annotations:string b)(float)",
+      "label": "bar(int a, string b)(float)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/objectAttachFunctionImpl3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/objectAttachFunctionImpl3.json
@@ -6,7 +6,7 @@
   "source": "function/source/objectAttachFunctionImpl3.bal",
   "items": [
     {
-      "label": "getFullName() returns lang.annotations:string",
+      "label": "getFullName() returns string",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
@@ -15,7 +15,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
         }
       },
-      "insertText": "getFullName() returns lang.annotations:string {\n\t${1}\n}",
+      "insertText": "getFullName() returns string {\n\t${1}\n}",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -23,7 +23,7 @@
       }
     },
     {
-      "label": "checkAndModifyAge(lang.annotations:int condition, lang.annotations:int a)",
+      "label": "checkAndModifyAge(int condition, int a)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
@@ -32,7 +32,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
         }
       },
-      "insertText": "checkAndModifyAge(lang.annotations:int condition, lang.annotations:int a) {\n\t${1}\n}",
+      "insertText": "checkAndModifyAge(int condition, int a) {\n\t${1}\n}",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",


### PR DESCRIPTION
## Purpose
> Fix disabled completion tests in #16992 
> 
> **Source Sample**
> ```ballerina
> function foo(int x, function (int, string) returns (float) bar) returns (float) {
>      return x * bar(10, "2");
> }
> ```
> **Completion Suggestion Before Fix**
> `bar(lang.annotations:int a, lang.annotations:string b)(float)`
>
> **Completion Suggestion After Fix**
> `bar(int a, string b)(float)`
## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
