### PR TITLE
Make public fields private

### DIFF
--- a/examples/http-to-websocket-upgrade/http_to_websocket_upgrade.bal
+++ b/examples/http-to-websocket-upgrade/http_to_websocket_upgrade.bal
@@ -21,7 +21,7 @@ service httpService on new http:Listener(9090) {
             resp.statusCode = 500;
         } else {
             io:println(payload);
-            resp.setPayload(string `HTTP POST received: ${untaint payload}`);
+            resp.setPayload(string `HTTP POST received: ${<@untainted> payload}`);
         }
 
         var err = caller->respond(resp);
@@ -53,7 +53,7 @@ service wsService = @http:WebSocketServiceConfig {subProtocols: ["xml, json"]
                                          ,idleTimeoutInSeconds: 20} service {
 
     resource function onOpen(http:WebSocketCaller caller) {
-        io:println("New WebSocket connection: " + caller.id);
+        io:println("New WebSocket connection: " + caller.getConnectionId());
     }
 
     resource function onText(http:WebSocketCaller caller, string text) {
@@ -65,6 +65,6 @@ service wsService = @http:WebSocketServiceConfig {subProtocols: ["xml, json"]
     }
 
     resource function onIdleTimeout(http:WebSocketCaller caller) {
-        io:println("Idle timeout: " + caller.id);
+        io:println("Idle timeout: " + caller.getConnectionId());
     }
 };

--- a/examples/http-to-websocket-upgrade/http_to_websocket_upgrade.out
+++ b/examples/http-to-websocket-upgrade/http_to_websocket_upgrade.out
@@ -1,6 +1,9 @@
 # To start the service, navigate to the directory that contains the
-# `.bal` file and use the `ballerina run` command.
-$ ballerina run http_to_websocket_upgrade.bal
+# `.bal` file and use the `ballerina build` command.
+$ ballerina build http_to_websocket_upgrade.bal
+
+# Run the sample using the `run` command on the jar file generated:
+ballerina run http_to_websocket_upgrade.jar
 
 # To check the sample, use the Chrome or Firefox JavaScript console and run the commands given below. <br>
 # Change "xml" to another sub protocol to observe the behavior of the WebSocket server.

--- a/examples/websocket-basic-sample/websocket_basic_sample.bal
+++ b/examples/websocket-basic-sample/websocket_basic_sample.bal
@@ -16,10 +16,10 @@ service basic on new http:WebSocketListener(9090) {
     // This `resource` is triggered after a successful client connection.
     resource function onOpen(http:WebSocketCaller caller) {
         io:println("\nNew client connected");
-        io:println("Connection ID: " + caller.id);
-        io:println("Negotiated Sub protocol: " + caller.negotiatedSubProtocol);
-        io:println("Is connection open: " + caller.isOpen.toString());
-        io:println("Is connection secured: " + caller.isSecure.toString());
+        io:println("Connection ID: " + caller.getConnectionId());
+        io:println("Negotiated Sub protocol: " + caller.getNegotiatedSubProtocol().toString());
+        io:println("Is connection open: " + caller.isOpen().toString());
+        io:println("Is connection secured: " + caller.isSecure().toString());
     }
 
     // This `resource` is triggered when a new text frame is received from a client.
@@ -77,7 +77,7 @@ service basic on new http:WebSocketListener(9090) {
     // `http:WebSocketServiceConfig` annotation.
     resource function onIdleTimeout(http:WebSocketCaller caller) {
         io:println("\nReached idle timeout");
-        io:println("Closing connection " + caller.id);
+        io:println("Closing connection " + caller.getConnectionId());
         var err = caller->close(statusCode = 1001, reason =
                                     "Connection timeout");
         if (err is http:WebSocketError) {

--- a/examples/websocket-basic-sample/websocket_basic_sample.out
+++ b/examples/websocket-basic-sample/websocket_basic_sample.out
@@ -1,6 +1,9 @@
 # To start the service, navigate to the directory that contains the
-# `.bal` file and use the `ballerina run` command.
-$ ballerina run websocket_basic_sample.bal
+# `.bal` file and use the `ballerina build` command.
+$ ballerina build websocket_basic_sample.bal
+
+# Run the sample using the `run` command on the jar file generated:
+$ ballerina run websocket_basic_sample.jar
 
 # To check the sample, use a Chrome or Firefox JavaScript console and run the following commands. <br>
 # Change `xml` to another sub protocol to observe the behavior of the WebSocket server.

--- a/examples/websocket-proxy-server/websocket_proxy_server.bal
+++ b/examples/websocket-proxy-server/websocket_proxy_server.bal
@@ -23,8 +23,8 @@ service SimpleProxyService on new http:WebSocketListener(9090) {
             readyOnConnect: false
         });
         //Associate connections before starting to read messages.
-        wsClientEp.attributes[ASSOCIATED_CONNECTION] = caller;
-        caller.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
+        wsClientEp.setAttribute(ASSOCIATED_CONNECTION, caller);
+        caller.setAttribute(ASSOCIATED_CONNECTION, wsClientEp);
 
         // Once the client is ready to receive frames the remote function `ready`
         // of the client need to be called separately.
@@ -71,8 +71,8 @@ service SimpleProxyService on new http:WebSocketListener(9090) {
             log:printError("Error occurred when closing the connection",
                             <error> e);
         }
-        _ = caller.attributes.remove(ASSOCIATED_CONNECTION);
-        log:printError("Unexpected error hense closing the connection",
+        _ = caller.removeAttribute(ASSOCIATED_CONNECTION);
+        log:printError("Unexpected error hence closing the connection",
                         <error> err);
     }
 
@@ -87,7 +87,7 @@ service SimpleProxyService on new http:WebSocketListener(9090) {
             log:printError("Error occurred when closing the connection",
                             <error> err);
         }
-        _ = caller.attributes.remove(ASSOCIATED_CONNECTION);
+        _ = caller.removeAttribute(ASSOCIATED_CONNECTION);
     }
 }
 
@@ -131,7 +131,7 @@ service ClientService = @http:WebSocketServiceConfig {} service {
             log:printError("Error occurred when closing the connection",
                             err = e);
         }
-        _ = caller.attributes.remove(ASSOCIATED_CONNECTION);
+        _ = caller.removeAttribute(ASSOCIATED_CONNECTION);
         log:printError("Unexpected error hense closing the connection",
                         <error> err);
     }
@@ -146,7 +146,7 @@ service ClientService = @http:WebSocketServiceConfig {} service {
             if (err is http:WebSocketError) {
                 log:printError("Error occurred when closing the connection", <error> err);
             }
-        _ = caller.attributes.remove(ASSOCIATED_CONNECTION);
+        _ = caller.removeAttribute(ASSOCIATED_CONNECTION);
     }
 };
 
@@ -154,7 +154,7 @@ service ClientService = @http:WebSocketServiceConfig {} service {
 function getAssociatedClientEndpoint(http:WebSocketCaller ep)
                                         returns (http:WebSocketClient) {
     http:WebSocketClient wsClient =
-            <http:WebSocketClient>ep.attributes[ASSOCIATED_CONNECTION];
+            <http:WebSocketClient>ep.getAttribute(ASSOCIATED_CONNECTION);
     return wsClient;
 }
 
@@ -162,6 +162,6 @@ function getAssociatedClientEndpoint(http:WebSocketCaller ep)
 function getAssociatedServerEndpoint(http:WebSocketClient ep)
                                         returns (http:WebSocketCaller) {
     http:WebSocketCaller wsEndpoint =
-            <http:WebSocketCaller>ep.attributes[ASSOCIATED_CONNECTION];
+            <http:WebSocketCaller>ep.getAttribute(ASSOCIATED_CONNECTION);
     return wsEndpoint;
 }

--- a/examples/websocket-proxy-server/websocket_proxy_server.out
+++ b/examples/websocket-proxy-server/websocket_proxy_server.out
@@ -1,6 +1,10 @@
 # To start the service, navigate to the directory that contains the
-# `.bal` file and use the `ballerina run` command.
-$ ballerina run websocket_proxy_server.bal
+# `.bal` file and use the `ballerina build` command.
+$ ballerina build websocket_proxy_server.bal
+
+# Run the sample using the `run` command on the jar file generated:
+$ ballerina run websocket_proxy_server.jar
+
 # Now, this service can be invoked by any WebSocket client using the url "ws://localhost:9090/proxy/ws"
 
 # To check the sample, you can use Chrome or Firefox JavaScript console and run the following commands. <br>

--- a/stdlib/http/src/main/ballerina/src/http/websocket/websocket_caller.bal
+++ b/stdlib/http/src/main/ballerina/src/http/websocket/websocket_caller.bal
@@ -15,19 +15,13 @@
 // under the License.
 
 # Represents a WebSocket caller.
-#
-# + id - The connection id
-# + negotiatedSubProtocol - The subprotocols that are negotiated with the client
-# + isSecure - `true` if the connection is secure
-# + isOpen - `true` if the connection is open
-# + attributes - A map to store connection related attributes
 public type WebSocketCaller client object {
 
-    public string id = "";
-    public string negotiatedSubProtocol = "";
-    public boolean isSecure = false;
-    public boolean isOpen = false;
-    public map<any> attributes = {};
+    private string id = "";
+    private string? negotiatedSubProtocol = ();
+    private boolean secure = false;
+    private boolean open = false;
+    private map<any> attributes = {};
 
     private WebSocketConnector conn = new;
 
@@ -36,8 +30,8 @@ public type WebSocketCaller client object {
     # + data - Data to be sent, if byte[] it is converted to a UTF-8 string for sending
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - `error` if an error occurs when sending
-    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean finalFrame = true)
-    returns WebSocketError? {
+    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data, 
+        public boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushText(data, finalFrame);
     }
 
@@ -46,7 +40,7 @@ public type WebSocketCaller client object {
     # + data - Binary data to be sent
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return - `error` if an error occurs when sending
-    public remote function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
+    public remote function pushBinary(byte[] data, public boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushBinary(data, finalFrame);
     }
 
@@ -79,5 +73,57 @@ public type WebSocketCaller client object {
     public remote function close(public int? statusCode = 1000, public string? reason = (),
         public int timeoutInSecs = 60) returns WebSocketError? {
         return self.conn.close(statusCode = statusCode, reason = reason, timeoutInSecs = timeoutInSecs);
+    }
+
+    # Sets a connection related attribute.
+    #
+    # + key - key that identifies the attribute
+    # + value - value of the attribute
+    public function setAttribute(string key, any value) {
+        self.attributes[key] = value;
+    }
+
+    # Gets connection related attribute if any.
+    #
+    # + key - the key to identify the attribute.
+    # + return - the attribute related to the given key or `nil`
+    public function getAttribute(string key) returns any {
+        return self.attributes[key];
+    }
+
+    # Removes connection related attribute if any.
+    #
+    # + key - the key to identify the attribute.
+    # + return - the attribute related to the given key or `nil`
+    public function removeAttribute(string key) returns any {
+        return self.attributes.remove(key);
+    }
+
+    # Gives the connection id associated with this connection.
+    #
+    # + return - the unique id associated with the connection
+    public function getConnectionId() returns string {
+        return self.id;
+    }
+
+    # Gives the subprotocol if any that is negotiated with the client.
+    #
+    # + return - The subprotocol if any negotiated with the client or `nil`
+    public function getNegotiatedSubProtocol() returns string? {
+        return self.negotiatedSubProtocol;
+    }
+
+    # Gives the secured status of the connection.
+    #
+    # + return - `true` if the connection is secure.
+    public function isSecure() returns boolean {
+        return self.secure;
+    }
+
+    # Gives the open or closed status of the connection.
+    #
+    # + return - `true` if the connection is open
+    public function isOpen() returns boolean {
+        return self.open;
     }
 };

--- a/stdlib/http/src/main/ballerina/src/http/websocket/websocket_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/websocket/websocket_client.bal
@@ -15,21 +15,14 @@
 // under the License.
 
 # Represents a WebSocket client endpoint.
-#
-# + id - The connection id
-# + negotiatedSubProtocol - The subprotocols that are negotiated with the server
-# + isSecure - `true` if the connection is secure
-# + isOpen - `true` if the connection is open
-# + response - Represents the HTTP response
-# + attributes - A map to store connection related attributes
 public type WebSocketClient client object {
 
-    public string id = "";
-    public string negotiatedSubProtocol = "";
-    public boolean isSecure = false;
-    public boolean isOpen = false;
-    public Response response = new;
-    public map<any> attributes = {};
+    private string id = "";
+    private string? negotiatedSubProtocol = ();
+    private boolean secure = false;
+    private boolean open = false;
+    private Response? response = ();
+    private map<any> attributes = {};
 
     private WebSocketConnector conn = new;
     private string url = "";
@@ -38,7 +31,7 @@ public type WebSocketClient client object {
     # Initializes the client when called.
     #
     # + c - The `WebSocketClientEndpointConfig` of the endpoint
-    public function __init(string url, WebSocketClientEndpointConfig? config = ()) {
+    public function __init(string url, public WebSocketClientEndpointConfig? config = ()) {
         self.url = url;
         self.config = config ?: {};
         self.initEndpoint();
@@ -52,8 +45,8 @@ public type WebSocketClient client object {
     # + data - Data to be sent, if byte[] it is converted to a UTF-8 string for sending
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - `error` if an error occurs when sending
-    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean finalFrame = true)
-    returns WebSocketError? {
+    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data, 
+    public boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushText(data, finalFrame);
     }
 
@@ -62,7 +55,7 @@ public type WebSocketClient client object {
     # + data - Binary data to be sent
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return - `error` if an error occurs when sending
-    public remote function pushBinary(byte[] data, boolean finalFrame = true) returns error? {
+    public remote function pushBinary(byte[] data, public boolean finalFrame = true) returns error? {
         return self.conn.pushBinary(data, finalFrame);
     }
 
@@ -104,6 +97,66 @@ public type WebSocketClient client object {
     public remote function ready() returns WebSocketError? {
         return self.conn.ready();
     }
+
+    # Sets a connection related attribute.
+    #
+    # + key - key that identifies the attribute
+    # + value - value of the attribute
+    public function setAttribute(string key, any value) {
+        self.attributes[key] = value;
+    }
+
+    # Gets connection related attribute if any.
+    #
+    # + key - the key to identify the attribute.
+    # + return - the attribute related to the given key or `nil`
+    public function getAttribute(string key) returns any {
+        return self.attributes[key];
+    }
+
+    # Removes connection related attribute if any.
+    #
+    # + key - the key to identify the attribute.
+    # + return - the attribute related to the given key or `nil`
+    public function removeAttribute(string key) returns any {
+        return self.attributes.remove(key);
+    }
+
+    # Gives the connection id associated with this connection.
+    #
+    # + return - the unique id associated with the connection
+    public function getConnectionId() returns string {
+        return self.id;
+    }
+
+    # Gives the subprotocol if any that is negotiated with the client.
+    #
+    # + return - The subprotocol if any negotiated with the client or `nil`
+    public function getNegotiatedSubProtocol() returns string? {
+        return self.negotiatedSubProtocol;
+    }
+
+    # Gives the secured status of the connection.
+    #
+    # + return - `true` if the connection is secure.
+    public function isSecure() returns boolean {
+        return self.secure;
+    }
+
+    # Gives the open or closed status of the connection.
+    #
+    # + return - `true` if the connection is open
+    public function isOpen() returns boolean {
+        return self.open;
+    }
+
+    # Gives the HTTP response if any received for the client handshake request.
+    #
+    # + return - the HTTP response received for the client handshake request
+    public function getHttpResponse() returns Response? {
+        return self.response;
+    }
+    
 };
 
 # Configuration for the WebSocket client endpoint.

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -70,18 +70,15 @@ public class WebSocketConstants {
     // WebSocketListener struct field names
     public static final String LISTENER_ID_FIELD = "id";
     public static final String LISTENER_NEGOTIATED_SUBPROTOCOLS_FIELD = "negotiatedSubProtocol";
-    public static final String LISTENER_IS_SECURE_FIELD = "isSecure";
-    public static final String LISTENER_IS_OPEN_FIELD = "isOpen";
+    public static final String LISTENER_IS_SECURE_FIELD = "secure";
+    public static final String LISTENER_IS_OPEN_FIELD = "open";
     public static final String LISTENER_CONNECTOR_FIELD = "conn";
-    public static final int LISTENER_HTTP_ENDPOINT_FIELD = 3;
 
     // WebSocketClient struct field names
     public static final String CLIENT_RESPONSE_FIELD = "response";
     public static final String CLIENT_CONNECTOR_FIELD = "conn";
 
-    public static final String WEBSOCKET_ERROR_CODE = "{" + FULL_PACKAGE_HTTP + "}WebSocketError";
     public static final String WEBSOCKET_ERROR_DETAILS = "Detail";
-    public static final String WEBSOCKET_ERROR = "WebSocket Error: ";
 
     // WebSocketConnector
     public static final String CONNECTOR_IS_READY_FIELD = "isReady";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -148,8 +148,7 @@ public class WebSocketUtil {
     public static void populateEndpoint(WebSocketConnection webSocketConnection, ObjectValue webSocketEndpoint) {
         webSocketEndpoint.set(WebSocketConstants.LISTENER_ID_FIELD, webSocketConnection.getChannelId());
         String negotiatedSubProtocol = webSocketConnection.getNegotiatedSubProtocol();
-        webSocketEndpoint.set(WebSocketConstants.LISTENER_NEGOTIATED_SUBPROTOCOLS_FIELD,
-                negotiatedSubProtocol != null ? negotiatedSubProtocol : "");
+        webSocketEndpoint.set(WebSocketConstants.LISTENER_NEGOTIATED_SUBPROTOCOLS_FIELD, negotiatedSubProtocol);
         webSocketEndpoint.set(WebSocketConstants.LISTENER_IS_SECURE_FIELD, webSocketConnection.isSecure());
         webSocketEndpoint.set(WebSocketConstants.LISTENER_IS_OPEN_FIELD, webSocketConnection.isOpen());
     }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/01_isOpen.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/01_isOpen.bal
@@ -26,14 +26,14 @@ service isOpen on socketListener {
 
     resource function onText(http:WebSocketCaller caller, string text) {
         http:WebSocketError? err = caller->close(timeoutInSecs = 0);
-        io:println("In onText isOpen " + caller.isOpen.toString());
+        io:println("In onText isOpen " + caller.isOpen().toString());
     }
 
     resource function onClose(http:WebSocketCaller caller, int code, string reason) {
-        io:println("In onClose isOpen " + caller.isOpen.toString());
+        io:println("In onClose isOpen " + caller.isOpen().toString());
     }
 
     resource function onError(http:WebSocketCaller caller, error err) {
-        io:println("In onError isOpen " + caller.isOpen.toString());
+        io:println("In onError isOpen " + caller.isOpen().toString());
     }
 }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/10_custom_header_client.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/10_custom_header_client.bal
@@ -28,8 +28,8 @@ service PingPongTestService1 on new http:WebSocketListener(21011) {
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new("ws://localhost:15100/websocket", { callbackService:
             clientCallbackService, readyOnConnect: false, customHeaders: { "X-some-header": "some-header-value" } });
-        wsEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
-        wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsEp;
+        wsEp.setAttribute(ASSOCIATED_CONNECTION, wsClientEp);
+        wsClientEp.setAttribute(ASSOCIATED_CONNECTION, wsEp);
         var returnVal = wsClientEp->ready();
         if (returnVal is http:WebSocketError) {
             panic <error> returnVal;
@@ -47,9 +47,12 @@ service PingPongTestService1 on new http:WebSocketListener(21011) {
         }
         if (text == "server-headers") {
             clientEp = getAssociatedClientEndpoint(wsEp);
-            var returnVal = clientEp->pushText(clientEp.response.getHeader("X-server-header"));
-            if (returnVal is http:WebSocketError) {
-                panic <error> returnVal;
+            var resp = clientEp.getHttpResponse();
+            if (resp is http:Response) {
+                var returnVal = clientEp->pushText(resp.getHeader("X-server-header"));
+                if (returnVal is http:WebSocketError) {
+                    panic <error> returnVal;
+                }
             }
         }
     }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/11_custom_header_server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/11_custom_header_server.bal
@@ -23,7 +23,7 @@ service simpleProxy3 = @http:WebSocketServiceConfig {} service {
 
     resource function onText(http:WebSocketCaller wsEp, string text) {
         if (text == "custom-headers") {
-            var returnVal = wsEp->pushText(<string>wsEp.attributes[CUSTOM_HEADER]);
+            var returnVal = wsEp->pushText(<string>wsEp.getAttribute(CUSTOM_HEADER));
             if (returnVal is http:WebSocketError) {
                 panic <error> returnVal;
             }
@@ -42,7 +42,7 @@ service simple3 on new http:Listener(21012) {
     resource function websocketProxy(http:Caller httpEp, http:Request req) {
         http:WebSocketCaller wsServiceEp;
         wsServiceEp = httpEp->acceptWebSocketUpgrade({ "X-some-header": "some-header-value" });
-        wsServiceEp.attributes[CUSTOM_HEADER] = req.getHeader(CUSTOM_HEADER);
+        wsServiceEp.setAttribute(CUSTOM_HEADER, req.getHeader(CUSTOM_HEADER));
     }
 }
 

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/14_query_and_path_param_support.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/14_query_and_path_param_support.bal
@@ -33,10 +33,10 @@ service simple6 on new http:Listener(21015) {
     resource function websocketProxy(http:Caller httpEp, http:Request req, string path1, string path2) {
         http:WebSocketCaller wsServiceEp;
         wsServiceEp = httpEp->acceptWebSocketUpgrade({ "X-some-header": "some-header-value" });
-        wsServiceEp.attributes[PATH1] = path1;
-        wsServiceEp.attributes[PATH2] = path2;
-        wsServiceEp.attributes[QUERY1] = req.getQueryParamValue("q1");
-        wsServiceEp.attributes[QUERY2] = req.getQueryParamValue("q2");
+        wsServiceEp.setAttribute(PATH1, path1);
+        wsServiceEp.setAttribute(PATH2, path2);
+        wsServiceEp.setAttribute(QUERY1, req.getQueryParamValue("q1"));
+        wsServiceEp.setAttribute(QUERY2, req.getQueryParamValue("q2"));
     }
 }
 
@@ -44,10 +44,10 @@ service simpleProxy6 = @http:WebSocketServiceConfig {} service {
 
     resource function onText(http:WebSocketCaller wsEp, string text) {
         if (text == "send") {
-            string path1 = <string>wsEp.attributes[PATH1];
-            string path2 = <string>wsEp.attributes[PATH2];
-            string query1 = <string>wsEp.attributes[QUERY1];
-            string query2 = <string>wsEp.attributes[QUERY2];
+            string path1 = <string>wsEp.getAttribute(PATH1);
+            string path2 = <string>wsEp.getAttribute(PATH2);
+            string query1 = <string>wsEp.getAttribute(QUERY1);
+            string query2 = <string>wsEp.getAttribute(QUERY2);
 
             string msg = string `path-params: ${path1}, ${path2}; query-params: ${query1}, ${query2}`;
             var returnVal = wsEp->pushText(msg);

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/15_resource_failure.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/15_resource_failure.bal
@@ -31,7 +31,7 @@ service simple7 on new http:Listener(21016) {
             error err = error("Query param not set");
             panic err;
         }
-        wsServiceEp.attributes["Query1"] = queryParam;
+        wsServiceEp.setAttribute("Query1", queryParam);
     }
 }
 
@@ -39,27 +39,27 @@ service castErrror = @http:WebSocketServiceConfig {idleTimeoutInSeconds: 10} ser
 
     resource function onText(http:WebSocketCaller wsEp, string text) {
         http:WebSocketClient val;
-        var returnVal = <http:WebSocketClient>wsEp.attributes[ASSOCIATED_CONNECTION];
+        var returnVal = <http:WebSocketClient>wsEp.getAttribute(ASSOCIATED_CONNECTION);
         val = returnVal;
     }
     resource function onBinary(http:WebSocketCaller wsEp, byte[] data) {
         http:WebSocketClient val;
-        var returnVal = <http:WebSocketClient>wsEp.attributes[ASSOCIATED_CONNECTION];
+        var returnVal = <http:WebSocketClient>wsEp.getAttribute(ASSOCIATED_CONNECTION);
         val = returnVal;
     }
     resource function onPing(http:WebSocketCaller wsEp, byte[] data) {
         http:WebSocketClient val;
-        var returnVal = <http:WebSocketClient>wsEp.attributes[ASSOCIATED_CONNECTION];
+        var returnVal = <http:WebSocketClient>wsEp.getAttribute(ASSOCIATED_CONNECTION);
         val = returnVal;
     }
     resource function onIdleTimeout(http:WebSocketCaller wsEp) {
         http:WebSocketClient val;
-        var returnVal = <http:WebSocketClient>wsEp.attributes[ASSOCIATED_CONNECTION];
+        var returnVal = <http:WebSocketClient>wsEp.getAttribute(ASSOCIATED_CONNECTION);
         val = returnVal;
     }
     resource function onClose(http:WebSocketCaller wsEp, int code, string reason) {
         http:WebSocketClient val;
-        var returnVal = <http:WebSocketClient>wsEp.attributes[ASSOCIATED_CONNECTION];
+        var returnVal = <http:WebSocketClient>wsEp.getAttribute(ASSOCIATED_CONNECTION);
         val = returnVal;
     }
 };

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/17_simple_proxy_server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/17_simple_proxy_server.bal
@@ -26,8 +26,8 @@ service on new http:WebSocketListener(21018) {
     resource function onOpen(http:WebSocketCaller wsEp) {
         http:WebSocketClient wsClientEp = new("ws://localhost:15300/websocket", { callbackService:
             clientCallbackService9, readyOnConnect: false });
-        wsEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
-        wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsEp;
+        wsEp.setAttribute(ASSOCIATED_CONNECTION, wsClientEp);
+        wsClientEp.setAttribute(ASSOCIATED_CONNECTION, wsEp);
         var returnVal = wsClientEp->ready();
         if (returnVal is http:WebSocketError) {
             panic <error> returnVal;
@@ -87,11 +87,11 @@ service clientCallbackService9 = @http:WebSocketServiceConfig {} service {
 };
 
 public function getAssociatedClientEndpoint(http:WebSocketCaller wsServiceEp) returns (http:WebSocketClient) {
-    var returnVal = <http:WebSocketClient>wsServiceEp.attributes[ASSOCIATED_CONNECTION];
+    var returnVal = <http:WebSocketClient>wsServiceEp.getAttribute(ASSOCIATED_CONNECTION);
     return returnVal;
 }
 
 public function getAssociatedListener(http:WebSocketClient wsClientEp) returns (http:WebSocketCaller) {
-    var returnVal = <http:WebSocketCaller>wsClientEp.attributes[ASSOCIATED_CONNECTION];
+    var returnVal = <http:WebSocketCaller>wsClientEp.getAttribute(ASSOCIATED_CONNECTION);
     return returnVal;
 }

--- a/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/20_ssl_proxy.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websocket/src/wsservices/20_ssl_proxy.bal
@@ -27,8 +27,8 @@ service on new http:WebSocketListener(21021) {
                 password: "ballerina"
             }
             }, readyOnConnect: false });
-        wsEp.attributes[ASSOCIATED_CONNECTION] = wsClientEp;
-        wsClientEp.attributes[ASSOCIATED_CONNECTION] = wsEp;
+        wsEp.setAttribute(ASSOCIATED_CONNECTION, wsClientEp);
+        wsClientEp.setAttribute(ASSOCIATED_CONNECTION, wsEp);
         var returnVal = wsClientEp->ready();
         if (returnVal is http:WebSocketError) {
             panic <error> returnVal;


### PR DESCRIPTION
## Purpose
> Make public fields private in WebSocket to make them immutable.

## Approach
>  Some WebSocket fields were public. This makes them private and allows accessing them via public methods. This is an API change.

## Samples
> Updated

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
