### PR TITLE
Add completion support for union of records with same field names

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/RecordTypeCompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/RecordTypeCompletionTest.java
@@ -39,6 +39,10 @@ public class RecordTypeCompletionTest extends CompletionTest {
                 {"recordTest1.json", "record"},
                 {"recordTest2.json", "record"},
                 {"recordTest3.json", "record"},
+                {"recordTest4.json", "record"},
+                {"recordTest5.json", "record"},
+                {"recordTest6.json", "record"},
+                {"recordTest7.json", "record"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest4.json
@@ -1,0 +1,40 @@
+{
+  "position": {
+    "line": 12,
+    "character": 29
+  },
+  "source": "record/source/recordTest4.bal",
+  "items": [
+    {
+      "label": "field1",
+      "kind": "Variable",
+      "detail": "string",
+      "insertText": "field1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+        }
+      },
+      "insertText": "toString(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "field2",
+      "kind": "Variable",
+      "detail": "boolean",
+      "insertText": "field2",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest5.json
@@ -1,0 +1,26 @@
+{
+  "position": {
+    "line": 12,
+    "character": 29
+  },
+  "source": "record/source/recordTest5.bal",
+  "items": [
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+        }
+      },
+      "insertText": "toString(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest6.json
@@ -1,0 +1,26 @@
+{
+  "position": {
+    "line": 12,
+    "character": 29
+  },
+  "source": "record/source/recordTest6.bal",
+  "items": [
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+        }
+      },
+      "insertText": "toString(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest7.json
@@ -1,0 +1,26 @@
+{
+  "position": {
+    "line": 12,
+    "character": 29
+  },
+  "source": "record/source/recordTest7.bal",
+  "items": [
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+        }
+      },
+      "insertText": "toString(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest4.bal
@@ -1,0 +1,14 @@
+type Person2 record {
+    float field1 = 12.0;
+    int field2 = 12;
+};
+
+type Person1 record {|
+    string field1 = "";
+    boolean field2 = true;
+|};
+
+function testFunction() {
+    Person1|Person2 p = {field1: 12.0, field2:12};
+    string|float testVar = p.
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest5.bal
@@ -1,0 +1,14 @@
+type Person2 record {
+    float field1 = 12.0;
+    int field2 = 12;
+};
+
+type Person1 record {|
+    string field1 = "";
+    boolean field2 = true;
+|};
+
+function testFunction() {
+    Person1|Person2|int p = {field1: 12.0, field2:12};
+    string|float testVar = p.
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest6.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest6.bal
@@ -1,0 +1,14 @@
+type Person2 record {
+    float field11 = 12.0;
+    int field22 = 12;
+};
+
+type Person1 record {|
+    string field1 = "";
+    boolean field2 = true;
+|};
+
+function testFunction() {
+    Person1|Person2|int p = {field1: 12.0, field2:12};
+    string|float testVar = p.
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest7.bal
@@ -1,0 +1,14 @@
+type Person2 record {
+
+
+};
+
+type Person1 record {|
+    string field1 = "";
+    boolean field2 = true;
+|};
+
+function testFunction() {
+    Person1|Person2|int p = {field1: 12.0, field2:12};
+    string|float testVar = p.
+}


### PR DESCRIPTION
## Purpose
> Add completion support for union of records with same field names

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
