### PR TITLE
Update Java interop annotations target to "external"

### DIFF
--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -506,6 +506,8 @@ function getJVMTypeSign(bir:BType bType) returns string {
         jvmType = io:sprintf("L%s;", FUTURE_VALUE);
     } else if (bType is bir:BInvokableType) {
         jvmType = io:sprintf("L%s;", FUNCTION_POINTER);
+    } else if (bType is bir:BTypeHandle) {
+        jvmType = io:sprintf("L%s;", HANDLE_VALUE);
     } else if (bType is bir:BTypeDesc) {
         jvmType = io:sprintf("L%s;", TYPEDESC_VALUE);
     }   else if (bType is bir:BTypeNil 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -415,6 +415,8 @@ public class BIRGen extends BLangNodeVisitor {
 
         // Populate annotation attachments on external in BIRFunction node
         populateBIRAnnotAttachments(astFunc.externalAnnAttachments, birFunc.annotAttachments, this.env);
+        // Populate annotation attachments on function in BIRFunction node
+        populateBIRAnnotAttachments(astFunc.annAttachments, birFunc.annotAttachments, this.env);
 
         birFunc.argsCount = astFunc.requiredParams.size()
                 + (astFunc.restParam != null ? 1 : 0) + astFunc.paramClosureMap.size();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -414,7 +414,7 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         // Populate annotation attachments on external in BIRFunction node
-        populateBIRAnnotAttachments(astFunc.annAttachments, birFunc.annotAttachments, this.env);
+        populateBIRAnnotAttachments(astFunc.externalAnnAttachments, birFunc.annotAttachments, this.env);
 
         birFunc.argsCount = astFunc.requiredParams.size()
                 + (astFunc.restParam != null ? 1 : 0) + astFunc.paramClosureMap.size();

--- a/stdlib/java/src/main/ballerina/src/java/annotations.bal
+++ b/stdlib/java/src/main/ballerina/src/java/annotations.bal
@@ -32,9 +32,8 @@ public type FieldData record {|
     boolean isStatic = false;
 |};
 
-#
-public annotation ConstructorData Constructor on function;
-public annotation MethodData Method on function;
-public annotation FieldData FieldGet on function;
-public annotation FieldData FieldSet on function;
+public const annotation ConstructorData Constructor on source external;
+public const annotation MethodData Method on source external;
+public const annotation FieldData FieldGet on source external;
+public const annotation FieldData FieldSet on source external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/arrays/java_array_passing_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/arrays/java_array_passing_tests.bal
@@ -18,12 +18,23 @@ public function testReturningSortedJavaStringArray() returns handle {
     return parts;
 }
 
-@java:Method {name:"sort", class: "java.util.Arrays", isStatic:true, paramTypes:["[I"]}
-public function sortJavaIntArray(handle arrayValue) = external;
+public function sortJavaIntArray(handle arrayValue) = @java:Method {
+    name:"sort",
+    class: "java.util.Arrays",
+    isStatic:true,
+    paramTypes:["[I"]
+} external;
 
-@java:Method {name:"sort", class: "java.util.Arrays", isStatic:true, paramTypes:["[Ljava.lang.String;"]}
-public function sortJavaStringArray(handle arrayValue) = external;
+public function sortJavaStringArray(handle arrayValue) = @java:Method {
+    name:"sort",
+    class: "java.util.Arrays",
+    isStatic:true,
+    paramTypes:["[Ljava.lang.String;"]
+} external;
 
-@java:Method {name:"split", class: "java/lang/String", isStatic:false}
-public function splitString(handle receiver, handle regex) returns handle = external;
+public function splitString(handle receiver, handle regex) returns handle = @java:Method {
+    name:"split",
+    class: "java/lang/String",
+    isStatic:false
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/constructor_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/constructor_tests.bal
@@ -14,12 +14,15 @@ function testTwoParamConstructor(handle h1, handle h2) returns handle {
 
 // Interop functions
 
-@java:Constructor {class:"org/ballerinalang/nativeimpl/jvm/tests/ClassWithDefaultConstructor"}
-public function newClassWithDefaultConstructor() returns handle = external;
+public function newClassWithDefaultConstructor() returns handle = @java:Constructor {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/ClassWithDefaultConstructor"
+} external;
 
-@java:Constructor {class:"org/ballerinalang/nativeimpl/jvm/tests/ClassWithOneParamConstructor"}
-public function newClassWithOneParamConstructor(handle h) returns handle = external;
+public function newClassWithOneParamConstructor(handle h) returns handle = @java:Constructor {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/ClassWithOneParamConstructor"
+} external;
 
-@java:Constructor {class:"org/ballerinalang/nativeimpl/jvm/tests/ClassWithTwoParamConstructor"}
-public function newClassWithTwoParamConstructor(handle h1, handle h2) returns handle = external;
+public function newClassWithTwoParamConstructor(handle h1, handle h2) returns handle = @java:Constructor {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/ClassWithTwoParamConstructor"
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/field_access_mutate_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/field_access_mutate_tests.bal
@@ -20,23 +20,27 @@ function testInstanceFieldMutate(handle receiver, handle value) {
 // Java interoperability external functions
 
 // Static field access and mutate
-@java:FieldGet {name:"contractId",
-                class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate",
-                isStatic:true}
-public function getContractId() returns handle = external;
+public function getContractId() returns handle = @java:FieldGet {
+    name:"contractId",
+    class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate",
+    isStatic:true
+} external;
 
-@java:FieldSet {name:"contractId",
-                class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate",
-                isStatic:true}
-public function setContractId(handle contractId) = external;
+public function setContractId(handle contractId) = @java:FieldSet {
+    name:"contractId",
+    class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate",
+    isStatic:true
+} external;
 
 
 // Instance field access and mutate
-@java:FieldGet {name:"createdAt",
-                class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate"}
-public function getCreatedAt(handle receiver) returns handle = external;
+public function getCreatedAt(handle receiver) returns handle = @java:FieldGet {
+    name:"createdAt",
+    class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate"
+} external;
 
-@java:FieldSet {name:"uuid",
-                class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate"}
-public function setUUID(handle receiver, handle uuid) = external;
+public function setUUID(handle receiver, handle uuid) = @java:FieldSet {
+    name:"uuid",
+    class:"org/ballerinalang/nativeimpl/jvm/tests/JavaFieldAccessMutate"
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
@@ -28,21 +28,28 @@ function testAcceptTwoParamsAndReturnSomething(handle receiver, handle h1, handl
 
 // Interop functions
 
-@java:Method{class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"}
-public function increaseCounterByOne(handle receiver) = external;
+public function increaseCounterByOne(handle receiver) = @java:Method{
+    class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
 
-@java:Method{class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods", name:"increaseCounterByOne"}
-public function interopFunctionWithDifferentName(handle receiver) = external;
+public function interopFunctionWithDifferentName(handle receiver) = @java:Method{
+    class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods",
+    name:"increaseCounterByOne"
+} external;
 
-@java:Method{class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"}
-public function getCounter(handle receiver) returns handle = external;
+public function getCounter(handle receiver) returns handle = @java:Method{
+    class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
 
-@java:Method{class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"}
-public function setCounterValue(handle receiver, handle h) = external;
+public function setCounterValue(handle receiver, handle h) = @java:Method{
+    class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
 
-@java:Method{class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"}
-public function setAndGetCounterValue(handle receiver, handle h) returns handle = external;
+public function setAndGetCounterValue(handle receiver, handle h) returns handle = @java:Method{
+    class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
 
-@java:Method{class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"}
-public function setTwiceAndGetCounterValue(handle receiver, handle h1, handle h2) returns handle = external;
+public function setTwiceAndGetCounterValue(handle receiver, handle h1, handle h2) returns handle = @java:Method{
+    class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -26,25 +26,34 @@ function testAcceptThreeParamsAndReturnSomething(handle h1, handle h2, handle h3
 
 
 // Interop functionsdsfs
+public function acceptNothingAndReturnNothing() = @java:Method {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    isStatic:true
+} external;
 
-@java:Method {class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods", isStatic:true}
-public function acceptNothingAndReturnNothing() = external;
+public function interopFunctionWithDifferentName() = @java:Method {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    name:"acceptNothingAndReturnNothing",
+    isStatic:true
+} external;
 
-@java:Method {class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
-              name:"acceptNothingAndReturnNothing",
-              isStatic:true
-}
-public function interopFunctionWithDifferentName() = external;
+public function acceptNothingButReturnDate() returns handle = @java:Method {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    isStatic:true
+} external;
 
-@java:Method {class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods", isStatic:true}
-public function acceptNothingButReturnDate() returns handle = external;
+public function acceptSomethingAndReturnSomething(handle h) returns handle = @java:Method {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    isStatic:true
+} external;
 
-@java:Method {class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods", isStatic:true}
-public function acceptSomethingAndReturnSomething(handle h) returns handle = external;
+public function acceptTwoParamsAndReturnSomething(handle h1, handle h2) returns handle = @java:Method {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    isStatic:true
+} external;
 
-@java:Method {class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods", isStatic:true}
-public function acceptTwoParamsAndReturnSomething(handle h1, handle h2) returns handle = external;
-
-@java:Method {class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods", isStatic:true}
-public function acceptThreeParamsAndReturnSomething(handle h1, handle h2, handle h3) returns handle = external;
+public function acceptThreeParamsAndReturnSomething(handle h1, handle h2, handle h3) returns handle = @java:Method {
+    class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    isStatic:true
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/java_array_list_interop_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/java_array_list_interop_tests.bal
@@ -8,12 +8,17 @@ public function interopWithJavaArrayList() returns handle {
         return toString(aList);
 }
 
-@java:Constructor {class:"java.util.ArrayList"}
-public function newArrayList() returns handle = external;
+public function newArrayList() returns handle = @java:Constructor {
+    class:"java.util.ArrayList"
+} external;
 
-@java:Method {class: "java.util.ArrayList", name:"add"}
-public function addElement(handle receiver, handle e) = external;
+public function addElement(handle receiver, handle e) = @java:Method {
+    name:"add",
+    class: "java.util.ArrayList"
+} external;
 
-@java:Method {class: "java.util.ArrayList", name:"toString"}
-public function toString(handle receiver) returns handle = external;
+public function toString(handle receiver) returns handle = @java:Method {
+    class: "java.util.ArrayList",
+    name:"toString"
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/overloading/overloaded_constructor_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/overloading/overloaded_constructor_test.bal
@@ -12,15 +12,23 @@ public function testOverloadedConstructorsWithOneParam() returns [handle, handle
     return [stringCreatedWithBuffer, stringCreatedWithBuilder];
 }
 
-@java:Constructor {class:"java.lang.StringBuffer", paramTypes:["java.lang.String"]}
-public function newStringBuffer(handle strValue) returns handle = external;
+public function newStringBuffer(handle strValue) returns handle = @java:Constructor {
+    class:"java.lang.StringBuffer",
+    paramTypes:["java.lang.String"]
+} external;
 
-@java:Constructor {class:"java.lang.StringBuilder", paramTypes:["java.lang.String"]}
-public function newStringBuilder(handle strValue) returns handle = external;
+public function newStringBuilder(handle strValue) returns handle = @java:Constructor {
+    class:"java.lang.StringBuilder",
+    paramTypes:["java.lang.String"]
+} external;
 
-@java:Constructor {class:"java.lang.String", paramTypes:["java.lang.StringBuffer"] }
-public function newStringWithStringBuffer(handle buffer) returns handle = external;
+public function newStringWithStringBuffer(handle buffer) returns handle = @java:Constructor {
+    class:"java.lang.String",
+    paramTypes:["java.lang.StringBuffer"]
+} external;
 
-@java:Constructor {class:"java.lang.String", paramTypes:["java.lang.StringBuilder"]}
-public function newStringWithStringBuilder(handle builder) returns handle = external;
+public function newStringWithStringBuilder(handle builder) returns handle = @java:Constructor {
+    class:"java.lang.String",
+    paramTypes:["java.lang.StringBuilder"]
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/primitive_types/functions_returning_primitives_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/primitive_types/functions_returning_primitives_test.bal
@@ -57,51 +57,75 @@ function testReturningBFloatJDouble(handle receiver) returns float {
 }
 
 // Interop Functions returns Ballerina boolean
-@java:Method {name:"contentEquals", class:"java.lang.String", paramTypes: ["java.lang.String", "java.lang.String"]}
-public function getBBooleanJBoolean(handle receiver, handle strValue) returns boolean = external;
+public function getBBooleanJBoolean(handle receiver, handle strValue) returns boolean = @java:Method {
+    name:"contentEquals",
+    class:"java.lang.String",
+    paramTypes: ["java.lang.String", "java.lang.String"]
+} external;
 
 
 // Interop Functions returns Ballerina byte
-@java:Method {name:"byteValue", class:"java.lang.Long"}
-public function getBByteJByte(handle receiver) returns byte = external;
+public function getBByteJByte(handle receiver) returns byte = @java:Method {
+    name:"byteValue",
+    class:"java.lang.Long"
+} external;
 
 
 // Interop Functions returns Ballerina int
-@java:Method {name:"byteValue", class:"java.lang.Long"}
-public function getBIntJByte(handle receiver) returns int = external;
+public function getBIntJByte(handle receiver) returns int = @java:Method {
+    name:"byteValue",
+    class:"java.lang.Long"
+} external;
 
-@java:Method {name:"shortValue", class:"java.lang.Long"}
-public function getBIntJShort(handle receiver) returns int = external;
+public function getBIntJShort(handle receiver) returns int = @java:Method {
+    name:"shortValue",
+    class:"java.lang.Long"
+} external;
 
 //@java:Method {name:"shortValue", class:"java.lang.Long"}
 //public function getBIntJChar(handle receiver) returns int = external;
 
-@java:Method {name:"intValue", class:"java.lang.Long", isStatic: false}
-public function getBIntJInt(handle receiver) returns int = external;
+public function getBIntJInt(handle receiver) returns int = @java:Method {
+    name:"intValue",
+    class:"java.lang.Long",
+    isStatic: false
+} external;
 
-@java:Method {name:"longValue", class:"java.lang.Long"}
-public function getBIntJLong(handle receiver) returns int = external;
+public function getBIntJLong(handle receiver) returns int = @java:Method {
+    name:"longValue",
+    class:"java.lang.Long"
+} external;
 
 
 
 
 
 // Interop Functions returns Ballerina float
-@java:Method {name:"byteValue", class:"java.lang.Double"}
-public function getBFloatJByte(handle receiver) returns float = external;
+public function getBFloatJByte(handle receiver) returns float = @java:Method {
+    name:"byteValue",
+    class:"java.lang.Double"
+} external;
 
-@java:Method {name:"shortValue", class:"java.lang.Double"}
-public function getBFloatJShort(handle receiver) returns float = external;
+public function getBFloatJShort(handle receiver) returns float = @java:Method {
+    name:"shortValue",
+    class:"java.lang.Double"
+} external;
 
 //@java:Method {name:"charValue", class:"java.lang.Double"}
 //public function getBFloatJChar(handle receiver) returns float = external;
 
-@java:Method {name:"intValue", class:"java.lang.Double"}
-public function getBFloatJInt(handle receiver) returns float = external;
+public function getBFloatJInt(handle receiver) returns float = @java:Method {
+    name:"intValue",
+    class:"java.lang.Double"
+} external;
 
-@java:Method {name:"floatValue", class:"java.lang.Double"}
-public function getBFloatJFloat(handle receiver) returns float = external;
+public function getBFloatJFloat(handle receiver) returns float = @java:Method {
+    name:"floatValue",
+    class:"java.lang.Double"
+} external;
 
-@java:Method {name:"doubleValue", class:"java.lang.Double"}
-public function getBFloatJDouble(handle receiver) returns float = external;
+public function getBFloatJDouble(handle receiver) returns float = @java:Method {
+    name:"doubleValue",
+    class:"java.lang.Double"
+} external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/primitive_types/primitive_type_function_params_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/primitive_types/primitive_type_function_params_test.bal
@@ -1,17 +1,23 @@
 import ballerina/java;
 
-@java:Constructor {class:"java.lang.Boolean", paramTypes:["boolean"]}
-public function createBoxedBooleanFromBBoolean(boolean value) returns handle = external;
+public function createBoxedBooleanFromBBoolean(boolean value) returns handle = @java:Constructor {
+    class:"java.lang.Boolean",
+    paramTypes:["boolean"]
+} external;
 
 public function testCreateBoxedBooleanFromBBoolean(boolean value) returns handle {
     return createBoxedBooleanFromBBoolean(value);
 }
 
-@java:Constructor {class:"java.lang.Byte", paramTypes:["byte"]}
-public function createBoxedByteFromBInt(int value) returns handle = external;
+public function createBoxedByteFromBInt(int value) returns handle = @java:Constructor {
+    class:"java.lang.Byte",
+    paramTypes:["byte"]
+} external;
 
-@java:Constructor {class:"java.lang.Byte", paramTypes:["java.lang.String"]}
-public function createBoxedByteFromJString(handle stringValue) returns handle = external;
+public function createBoxedByteFromJString(handle stringValue) returns handle = @java:Constructor {
+    class:"java.lang.Byte",
+    paramTypes:["java.lang.String"]
+} external;
 
 public function testCreateBoxedByteFromBInt(int value)  returns handle {
     return createBoxedByteFromBInt(value);
@@ -21,29 +27,37 @@ public function testCreateBoxedByteFromJString(handle stringValue)  returns hand
     return createBoxedByteFromJString(stringValue);
 }
 
-@java:Constructor {class:"java.lang.Short", paramTypes:["short"]}
-public function createBoxedShortFromBInt(int value) returns handle = external;
+public function createBoxedShortFromBInt(int value) returns handle = @java:Constructor {
+    class:"java.lang.Short",
+    paramTypes:["short"]
+} external;
 
 public function testCreateBoxedShortFromBInt(int value) returns handle {
     return createBoxedShortFromBInt(value);
 }
 
-@java:Constructor {class:"java.lang.Character", paramTypes:["char"]}
-public function createBoxedCharacterFromBInt(int value) returns handle = external;
+public function createBoxedCharacterFromBInt(int value) returns handle = @java:Constructor {
+    class:"java.lang.Character",
+    paramTypes:["char"]
+} external;
 
 public function testCreateBoxedCharacterFromBInt(int value) returns handle {
     return createBoxedCharacterFromBInt(value);
 }
 
-@java:Constructor {class:"java.lang.Integer", paramTypes:["int"]}
-public function createBoxedIntegerFromBInt(int value) returns handle = external;
+public function createBoxedIntegerFromBInt(int value) returns handle = @java:Constructor {
+    class:"java.lang.Integer",
+    paramTypes:["int"]
+} external;
 
 public function testCreateBoxedIntegerFromBInt(int value) returns handle {
     return createBoxedIntegerFromBInt(value);
 }
 
-@java:Constructor {class:"java.lang.Long", paramTypes:["long"]}
-public function createBoxedLongFromBInt(int value) returns handle = external;
+public function createBoxedLongFromBInt(int value) returns handle = @java:Constructor {
+    class:"java.lang.Long",
+    paramTypes:["long"]
+} external;
 
 public function testCreateBoxedLongFromBInt(int value) returns handle {
     return createBoxedLongFromBInt(value);
@@ -51,50 +65,64 @@ public function testCreateBoxedLongFromBInt(int value) returns handle {
 
 // From java double from
 
-@java:Constructor {class:"java.lang.Byte", paramTypes:["byte"]}
-public function createBoxedByteFromBFloat(float value) returns handle = external;
+public function createBoxedByteFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Byte",
+    paramTypes:["byte"]
+} external;
 
 public function testCreateBoxedByteFromBFloat(float value)  returns handle {
     return createBoxedByteFromBFloat(value);
 }
 
-@java:Constructor {class:"java.lang.Short", paramTypes:["short"]}
-public function createBoxedShortFromBFloat(float value) returns handle = external;
+public function createBoxedShortFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Short",
+    paramTypes:["short"]
+} external;
 
 public function testCreateBoxedShortFromBFloat(float value) returns handle {
     return createBoxedShortFromBFloat(value);
 }
 
-@java:Constructor {class:"java.lang.Character", paramTypes:["char"]}
-public function createBoxedCharacterFromBFloat(float value) returns handle = external;
+public function createBoxedCharacterFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Character",
+    paramTypes:["char"]
+} external;
 
 public function testCreateBoxedCharacterFromBFloat(float value) returns handle {
     return createBoxedCharacterFromBFloat(value);
 }
 
-@java:Constructor {class:"java.lang.Integer", paramTypes:["int"]}
-public function createBoxedIntegerFromBFloat(float value) returns handle = external;
+public function createBoxedIntegerFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Integer",
+    paramTypes:["int"]
+} external;
 
 public function testCreateBoxedIntegerFromBFloat(float value) returns handle {
     return createBoxedIntegerFromBFloat(value);
 }
 
-@java:Constructor {class:"java.lang.Long", paramTypes:["long"]}
-public function createBoxedLongFromBFloat(float value) returns handle = external;
+public function createBoxedLongFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Long",
+    paramTypes:["long"]
+} external;
 
 public function testCreateBoxedLongFromBFloat(float value) returns handle {
     return createBoxedLongFromBFloat(value);
 }
 
-@java:Constructor {class:"java.lang.Float", paramTypes:["float"]}
-public function createBoxedFloatFromBFloat(float value) returns handle = external;
+public function createBoxedFloatFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Float",
+    paramTypes:["float"]
+} external;
 
 public function testCreateBoxedFloatFromBFloat(float value) returns handle {
     return createBoxedFloatFromBFloat(value);
 }
 
-@java:Constructor {class:"java.lang.Double", paramTypes:["double"]}
-public function createBoxedDoubleFromBFloat(float value) returns handle = external;
+public function createBoxedDoubleFromBFloat(float value) returns handle = @java:Constructor {
+    class:"java.lang.Double",
+    paramTypes:["double"]
+} external;
 
 public function testCreateBoxedDoubleFromBFloat(float value) returns handle {
     return createBoxedDoubleFromBFloat(value);

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -120,6 +120,7 @@
             <package name="org.ballerinalang.test.taintchecking.*"/>
             <package name="org.ballerinalang.test.statements.transaction.*"/>
             <package name="org.ballerinalang.test.functions.*"/>
+            <package name="org.ballerinalang.test.javainterop.*"/>
         </packages>
 
         <classes>


### PR DESCRIPTION
## Purpose
This PR updates the Java interop annotations target from `function` to `external`. 

Here is an example usage of this annotation. 

```ballerina
public function newArrayList() returns handle = @java:Constructor {
    class:"java.util.ArrayList"
} external;

public function addElement(handle receiver, handle e) = @java:Method {
    name:"add",
    class: "java.util.ArrayList"
} external;

public function toString(handle receiver) returns handle = @java:Method {
    class: "java.util.ArrayList",
    name:"toString"
} external;
 ```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
