### PR TITLE
Introduce detach method of HTTP listener to unregister services

### DIFF
--- a/stdlib/http/src/main/ballerina/src/http/non_listening_service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/non_listening_service_endpoint.bal
@@ -55,4 +55,6 @@ public type MockListener object {
     public function start() returns error? = external;
 
     public function stop() = external;
+
+    public function detach(service s) returns error? = external;
 };

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -91,7 +91,7 @@ public type Listener object {
     # Stops the registered service.
     function stop() = external;
 
-    # Disengage an attached service from listener.
+    # Disengage an attached service from the listener.
     #
     # + s - The service that needs to be detached
     # + return - An `error` if there is any error occurred during the service detachment process or else nil

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -90,6 +90,12 @@ public type Listener object {
 
     # Stops the registered service.
     function stop() = external;
+
+    # Disengage an attached service from listener.
+    #
+    # + s - The service that needs to be detached
+    # + return - An `error` if there is any error occurred during the service detachment process or else nil
+    public function detach(service s) returns error? = external;
 };
 
 function initListener(ServiceEndpointConfiguration config) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HTTPServicesRegistry.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HTTPServicesRegistry.java
@@ -202,4 +202,34 @@ public class HTTPServicesRegistry {
             this.sortedServiceURIs = sortedServiceURIs;
         }
     }
+
+    /**
+     * Un-register a service from the map.
+     *
+     * @param service requested service to be unregistered.
+     */
+    public void unRegisterService(ObjectValue service) {
+        List<HttpService> httpServices = HttpService.buildHttpService(service);
+        for (HttpService httpService : httpServices) {
+            String hostName = httpService.getHostName();
+            ServicesMapHolder servicesMapHolder = servicesMapByHost.get(hostName);
+            if (servicesMapHolder == null) {
+                continue;
+            }
+            servicesByBasePath = getServicesByHost(hostName);
+            sortedServiceURIs = getSortedServiceURIsByHost(hostName);
+
+            String basePath = httpService.getBasePath();
+            if (!servicesByBasePath.containsKey(basePath)) {
+                continue;
+            }
+            servicesByBasePath.remove(basePath);
+            sortedServiceURIs.remove(basePath);
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("Service detached : %s with context %s", service.getType().getName(),
+                                           basePath));
+            }
+            sortedServiceURIs.sort((basePath1, basePath2) -> basePath2.length() - basePath1.length());
+        }
+    }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/NonListeningDetachEndpoint.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/NonListeningDetachEndpoint.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.mock.nonlistening;
+
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+import static org.ballerinalang.net.http.HttpConstants.MOCK_LISTENER_ENDPOINT;
+
+/**
+ * Disengage a service from the listener.
+ *
+ * @since 1.0
+ */
+
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "http",
+        functionName = "detach",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = MOCK_LISTENER_ENDPOINT,
+                structPackage = "ballerina.http"),
+        returnType = {@ReturnType(type = TypeKind.OBJECT)},
+        isPublic = true
+)
+public class NonListeningDetachEndpoint extends org.ballerinalang.net.http.serviceendpoint.Detach {
+}

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/serviceendpoint/Detach.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/serviceendpoint/Detach.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.serviceendpoint;
+
+import org.ballerinalang.jvm.BallerinaErrors;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.util.exceptions.BallerinaException;
+import org.ballerinalang.jvm.values.ObjectValue;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.http.HTTPServicesRegistry;
+
+import static org.ballerinalang.net.http.HttpConstants.HTTP_LISTENER_ENDPOINT;
+
+/**
+ * Disengage a service from the listener.
+ *
+ * @since 1.0
+ */
+
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "http",
+        functionName = "detach",
+        receiver = @Receiver(type = TypeKind.OBJECT, structType = HTTP_LISTENER_ENDPOINT,
+                             structPackage = "ballerina/http"),
+        args = {@Argument(name = "serviceType", type = TypeKind.SERVICE)},
+        isPublic = true
+)
+public class Detach extends AbstractHttpNativeFunction {
+    public static Object detach(Strand strand, ObjectValue serviceEndpoint, ObjectValue service) {
+        HTTPServicesRegistry httpServicesRegistry = getHttpServicesRegistry(serviceEndpoint);
+        try {
+            httpServicesRegistry.unRegisterService(service);
+        } catch (BallerinaException ex) {
+            return BallerinaErrors.createError(ex.getMessage());
+        }
+        return null;
+    }
+}

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/endpoint/DetachServiceTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/endpoint/DetachServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.stdlib.services.nativeimpl.endpoint;
+
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.stdlib.utils.HTTPTestRequest;
+import org.ballerinalang.stdlib.utils.MessageUtils;
+import org.ballerinalang.stdlib.utils.ResponseReader;
+import org.ballerinalang.stdlib.utils.Services;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+
+/**
+ * Test cases for service detach method.
+ */
+public class DetachServiceTest {
+    private static final int SERVICE_EP_PORT = 9090;
+
+    @BeforeClass
+    public void setup() {
+        BCompileUtil.compile("test-src/services/nativeimpl/endpoint/service-detach-test.bal");
+    }
+
+    @Test(description = "Test the detach method with multiple services attachments")
+    public void testServiceDetach() {
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage("/mock1", HttpConstants.HTTP_METHOD_GET);
+        HttpCarbonMessage response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 200);
+        Assert.assertEquals(ResponseReader.getReturnValue(response), "Mock1 invoked. Mock2 attached. Mock3 attached");
+
+        //Invoke recently attached mock2 services. Test detaching and re attaching mock3 service
+        cMsg = MessageUtils.generateHTTPMessage("/mock2", HttpConstants.HTTP_METHOD_GET);
+        response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 200);
+        Assert.assertEquals(ResponseReader.getReturnValue(response), "Mock2 resource was invoked");
+
+        //Invoke recently attached mock3 service. That detached the mock2 service and attach mock3
+        cMsg = MessageUtils.generateHTTPMessage("/mock3", HttpConstants.HTTP_METHOD_GET);
+        response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 200);
+        Assert.assertEquals(ResponseReader.getReturnValue(response), "Mock3 invoked. Mock2 detached. Mock4 attached");
+
+        //Invoke detached mock2 services expecting a 404
+        cMsg = MessageUtils.generateHTTPMessage("/mock2", HttpConstants.HTTP_METHOD_GET);
+        response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 404);
+        Assert.assertEquals(ResponseReader.getReturnValue(response), "no matching service found for path : /mock2");
+
+        //Invoke mock3 services again expecting a error for re-attaching already available service
+        cMsg = MessageUtils.generateHTTPMessage("/mock3", HttpConstants.HTTP_METHOD_GET);
+        response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 500);
+        Assert.assertEquals(ResponseReader.getReturnValue(response),
+                            "service registration failed: two services have the same basePath : '/mock4'");
+
+        //Invoke mock4 service. mock2 service is re attached
+        cMsg = MessageUtils.generateHTTPMessage("/mock4", HttpConstants.HTTP_METHOD_GET);
+        response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 200);
+        Assert.assertEquals(ResponseReader.getReturnValue(response), "Mock4 invoked. Mock2 attached");
+
+        //Invoke recently re-attached mock2 services
+        cMsg = MessageUtils.generateHTTPMessage("/mock2", HttpConstants.HTTP_METHOD_GET);
+        response = Services.invoke(SERVICE_EP_PORT, cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals((int) response.getHttpStatusCode(), 200);
+        Assert.assertEquals(ResponseReader.getReturnValue(response), "Mock2 resource was invoked");
+    }
+}

--- a/stdlib/http/src/test/resources/test-src/services/nativeimpl/endpoint/service-detach-test.bal
+++ b/stdlib/http/src/test/resources/test-src/services/nativeimpl/endpoint/service-detach-test.bal
@@ -1,0 +1,107 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+
+listener http:MockListener backendEP = new(9090);
+
+@http:ServiceConfig {
+    basePath: "/mock1"
+}
+service mock1 on backendEP {
+    @http:ResourceConfig {
+        path: "/"
+    }
+    resource function mock2Resource(http:Caller caller, http:Request req) {
+        checkpanic backendEP.__attach(mock2);
+        checkpanic backendEP.__attach(mock3);
+        var responseToCaller = caller->respond("Mock1 invoked. Mock2 attached. Mock3 attached");
+        if (responseToCaller is error) {
+            log:printError("Error sending response from mock service", err = responseToCaller);
+        }
+    }
+}
+
+service mock2 =
+@http:ServiceConfig {
+    basePath: "/mock2"
+}
+service {
+    @http:ResourceConfig {
+        path: "/"
+    }
+    resource function mock2Resource(http:Caller caller, http:Request req) {
+        checkpanic backendEP.detach(mock3);
+        checkpanic backendEP.__attach(mock3);
+        var responseToCaller = caller->respond("Mock2 resource was invoked");
+        if (responseToCaller is error) {
+            log:printError("Error sending response from mock service", err = responseToCaller);
+        }
+    }
+};
+
+service mock3 =
+@http:ServiceConfig {
+    basePath: "/mock3"
+}
+service {
+    @http:ResourceConfig {
+        path: "/"
+    }
+    resource function mock3Resource(http:Caller caller, http:Request req) {
+        checkpanic backendEP.detach(mock2);
+        checkpanic backendEP.__attach(mock4);
+        var responseToCaller = caller->respond("Mock3 invoked. Mock2 detached. Mock4 attached");
+        if (responseToCaller is error) {
+            log:printError("Error sending response from mock service", err = responseToCaller);
+        }
+    }
+};
+
+service mock4 =
+@http:ServiceConfig {
+    basePath: "/mock4"
+}
+service {
+    @http:ResourceConfig {
+        path: "/"
+    }
+    resource function mock4Resource(http:Caller caller, http:Request req) {
+        checkpanic backendEP.__attach(mock2);
+        checkpanic backendEP.detach(mock5);
+        var responseToCaller = caller->respond("Mock4 invoked. Mock2 attached");
+        if (responseToCaller is error) {
+            log:printError("Error sending response from mock service", err = responseToCaller);
+        }
+    }
+};
+
+service mock5 =
+@http:ServiceConfig {
+    basePath: "/mock5"
+}
+service {
+    @http:ResourceConfig {
+        path: "/"
+    }
+    resource function mock5Resource(http:Caller caller, http:Request req) {
+        var responseToCaller = caller->respond("Mock5 invoked");
+        if (responseToCaller is error) {
+            log:printError("Error sending response from mock service", err = responseToCaller);
+        }
+    }
+};

--- a/stdlib/http/src/test/resources/testng.xml
+++ b/stdlib/http/src/test/resources/testng.xml
@@ -48,6 +48,7 @@ under the License.
             <package name="org.ballerinalang.stdlib.services.cors.*"/>
             <!--<package name="org.ballerinalang.stdlib.services.dispatching.*"/>-->
             <!--<package name="org.ballerinalang.stdlib.services.nativeimpl.*"/>-->
+            <package name="org.ballerinalang.stdlib.services.nativeimpl.endpoint.*"/>
             <package name="org.ballerinalang.stdlib.websocket.*"/>
             <package name="org.ballerinalang.stdlib.cachingclient.*"/>
             <package name="org.ballerinalang.stdlib.connectionpool.*"/>
@@ -75,8 +76,7 @@ under the License.
             <class name="org.ballerinalang.stdlib.services.nativeimpl.ParseHeaderSuccessTest"/>
             <class name="org.ballerinalang.stdlib.services.nativeimpl.ParseHeaderNegativeTest"/>
             <class name="org.ballerinalang.stdlib.services.nativeimpl.connection.ConnectionNativeFunctionTest"/>
-            <class name="org.ballerinalang.stdlib.services.nativeimpl.endpoint.ServiceEndpointTest"/>
-            <!--            
+            <!--
             TODO: enable after maryam's jvm value fix
             <class name="org.ballerinalang.stdlib.services.nativeimpl.response.ResponseNativeFunctionNegativeTest"/>
             <class name="org.ballerinalang.stdlib.services.nativeimpl.response.ResponseNativeFunctionSuccessTest"/>


### PR DESCRIPTION
## Purpose
> $Title
> Add test cases for __attach and detach

Fixes #<Issue Number>

## Approach
> Un-register service object from HTTPServiceRegistry

## Samples
```ballerina
listener http:MockListener backendEP = new(9090);

@http:ServiceConfig {
    basePath: "/mock1"
}
service mock1 on backendEP {
    @http:ResourceConfig {
        path: "/"
    }
    resource function mock2Resource(http:Caller caller, http:Request req) {
        error? res = backendEP.detach(mock3);
        var responseToCaller = caller->respond("Mock1 invoked");
        if (responseToCaller is error) {
            log:printError("Error sending response from mock service", err = responseToCaller);
        }
    }
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
