### PR TITLE
Update record equivalency rules for optional fields

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -551,12 +551,17 @@ public class TypeChecker {
         for (BField targetField : targetType.getFields().values()) {
             BField sourceField = sourceFields.get(targetField.getFieldName());
 
-            // If the LHS field is a required one, there has to be a corresponding required field in the RHS record.
-            if (sourceField == null && !Flags.isFlagOn(targetField.flags, Flags.OPTIONAL)) {
+            if (sourceField == null) {
                 return false;
             }
 
-            if (sourceField != null && !checkIsType(sourceField.type, targetField.type, unresolvedTypes)) {
+            // If the target field is required, the source field should be required as well.
+            if (!Flags.isFlagOn(targetField.flags, Flags.OPTIONAL)
+                    && Flags.isFlagOn(sourceField.flags, Flags.OPTIONAL)) {
+                return false;
+            }
+
+            if (!checkIsType(sourceField.type, targetField.type, unresolvedTypes)) {
                 return false;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1847,13 +1847,18 @@ public class Types {
         for (BField lhsField : lhsType.fields) {
             BField rhsField = rhsFields.get(lhsField.name);
 
-            // If the LHS field is a required one, there has to be a corresponding required field in the RHS record.
-            if (!Symbols.isOptional(lhsField.symbol) && (rhsField == null || Symbols.isOptional(rhsField.symbol))) {
+            // There should be a corresponding RHS field
+            if (rhsField == null) {
                 return false;
             }
 
-            // If there is a corresponding RHS field, it should be assignable to the LHS field.
-            if (rhsField != null && !isAssignable(rhsField.type, lhsField.type, unresolvedTypes)) {
+            // If LHS field is required, so should the RHS field
+            if (!Symbols.isOptional(lhsField.symbol) && Symbols.isOptional(rhsField.symbol)) {
+                return false;
+            }
+
+            // The corresponding RHS field should be assignable to the LHS field.
+            if (!isAssignable(rhsField.type, lhsField.type, unresolvedTypes)) {
                 return false;
             }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorBindingPatternsTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorBindingPatternsTests.java
@@ -82,9 +82,9 @@ public class ForeachErrorBindingPatternsTests {
         BAssertUtil.validateError(negative, i++, "incompatible types: expected '(string|boolean)', found 'string?'",
                 110, 28);
         BAssertUtil.validateError(negative, i++,
-                "invalid error binding pattern with type '$anonType$28'",
-                125, 17);
+                                  "invalid error binding pattern with type '$anonType$28'",
+                                  126, 17);
         BAssertUtil.validateError(negative, i++,
-                "undefined symbol 'otherVar'", 128, 17);
+                                  "undefined symbol 'otherVar'", 129, 17);
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_errors_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_errors_negative.bal
@@ -115,6 +115,7 @@ function testMapWithErrors3() returns string {
 type ReasonT record {|
     string message;
     boolean fatal;
+    error cause?;
 |};
 
 function testForeachReasonBinding() {

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/load_balance_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/load_balance_client_endpoint.bal
@@ -207,13 +207,15 @@ public type LoadBalanceClient client object {
 
 # Represents an error occurred in an remote function of the Load Balance connector.
 #
-# + message - An error message explaining about the error
-# + statusCode - HTTP status code of the LoadBalanceActionError
+# + statusCode - HTTP status code of the `LoadBalanceActionError`
 # + httpActionErr - Array of errors occurred at each endpoint
+# + message - An explanation of the error
+# + cause - The original error which resulted in a `LoadBalanceActionError`
 public type LoadBalanceActionErrorData record {|
-    string message = "";
     int statusCode = 0;
     error?[] httpActionErr = [];
+    string message?;
+    error cause?;
 |};
 
 public type LoadBalanceActionError error<string, LoadBalanceActionErrorData>;

--- a/stdlib/time/src/main/ballerina/src/time/time_errors.bal
+++ b/stdlib/time/src/main/ballerina/src/time/time_errors.bal
@@ -16,6 +16,7 @@
 
 type Detail record {
     string message;
+    error cause?;
 };
 
 public const TIME_ERROR_REASON = "{ballerina/time}TimeError";

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -242,24 +242,24 @@ public class ErrorTest {
         BAssertUtil.validateError(negativeCompileResult, 1,
                                   "incompatible types: expected 'reason one', found 'reason two'", 31, 31);
         BAssertUtil.validateError(negativeCompileResult, 2,
-                                  "invalid error reason type 'int', expected a subtype of 'string'", 40, 28);
+                                  "invalid error reason type 'int', expected a subtype of 'string'", 41, 28);
         BAssertUtil.validateError(negativeCompileResult, 3, "invalid error detail type 'map', expected a subtype of " 
-                + "'record {| string message?; $error0 cause?; (anydata|error)...; |}'", 40, 33);
+                + "'record {| string message?; $error0 cause?; (anydata|error)...; |}'", 41, 33);
         BAssertUtil.validateError(negativeCompileResult, 4, "invalid error detail type 'boolean', expected a subtype "
-                + "of 'record {| string message?; $error0 cause?; (anydata|error)...; |}'", 41, 36);
+                + "of 'record {| string message?; $error0 cause?; (anydata|error)...; |}'", 42, 36);
         BAssertUtil.validateError(negativeCompileResult, 5,
-                                  "invalid error reason type '1.0f', expected a subtype of 'string'", 44, 7);
+                                  "invalid error reason type '1.0f', expected a subtype of 'string'", 45, 7);
         BAssertUtil.validateError(negativeCompileResult, 6,
-                                  "invalid error reason type 'boolean', expected a subtype of 'string'", 47, 11);
-        BAssertUtil.validateError(negativeCompileResult, 7, "self referenced variable 'e3'", 53, 22);
-        BAssertUtil.validateError(negativeCompileResult, 8, "self referenced variable 'e3'", 53, 43);
-        BAssertUtil.validateError(negativeCompileResult, 9, "self referenced variable 'e4'", 54, 42);
+                                  "invalid error reason type 'boolean', expected a subtype of 'string'", 48, 11);
+        BAssertUtil.validateError(negativeCompileResult, 7, "self referenced variable 'e3'", 54, 22);
+        BAssertUtil.validateError(negativeCompileResult, 8, "self referenced variable 'e3'", 54, 43);
+        BAssertUtil.validateError(negativeCompileResult, 9, "self referenced variable 'e4'", 55, 42);
         BAssertUtil.validateError(negativeCompileResult, 10,
-                "cannot infer reason from error constructor: 'UserDefErrorOne'", 55, 27);
+                "cannot infer reason from error constructor: 'UserDefErrorOne'", 56, 27);
         BAssertUtil.validateError(negativeCompileResult, 11,
-                "cannot infer reason from error constructor: 'MyError'", 56, 19);
+                "cannot infer reason from error constructor: 'MyError'", 57, 19);
         BAssertUtil.validateError(negativeCompileResult, 12,
-                "cannot infer type of the error from '(UserDefErrorOne|UserDefErrorTwo)'", 74, 12);
+                "cannot infer type of the error from '(UserDefErrorOne|UserDefErrorTwo)'", 75, 12);
     }
     @DataProvider(name = "userDefTypeAsReasonTests")
     public Object[][] userDefTypeAsReasonTests() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
@@ -192,14 +192,14 @@ public class ErrorVariableReferenceTest {
         BAssertUtil.validateError(resultNegative, ++i,
                 incompatibleTypes + "expected 'boolean', found 'string'", 65, 18);
         BAssertUtil.validateError(resultNegative, ++i, incompatibleTypes +
-                "expected '[any,string,map,[error,any]]', found '[int,string,error,[error,Foo]]'", 78, 58);
+                "expected '[any,string,map,[error,any]]', found '[int,string,error,[error,Foo]]'", 79, 58);
         BAssertUtil.validateError(resultNegative, ++i, incompatibleTypes + "expected 'Bar', " +
-                "found 'record {| string message?; $error0 cause?; (anydata|error)...; |}'", 92, 32);
+                "found 'record {| string message?; $error0 cause?; (anydata|error)...; |}'", 93, 32);
         BAssertUtil.validateError(resultNegative, ++i,
-                incompatibleTypes + "expected 'boolean', found 'string'", 93, 20);
+                incompatibleTypes + "expected 'boolean', found 'string'", 94, 20);
         BAssertUtil.validateError(resultNegative, ++i,
-                                  "error binding pattern does not support index based assignment", 111, 39);
+                                  "error binding pattern does not support index based assignment", 112, 39);
         BAssertUtil.validateError(resultNegative, ++i,
-                                  "error binding pattern does not support index based assignment", 111, 79);
+                                  "error binding pattern does not support index based assignment", 112, 79);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
@@ -190,7 +190,7 @@ public class ErrorVariableReferenceTest {
         BAssertUtil.validateError(resultNegative, ++i,
                 "error constructor expression is not supported for error binding pattern", 43, 81);
         BAssertUtil.validateError(resultNegative, ++i,
-                incompatibleTypes + "expected 'boolean', found 'string'", 64, 18);
+                incompatibleTypes + "expected 'boolean', found 'string'", 65, 18);
         BAssertUtil.validateError(resultNegative, ++i, incompatibleTypes +
                 "expected '[any,string,map,[error,any]]', found '[int,string,error,[error,Foo]]'", 78, 58);
         BAssertUtil.validateError(resultNegative, ++i, incompatibleTypes + "expected 'Bar', " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -92,7 +92,7 @@ public class ObjectInitializerTest {
         validateError(result, 6,
                       "invalid object constructor for 'Person4': expected sub-type of 'error?', but found " +
                               "'(FooErr|BarErr)'",
-                      85, 5);
+                      89, 5);
     }
 
     @Test(description = "Test object initializer invocation")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyRulesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyRulesTest.java
@@ -22,7 +22,6 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
-import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -47,9 +46,12 @@ public class ClosedRecordEquivalencyRulesTest {
     @Test(description = "Negative tests for when both LHS and RHS are closed")
     public void testClosedRecordNegatives() {
         CompileResult negative = BCompileUtil.compile("test-src/record/equiv_rules_neg_cr_to_cr.bal");
-        assertEquals(negative.getErrorCount(), 2);
-        validateError(negative, 0, "incompatible types: expected 'AnotherPerson', found 'Person1'", 28, 24);
-        validateError(negative, 1, "incompatible types: expected 'AnotherPerson', found 'Person2'", 38, 24);
+        int i = 0;
+        validateError(negative, i++, "incompatible types: expected 'AnotherPerson', found 'Person1'", 28, 24);
+        validateError(negative, i++, "incompatible types: expected 'AnotherPerson', found 'Person2'", 38, 24);
+        validateError(negative, i++, "incompatible types: expected 'AnotherPerson3', found 'Person1'", 49, 25);
+        validateError(negative, i++, "incompatible types: expected 'AnotherPerson3', found 'Person1'", 55, 25);
+        assertEquals(negative.getErrorCount(), i);
     }
 
     @Test(description = "Test assigning a closed record to a cloesd record type variable")
@@ -62,20 +64,6 @@ public class ClosedRecordEquivalencyRulesTest {
     public void testCRToCRClosedToClosedAssignment2() {
         BValue[] returns = BRunUtil.invoke(closedRecToClosedRec, "testClosedToClosedAssignment2");
         assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
-    }
-
-    @Test(description = "RHS and LHS closed with additional fields (optional) than RHS")
-    public void testCRToCRClosedToClosedAssignment3() {
-        BValue[] returns = BRunUtil.invoke(closedRecToClosedRec, "testClosedToClosedAssignment3");
-        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
-    }
-
-    @Test(description = "RHS and LHS closed with additional fields (optional) than RHS",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*invalid field access: field 'weight' not found in record type " +
-                  "'Person1'.*")
-    public void testCRToCRClosedToClosedAssignment4() {
-        BRunUtil.invoke(closedRecToClosedRec, "testClosedToClosedAssignment4");
     }
 
     @Test(description = "RHS and LHS closed with RHS required fields corresponding to LHS optional fields")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyRulesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyRulesTest.java
@@ -49,21 +49,24 @@ public class OpenRecordEquivalencyRulesTest {
     public void testORToORNeg() {
         CompileResult negative = BCompileUtil.compile("test-src/record/equiv_rules_neg_or_to_or.bal");
         int index = 0;
-        assertEquals(negative.getErrorCount(), 4);
         validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person1'", 28, 24);
         validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person2'", 38, 24);
         validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person3'", 50, 24);
-        validateError(negative, index, "incompatible types: expected 'AnotherPerson', found 'Person4'", 61, 24);
+        validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person4'", 61, 24);
+        validateError(negative, index++, "incompatible types: expected 'AnotherPerson2', found 'Person1'", 72, 25);
+        assertEquals(negative.getErrorCount(), index);
     }
 
     @Test(description = "Negative tests for when LHS is open and RHS is closed")
     public void testCRToORNeg() {
         CompileResult negative = BCompileUtil.compile("test-src/record/equiv_rules_neg_cr_to_or.bal");
         int index = 0;
-        assertEquals(negative.getErrorCount(), 3);
         validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person1'", 28, 24);
         validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person2'", 38, 24);
-        validateError(negative, index, "incompatible types: expected 'AnotherPerson', found 'Person3'", 50, 24);
+        validateError(negative, index++, "incompatible types: expected 'AnotherPerson', found 'Person3'", 50, 24);
+        validateError(negative, index++, "incompatible types: expected 'AnotherPerson2', found 'Person1'", 61, 25);
+        validateError(negative, index++, "incompatible types: expected 'AnotherPerson2', found 'Person1'", 67, 25);
+        assertEquals(negative.getErrorCount(), index);
     }
 
     @Test(description = "Test assigning a closed record to an open record type variable")
@@ -78,26 +81,12 @@ public class OpenRecordEquivalencyRulesTest {
         assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
     }
 
-    @Test(description = "RHS closed and LHS open with additional fields (optional) than RHS")
-    public void testCRToORClosedToOpenAssignment3() {
-        BValue[] returns = BRunUtil.invoke(closedRecToOpenRec, "testClosedToOpenAssignment3");
-        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
-    }
-
-    @Test(description = "RHS closed and LHS open and assigning to an extra optional field in LHS",
-          expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*invalid field access: field 'weight' not found in record type " +
-                  "'Person1'.*")
-    public void testCRToORClosedToOpenAssignment4() {
-        BRunUtil.invoke(closedRecToOpenRec, "testClosedToOpenAssignment4");
-    }
-
     @Test(description = "RHS closed and LHS open and adding a rest field in LHS",
           expectedExceptions = BLangRuntimeException.class,
           expectedExceptionsMessageRegExp = ".*invalid field access: field 'rest' not found in record type " +
                   "'Person1'.*")
-    public void testCRToORClosedToOpenAssignment5() {
-        BRunUtil.invoke(closedRecToOpenRec, "testClosedToOpenAssignment5");
+    public void testCRToORClosedToOpenAssignment3() {
+        BRunUtil.invoke(closedRecToOpenRec, "testClosedToOpenAssignment3");
     }
 
     @Test(description = "RHS closed and LHS open with RHS required fields corresponding to LHS optional fields")
@@ -136,12 +125,6 @@ public class OpenRecordEquivalencyRulesTest {
     @Test(description = "RHS and LHS both open with RHS field types which are assignable to LHS field types")
     public void testORToOROpenToOpenAssignment2() {
         BValue[] returns = BRunUtil.invoke(openRecToOpenRec, "testOpenToOpenAssignment2");
-        assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
-    }
-
-    @Test(description = "RHS and LHS both open with additional fields (optional) than RHS")
-    public void testORToOROpenToOpenAssignment3() {
-        BValue[] returns = BRunUtil.invoke(openRecToOpenRec, "testOpenToOpenAssignment3");
         assertEquals(returns[0].stringValue(), "{name:\"John Doe\", age:25}");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredErrorPatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredErrorPatternsTest.java
@@ -196,7 +196,7 @@ public class MatchStructuredErrorPatternsTest {
         BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 48, 13);
         BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 58, 13);
         BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 63, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 77, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 82, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 78, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 83, 13);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredErrorPatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredErrorPatternsTest.java
@@ -190,13 +190,13 @@ public class MatchStructuredErrorPatternsTest {
         int i = -1;
         String unreachablePattern = "unreachable pattern: " +
                 "preceding patterns are too general or the pattern ordering is not correct";
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 27, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 32, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 42, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 48, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 58, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 63, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 78, 13);
-        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 83, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 29, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 34, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 44, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 50, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 60, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 65, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 80, 13);
+        BAssertUtil.validateError(resultNegative, ++i, unreachablePattern, 85, 13);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/closures/var-mutability-closure.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/closures/var-mutability-closure.bal
@@ -307,6 +307,8 @@ function test12() returns xml {
 
 type AccountNotFoundErrorData record {
     int accountID;
+    string message?;
+    error cause?;
 };
 
 type AccountNotFoundError error<string, AccountNotFoundErrorData>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -252,6 +252,8 @@ function testIndirectErrorConstructor() returns [UserDefErrorTwoA, UserDefErrorT
 
 type Detail record {
     int code;
+    string message?;
+    error cause?;
 };
 
 const FOO = "foo";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -34,6 +34,7 @@ function testInvalidErrorReasonWithConstantAsReason() returns error {
 
 type Foo record {|
     string message;
+    error cause?;
     int...;
 |};
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -103,6 +103,7 @@ function checkEqualityToNilNegative(any a) returns boolean {
 
 type ErrorDetail record {
     string message?;
+    error cause?;
 };
 
 type MyError error<string, ErrorDetail>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -748,6 +748,7 @@ const ERR_REASON_TWO = "error reason two";
 
 type Details record {
     string message;
+    error cause?;
 };
 
 type MyError error<ERR_REASON, Details>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_negative.bal
@@ -17,9 +17,9 @@ function testCheckedExprSemanticErrors2() returns error? {
     return ();
 }
 
-public type MyError error<string, record { int code; }>;
+public type MyError error<string, record { int code; string message?; error cause?; }>;
 
-public type CustomError error<string, record { int code; string data; }>;
+public type CustomError error<string, record { int code; string data; string message?; error cause?;}>;
 
 function readLine() returns MyError | CustomError {
     MyError e = error("io error", code = 0);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
@@ -78,12 +78,16 @@ type Person record {
 };
 
 public type MyErrorData record {|
+    string message?;
+    error cause?;
 |};
 
 type MyError error<string, MyErrorData>;
 
 public type CustomErrorData record {|
     string data;
+    string message?;
+    error cause?;
 |};
 
 type CustomError error<string, CustomErrorData>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkpanicexpr/check_panic_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkpanicexpr/check_panic_expr.bal
@@ -53,7 +53,7 @@ function returnBallerinaPanicedError() returns int|error {
     return ret;
 }
 
-public type MyError error<string, record { int code; }>;
+public type MyError error<string, record { int code; string message?; error cause?;}>;
 
 function getCustomError() returns int|MyError {
     MyError e = error("My Error", code = 12);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkpanicexpr/check_panic_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkpanicexpr/check_panic_expr_negative.bal
@@ -16,9 +16,9 @@ function testCheckedExprSemanticErrors2() returns error? {
     string line = checkpanic readLineError();
 }
 
-public type MyError error<string, record { int code; }>;
+public type MyError error<string, record { int code; string message?; error cause?; }>;
 
-public type CustomError error<string, record { int code; string data; }>;
+public type CustomError error<string, record { int code; string data; string message?; error cause?; }>;
 
 function readLine() returns MyError | CustomError {
     MyError e = error("io error", code = 0);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr.bal
@@ -21,6 +21,7 @@ type MyErrorTwo error<ERR_REASON, ErrorDetails>;
 
 type ErrorDetails record {
    string message;
+   error cause?;
 };
 
 type Employee record {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference.bal
@@ -18,10 +18,10 @@ type StringRestRec record {|
     string...;
 |};
 
-type SMS error <string, record {| string...; |}>;
-type SMA error <string, record {| string|boolean...; |}>;
-type CMS error <string, record {| string...; |}>;
-type CMA error <string, record {| anydata...; |}>;
+type SMS error <string, record {| string message?; error cause?; string...; |}>;
+type SMA error <string, record {| string message?; error cause?; string|boolean...; |}>;
+type CMS error <string, record {| string message?; error cause?; string...; |}>;
+type CMA error <string, record {| string message?; error cause?; anydata...; |}>;
 
 const ERROR1 = "Some Error One";
 const ERROR2 = "Some Error Two";
@@ -87,6 +87,7 @@ function testBasicErrorVariableWithConstAndMap() returns [string, string, string
 type Foo record {
     string message;
     boolean fatal;
+    error cause?;
 };
 
 type FooError error <string, Foo>;
@@ -181,7 +182,8 @@ function testErrorInRecordWithDestructure2() returns [int, string, anydata|error
 }
 
 function testErrorWithRestParam() returns map<string> {
-    error<string, record {| string...; |}> errWithMap = error("Error", message = "Fatal", fatal = "true");
+    error<string, record {| string message?; error cause?; string...; |}> errWithMap
+                                                    = error("Error", message = "Fatal", fatal = "true");
 
     string reason;
     string? message;
@@ -193,7 +195,8 @@ function testErrorWithRestParam() returns map<string> {
 }
 
 function testErrorWithUnderscore() returns [string, map<string>] {
-    error<string, record {| string...; |}> errWithMap = error("Error", message = "Fatal", fatal = "true");
+    error<string, record {| string message?; error cause?; string...; |}> errWithMap
+                                                        = error("Error", message = "Fatal", fatal = "true");
 
     string reason;
     map<string> detail;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference_negative.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-type SMS error <string, record {| string...; |}>;
-type SMA error <string, record {| string|boolean...; |}>;
+type SMS error <string, record {| string message?; error cause?; string...; |}>;
+type SMA error <string, record {| string message?; error cause?; string|boolean...; |}>;
 
 function testBasicErrorVariableWithMapDetails() {
     SMS err1 = error("Error One", message = "Msg One", detail = "Detail Msg");
@@ -46,6 +46,7 @@ function testBasicErrorVariableWithMapDetails() {
 type Foo record {
     string message;
     boolean fatal;
+    error cause?;
 };
 
 type FooError error <string, Foo>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/checked_expr_operator_basics.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/checked_expr_operator_basics.bal
@@ -78,12 +78,16 @@ type Person record {
 };
 
 public type MyErrorData record {|
+    string message?;
+    error cause?;
 |};
 
 type MyError error<string, MyErrorData>;
 
 public type CustomErrorData record {|
     string data;
+    string message?;
+    error cause?;
 |};
 
 type CustomError error<string, CustomErrorData>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/error_test.bal
@@ -125,6 +125,7 @@ function panicWithReasonAndDetailMap() {
 type DetailRec record {
     string message;
     int statusCode;
+    error cause?;
 };
 
 function panicWithReasonAndDetailRecord() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/main.function/test_main_with_error_or_nil_return.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/main.function/test_main_with_error_or_nil_return.bal
@@ -20,6 +20,7 @@ const ERR_REASON = "const error reason";
 type ErrorRecord record {
     string message;
     int statusCode;
+    error cause?;
 };
 
 type USER_DEF_ERROR error<ERR_REASON, ErrorRecord>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -142,6 +142,8 @@ type Person3 object {
 
 type ErrorDetails record {
     int id;
+    string message?;
+    error cause?;
 };
 
 type Err error<string, ErrorDetails>;
@@ -169,12 +171,16 @@ type Person4 object {
 
 type FooErrData record {
     string f;
+    string message?;
+    error cause?;
 };
 
 type FooErr error<string, FooErrData>;
 
 type BarErrData record {
     string b;
+    string message?;
+    error cause?;
 };
 
 type BarErr error<string, BarErrData>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_initializer_negative.bal
@@ -69,12 +69,16 @@ type Person3 object {
 
 type FooErrData record {
     string f;
+    string message?;
+    error cause?;
 };
 
 type FooErr error<string, FooErrData>;
 
 type BarErrData record {
     string b;
+    string message?;
+    error cause?;
 };
 
 type BarErr error<string, BarErrData>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equiv_rules_neg_cr_to_cr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equiv_rules_neg_cr_to_cr.bal
@@ -37,3 +37,21 @@ function testMissingRequiredField2() {
     Person2 p = {name:"John"};
     AnotherPerson ap = p;
 }
+
+type AnotherPerson3 record {|
+    string name;
+    float weight?;
+|};
+
+// Tests assignment when the LHS type has optional fields which don't correspond to any fields in the RHS type.
+function testClosedToClosedAssignment1() returns AnotherPerson3 {
+    Person1 p = {name:"John Doe"};
+    AnotherPerson3 ap = p;
+    return ap;
+}
+
+function testClosedToClosedAssignment2() {
+    Person1 p = {name:"John Doe"};
+    AnotherPerson3 ap = p;
+    ap.weight = 60.5;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equiv_rules_neg_cr_to_or.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equiv_rules_neg_cr_to_or.bal
@@ -49,3 +49,21 @@ function testMismatchingRestField1() {
     Person3 p = {name:"John", age:25, address:adr};
     AnotherPerson ap = p;
 }
+
+type AnotherPerson2 record {
+    string name;
+    int age;
+    float weight?;
+};
+
+function testMissingOptionalFieldInRHS1() returns AnotherPerson2 {
+    Person1 p = {name:"John Doe"};
+    AnotherPerson2 ap = p;
+    return ap;
+}
+
+function testMissingOptionalFieldInRHS2() {
+    Person1 p = {name:"John Doe"};
+    AnotherPerson2 ap = p;
+    ap.weight = 60.5;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equiv_rules_neg_or_to_or.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equiv_rules_neg_or_to_or.bal
@@ -60,3 +60,15 @@ function testMismatchingRestField2() {
     Person4 p = {name:"John", age:25};
     AnotherPerson ap = p;
 }
+
+type AnotherPerson2 record {
+    string name;
+    int age;
+    float weight?;
+};
+
+function testMissingOptFieldInRHS() returns AnotherPerson2 {
+    Person1 p = {name:"John Doe"};
+    AnotherPerson2 ap = p;
+    return ap;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_cr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_cr.bal
@@ -41,25 +41,6 @@ function testClosedToClosedAssignment2() returns AnotherPerson2 {
     return ap;
 }
 
-type AnotherPerson3 record {|
-    string name;
-    int age;
-    float weight?;
-|};
-
-// Tests assignment when the LHS type has optional fields which don't correspond to any fields in the RHS type.
-function testClosedToClosedAssignment3() returns AnotherPerson3 {
-    Person1 p = {name:"John Doe", age:25};
-    AnotherPerson3 ap = p;
-    return ap;
-}
-
-function testClosedToClosedAssignment4() {
-    Person1 p = {name:"John Doe", age:25};
-    AnotherPerson3 ap = p;
-    ap.weight = 60.5;
-}
-
 
 //////////////////////////////////////////////////////////////////
 // Test for when the LHS type has optional fields which correspond to required fields of the RHS type.

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_or.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_cr_to_or.bal
@@ -41,27 +41,9 @@ function testClosedToOpenAssignment2() returns AnotherPerson2 {
     return ap;
 }
 
-type AnotherPerson3 record {
-    string name;
-    int age;
-    float weight?;
-};
-
-function testClosedToOpenAssignment3() returns AnotherPerson3 {
+function testClosedToOpenAssignment3() {
     Person1 p = {name:"John Doe", age:25};
-    AnotherPerson3 ap = p;
-    return ap;
-}
-
-function testClosedToOpenAssignment4() {
-    Person1 p = {name:"John Doe", age:25};
-    AnotherPerson3 ap = p;
-    ap.weight = 60.5;
-}
-
-function testClosedToOpenAssignment5() {
-    Person1 p = {name:"John Doe", age:25};
-    AnotherPerson3 ap = p;
+    AnotherPerson2 ap = p;
     ap["rest"] = "foo";
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_or_to_or.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/equivalency_rules_or_to_or.bal
@@ -41,19 +41,6 @@ function testOpenToOpenAssignment2() returns AnotherPerson2 {
     return ap;
 }
 
-type AnotherPerson3 record {
-    string name;
-    int age;
-    float weight?;
-};
-
-function testOpenToOpenAssignment3() returns AnotherPerson3 {
-    Person1 p = {name:"John Doe", age:25};
-    AnotherPerson3 ap = p;
-    return ap;
-}
-
-
 //////////////////////////////////////////////////////////////////
 // Test for when the LHS type has optional fields which correspond to required fields of the RHS type.
 // This is allowed.

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -403,7 +403,7 @@ function testTypeGuardsWithRecords_2() returns string {
     }
 }
 
-public type CustomError error<string, record { int status = 500; }>;
+public type CustomError error<string, record { int status = 500; string message?; error cause?; }>;
 
 function testTypeGuardsWithError() returns string {
     CustomError err = error("some error");
@@ -903,6 +903,7 @@ const ERR_REASON_TWO = "error reason two";
 
 type Details record {
     string message;
+    error cause?;
 };
 
 type MyError error<ERR_REASON, Details>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_error_match_patterns.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_error_match_patterns.bal
@@ -35,12 +35,16 @@ type ErrorData record {
     string a?;
     error err?;
     map<string> m?;
+    string message?;
+    error cause?;
 };
 
 type ErrorData2 record {
     string a?;
     error err?;
     map<string|boolean> m?;
+    string message?;
+    error cause?;
 };
 
 function testBasicErrorMatch() returns string {
@@ -104,6 +108,7 @@ function testBasicErrorMatch3() returns string {
 type Foo record {|
     boolean fatal;
     string message?;
+    error cause?;
 |};
 
 type ER1 error <string, Foo>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_error_match_patterns_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_error_match_patterns_negative.bal
@@ -18,6 +18,8 @@ import ballerina/io;
 
 type ClosedFoo record {|
     string s;
+    string message?;
+    error cause?;
 |};
 
 function testErrorPattern1() returns string {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_error_match_patterns_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/structured_error_match_patterns_negative.bal
@@ -67,6 +67,7 @@ function testErrorPattern3() returns string {
 
 type OpenedFoo record {
     string message;
+    error cause?;
 };
 
 function testErrorPattern5() returns string {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/error_variable_definition_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/error_variable_definition_stmt.bal
@@ -14,10 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-type SMS error <string, record {| string...; |}>;
-type SMA error <string, record {| anydata...; |}>;
-type CMS error <string, record {| string...; |}>;
-type CMA error <string, record {| anydata...; |}>;
+type SMS error <string, record {| string message?; error cause?; string...; |}>;
+type SMA error <string, record {| string message?; error cause?; anydata...; |}>;
+type CMS error <string, record {| string message?; error cause?; string...; |}>;
+type CMA error <string, record {| string message?; error cause?; anydata...; |}>;
 const ERROR1 = "Some Error One";
 const ERROR2 = "Some Error Two";
 
@@ -76,6 +76,7 @@ function testVarBasicErrorVariableWithConstAndMap() returns [string, string, str
 type Foo record {
     string message;
     boolean fatal;
+    error cause?;
 };
 
 type FooError error <string, Foo>;
@@ -128,16 +129,16 @@ function testErrorInRecordWithDestructure() returns [int, string, anydata|error]
 }
 
 function testErrorWithAnonErrorType() returns [string, string?] {
-    error <string, record {| string...; |}> err = error("Error Code", message = "Fatal");
-    error <string, record {| string...; |}> error(reason, message = message) = err;
+    error <string, record {| string message?; error cause?; string...; |}> err = error("Error Code", message = "Fatal");
+    error <string, record {| string message?; error cause?; string...; |}> error(reason, message = message) = err;
     return [reason, message];
 }
 
 function testErrorWithUnderscore() returns [string, string, string, string, string, string, string, string,
                                                string?, anydata|error?, anydata|error?] {
-    error <string, record {| string...; |}> err = error("Error Code", message = "Fatal");
-    error <string, record {| string...; |}> error (reason, ... _) = err;
-    error <string, record {| string...; |}> error (reason2) = err;
+    error <string, record {| string message?; error cause?; string...; |}> err = error("Error Code", message = "Fatal");
+    error <string, record {| string message?; error cause?; string...; |}> error (reason, ... _) = err;
+    error <string, record {| string message?; error cause?; string...; |}> error (reason2) = err;
 
     SMS err1 = error("Error One", message = "Msg One", detail = "Detail Msg");
     SMS error (reason3, ... _) = err1;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/error_variable_definition_stmt_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/error_variable_definition_stmt_negative.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-type SMS error <string, record {| string...; |}>;
-type SMA error <string, record {| anydata...; |}>;
+type SMS error <string, record {| string message?; error cause?; string...; |}>;
+type SMA error <string, record {| string message?; error cause?; anydata...; |}>;
 
 function testBasicErrorVariableWithMapDetails() {
     SMS err1 = error("Error One", message = "Msg One", detail = "Detail Msg");
@@ -63,13 +63,13 @@ function errorVarInTupleVar() {
 }
 
 function errorVarWithConstrainedMap() {
-    error <string, record {| string...; |}> err = error("Error Code", message = "Fatal");
+    error <string, record {| string message?; error cause?; string...; |}> err = error("Error Code", message = "Fatal");
     var error (reason, message = message) = err;
     string m = message; // incompatible types: expected 'string', found 'string?'
 }
 
 function errorVarWithUnderscore() {
-    error <string, record {| string...; |}> err = error("Error Code", message = "Fatal");
+    error <string, record {| string message?; error cause?; string...; |}> err = error("Error Code", message = "Fatal");
     var error (_, ..._) = err; // no new variables on left side
     var error (_) = err; // no new variables on left side
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -863,6 +863,8 @@ type MyError error<string, MyErrorDetail>;
 type MyErrorDetail record {|
     error e1;
     error e2;
+    string message?;
+    error cause?;
 |};
 
 error e1 = error("err reason");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/errors/error-return.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/errors/error-return.bal
@@ -1,4 +1,4 @@
-public type InvalidNameError error<string, record { string companyName; }>;
+public type InvalidNameError error<string, record { string companyName; string message?; error cause?; }>;
 
 function getQuote(string name) returns (float|InvalidNameError) {
 


### PR DESCRIPTION
## Purpose
> This PR disallows cases where a record was considered assignable even if the value's type didn't have the optional fields defined in the LHS type.

Fixes #17121 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
