### PR TITLE
Reset all expandings if a certain depth is picked

### DIFF
--- a/composer/packages/diagram/src/diagram/overview.tsx
+++ b/composer/packages/diagram/src/diagram/overview.tsx
@@ -3,6 +3,7 @@ import { IBallerinaLangClient, ProjectAST } from "@ballerina/lang-service";
 import { PanZoom } from "panzoom";
 import React from "react";
 import { DropdownItemProps, List, ListItemProps, Loader } from "semantic-ui-react";
+import { visitor as expandingResettingVisitor } from "../visitors/expandings-undoing-visitor";
 import { CommonDiagramProps, Diagram } from "./diagram";
 import { DiagramMode } from "./diagram-context";
 import { DiagramUtils } from "./diagram-utils";
@@ -133,9 +134,49 @@ export class Overview extends React.Component<OverviewProps, OverviewState> {
             return this.renderModulesList();
         }
 
-        const selectedModule = this.state.selectedConstruct.moduleName;
-        const selectedConstruct = this.state.selectedConstruct.constructName;
-        const selectedSubConstruct = this.state.selectedConstruct.subConstructName;
+        const {
+            selectedAST,
+            selectedUri,
+        } = this.getSelected(this.state.selectedConstruct);
+
+        return (
+            <div style={{height: "100%"}}>
+                <TopMenu
+                    modes={modes}
+                    handleModeChange={this.handleModeChange}
+                    selectedModeText={this.state.modeText}
+                    openedState={this.state.openedState}
+                    handleBackClick={this.handleBackClick}
+                    handleFitClick={this.handleFitClick}
+                    handleZoomIn={this.handleZoomIn}
+                    handleZoomOut={this.handleZoomOut}
+                    handleOpened={this.handleOpened}
+                    handleClosed={this.handleClosed}
+                    zoomFactor={this.state.zoomFactor}
+                    handleReset={this.handleReset}
+                    handleDepthSelect={this.setMaxInvocationDepth}
+                    maxInvocationDepth={this.state.maxInvocationDepth}
+                />
+                <Diagram ast={selectedAST}
+                    langClient={this.props.langClient}
+                    projectAst={modules}
+                    docUri={selectedUri}
+                    zoom={0} height={0} width={1000}
+                    mode={this.state.mode}
+                    setPanZoomComp={this.setPanZoomComp}
+                    maxInvocationDepth={this.state.maxInvocationDepth}>
+                </Diagram>
+            </div>
+        );
+    }
+
+    private getSelected(selectConstructDetails: ConstructIdentifier): {
+        selectedAST: ASTNode | undefined,
+        selectedUri: string,
+    } {
+        const selectedModule = selectConstructDetails.moduleName;
+        const selectedConstruct = selectConstructDetails.constructName;
+        const selectedSubConstruct = selectConstructDetails.subConstructName;
         const moduleList = this.getModuleList();
 
         const moduleNames: string[] = [];
@@ -167,35 +208,10 @@ export class Overview extends React.Component<OverviewProps, OverviewState> {
             }
         });
 
-        return (
-            <div style={{height: "100%"}}>
-                <TopMenu
-                    modes={modes}
-                    handleModeChange={this.handleModeChange}
-                    selectedModeText={this.state.modeText}
-                    openedState={this.state.openedState}
-                    handleBackClick={this.handleBackClick}
-                    handleFitClick={this.handleFitClick}
-                    handleZoomIn={this.handleZoomIn}
-                    handleZoomOut={this.handleZoomOut}
-                    handleOpened={this.handleOpened}
-                    handleClosed={this.handleClosed}
-                    zoomFactor={this.state.zoomFactor}
-                    handleReset={this.handleReset}
-                    handleDepthSelect={this.setMaxInvocationDepth}
-                    maxInvocationDepth={this.state.maxInvocationDepth}
-                />
-                <Diagram ast={selectedAST}
-                    langClient={this.props.langClient}
-                    projectAst={modules}
-                    docUri={selectedUri}
-                    zoom={0} height={0} width={1000}
-                    mode={this.state.mode}
-                    setPanZoomComp={this.setPanZoomComp}
-                    maxInvocationDepth={this.state.maxInvocationDepth}>
-                </Diagram>
-            </div>
-        );
+        return {
+            selectedAST,
+            selectedUri
+        };
     }
 
     private renderModulesList() {
@@ -363,6 +379,19 @@ export class Overview extends React.Component<OverviewProps, OverviewState> {
     }
 
     private setMaxInvocationDepth(depth: number) {
+        // reset any expandings
+        if (!this.state.selectedConstruct) {
+            return;
+        }
+
+        const {
+            selectedAST
+        } = this.getSelected(this.state.selectedConstruct);
+
+        if (selectedAST) {
+            ASTUtil.traversNode(selectedAST, expandingResettingVisitor);
+        }
+
         this.setState({
             maxInvocationDepth: depth,
         });

--- a/composer/packages/diagram/src/diagram/top-menu.tsx
+++ b/composer/packages/diagram/src/diagram/top-menu.tsx
@@ -116,14 +116,14 @@ export const TopMenu = (props: TopMenuProps) => {
                             </Dropdown.Menu>
                         </Dropdown>
                         <Popup
-                            trigger={<Icon onClick={() => handleDepthSelect(0)}  className="fw fw-expand-all"/>}
+                            trigger={<Icon onClick={() => handleDepthSelect(-1)}  className="fw fw-expand-all"/>}
                             content="Expand all"
                             position="top center"
                             size="small"
                             inverted
                         />
                         <Popup
-                            trigger={<Icon onClick={() => handleDepthSelect(-1)} className="fw fw-collapse-all"/>}
+                            trigger={<Icon onClick={() => handleDepthSelect(0)} className="fw fw-collapse-all"/>}
                             content="Collapse all"
                             position="top center"
                             size="small"

--- a/composer/packages/diagram/src/visitors/expandings-undoing-visitor.ts
+++ b/composer/packages/diagram/src/visitors/expandings-undoing-visitor.ts
@@ -1,0 +1,35 @@
+import { Assignment, ASTKindChecker, ASTNode, ASTUtil,
+         ExpressionStatement, VariableDef, Visitor } from "@ballerina/ast-model";
+import { StmntViewState } from "../view-model/index";
+
+export const visitor: Visitor = {
+    endVisitExpressionStatement(node: ExpressionStatement) {
+        if (ASTUtil.isActionInvocation(node)) {
+            return;
+        }
+
+        const viewState = node.viewState as StmntViewState;
+        if (ASTKindChecker.isInvocation(node.expression)) {
+            resetExpandings(node.expression, viewState);
+        }
+    },
+
+    endVisitVariableDef(node: VariableDef) {
+        if (ASTKindChecker.isVariable(node.variable) && node.variable.initialExpression) {
+            resetExpandings(node.variable.initialExpression, node.viewState as StmntViewState);
+        }
+    },
+
+    endVisitAssignment(node: Assignment) {
+        resetExpandings(node.expression, node.viewState as StmntViewState);
+    }
+};
+
+function resetExpandings(expression: ASTNode, viewState: StmntViewState) {
+    if (viewState.expandContext) {
+        viewState.expandContext.skipDepthCheck = false;
+        if (viewState.expandContext.expandedSubTree) {
+            ASTUtil.traversNode(viewState.expandContext.expandedSubTree, visitor);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
User can expand or collapse any invocation even though a global invocation depth is picked. But these should reset if user picks expand-all or collpase-all or any given depth.

This PR implements this.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
