### PR TITLE
Add support for prioritized loading of completion providers

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/LSCompletionProviderFactory.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/LSCompletionProviderFactory.java
@@ -54,7 +54,12 @@ public class LSCompletionProviderFactory {
         for (LSCompletionProvider provider : providerServices) {
             if (provider != null) {
                 for (Class attachmentPoint : provider.getAttachmentPoints()) {
-                    this.providers.put(attachmentPoint, provider);
+                    if (!this.providers.containsKey(attachmentPoint)
+                            || (this.providers.get(attachmentPoint).getPrecedence() == 
+                            LSCompletionProvider.Precedence.LOW
+                            && provider.getPrecedence() == LSCompletionProvider.Precedence.HIGH)) {
+                        this.providers.put(attachmentPoint, provider);
+                    }
                 }
             }
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/spi/LSCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/spi/LSCompletionProvider.java
@@ -88,6 +88,8 @@ import java.util.stream.IntStream;
 public abstract class LSCompletionProvider {
 
     protected List<Class> attachmentPoints = new ArrayList<>();
+    
+    private Precedence precedence = Precedence.LOW;
 
     /**
      * Get Completion items for the scope/ context.
@@ -104,6 +106,15 @@ public abstract class LSCompletionProvider {
      */
     public List<Class> getAttachmentPoints() {
         return this.attachmentPoints;
+    }
+
+    /**
+     * Get the precedence of the provider.
+     * 
+     * @return {@link Precedence} precedence of the provider
+     */
+    public Precedence getPrecedence() {
+        return precedence;
     }
 
     /**
@@ -790,5 +801,15 @@ public abstract class LSCompletionProvider {
         if (!found) {
             items.add(snippet.build(ctx));
         }
+    }
+
+    /**
+     * Precedence for a given provider.
+     * 
+     * @since 1.0
+     */
+    public enum Precedence {
+        LOW,
+        HIGH
     }
 }


### PR DESCRIPTION
## Purpose
> With this, add the support for prioritized loading of the Completion providers in the language server. For the Default completion providers in the language server, Precedence will be LOW. When plugin developers need to write their own provider for an existing scope, then the precedence should set to HIGH 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
