### PR TITLE
Update vscode and composer version updating logic

### DIFF
--- a/composer/scripts/update-version.js
+++ b/composer/scripts/update-version.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const packageJson = require("../package.json");
-packageJson.version = process.argv[2].match(/\d+/g).slice(0,3).join(".");
+packageJson.version = process.argv[2];
 
 fs.writeFileSync(
     path.join(__dirname, "..", "package.json"),

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "ballerina",
     "displayName": "Ballerina",
     "description": "Intellisense, Diagram View, Debugging, code formatting and refactoring for Ballerina",
-    "version": "0.992.0",
+    "version": "1.0.0-alpha",
     "publisher": "ballerina",
     "repository": {
         "type": "git",

--- a/tool-plugins/vscode/scripts/update-version.js
+++ b/tool-plugins/vscode/scripts/update-version.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const packageJson = require("../package.json");
-packageJson.version = process.argv[2].match(/\d+/g).slice(0,3).join(".");
+packageJson.version = process.argv[2];
 
 fs.writeFileSync(
     path.join(__dirname, "..", "package.json"),


### PR DESCRIPTION
## Purpose
This avoid vscode extension build from replacing 1.0.0-alpha with 1.0.0

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
