### PR TITLE
Add time unit to HTTP & gRPC properties

### DIFF
--- a/examples/cache/cache.bal
+++ b/examples/cache/cache.bal
@@ -7,7 +7,7 @@ public function main() {
     // and clears all the expired caches. In this example, the cache expiry time
     // is set to four seconds in order to demonstrate how cache cleaning is
     // carried out.
-    cache:Cache cache = new(expiryTimeMillis = 4000);
+    cache:Cache cache = new(expiryTimeInMillis = 4000);
 
     // Adds a new entry to the cache.
     cache.put("Name", "Ballerina");

--- a/examples/http-circuit-breaker/http_circuit_breaker.bal
+++ b/examples/http-circuit-breaker/http_circuit_breaker.bal
@@ -16,20 +16,20 @@ http:Client backendClientEP = new("http://localhost:8080", config = {
 
                 // Time period in milliseconds for which the failure threshold
                 // is calculated.
-                timeWindowMillis: 10000,
+                timeWindowInMillis: 10000,
 
                 // The granularity at which the time window slides.
                 // This is measured in milliseconds.
                 // The `RollingWindow` is divided into buckets
                 //  and slides by these increments.
-                // For example, if this `timeWindowMillis` is set to
-                // 10000 milliseconds and `bucketSizeMillis` 2000.
+                // For example, if this `timeWindowInMillis` is set to
+                // 10000 milliseconds and `bucketSizeInMillis` 2000.
                 // Then `RollingWindow` breaks into sub windows with
                 // 2-second buckets and stats are collected with
                 // respect to the buckets. As time rolls a new bucket
                 // will be appended to the end of the window and the
                 // old bucket will be removed.
-                bucketSizeMillis: 2000,
+                bucketSizeInMillis: 2000,
 
                 // Minimum number of requests in a `RollingWindow`
                 // that will trip the circuit.
@@ -47,15 +47,15 @@ http:Client backendClientEP = new("http://localhost:8080", config = {
             // attempting to make another request to the upstream service.
             // When the failure threshold exceeds, the circuit trips to
             // `OPEN` state. Once the circuit is in `OPEN` state
-            // circuit breaker waits for the time configured in `resetTimeMillis`
+            // circuit breaker waits for the time configured in `resetTimeInMillis`
             // and switch the circuit to the `HALF_OPEN` state.
-            resetTimeMillis: 10000,
+            resetTimeInMillis: 10000,
 
             // HTTP response status codes that are considered as failures
             statusCodes: [400, 404, 500]
 
         },
-        timeoutMillis: 2000
+        timeoutInMillis: 2000
     });
 
 // Create an HTTP service bound to the endpoint (circuitBreakerEP).

--- a/examples/http-failover/http_failover.bal
+++ b/examples/http-failover/http_failover.bal
@@ -7,9 +7,9 @@ listener http:Listener backendEP = new(8080);
 
 // Define the failover client endpoint to call the backend services.
 http:FailoverClient foBackendEP = new({
-        timeoutMillis: 5000,
+        timeoutInMillis: 5000,
         failoverCodes: [501, 502, 503],
-        intervalMillis: 5000,
+        intervalInMillis: 5000,
         // Define a set of HTTP Clients that are targeted for failover.
         targets: [
             { url: "http://nonexistentEP/mock1" },

--- a/examples/http-load-balancer/http_load_balancer.bal
+++ b/examples/http-load-balancer/http_load_balancer.bal
@@ -12,7 +12,7 @@ http:LoadBalanceClient lbBackendEP = new({
             { url: "http://localhost:8080/mock2" },
             { url: "http://localhost:8080/mock3" }
         ],
-        timeoutMillis: 5000
+        timeoutInMillis: 5000
 });
 
 

--- a/examples/http-retry/http_retry.bal
+++ b/examples/http-retry/http_retry.bal
@@ -8,7 +8,7 @@ http:Client backendClientEP = new("http://localhost:8080", config = {
         retryConfig: {
 
             // Initial retry interval in milliseconds.
-            interval: 3000,
+            intervalInMillis: 3000,
 
             // Number of retry attempts before giving up.
             count: 3,
@@ -18,13 +18,13 @@ http:Client backendClientEP = new("http://localhost:8080", config = {
             backOffFactor: 2.0,
 
             // Upper limit of the retry interval in milliseconds.
-            // If `interval` into `backOffFactor` value exceeded
-            // `maxWaitInterval` interval value. `maxWaitInterval`
+            // If `intervalInMillis` into `backOffFactor` value exceeded
+            // `maxWaitIntervalInMillis` interval value. `maxWaitIntervalInMillis`
             // will be considered as the retry interval.
-            maxWaitInterval: 20000
+            maxWaitIntervalInMillis: 20000
 
         },
-        timeoutMillis: 2000
+        timeoutInMillis: 2000
     });
 
 @http:ServiceConfig {

--- a/examples/http-timeout/http_timeout.bal
+++ b/examples/http-timeout/http_timeout.bal
@@ -4,7 +4,7 @@ import ballerina/runtime;
 
 http:Client backendClientEP = new("http://localhost:8080", config = {
     // Timeout configuration.
-    timeoutMillis: 10000
+    timeoutInMillis: 10000
 
 });
 

--- a/examples/task-scheduler-timer/task_scheduler_timer.bal
+++ b/examples/task-scheduler-timer/task_scheduler_timer.bal
@@ -11,11 +11,11 @@ public type Person record {|
 
 public function main() {
     // The interval in which the timer should trigger.
-    int interval = 1000;
+    int intervalInMillis = 1000;
 
     // Initializes the timer scheduler using the interval value.
     // The delay will be equal to the interval as an initial delay is not provided.
-    task:Scheduler timer = new({ interval: interval });
+    task:Scheduler timer = new({ intervalInMillis: intervalInMillis });
 
     // Define a person object
     Person person = { name: "Sam", age: 0, maxAge: 10 };

--- a/examples/task-service-timer/task_service_timer.bal
+++ b/examples/task-service-timer/task_service_timer.bal
@@ -3,7 +3,7 @@ import ballerina/task;
 
 // The Task Timer configuration record to configure the Task Listener.
 task:TimerConfiguration timerConfiguration = {
-    interval: 1000,
+    intervalInMillis: 1000,
     initialDelay: 3000,
     // Number of recurrences will limit the number of times the timer runs.
     noOfRecurrences: 10

--- a/stdlib/grpc/src/main/ballerina/src/grpc/client_connection_pool.bal
+++ b/stdlib/grpc/src/main/ballerina/src/grpc/client_connection_pool.bal
@@ -20,12 +20,12 @@ import ballerina/config;
 #
 # + maxActiveConnections - Max active connections per route(host:port). Default value is -1 which indicates unlimited.
 # + maxIdleConnections - Maximum number of idle connections allowed per pool.
-# + waitTimeinMillis - Maximum amount of time, the client should wait for an idle connection before it sends an error when the pool is exhausted
+# + waitTimeInMillis - Maximum amount of time, the client should wait for an idle connection before it sends an error when the pool is exhausted
 # + maxActiveStreamsPerConnection - Maximum active streams per connection. This only applies to HTTP/2.
 public type PoolConfiguration record {|
     int maxActiveConnections = config:getAsInt("b7a.http.pool.maxActiveConnections", -1);
     int maxIdleConnections = config:getAsInt("b7a.http.pool.maxIdleConnections", 1000);
-    int waitTimeinMillis = config:getAsInt("b7a.http.pool.waitTimeinMillis", 60000);
+    int waitTimeInMillis = config:getAsInt("b7a.http.pool.waitTimeInMillis", 60000);
     int maxActiveStreamsPerConnection = config:getAsInt("b7a.http.pool.maxActiveStreamsPerConnection", 50);
 |};
 

--- a/stdlib/grpc/src/main/ballerina/src/grpc/client_endpoint.bal
+++ b/stdlib/grpc/src/main/ballerina/src/grpc/client_endpoint.bal
@@ -77,7 +77,7 @@ public type Client client object {
 
 # Represents client endpoint configuration.
 #
-# + timeoutMillis - The maximum time to wait (in milliseconds) for a response before closing the connection
+# + timeoutInMillis - The maximum time to wait (in milliseconds) for a response before closing the connection
 # + httpVersion - The HTTP version understood by the client
 # + forwarded - The choice of setting `forwarded`/`x-forwarded` header
 # + proxy - Proxy server related options
@@ -85,7 +85,7 @@ public type Client client object {
 # + secureSocket - SSL/TLS related options
 # + compression - Specifies the way of handling compression (`accept-encoding`) header
 public type ClientEndpointConfig record {|
-    int timeoutMillis = 60000;
+    int timeoutInMillis = 60000;
     string httpVersion = "2.0";
     string forwarded = "disable";
     ProxyConfig? proxy = ();

--- a/stdlib/grpc/src/main/ballerina/src/grpc/service_endpoint.bal
+++ b/stdlib/grpc/src/main/ballerina/src/grpc/service_endpoint.bal
@@ -85,7 +85,7 @@ const int DEFAULT_LISTENER_TIMEOUT = 120000; //2 mins
 #               which always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection
 # + secureSocket - The SSL configurations for the client endpoint.
 # + httpVersion - HTTP version supported by the endpoint. This should be 2.0 as gRPC works only with HTTP/2.
-# + timeoutMillis - Period of time in milliseconds that a connection waits for a read/write operation. Use value 0 to
+# + timeoutInMillis - Period of time in milliseconds that a connection waits for a read/write operation. Use value 0 to
 #                   disable timeout.
 # + requestLimits - Configures the parameters for request validation.
 # + maxPipelinedRequests - Defines the maximum number of requests that can be processed at a given time on a single
@@ -97,7 +97,7 @@ public type ServiceEndpointConfiguration record {|
     ServiceSecureSocket? secureSocket = ();
     string httpVersion = "2.0";
     RequestLimits? requestLimits = ();
-    int timeoutMillis = DEFAULT_LISTENER_TIMEOUT;
+    int timeoutInMillis = DEFAULT_LISTENER_TIMEOUT;
     int maxPipelinedRequests = MAX_PIPELINED_REQUESTS;
 |};
 
@@ -116,8 +116,8 @@ public type ServiceEndpointConfiguration record {|
 # + sslVerifyClient - The type of client certificate verification
 # + shareSession - Enable/disable new SSL session creation
 # + ocspStapling - Enable/disable OCSP stapling
-# + handshakeTimeout - SSL handshake time out
-# + sessionTimeout - SSL session time out
+# + handshakeTimeoutInSeconds - SSL handshake time out
+# + sessionTimeoutInSeconds - SSL session time out
 public type ServiceSecureSocket record {|
     crypto:TrustStore? trustStore = ();
     crypto:KeyStore? keyStore = ();
@@ -131,8 +131,8 @@ public type ServiceSecureSocket record {|
     string sslVerifyClient = "";
     boolean shareSession = true;
     ServiceOcspStapling? ocspStapling = ();
-    int handshakeTimeout?;
-    int sessionTimeout?;
+    int handshakeTimeoutInSeconds?;
+    int sessionTimeoutInSeconds?;
 |};
 
 # Configures limits for requests. If these limits are violated, the request is rejected.

--- a/stdlib/http/src/main/ballerina/src/http/annotation.bal
+++ b/stdlib/http/src/main/ballerina/src/http/annotation.bal
@@ -75,7 +75,7 @@ public type Versioning record {|
 # + path - Path of the WebSocket service
 # + subProtocols - Negotiable sub protocol by the service
 # + idleTimeoutInSeconds - Idle timeout for the client connection. Upon timeout, `onIdleTimeout` resource (if defined)
-#                          in the server service will be triggered. Note that this overrides the `timeoutMillis` config
+#                          in the server service will be triggered. Note that this overrides the `timeoutInMillis` config
 #                          in the `http:Listener`.
 # + maxFrameSize - The maximum payload size of a WebSocket frame in bytes.
 #                  If this is not set or is negative or zero, the default frame size will be used.

--- a/stdlib/http/src/main/ballerina/src/http/caching/http_cache.bal
+++ b/stdlib/http/src/main/ballerina/src/http/caching/http_cache.bal
@@ -35,7 +35,7 @@ public type HttpCache object {
     #
     # + config - The configurations for the HTTP cache
     public function __init(CacheConfig cacheConfig) {
-            self.cache = new cache:Cache(cacheConfig.expiryTimeMillis, cacheConfig.capacity, cacheConfig.evictionFactor);
+            self.cache = new cache:Cache(cacheConfig.expiryTimeInMillis, cacheConfig.capacity, cacheConfig.evictionFactor);
             self.policy = cacheConfig.policy;
             self.isShared = cacheConfig.isShared;
     }

--- a/stdlib/http/src/main/ballerina/src/http/caching/http_caching_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/caching/http_caching_client.bal
@@ -54,7 +54,7 @@ public const RFC_7234 = "RFC_7234";
 #
 # + enabled - Specifies whether HTTP caching is enabled. Caching is enabled by default.
 # + isShared - Specifies whether the HTTP caching layer should behave as a public cache or a private cache
-# + expiryTimeMillis - The number of milliseconds to keep an entry in the cache
+# + expiryTimeInMillis - The number of milliseconds to keep an entry in the cache
 # + capacity - The capacity of the cache
 # + evictionFactor - The fraction of entries to be removed when the cache is full. The value should be
 #                    between 0 (exclusive) and 1 (inclusive).
@@ -64,7 +64,7 @@ public const RFC_7234 = "RFC_7234";
 public type CacheConfig record {|
     boolean enabled = true;
     boolean isShared = false;
-    int expiryTimeMillis = 86400;
+    int expiryTimeInMillis = 86400;
     int capacity = 8388608; // 8MB
     float evictionFactor = 0.2;
     CachingPolicy policy = CACHE_CONTROL_AND_VALIDATORS;

--- a/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
@@ -220,7 +220,7 @@ public type TargetService record {|
 # + httpVersion - The HTTP version understood by the client
 # + http1Settings - Configurations related to HTTP/1.x protocol
 # + http2Settings - Configurations related to HTTP/2 protocol
-# + timeoutMillis - The maximum time to wait (in milliseconds) for a response before closing the connection
+# + timeoutInMillis - The maximum time to wait (in milliseconds) for a response before closing the connection
 # + forwarded - The choice of setting `forwarded`/`x-forwarded` header
 # + followRedirects - Configurations associated with Redirection
 # + poolConfig - Configurations associated with request pooling
@@ -235,7 +235,7 @@ public type ClientEndpointConfig record {|
     string httpVersion = HTTP_1_1;
     Http1Settings http1Settings = {};
     Http2Settings http2Settings = {};
-    int timeoutMillis = 60000;
+    int timeoutInMillis = 60000;
     string forwarded = "disable";
     FollowRedirects? followRedirects = ();
     ProxyConfig? proxy = ();
@@ -269,15 +269,15 @@ public type Http2Settings record {|
 # Provides configurations for controlling the retrying behavior in failure scenarios.
 #
 # + count - Number of retry attempts before giving up
-# + interval - Retry interval in milliseconds
+# + intervalInMillis - Retry interval in milliseconds
 # + backOffFactor - Multiplier, which increases the retry interval exponentially.
-# + maxWaitInterval - Maximum time of the retry interval in milliseconds
+# + maxWaitIntervalInMillis - Maximum time of the retry interval in milliseconds
 # + statusCodes - HTTP response status codes which are considered as failures
 public type RetryConfig record {|
     int count = 0;
-    int interval = 0;
+    int intervalInMillis = 0;
     float backOffFactor = 0.0;
-    int maxWaitInterval = 0;
+    int maxWaitIntervalInMillis = 0;
     int[] statusCodes = [];
 |};
 
@@ -296,8 +296,8 @@ public type RetryConfig record {|
 # + verifyHostname - Enable/disable host name verification
 # + shareSession - Enable/disable new SSL session creation
 # + ocspStapling - Enable/disable OCSP stapling
-# + handshakeTimeout - SSL handshake time out
-# + sessionTimeout - SSL session time out
+# + handshakeTimeoutInSeconds - SSL handshake time out
+# + sessionTimeoutInSeconds - SSL session time out
 public type SecureSocket record {|
     crypto:TrustStore? trustStore = ();
     crypto:KeyStore? keyStore = ();
@@ -311,8 +311,8 @@ public type SecureSocket record {|
     boolean verifyHostname = true;
     boolean shareSession = true;
     boolean ocspStapling = false;
-    int handshakeTimeout?;
-    int sessionTimeout?;
+    int handshakeTimeoutInSeconds?;
+    int sessionTimeoutInSeconds?;
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.
@@ -427,7 +427,7 @@ function createCircuitBreakerClient(string uri, ClientEndpointConfig configurati
         }
 
         time:Time circuitStartTime = time:currentTime();
-        int numberOfBuckets = (cbConfig.rollingWindow.timeWindowMillis / cbConfig.rollingWindow.bucketSizeMillis);
+        int numberOfBuckets = (cbConfig.rollingWindow.timeWindowInMillis / cbConfig.rollingWindow.bucketSizeInMillis);
         Bucket?[] bucketArray = [];
         int bucketIndex = 0;
         while (bucketIndex < numberOfBuckets) {
@@ -437,7 +437,7 @@ function createCircuitBreakerClient(string uri, ClientEndpointConfig configurati
 
         CircuitBreakerInferredConfig circuitBreakerInferredConfig = {
             failureThreshold: cbConfig.failureThreshold,
-            resetTimeMillis: cbConfig.resetTimeMillis,
+            resetTimeInMillis: cbConfig.resetTimeInMillis,
             statusCodes: statusCodes,
             noOfBuckets: numberOfBuckets,
             rollingWindow: cbConfig.rollingWindow
@@ -466,9 +466,9 @@ function createRetryClient(string url, ClientEndpointConfig configuration) retur
         boolean[] statusCodes = populateErrorCodeIndex(retryConfig.statusCodes);
         RetryInferredConfig retryInferredConfig = {
             count: retryConfig.count,
-            interval: retryConfig.interval,
+            intervalInMillis: retryConfig.intervalInMillis,
             backOffFactor: retryConfig.backOffFactor,
-            maxWaitInterval: retryConfig.maxWaitInterval,
+            maxWaitIntervalInMillis: retryConfig.maxWaitIntervalInMillis,
             statusCodes: statusCodes
         };
         if (configuration.cache.enabled) {

--- a/stdlib/http/src/main/ballerina/src/http/http_client_connection_pool.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_client_connection_pool.bal
@@ -18,12 +18,12 @@
 #
 # + maxActiveConnections - Max active connections per route(host:port). Default value is -1 which indicates unlimited.
 # + maxIdleConnections - Maximum number of idle connections allowed per pool.
-# + waitTimeinMillis - Maximum amount of time, the client should wait for an idle connection before it sends an error when the pool is exhausted
+# + waitTimeInMillis - Maximum amount of time, the client should wait for an idle connection before it sends an error when the pool is exhausted
 # + maxActiveStreamsPerConnection - Maximum active streams per connection. This only applies to HTTP/2.
 public type PoolConfiguration record {
     int maxActiveConnections = config:getAsInt("b7a.http.pool.maxActiveConnections", -1);
     int maxIdleConnections = config:getAsInt("b7a.http.pool.maxIdleConnections", 100);
-    int waitTimeinMillis = config:getAsInt("b7a.http.pool.waitTimeinMillis", 30000);
+    int waitTimeInMillis = config:getAsInt("b7a.http.pool.waitTimeInMillis", 30000);
     int maxActiveStreamsPerConnection = config:getAsInt("b7a.http.pool.maxActiveStreamsPerConnection", 50);
 };
 

--- a/stdlib/http/src/main/ballerina/src/http/redirect/redirect_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/redirect/redirect_client.bal
@@ -351,7 +351,7 @@ function createNewEndpointConfig(ClientEndpointConfig config) returns ClientEndp
         http1Settings: config.http1Settings,
         http2Settings: config.http2Settings,
         circuitBreaker: config.circuitBreaker,
-        timeoutMillis: config.timeoutMillis,
+        timeoutInMillis: config.timeoutInMillis,
         httpVersion: config.httpVersion,
         forwarded: config.forwarded,
         followRedirects: config.followRedirects,

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/failover_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/failover_client_endpoint.bal
@@ -21,10 +21,10 @@ import ballerina/io;
 # Provides a set of configurations for controlling the failover behaviour of the endpoint.
 #
 # + failoverCodes - Array of HTTP response status codes for which the failover mechanism triggers
-# + interval - Failover delay interval in milliseconds
+# + intervalInMillis - Failover delay intervalInMillis in milliseconds
 public type FailoverConfig record {|
     int[] failoverCodes = [];
-    int interval = 0;
+    int intervalInMillis = 0;
 |};
 
 // TODO: This can be made package private
@@ -66,7 +66,7 @@ public type FailoverClient client object {
             FailoverInferredConfig failoverInferredConfig = {
                 failoverClientsArray:clients,
                 failoverCodesIndex:failoverCodes,
-                failoverInterval:failoverClientConfig.intervalMillis
+                failoverInterval:failoverClientConfig.intervalInMillis
             };
             self.failoverInferredConfig = failoverInferredConfig;
         }
@@ -441,7 +441,7 @@ function populateErrorsFromLastResponse (Response inResponse, ClientError?[] fai
 # + httpVersion - The HTTP version to be used to communicate with the endpoint
 # + http1Settings - Configurations related to HTTP/1.x protocol
 # + http2Settings - Configurations related to HTTP/2 protocol
-# + timeoutMillis - The maximum time to wait (in milliseconds) for a response before closing the connection
+# + timeoutInMillis - The maximum time to wait (in milliseconds) for a response before closing the connection
 # + forwarded - The choice of setting `forwarded`/`x-forwarded` header
 # + followRedirects - Redirect related options
 # + poolConfig - Configurations associated with request pooling
@@ -453,12 +453,12 @@ function populateErrorsFromLastResponse (Response inResponse, ClientError?[] fai
 # + circuitBreaker - Circuit Breaker behaviour configurations
 # + retryConfig - Retry related options
 # + failoverCodes - Array of HTTP response status codes for which the failover behaviour should be triggered
-# + intervalMillis - Failover delay interval in milliseconds
+# + intervalInMillis - Failover delay interval in milliseconds
 public type FailoverClientEndpointConfiguration record {|
     string httpVersion = HTTP_1_1;
     Http1Settings http1Settings = {};
     Http2Settings http2Settings = {};
-    int timeoutMillis = 60000;
+    int timeoutInMillis = 60000;
     string forwarded = "disable";
     FollowRedirects? followRedirects = ();
     ProxyConfig? proxy = ();
@@ -470,7 +470,7 @@ public type FailoverClientEndpointConfiguration record {|
     CircuitBreakerConfig? circuitBreaker = ();
     RetryConfig? retryConfig = ();
     int[] failoverCodes = [501, 502, 503, 504];
-    int intervalMillis = 0;
+    int intervalInMillis = 0;
 |};
 
 function createClientEPConfigFromFailoverEPConfig(FailoverClientEndpointConfiguration foConfig,
@@ -479,7 +479,7 @@ function createClientEPConfigFromFailoverEPConfig(FailoverClientEndpointConfigur
         http1Settings: foConfig.http1Settings,
         http2Settings: foConfig.http2Settings,
         circuitBreaker:foConfig.circuitBreaker,
-        timeoutMillis:foConfig.timeoutMillis,
+        timeoutInMillis:foConfig.timeoutInMillis,
         httpVersion:foConfig.httpVersion,
         forwarded:foConfig.forwarded,
         followRedirects:foConfig.followRedirects,

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/failover_connector.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/failover_connector.bal
@@ -22,7 +22,7 @@
 //# Provides a set of configurations for controlling the failover behaviour of the endpoint.
 //#
 //# + failoverCodes - Array of HTTP response status codes for which the failover mechanism triggers
-//# + intervalInMillis - Failover delay intervalInMillis in milliseconds
+//# + intervalInMillis - Failover delay interval in milliseconds
 //public type FailoverConfig record {
 //    int[] failoverCodes = [];
 //    int intervalInMillis = 0;
@@ -35,11 +35,11 @@
 //#
 //# + failoverClientsArray - Array of HTTP Clients that needs to be Failover
 //# + failoverCodesIndex - An indexed array of HTTP response status codes for which the failover mechanism triggers
-//# + failoverInterval - Failover delay intervalInMillis in milliseconds
+//# + failoverIntervalInMillis - Failover delay interval in milliseconds
 //public type FailoverInferredConfig record {
 //    CallerActions[] failoverClientsArray = [];
 //    boolean[] failoverCodesIndex = [];
-//    int failoverInterval = 0;
+//    int failoverIntervalInMillis = 0;
 //    !...;
 //};
 //
@@ -285,7 +285,7 @@
 //    int currentIndex = failoverActions.succeededEndpointIndex;
 //    int initialIndex = failoverActions.succeededEndpointIndex;
 //    int startIndex = -1;
-//    int failoverInterval = failoverInferredConfig.failoverInterval;
+//    int failoverIntervalInMillis = failoverInferredConfig.failoverIntervalInMillis;
 //
 //    CallerActions[] failoverClients = failoverInferredConfig.failoverClientsArray;
 //    CallerActions failoverClient = failoverClients[failoverActions.succeededEndpointIndex];
@@ -389,7 +389,7 @@
 //            }
 //        }
 //        failoverRequest = check createFailoverRequest(failoverRequest, requestEntity);
-//        runtime:sleep(failoverInterval);
+//        runtime:sleep(failoverIntervalInMillis);
 //        failoverClient = failoverClients[currentIndex];
 //    }
 //    return inResponse;

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/failover_connector.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/failover_connector.bal
@@ -22,10 +22,10 @@
 //# Provides a set of configurations for controlling the failover behaviour of the endpoint.
 //#
 //# + failoverCodes - Array of HTTP response status codes for which the failover mechanism triggers
-//# + interval - Failover delay interval in milliseconds
+//# + intervalInMillis - Failover delay intervalInMillis in milliseconds
 //public type FailoverConfig record {
 //    int[] failoverCodes = [];
-//    int interval = 0;
+//    int intervalInMillis = 0;
 //    !...;
 //};
 //
@@ -35,7 +35,7 @@
 //#
 //# + failoverClientsArray - Array of HTTP Clients that needs to be Failover
 //# + failoverCodesIndex - An indexed array of HTTP response status codes for which the failover mechanism triggers
-//# + failoverInterval - Failover delay interval in milliseconds
+//# + failoverInterval - Failover delay intervalInMillis in milliseconds
 //public type FailoverInferredConfig record {
 //    CallerActions[] failoverClientsArray = [];
 //    boolean[] failoverCodesIndex = [];

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/http_circuit_breaker.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/http_circuit_breaker.bal
@@ -64,25 +64,25 @@ public type CircuitHealth record {|
 # + rollingWindow - `RollingWindow` options of the `CircuitBreaker`
 # + failureThreshold - The threshold for request failures. When this threshold exceeds, the circuit trips.
 #                      The threshold should be a value between 0 and 1.
-# + resetTimeMillis - The time period(in milliseconds) to wait before attempting to make another request to
+# + resetTimeInMillis - The time period(in milliseconds) to wait before attempting to make another request to
 #                     the upstream service
 # + statusCodes - Array of HTTP response status codes which are considered as failures
 public type CircuitBreakerConfig record {|
     RollingWindow rollingWindow = {};
     float failureThreshold = 0.0;
-    int resetTimeMillis = 0;
+    int resetTimeInMillis = 0;
     int[] statusCodes = [];
 |};
 
 # Represents a rolling window in the Circuit Breaker.
 #
 # + requestVolumeThreshold - Minimum number of requests in a `RollingWindow` that will trip the circuit.
-# + timeWindowMillis - Time period in milliseconds for which the failure threshold is calculated
-# + bucketSizeMillis - The granularity at which the time window slides. This is measured in milliseconds.
+# + timeWindowInMillis - Time period in milliseconds for which the failure threshold is calculated
+# + bucketSizeInMillis - The granularity at which the time window slides. This is measured in milliseconds.
 public type RollingWindow record {|
     int requestVolumeThreshold = 10;
-    int timeWindowMillis = 60000;
-    int bucketSizeMillis = 10000;
+    int timeWindowInMillis = 60000;
+    int bucketSizeInMillis = 10000;
 |};
 
 # Represents a discrete sub-part of the time window (Bucket).
@@ -102,14 +102,14 @@ public type Bucket record {|
 #
 # + failureThreshold - The threshold for request failures. When this threshold exceeds, the circuit trips.
 #                      The threshold should be a value between 0 and 1
-# + resetTimeMillis - The time period(in milliseconds) to wait before attempting to make another request to
+# + resetTimeInMillis - The time period(in milliseconds) to wait before attempting to make another request to
 #                     the upstream service
 # + statusCodes - Array of HTTP response status codes which are considered as failures
 # + noOfBuckets - Number of buckets derived from the `RollingWindow`
 # + rollingWindow - `RollingWindow` options provided in the `CircuitBreakerConfig`
 public type CircuitBreakerInferredConfig record {|
     float failureThreshold = 0.0;
-    int resetTimeMillis = 0;
+    int resetTimeInMillis = 0;
     boolean[] statusCodes = [];
     int noOfBuckets = 0;
     RollingWindow rollingWindow = {};
@@ -415,7 +415,7 @@ public type CircuitBreakerClient client object {
     }
 
     # Force the circuit into a open state in which it will suspend all requests
-    # until `resetTimeMillis` interval exceeds.
+    # until `resetTimeInMillis` interval exceeds.
     public function forceOpen() {
         self.currentCircuitState = CB_OPEN_STATE;
         self.circuitHealth.lastForcedOpenTime = time:currentTime();
@@ -540,7 +540,7 @@ function handleOpenCircuit(CircuitHealth circuitHealth, CircuitBreakerInferredCo
     updateRejectedRequestCount(circuitHealth, circuitBreakerInferredConfig);
     time:Time effectiveErrorTime = getEffectiveErrorTime(circuitHealth);
     int timeDif = time:currentTime().time - effectiveErrorTime.time;
-    int timeRemaining = circuitBreakerInferredConfig.resetTimeMillis - timeDif;
+    int timeRemaining = circuitBreakerInferredConfig.resetTimeInMillis - timeDif;
     string errorMessage = "Upstream service unavailable. Requests to upstream service will be suspended for "
         + timeRemaining.toString() + " milliseconds.";
     UpstreamServiceUnavailableError httpConnectorErr = error(UPSTREAM_SERVICE_UNAVAILABLE, message = errorMessage);
@@ -601,8 +601,8 @@ function getTotalRequestsCount(CircuitHealth circuitHealth) returns int {
 function getCurrentBucketId(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig)
              returns int {
     int elapsedTime = (time:currentTime().time - circuitHealth.startTime.time) % circuitBreakerInferredConfig.
-        rollingWindow.timeWindowMillis;
-    int currentBucketId = ((elapsedTime / circuitBreakerInferredConfig.rollingWindow.bucketSizeMillis) + 1)
+        rollingWindow.timeWindowInMillis;
+    int currentBucketId = ((elapsedTime / circuitBreakerInferredConfig.rollingWindow.bucketSizeInMillis) + 1)
         % circuitBreakerInferredConfig.noOfBuckets;
     return currentBucketId;
 }
@@ -653,16 +653,16 @@ function prepareRollingWindow(CircuitHealth circuitHealth, CircuitBreakerInferre
         idleTime = currentTime - lastRequestTime.time;
     }
     RollingWindow rollingWindow = circuitBreakerInferredConfig.rollingWindow;
-    // If the time duration between two requests greater than timeWindowMillis values, reset the buckets to default.
-    if (idleTime > rollingWindow.timeWindowMillis) {
+    // If the time duration between two requests greater than timeWindowInMillis values, reset the buckets to default.
+    if (idleTime > rollingWindow.timeWindowInMillis) {
         reInitializeBuckets(circuitHealth);
     } else {
         int currentBucketId = getCurrentBucketId(circuitHealth, circuitBreakerInferredConfig);
         int lastUsedBucketId = circuitHealth.lastUsedBucketId;
         // Check whether subsequent requests received within same bucket(sub time window). If the idle time is greater
-        // than bucketSizeMillis means subsequent calls are received time exceeding the rolling window. if we need to
+        // than bucketSizeInMillis means subsequent calls are received time exceeding the rolling window. if we need to
         // reset the buckets to default.
-        if (currentBucketId == circuitHealth.lastUsedBucketId && idleTime > rollingWindow.bucketSizeMillis) {
+        if (currentBucketId == circuitHealth.lastUsedBucketId && idleTime > rollingWindow.bucketSizeInMillis) {
             reInitializeBuckets(circuitHealth);
         // If the current bucket (sub time window) is less than last updated bucket. Stats of the current bucket to
         // zeroth bucket and Last bucket to last used bucket needs to be reset to default.
@@ -680,7 +680,7 @@ function prepareRollingWindow(CircuitHealth circuitHealth, CircuitBreakerInferre
         } else {
             // If the current bucket (sub time window) is greater than last updated bucket. Stats of current bucket to
             // last used bucket needs to be reset without resetting last used bucket stat.
-            while (currentBucketId > lastUsedBucketId && idleTime > rollingWindow.bucketSizeMillis) {
+            while (currentBucketId > lastUsedBucketId && idleTime > rollingWindow.bucketSizeInMillis) {
                 resetBucketStats(circuitHealth, currentBucketId);
                 currentBucketId -= 1;
             }
@@ -724,7 +724,7 @@ function switchCircuitStateOpenToHalfOpenOnResetTime(CircuitBreakerInferredConfi
     if (currentState == CB_OPEN_STATE) {
         time:Time effectiveErrorTime = getEffectiveErrorTime(circuitHealth);
         int elapsedTime = time:currentTime().time - effectiveErrorTime.time;
-        if (elapsedTime > circuitBreakerInferredConfig.resetTimeMillis) {
+        if (elapsedTime > circuitBreakerInferredConfig.resetTimeInMillis) {
             currentCircuitState = CB_HALF_OPEN_STATE;
             log:printInfo("CircuitBreaker reset timeout reached. Circuit switched from OPEN to HALF_OPEN state.");
         }

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/http_retry_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/http_retry_client.bal
@@ -22,15 +22,15 @@ import ballerina/runtime;
 # Derived set of configurations from the `RetryConfig`.
 #
 # + count - Number of retry attempts before giving up
-# + interval - Retry interval in milliseconds
+# + intervalInMillis - Retry interval in milliseconds
 # + backOffFactor - Multiplier of the retry interval to exponentially increase retry interval
-# + maxWaitInterval - Maximum time of the retry interval in milliseconds
+# + maxWaitIntervalInMillis - Maximum time of the retry interval in milliseconds
 # + statusCodes - HTTP response status codes which are considered as failures
 public type RetryInferredConfig record {|
     int count = 0;
-    int interval = 0;
+    int intervalInMillis = 0;
     float backOffFactor = 0.0;
-    int maxWaitInterval = 0;
+    int maxWaitIntervalInMillis = 0;
     boolean[] statusCodes = [];
 |};
 
@@ -284,7 +284,7 @@ function performRetryAction(@untainted string path, Request request, HttpOperati
     HttpClient httpClient = retryClient.httpClient;
     int currentRetryCount = 0;
     int retryCount = retryClient.retryInferredConfig.count;
-    int interval = retryClient.retryInferredConfig.interval;
+    int intervalInMillis = retryClient.retryInferredConfig.intervalInMillis;
     boolean[] statusCodeIndex = retryClient.retryInferredConfig.statusCodes;
     initializeBackOffFactorAndMaxWaitInterval(retryClient);
     
@@ -303,8 +303,8 @@ function performRetryAction(@untainted string path, Request request, HttpOperati
             int responseStatusCode = backendResponse.statusCode;
             if (statusCodeIndex.length() > responseStatusCode && (statusCodeIndex[responseStatusCode])
                                                               && currentRetryCount < (retryCount)) {
-                [interval, currentRetryCount] =
-                                calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, interval);
+                [intervalInMillis, currentRetryCount] =
+                                calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, intervalInMillis);
             } else {
                 return backendResponse;
             }
@@ -314,23 +314,23 @@ function performRetryAction(@untainted string path, Request request, HttpOperati
                 int responseStatusCode = response.statusCode;
                 if (statusCodeIndex.length() > responseStatusCode && (statusCodeIndex[responseStatusCode])
                                                                   && currentRetryCount < (retryCount)) {
-                    [interval, currentRetryCount] =
-                                    calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, interval);
+                    [intervalInMillis, currentRetryCount] =
+                                    calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, intervalInMillis);
                 } else {
                     // We return the HttpFuture object as this is called by submit method.
                     return backendResponse;
                 }
             } else {
-                [interval, currentRetryCount] =
-                                calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, interval);
+                [intervalInMillis, currentRetryCount] =
+                                calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, intervalInMillis);
                 httpConnectorErr = response;
             }
         } else {
-            [interval, currentRetryCount] =
-                            calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, interval);
+            [intervalInMillis, currentRetryCount] =
+                            calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, intervalInMillis);
             httpConnectorErr = backendResponse;
         }
-        runtime:sleep(interval);
+        runtime:sleep(intervalInMillis);
     }
     return httpConnectorErr;
 }
@@ -339,8 +339,8 @@ function initializeBackOffFactorAndMaxWaitInterval(RetryClient retryClient) {
     if (retryClient.retryInferredConfig.backOffFactor <= 0.0) {
         retryClient.retryInferredConfig.backOffFactor = 1.0;
     }
-    if (retryClient.retryInferredConfig.maxWaitInterval == 0) {
-        retryClient.retryInferredConfig.maxWaitInterval = 60000;
+    if (retryClient.retryInferredConfig.maxWaitIntervalInMillis == 0) {
+        retryClient.retryInferredConfig.maxWaitIntervalInMillis = 60000;
     }
 }
 
@@ -355,7 +355,7 @@ function calculateEffectiveIntervalAndRetryCount(RetryClient retryClient, int cu
     int interval = currentDelay;
     if (currentRetryCount != 0) {
         interval = getWaitTime(retryClient.retryInferredConfig.backOffFactor,
-                    retryClient.retryInferredConfig.maxWaitInterval, interval);
+                    retryClient.retryInferredConfig.maxWaitIntervalInMillis, interval);
     }
     int retryCount = currentRetryCount + 1;
     return [interval, retryCount];

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/load_balance_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/load_balance_client_endpoint.bal
@@ -306,7 +306,7 @@ function populateGenericLoadBalanceActionError(LoadBalanceActionErrorData loadBa
 # + httpVersion - The HTTP version to be used to communicate with the endpoint
 # + http1Settings - Configurations related to HTTP/1.x protocol
 # + http2Settings - Configurations related to HTTP/2 protocol
-# + timeoutMillis - The maximum time to wait (in milli seconds) for a response before closing the connection
+# + timeoutInMillis - The maximum time to wait (in milli seconds) for a response before closing the connection
 # + forwarded - The choice of setting forwarded/x-forwarded header
 # + followRedirects - Redirect related options
 # + poolConfig - Configurations associated with request pooling
@@ -323,7 +323,7 @@ public type LoadBalanceClientEndpointConfiguration record {|
     string httpVersion = HTTP_1_1;
     Http1Settings http1Settings = {};
     Http2Settings http2Settings = {};
-    int timeoutMillis = 60000;
+    int timeoutInMillis = 60000;
     string forwarded = "disable";
     FollowRedirects? followRedirects = ();
     ProxyConfig? proxy = ();
@@ -344,7 +344,7 @@ function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientEndpointCo
         http1Settings: lbConfig.http1Settings,
         http2Settings: lbConfig.http2Settings,
         circuitBreaker:lbConfig.circuitBreaker,
-        timeoutMillis:lbConfig.timeoutMillis,
+        timeoutInMillis:lbConfig.timeoutInMillis,
         httpVersion:lbConfig.httpVersion,
         forwarded:lbConfig.forwarded,
         followRedirects:lbConfig.followRedirects,

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -146,7 +146,7 @@ public type RequestLimits record {|
 # + requestLimits - Configures the parameters for request validation
 # + filters - If any pre-processing needs to be done to the request before dispatching the request to the
 #             resource, filters can applied
-# + timeoutMillis - Period of time in milliseconds that a connection waits for a read/write operation. Use value 0 to
+# + timeoutInMillis - Period of time in milliseconds that a connection waits for a read/write operation. Use value 0 to
 #                   disable timeout
 # + maxPipelinedRequests - Defines the maximum number of requests that can be processed at a given time on a single
 #                          connection. By default, 10 requests can be pipelined on a single connection and the user can
@@ -161,7 +161,7 @@ public type ServiceEndpointConfiguration record {|
     RequestLimits requestLimits = {};
     //TODO: update as a optional field
     Filter[] filters = [];
-    int timeoutMillis = DEFAULT_LISTENER_TIMEOUT;
+    int timeoutInMillis = DEFAULT_LISTENER_TIMEOUT;
     int maxPipelinedRequests = MAX_PIPELINED_REQUESTS;
     ListenerAuth auth?;
     string? server = ();
@@ -198,8 +198,8 @@ public type ListenerAuth record {|
 #             TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)
 # + sslVerifyClient - The type of client certificate verification
 # + shareSession - Enable/disable new SSL session creation
-# + handshakeTimeout - SSL handshake time out
-# + sessionTimeout - SSL session time out
+# + handshakeTimeoutInSeconds - SSL handshake time out
+# + sessionTimeoutInSeconds - SSL session time out
 # + ocspStapling - Enable/disable OCSP stapling
 public type ServiceSecureSocket record {|
     crypto:TrustStore? trustStore = ();
@@ -217,8 +217,8 @@ public type ServiceSecureSocket record {|
                         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"];
     string sslVerifyClient = "";
     boolean shareSession = true;
-    int? handshakeTimeout = ();
-    int? sessionTimeout = ();
+    int? handshakeTimeoutInSeconds = ();
+    int? sessionTimeoutInSeconds = ();
     ServiceOcspStapling? ocspStapling = ();
 |};
 
@@ -226,13 +226,13 @@ public type ServiceSecureSocket record {|
 #
 # + enabled - Specifies whether authorization caching is enabled. Caching is enabled by default.
 # + capacity - The capacity of the cache
-# + expiryTimeMillis - The number of milliseconds to keep an entry in the cache
+# + expiryTimeInMillis - The number of milliseconds to keep an entry in the cache
 # + evictionFactor - The fraction of entries to be removed when the cache is full. The value should be
 #                    between 0 (exclusive) and 1 (inclusive).
 public type AuthCacheConfig record {|
     boolean enabled = true;
     int capacity = 100;
-    int expiryTimeMillis = 5 * 1000; // 5 seconds;
+    int expiryTimeInMillis = 5 * 1000; // 5 seconds;
     float evictionFactor = 1;
 |};
 
@@ -261,10 +261,10 @@ function addAuthFiltersForSecureListener(ServiceEndpointConfiguration config) {
         authFilters[0] = authnFilter;
 
         var scopes = auth["scopes"];
-        cache:Cache positiveAuthzCache = new(auth.positiveAuthzCache.expiryTimeMillis,
+        cache:Cache positiveAuthzCache = new(auth.positiveAuthzCache.expiryTimeInMillis,
                                              auth.positiveAuthzCache.capacity,
                                              auth.positiveAuthzCache.evictionFactor);
-        cache:Cache negativeAuthzCache = new(auth.negativeAuthzCache.expiryTimeMillis,
+        cache:Cache negativeAuthzCache = new(auth.negativeAuthzCache.expiryTimeInMillis,
                                              auth.negativeAuthzCache.capacity,
                                              auth.negativeAuthzCache.evictionFactor);
         AuthzHandler authzHandler = new(positiveAuthzCache, negativeAuthzCache);

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -256,7 +256,7 @@ public class HttpConstants {
     //Retry Struct field names
     public static final int RETRY_STRUCT_FIELD = 4;
     public static final String RETRY_COUNT_FIELD = "count";
-    public static final String RETRY_INTERVAL_FIELD = "interval";
+    public static final String RETRY_INTERVAL_FIELD = "intervalInMillis";
 
     // ResponseCacheControl struct field names
     public static final String RES_CACHE_CONTROL_MUST_REVALIDATE_FIELD = "mustRevalidate";
@@ -305,7 +305,7 @@ public class HttpConstants {
     public static final String ENDPOINT_CONFIG_HOST = "host";
     public static final String ENDPOINT_CONFIG_PORT = "port";
     public static final String ENDPOINT_CONFIG_KEEP_ALIVE = "keepAlive";
-    public static final String ENDPOINT_CONFIG_TIMEOUT = "timeoutMillis";
+    public static final String ENDPOINT_CONFIG_TIMEOUT = "timeoutInMillis";
     public static final String ENDPOINT_CONFIG_CHUNKING = "chunking";
     public static final String ENDPOINT_CONFIG_VERSION = "httpVersion";
     public static final String ENDPOINT_REQUEST_LIMITS = "requestLimits";
@@ -332,8 +332,8 @@ public class HttpConstants {
     public static final String ENDPOINT_CONFIG_KEY = "keyFile";
     public static final String ENDPOINT_CONFIG_KEY_PASSWORD = "keyPassword";
     public static final String ENDPOINT_CONFIG_TRUST_CERTIFICATES = "trustedCertFile";
-    public static final String ENDPOINT_CONFIG_HANDSHAKE_TIMEOUT = "handshakeTimeout";
-    public static final String ENDPOINT_CONFIG_SESSION_TIMEOUT = "sessionTimeout";
+    public static final String ENDPOINT_CONFIG_HANDSHAKE_TIMEOUT = "handshakeTimeoutInSeconds";
+    public static final String ENDPOINT_CONFIG_SESSION_TIMEOUT = "sessionTimeoutInSeconds";
 
     //SslConfiguration indexes
     public static final String SSL_CONFIG_SSL_VERIFY_CLIENT = "sslVerifyClient";
@@ -352,7 +352,7 @@ public class HttpConstants {
 
     //Client Endpoint Config
     public static final String CLIENT_EP_CHUNKING = "chunking";
-    public static final String CLIENT_EP_ENDPOINT_TIMEOUT = "timeoutMillis";
+    public static final String CLIENT_EP_ENDPOINT_TIMEOUT = "timeoutInMillis";
     public static final String CLIENT_EP_IS_KEEP_ALIVE = "keepAlive";
     public static final String CLIENT_EP_HTTP_VERSION = "httpVersion";
     public static final String CLIENT_EP_FORWARDED = "forwarded";
@@ -372,7 +372,7 @@ public class HttpConstants {
     //Client connection pooling configs
     public static final String CONNECTION_POOLING_MAX_ACTIVE_CONNECTIONS = "maxActiveConnections";
     public static final String CONNECTION_POOLING_MAX_IDLE_CONNECTIONS = "maxIdleConnections";
-    public static final String CONNECTION_POOLING_WAIT_TIME = "waitTimeinMillis";
+    public static final String CONNECTION_POOLING_WAIT_TIME = "waitTimeInMillis";
     public static final String CONNECTION_POOLING_MAX_ACTIVE_STREAMS_PER_CONNECTION = "maxActiveStreamsPerConnection";
     public static final String HTTP_CLIENT_CONNECTION_POOL = "PoolConfiguration";
     public static final String CONNECTION_MANAGER = "ConnectionManager";
@@ -400,7 +400,7 @@ public class HttpConstants {
     // Retry Config
     public static final String CLIENT_EP_RETRY = "retry";
     public static final String RETRY_COUNT = "count";
-    public static final String RETRY_INTERVAL = "interval";
+    public static final String RETRY_INTERVAL = "intervalInMillis";
 
     public static final String SERVICE_ENDPOINT_PROTOCOL_FIELD = "protocol";
 

--- a/stdlib/http/src/test/resources/test-src/resiliency/circuit-breaker-test.bal
+++ b/stdlib/http/src/test/resources/test-src/resiliency/circuit-breaker-test.bal
@@ -40,7 +40,7 @@ function testTypicalScenario() returns [http:Response[], error?[]] {
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[400, 404, 500, 502, 503]
         },
         timeoutInMillis:2000
@@ -80,7 +80,7 @@ function testTrialRunFailure() returns [http:Response[], error?[]] {
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[400, 404, 500, 502, 503]
         },
         timeoutInMillis:2000
@@ -121,7 +121,7 @@ function testHttpStatusCodeFailure() returns [http:Response[], error?[]] {
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[400, 404, 500, 502, 503]
         },
         timeoutInMillis:2000
@@ -157,7 +157,7 @@ function testForceOpenScenario() returns [http:Response[], error?[]] {
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[500, 502, 503]
         },
         timeoutInMillis:2000
@@ -196,7 +196,7 @@ function testForceCloseScenario() returns [http:Response[], error?[]] {
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[500, 502, 503]
         },
         timeoutInMillis:2000
@@ -236,7 +236,7 @@ function testRequestVolumeThresholdSuccessResponseScenario() returns [http:Respo
                 requestVolumeThreshold: 6
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[500, 502, 503]
         },
         timeoutInMillis:2000
@@ -273,7 +273,7 @@ function testRequestVolumeThresholdFailureResponseScenario() returns [http:Respo
                 requestVolumeThreshold: 6
             },
             failureThreshold:0.3,
-            resetTimeMillis:1000,
+            resetTimeInMillis:1000,
             statusCodes:[500, 502, 503]
         },
         timeoutInMillis:2000
@@ -549,7 +549,7 @@ http:Client clientEP = new("http://localhost:8080", {
             bucketSizeInMillis: 2000
         },
         failureThreshold: 0.3,
-        resetTimeMillis: 1000,
+        resetTimeInMillis: 1000,
         statusCodes: [500, 502, 503]
     },
     timeoutInMillis: 2000

--- a/stdlib/http/src/test/resources/test-src/resiliency/circuit-breaker-test.bal
+++ b/stdlib/http/src/test/resources/test-src/resiliency/circuit-breaker-test.bal
@@ -35,15 +35,15 @@ function testTypicalScenario() returns [http:Response[], error?[]] {
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[400, 404, 500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -75,15 +75,15 @@ function testTrialRunFailure() returns [http:Response[], error?[]] {
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[400, 404, 500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -116,15 +116,15 @@ function testHttpStatusCodeFailure() returns [http:Response[], error?[]] {
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[400, 404, 500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -152,15 +152,15 @@ function testForceOpenScenario() returns [http:Response[], error?[]] {
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -191,15 +191,15 @@ function testForceCloseScenario() returns [http:Response[], error?[]] {
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 0
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -231,15 +231,15 @@ function testRequestVolumeThresholdSuccessResponseScenario() returns [http:Respo
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 6
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -268,15 +268,15 @@ function testRequestVolumeThresholdFailureResponseScenario() returns [http:Respo
     http:Client backendClientEP = new("http://localhost:8080", {
         circuitBreaker: {
             rollingWindow: {
-                timeWindowMillis:10000,
-                bucketSizeMillis:2000,
+                timeWindowInMillis:10000,
+                bucketSizeInMillis:2000,
                 requestVolumeThreshold: 6
             },
             failureThreshold:0.3,
             resetTimeMillis:1000,
             statusCodes:[500, 502, 503]
         },
-        timeoutMillis:2000
+        timeoutInMillis:2000
     });
 
     http:Response[] responses = [];
@@ -545,14 +545,14 @@ listener http:MockListener mockEP = new(9090);
 http:Client clientEP = new("http://localhost:8080", {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 10000,
-            bucketSizeMillis: 2000
+            timeWindowInMillis: 10000,
+            bucketSizeInMillis: 2000
         },
         failureThreshold: 0.3,
         resetTimeMillis: 1000,
         statusCodes: [500, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 });
 
 @http:ServiceConfig { basePath: "/cb" }

--- a/stdlib/http/src/test/resources/test-src/resiliency/failover-connector-test.bal
+++ b/stdlib/http/src/test/resources/test-src/resiliency/failover-connector-test.bal
@@ -27,7 +27,7 @@ function testSuccessScenario () returns @tainted http:Response | error {
         targets: [
                  {url: "http://invalidEP"},
                  {url: "http://localhost:8080"}],
-        timeoutMillis:5000
+        timeoutInMillis:5000
     });
 
     http:Response clientResponse = new;
@@ -54,7 +54,7 @@ function testFailureScenario () returns @tainted http:Response | error {
         targets: [
                  {url: "http://invalidEP"},
                  {url: "http://localhost:50000000"}],
-        timeoutMillis:5000
+        timeoutInMillis:5000
     });
 
     http:Response response = new;

--- a/stdlib/transactions/src/main/ballerina/src/transactions/commons.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/commons.bal
@@ -283,8 +283,8 @@ function getInitiatorClient(string registerAtURL) returns InitiatorClientEP {
             if (httpClientCache.hasKey(registerAtURL)) {
                 return <InitiatorClientEP>httpClientCache.get(registerAtURL);
             }
-            initiatorEP = new({ registerAtURL: registerAtURL, timeoutMillis: 15000,
-                retryConfig: { count: 2, interval: 5000 }
+            initiatorEP = new({ registerAtURL: registerAtURL, timeoutInMillis: 15000,
+                retryConfig: { count: 2, intervalInMillis: 5000 }
             });
             httpClientCache.put(registerAtURL, initiatorEP);
             return initiatorEP;
@@ -302,7 +302,7 @@ function getParticipant2pcClient(string participantURL) returns Participant2pcCl
                 return <Participant2pcClientEP>httpClientCache.get(<@untainted>participantURL);
             }
             participantEP = new({ participantURL: participantURL,
-                timeoutMillis: 15000, retryConfig: { count: 2, interval: 5000 }
+                timeoutInMillis: 15000, retryConfig: { count: 2, intervalInMillis: 5000 }
             });
             httpClientCache.put(participantURL, participantEP);
             return participantEP;

--- a/stdlib/transactions/src/main/ballerina/src/transactions/connector_initiator.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/connector_initiator.bal
@@ -18,10 +18,10 @@ import ballerina/http;
 
 type InitiatorClientConfig record {
     string registerAtURL = "";
-    int timeoutMillis = 0;
+    int timeoutInMillis = 0;
     record {
         int count = 0;
-        int interval = 0;
+        int intervalInMillis = 0;
     } retryConfig = {};
 };
 
@@ -30,10 +30,10 @@ type InitiatorClientEP client object {
 
     function __init(InitiatorClientConfig conf) {
         http:Client httpEP = new(conf.registerAtURL, {
-                timeoutMillis:conf.timeoutMillis,
+                timeoutInMillis:conf.timeoutInMillis,
                 retryConfig:{
                     count:conf.retryConfig.count,
-                    interval:conf.retryConfig.interval
+                    intervalInMillis:conf.retryConfig.intervalInMillis
                 }
             });
         self.httpClient = httpEP;

--- a/stdlib/transactions/src/main/ballerina/src/transactions/connector_participant_2pc.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/connector_participant_2pc.bal
@@ -18,10 +18,10 @@ import ballerina/http;
 
 public type Participant2pcClientConfig record {
     string participantURL = "";
-    int timeoutMillis = 0;
+    int timeoutInMillis = 0;
     record {
         int count = 0;
-        int interval = 0;
+        int intervalInMillis = 0;
     } retryConfig = {};
 };
 
@@ -32,9 +32,9 @@ public type Participant2pcClientEP client object {
 
     public function __init(Participant2pcClientConfig c) {
         http:Client httpEP = new(c.participantURL, {
-            timeoutMillis: c.timeoutMillis,
+            timeoutInMillis: c.timeoutInMillis,
             retryConfig:{
-                count: c.retryConfig.count, interval: c.retryConfig.interval
+                count: c.retryConfig.count, intervalInMillis: c.retryConfig.intervalInMillis
             }
         });
         self.httpClient = httpEP;

--- a/tests/jballerina-integration-test/src/test/resources/grpc/src/clients/14_grpc_client_socket_timeout.bal
+++ b/tests/jballerina-integration-test/src/test/resources/grpc/src/clients/14_grpc_client_socket_timeout.bal
@@ -26,7 +26,7 @@ import ballerina/io;
 public function testClientSocketTimeout() returns string {
     // Client endpoint configuration
     HelloWorld14BlockingClient helloWorldBlockingEp = new("http://localhost:9104", {
-                                        timeoutMillis : 1000});
+                                        timeoutInMillis : 1000});
 
     // Executes unary blocking call.
     var unionResp = helloWorldBlockingEp->hello("WSO2");

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/12_http_retry.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/12_http_retry.bal
@@ -27,11 +27,11 @@ listener http:Listener serviceEndpoint1 = new(9105);
 http:Client backendClientEP = new ("http://localhost:9105", {
     // Retry configuration options.
     retryConfig: {
-        interval: 3000,
+        intervalInMillis: 3000,
         count: 3,
         backOffFactor: 0.5
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 });
 
 @http:ServiceConfig {

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/16_idle_timeout.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/16_idle_timeout.bal
@@ -21,7 +21,7 @@ import ballerina/runtime;
 @http:ServiceConfig {
     basePath: "/idle"
 }
-service idleTimeout on new http:Listener(9112, { timeoutMillis: 1000, server: "Mysql" }) {
+service idleTimeout on new http:Listener(9112, { timeoutInMillis: 1000, server: "Mysql" }) {
     @http:ResourceConfig {
         methods: ["POST"],
         path: "/timeout408"

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/20_mutual_ssl_server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/20_mutual_ssl_server.bal
@@ -39,8 +39,8 @@ http:ServiceEndpointConfiguration mutualSslServiceConf = {
         ocspStapling: {
             enable: false
         },
-        handshakeTimeout: 20,
-        sessionTimeout: 30
+        handshakeTimeoutInSeconds: 20,
+        sessionTimeoutInSeconds: 30
     }
 };
 

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/24_http_pipelining.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/24_http_pipelining.bal
@@ -52,7 +52,7 @@ service pipeliningTest on new http:Listener(9220) {
     }
 }
 
-service pipelining on new http:Listener(9221, { timeoutMillis: 1000 }) {
+service pipelining on new http:Listener(9221, { timeoutInMillis: 1000 }) {
 
     resource function testTimeout(http:Caller caller, http:Request req) {
         http:Response response = new;

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/26_http_retry_status_codes.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/26_http_retry_status_codes.bal
@@ -20,13 +20,13 @@ import ballerina/runtime;
 
 http:Client internalErrorEP = new("http://localhost:8080", {
     retryConfig: {
-        interval: 3000,
+        intervalInMillis: 3000,
         count: 3,
         backOffFactor: 2.0,
-        maxWaitInterval: 20000,
+        maxWaitIntervalInMillis: 20000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 });
 
 @http:ServiceConfig {

--- a/tests/jballerina-integration-test/src/test/resources/mutualSSL/mutual_ssl_client.bal
+++ b/tests/jballerina-integration-test/src/test/resources/mutualSSL/mutual_ssl_client.bal
@@ -36,8 +36,8 @@ http:ClientEndpointConfig mutualSslClientConf = {
             enable: false
         },
         ocspStapling: false,
-        handshakeTimeout: 20,
-        sessionTimeout: 30
+        handshakeTimeoutInSeconds: 20,
+        sessionTimeoutInSeconds: 30
     }
 };
 

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/01_http_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/01_http_failover.bal
@@ -28,9 +28,9 @@ listener http:Listener backendEP00 = new(8080);
 
 // Define the failover client end point to call the backend services.
 http:FailoverClient foBackendEP00 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -41,9 +41,9 @@ http:FailoverClient foBackendEP00 = new({
 });
 
 http:FailoverClient foBackendFailureEP00 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -53,9 +53,9 @@ http:FailoverClient foBackendFailureEP00 = new({
 });
 
 http:FailoverClient foStatusCodesEP00 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:8080/statuscodes" },

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/02_http_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/02_http_failover.bal
@@ -28,9 +28,9 @@ listener http:Listener backendEP01 = new(8081);
 
 // Define the failover client end point to call the backend services.
 http:FailoverClient foBackendEP01 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -41,9 +41,9 @@ http:FailoverClient foBackendEP01 = new({
 });
 
 http:FailoverClient foBackendFailureEP01 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -53,9 +53,9 @@ http:FailoverClient foBackendFailureEP01 = new({
 });
 
 http:FailoverClient foStatusCodesEP01 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:8080/statuscodes" },

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/03_http_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/03_http_failover.bal
@@ -28,9 +28,9 @@ listener http:Listener backendEP02 = new(8082);
 
 // Define the failover client end point to call the backend services.
 http:FailoverClient foBackendEP02 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -41,9 +41,9 @@ http:FailoverClient foBackendEP02 = new({
 });
 
 http:FailoverClient foBackendFailureEP02 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -53,9 +53,9 @@ http:FailoverClient foBackendFailureEP02 = new({
 });
 
 http:FailoverClient foStatusCodesEP02 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:8080/statuscodes" },

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/04_http_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/04_http_failover.bal
@@ -28,9 +28,9 @@ listener http:Listener backendEP03 = new(8083);
 
 // Define the failover client end point to call the backend services.
 http:FailoverClient foBackendEP03 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -41,9 +41,9 @@ http:FailoverClient foBackendEP03 = new({
 });
 
 http:FailoverClient foBackendFailureEP03 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -53,9 +53,9 @@ http:FailoverClient foBackendFailureEP03 = new({
 });
 
 http:FailoverClient foStatusCodesEP03 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:8080/statuscodes" },

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/05_http_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/05_http_failover.bal
@@ -28,9 +28,9 @@ listener http:Listener backendEP04 = new(8084);
 
 // Define the failover client end point to call the backend services.
 http:FailoverClient foBackendEP04 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -41,9 +41,9 @@ http:FailoverClient foBackendEP04 = new({
 });
 
 http:FailoverClient foBackendFailureEP04 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },
@@ -53,9 +53,9 @@ http:FailoverClient foBackendFailureEP04 = new({
 });
 
 http:FailoverClient foStatusCodesEP04 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:8080/statuscodes" },

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/06_http_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/06_http_failover.bal
@@ -28,9 +28,9 @@ listener http:Listener backendEP05 = new(8085);
 
 // Define the failover client end point to call the backend services.
 http:FailoverClient foBackendEP05 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     // Define set of HTTP Clients that needs to be Failover.
     targets: [
         { url: "http://localhost:3467/inavalidEP" },

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/07_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/07_http_circuit_breaker.bal
@@ -26,15 +26,15 @@ listener http:Listener circuitBreakerEP00 = new(9306);
 http:ClientEndpointConfig conf = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 0
         },
         failureThreshold: 0.3,
-        resetTimeMillis: 3000,
+        resetTimeInMillis: 3000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client backendClientEP00 = new("http://localhost:8086", conf);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/08_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/08_http_circuit_breaker.bal
@@ -26,15 +26,15 @@ listener http:Listener circuitBreakerEP01 = new(9307);
 http:ClientEndpointConfig conf01 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 0
         },
         failureThreshold: 0.2,
-        resetTimeMillis: 1000,
+        resetTimeInMillis: 1000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client healthyClientEP = new("http://localhost:8087", conf01);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/09_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/09_http_circuit_breaker.bal
@@ -26,15 +26,15 @@ listener http:Listener circuitBreakerEP02 = new(9308);
 http:ClientEndpointConfig conf02 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 2
         },
         failureThreshold: 0.6,
-        resetTimeMillis: 1000,
+        resetTimeInMillis: 1000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client unhealthyClientEP = new("http://localhost:8088", conf02);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/10_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/10_http_circuit_breaker.bal
@@ -24,15 +24,15 @@ listener http:Listener circuitBreakerEP03 = new(9309);
 http:ClientEndpointConfig conf03 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 0
         },
         failureThreshold: 0.2,
-        resetTimeMillis: 1000,
+        resetTimeInMillis: 1000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client simpleClientEP = new("http://localhost:8089", conf03);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/11_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/11_http_circuit_breaker.bal
@@ -24,15 +24,15 @@ listener http:Listener circuitBreakerEP04 = new(9310);
 http:ClientEndpointConfig conf04 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 6
         },
         failureThreshold: 0.3,
-        resetTimeMillis: 10000,
+        resetTimeInMillis: 10000,
         statusCodes: [500, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client errornousClientEP = new("http://localhost:8090", conf04);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/12_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/12_http_circuit_breaker.bal
@@ -24,15 +24,15 @@ listener http:Listener circuitBreakerEP05 = new(9311);
 http:ClientEndpointConfig conf05 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 3
         },
         failureThreshold: 0.3,
-        resetTimeMillis: 1000,
+        resetTimeInMillis: 1000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client backendClientEP05 = new("http://localhost:8091", conf05);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/13_http_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/13_http_circuit_breaker.bal
@@ -27,15 +27,15 @@ listener http:Listener circuitBreakerEP06 = new(9312);
 http:ClientEndpointConfig conf06 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 0
         },
         failureThreshold: 0.3,
-        resetTimeMillis: 2000,
+        resetTimeInMillis: 2000,
         statusCodes: [501, 502, 503]
     },
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 };
 
 http:Client backendClientEP06 = new("http://localhost:8092", conf06);

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/14_http_load_balancer.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/14_http_load_balancer.bal
@@ -28,7 +28,7 @@ http:LoadBalanceClient lbBackendEP = new({
         { url: "http://localhost:8093/mock2" },
         { url: "http://localhost:8093/mock3" }
     ],
-    timeoutMillis: 5000
+    timeoutInMillis: 5000
 });
 
 http:LoadBalanceClient lbFailoverBackendEP = new({
@@ -38,7 +38,7 @@ http:LoadBalanceClient lbFailoverBackendEP = new({
         { url: "http://localhost:8093/mock3" }
     ],
     failover: true,
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 });
 
 http:LoadBalanceClient delayedBackendEP = new({
@@ -47,7 +47,7 @@ http:LoadBalanceClient delayedBackendEP = new({
         { url: "http://localhost:8093/mock5" }
     ],
     failover: true,
-    timeoutMillis: 2000
+    timeoutInMillis: 2000
 });
 
 CustomLoadBalancerRule customLbRule = new CustomLoadBalancerRule(2);
@@ -59,7 +59,7 @@ http:LoadBalanceClient customLbBackendEP = new ({
         { url: "http://localhost:8093/mock3" }
     ],
     lbRule: customLbRule,
-    timeoutMillis: 5000
+    timeoutInMillis: 5000
 });
 
 @http:ServiceConfig {

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/15_http2_failover.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/15_http2_failover.bal
@@ -7,9 +7,9 @@ listener http:Listener failoverEP06 = new(9314, { httpVersion: "2.0" });
 listener http:Listener backendEP06 = new(8094, { httpVersion: "2.0" });
 
 http:FailoverClient foBackendEP06 = new({
-    timeoutMillis: 5000,
+    timeoutInMillis: 5000,
     failoverCodes: [500, 501, 502, 503],
-    intervalMillis: 5000,
+    intervalInMillis: 5000,
     httpVersion: "2.0",
     // Define set of HTTP Clients that needs to be Failover.
     targets: [

--- a/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/16_http2_circuit_breaker.bal
+++ b/tests/jballerina-integration-test/src/test/resources/resiliency/src/resiliencyservices/16_http2_circuit_breaker.bal
@@ -6,15 +6,15 @@ listener http:Listener circuitBreakerEP07 = new(9315, { httpVersion: "2.0" });
 http:ClientEndpointConfig conf07 = {
     circuitBreaker: {
         rollingWindow: {
-            timeWindowMillis: 60000,
-            bucketSizeMillis: 20000,
+            timeWindowInMillis: 60000,
+            bucketSizeInMillis: 20000,
             requestVolumeThreshold: 0
         },
         failureThreshold: 0.3,
-        resetTimeMillis: 2000,
+        resetTimeInMillis: 2000,
         statusCodes: [500, 501, 502, 503]
     },
-    timeoutMillis: 2000,
+    timeoutInMillis: 2000,
     httpVersion: "2.0"
 };
 


### PR DESCRIPTION
## Purpose
> Add time unit to HTTP properties
timeoutMillis 	>> timeoutInMillis
maxWaitInterval >> maxWaitIntervalInMillis
waitTimeinMillis >> waitTimeInMillis
sessionTimeout >> sessionTimeoutInSeconds
handshakeTimeout >> handshakeTimeoutInSeconds
expiryTimeMillis >> expiryTimeInMillis
intervalMillis >> intervalInMillis
resetTimeMillis >> resetTimeInMillis
timeWindowMillis >> timeWindowInMillis
bucketSizeMillis >> bucketSizeInMillis
interval >> intervalInMillis

maxAge, maxStale, minFresh and sMaxAge were kept as it is since they are standard names in cache control

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
