### PR TITLE
Fix Oracle DDL statement failure, allow mapping 0 scale decimals to int

### DIFF
--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/table/SQLDataIterator.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/table/SQLDataIterator.java
@@ -260,6 +260,21 @@ public class SQLDataIterator extends TableIterator {
             throw new PanickingApplicationException(exceptionMessage);
         }
     }
+    private void validateAndSetDecimalValue(MapValue<String, Object> bStruct, String fieldName, int actualTypeTag,
+            DecimalValue value, String exceptionMessage)
+            throws PanickingApplicationException {
+        boolean typeMatches = isValidType(actualTypeTag, value);
+        setMatchingRefRecordField(bStruct, fieldName, value, typeMatches, exceptionMessage);
+    }
+
+    private boolean isValidType(int actualTypeTag, DecimalValue value) {
+        if (actualTypeTag == TypeTags.DECIMAL_TAG) {
+            return true;
+        } else if (actualTypeTag == TypeTags.INT_TAG) {
+            return value == null || value.value().scale() == 0;
+        }
+        return false;
+    }
 
     private void handleNilToNonNillableFieldAssignment() throws PanickingApplicationException {
         throw new PanickingApplicationException("Trying to assign a Nil value to a non-nillable field");
@@ -631,14 +646,14 @@ public class SQLDataIterator extends TableIterator {
         int fieldTypeTag = fieldType.getTag();
         if (fieldTypeTag == TypeTags.UNION_TAG) {
             DecimalValue refValue = isOriginalValueNull ? null : new DecimalValue(fValue);
-            validateAndSetRefRecordField(bStruct, fieldName, TypeTags.DECIMAL_TAG, retrieveNonNilTypeTag(fieldType),
-                    refValue, UNASSIGNABLE_UNIONTYPE_EXCEPTION);
+            validateAndSetDecimalValue(bStruct, fieldName, retrieveNonNilTypeTag(fieldType), refValue,
+                    UNASSIGNABLE_UNIONTYPE_EXCEPTION);
         } else {
             if (isOriginalValueNull) {
                 handleNilToNonNillableFieldAssignment();
             } else {
-                validateAndSetRefRecordField(bStruct, fieldName, TypeTags.DECIMAL_TAG, fieldTypeTag,
-                        new DecimalValue(fValue), MISMATCHING_FIELD_ASSIGNMENT);
+                validateAndSetDecimalValue(bStruct, fieldName, fieldTypeTag, new DecimalValue(fValue),
+                        MISMATCHING_FIELD_ASSIGNMENT);
             }
         }
     }


### PR DESCRIPTION
## Purpose
Fixes #17150

Fixes #17203

## Samples
With the fix of #17204 following is supported with oracle

```sql
CREATE TABLE Employee (id INT, name VARCHAR(100), age INT, PRIMARY KEY(id));

INSERT INTO Employee (id, name, age) VALUES (1, 'Tom', 25);
```

```ballerina
import ballerina/io;
import ballerinax/java.jdbc;

type Employee record {
    int id; // Previously only decimal type was allowed for this
    string name;
    int age; // Previously only decimal type was allowed for this
};

jdbc:Client testDB = new({
        url: "jdbc:oracle:thin:@localhost:49161:xe",
        username: "system",
        password: "oracle",
        poolOptions: { maximumPoolSize: 1 }
    });

public function main() {
    var dt1 = testDB->select("select * from Employee", Employee);

    if (dt1 is table<Employee>) {
        foreach var entry in dt1 {
            io:println(entry.id, "|", entry.name, "|", entry.age);
        }
    } else {
        io:println(dt1.detail()["message"]);
    }
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
