### PR TITLE
Fix nullpointer when no reason type given

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -428,7 +428,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangErrorType errorType) {
-        BType reasonType = errorType.reasonType.type;
+        BType reasonType = getReasonType(errorType);
 
         if (!types.isAssignable(reasonType, symTable.stringType)) {
             dlog.error(errorType.reasonType.pos, DiagnosticCode.INVALID_ERROR_REASON_TYPE, reasonType);
@@ -443,6 +443,14 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             dlog.error(errorType.detailType.pos, DiagnosticCode.INVALID_ERROR_DETAIL_TYPE, detailType,
                     symTable.detailType);
         }
+    }
+
+    private BType getReasonType(BLangErrorType errorType) {
+        // Reason type not specified take default reason type.
+        if (errorType.reasonType == null) {
+            return symTable.stringType;
+        }
+        return errorType.reasonType.type;
     }
 
     public void visit(BLangAnnotation annotationNode) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
@@ -166,6 +166,12 @@ public class ErrorVariableReferenceTest {
         Assert.assertEquals(results.get("fatal").stringValue(), "true");
     }
 
+    @Test(description = "Test default error var ref with rest underscore")
+    public void testDefaultErrorRefBindingPattern() {
+        BValue[] returns = BRunUtil.invoke(result, "testDefaultErrorRefBindingPattern");
+        Assert.assertEquals(returns[0].stringValue(), "the reason");
+    }
+
     @Test
     public void testNegativeRecordVariables() {
         Assert.assertEquals(resultNegative.getErrorCount(), 12);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference.bal
@@ -203,3 +203,12 @@ function testErrorWithUnderscore() returns [string, map<string>] {
 
     return [reason, detail];
 }
+
+type SampleError error;
+
+function testDefaultErrorRefBindingPattern() returns string {
+    SampleError e = error("the reason");
+    string reason;
+    error(reason, ... _) = e;
+    return reason;
+}


### PR DESCRIPTION
$subject

Null pointer exception was thrown when following code is encountered.

```ballerina
type SampleError error;
```

