### PR TITLE
Fix  ballerina path detection on windows with zip dist

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -368,7 +368,7 @@ export class BallerinaExtension {
                     return process.env.BALLERINA_HOME;
                 }
                 try {
-                    ballerinaPath = execSync('where ballerina').toString().trim();
+                    ballerinaPath = execSync('where ballerina.bat').toString().trim();
                 } catch (error) {
                     return ballerinaPath;
                 }


### PR DESCRIPTION
When using the tools zip on windows, ```where ballerina``` returns two lines output where it lists down both ballerina.sh and ballerina.bat (This is on latest windows 10).
It breaks path detection logic, hence scoping it down to ```where ballerina.bat``` on windows.
![whereballerina](https://user-images.githubusercontent.com/1505855/62176791-53763980-b360-11e9-872d-fb993301949d.PNG)

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
