### PR TITLE
Fix documentation preview for functions

### DIFF
--- a/composer/packages/documentation/src/components/DocPreview.jsx
+++ b/composer/packages/documentation/src/components/DocPreview.jsx
@@ -90,14 +90,7 @@ export default class DocPreview extends React.Component {
             parameters[param.name.value] = {
                 name: param.name.value,
                 type: ASTUtil.genSource(param.typeNode),
-            };
-        });
-
-        node.defaultableParameters.forEach(param => {
-            parameters[param.variable.name.value] = {
-                name: param.variable.name.value,
-                type: ASTUtil.genSource(param.variable.typeNode),
-                defaultValue: param.variable.initialExpression.value,
+                defaultValue: param.initialExpression ? param.initialExpression.value : undefined,
             };
         });
 


### PR DESCRIPTION
## Purpose
Fix doc preview for public functions. This was broken due to removing defaultableParameters field from function node. 

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
