### PR TITLE
Enable Failing WebSocket tests

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -102,7 +102,7 @@ public class WebSocketUtil {
             @Override
             public void onError(Throwable throwable) {
                 if (callback != null) {
-                    callback.notifyFailure(createWebSocketError(WsInvalidHandshakeError ,
+                    callback.notifyFailure(createWebSocketError(WsInvalidHandshakeError,
                             "Unable to complete handshake:" + throwable.getMessage()));
                 } else {
                     throw new WebSocketException("Unable to complete handshake", throwable);
@@ -159,7 +159,7 @@ public class WebSocketUtil {
             Throwable cause = future.cause();
             if (!future.isSuccess() && cause != null) {
                 //TODO Temp fix to get return values. Remove
-                callback.setReturnValues(createWebSocketError(null, cause.getMessage()));
+                callback.setReturnValues(createWebSocketError(cause.getMessage()));
 
             } else {
                 //TODO Temp fix to get return values. Remove

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
@@ -29,34 +29,32 @@ import org.testng.annotations.Test;
  */
 public class WebSocketCompilationTest {
 
-    //The success tests have been disabled till https://github.com/ballerina-platform/ballerina-lang/issues/15867 is
-    // resolved
     private static final String TEST_PATH = "test-src/websocket/";
 
-    @Test(description = "Successfully compiling WebSocketService", enabled = false)
+    @Test(description = "Successfully compiling WebSocketService")
     public void testSuccessServer() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "success.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "success.bal");
 
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }
 
-    @Test(description = "Successfully compiling WebSocketClientService", enabled = false)
+    @Test(description = "Successfully compiling WebSocketClientService")
     public void testSuccessClient() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "success_client.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "success_client.bal");
 
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }
 
-    @Test(description = "Successfully compiling WebSocket upgrade resource", enabled = false)
+    @Test(description = "Successfully compiling WebSocket upgrade resource")
     public void testSuccessWebSocketUpgrade() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "success_websocket_upgrade.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "success_websocket_upgrade.bal");
 
         Assert.assertEquals(compileResult.toString(), "Compilation Successful");
     }
 
     @Test(description = "Invalid signature for onOpen and onIdle resources")
     public void testFailOnOpenOnIdle() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onOpen_onIdle.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onOpen_onIdle.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 3);
         BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onOpen resource in service " +
@@ -69,7 +67,7 @@ public class WebSocketCompilationTest {
 
     @Test(description = "Invalid parameter count for onText resource")
     public void testFailOnTextParamCount() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onText_param_count.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onText_param_count.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onText resource in service " +
@@ -78,63 +76,63 @@ public class WebSocketCompilationTest {
 
     @Test(description = "Invalid signature for onText resource with int")
     public void testFailOnTextInt() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onText.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onText.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0,
-                                  "Invalid resource signature for onText resource in service : The second " +
-                                          "parameter should be a string, json, xml, byte[] or a record type", 21, 5);
+                "Invalid resource signature for onText resource in service : The second " +
+                        "parameter should be a string, json, xml, byte[] or a record type", 21, 5);
     }
 
     @Test(description = "Invalid signature for onText resource with JSON and final fragment")
     public void testFailOnTextJSON() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onText_JSON.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onText_JSON.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0,
-                                  "Invalid resource signature for onText resource in service : Final " +
-                                          "fragment is not valid if the second parameter is not a string", 21, 5);
+                "Invalid resource signature for onText resource in service : Final " +
+                        "fragment is not valid if the second parameter is not a string", 21, 5);
     }
 
     @Test(description = "Invalid signature for onBinary resource")
     public void testFailOnBinary() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onBinary.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onBinary.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0,
-                                  "Invalid resource signature for onBinary resource in service : The second " +
-                                          "parameter should be a byte[]", 27, 5);
+                "Invalid resource signature for onBinary resource in service : The second " +
+                        "parameter should be a byte[]", 27, 5);
     }
 
     @Test(description = "Invalid signature for onPing and onPong resources")
     public void testFailOnPingOnPong() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onPing_onPong.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onPing_onPong.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 3);
         BAssertUtil.validateError(compileResult, 0,
-                                  "Invalid resource signature for onPing resource in service : The second " +
-                                          "parameter should be a byte[]", 27, 5);
+                "Invalid resource signature for onPing resource in service : The second " +
+                        "parameter should be a byte[]", 27, 5);
         BAssertUtil.validateError(compileResult, 1, "Invalid resource signature for onPong resource in service " +
                 ": Expected parameter count = 2", 31, 5);
         BAssertUtil.validateError(compileResult, 2,
-                                  "Invalid resource signature for onPong resource in service : The second " +
-                                          "parameter should be a byte[]", 31, 5);
+                "Invalid resource signature for onPong resource in service : The second " +
+                        "parameter should be a byte[]", 31, 5);
     }
 
     @Test(description = "Invalid signature for onClose resource")
     public void testFailOnClose() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onClose.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onClose.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0,
-                                  "Invalid resource signature for onClose resource in service : The third parameter " +
-                                          "should be a string",
-                                  27, 5);
+                "Invalid resource signature for onClose resource in service : The third parameter " +
+                        "should be a string",
+                27, 5);
     }
 
     @Test(description = "Invalid signature for onError resources")
     public void testFailOnError() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onError.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onError.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 2);
         BAssertUtil.validateError(compileResult, 0, "Invalid resource signature for onError resource in service " +
@@ -145,7 +143,7 @@ public class WebSocketCompilationTest {
 
     @Test(description = "Invalid resource in WebSocketService")
     public void testInValidResource() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "invalid_resource.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "invalid_resource.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0, "Invalid resource name onFind in service ", 27, 5);
@@ -153,26 +151,26 @@ public class WebSocketCompilationTest {
 
     @Test(description = "Invalid resource onOpen in WebSocketClientService")
     public void testFailOnOpenClient() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_onOpen_client.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_onOpen_client.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0,
-                                  "onOpen resource is not supported for WebSocketClientService",
-                                  22, 5);
+                "onOpen resource is not supported for WebSocketClientService",
+                22, 5);
     }
 
     @Test(description = "WebSocket upgrade resource config has a no upgradeService")
     public void testFailWebSocketUpgradeNoService() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "fail_websocket_upgrade_no_service.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "fail_websocket_upgrade_no_service.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0,
-                                  "An upgradeService need to be specified for the WebSocket upgrade resource", 24, 5);
+                "An upgradeService need to be specified for the WebSocket upgrade resource", 24, 5);
     }
 
     @Test(description = "Resource returns can only be error or nil")
     public void testResourceReturn() {
-        CompileResult compileResult = BCompileUtil.compile(TEST_PATH + "resource_return.bal");
+        CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "resource_return.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
         BAssertUtil.validateError(compileResult, 0, "Invalid return type: expected error?", 21, 5);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -134,14 +134,27 @@ public class BCompileUtil {
      */
     public static CompileResult compile(String sourceFilePath) {
         if (jBallerinaTestsEnabled()) {
-            return compileOnJBallerina(sourceFilePath, false);
+            return compileOnJBallerina(sourceFilePath, false, true);
+        }
+        return compile(sourceFilePath, CompilerPhase.CODE_GEN);
+    }
+
+    /**
+     * Only compiles the file and does not run them.
+     *
+     * @param sourceFilePath Path to source module/file
+     * @return compiled results
+     */
+    public static CompileResult compileOnly(String sourceFilePath) {
+        if (jBallerinaTestsEnabled()) {
+            return compileOnJBallerina(sourceFilePath, false, false);
         }
         return compile(sourceFilePath, CompilerPhase.CODE_GEN);
     }
 
     // This is a temp fix until service test are fix
     public static CompileResult compile(boolean temp, String sourceFilePath) {
-        return compileOnJBallerina(sourceFilePath, temp);
+        return compileOnJBallerina(sourceFilePath, temp, true);
     }
 
     private static void runInit(BLangPackage bLangPackage, JBallerinaInMemoryClassLoader classLoader, boolean temp) {
@@ -158,11 +171,10 @@ public class BCompileUtil {
         }
     }
 
-    private static void runOnSchedule(Class<?> initClazz, BLangIdentifier name, Scheduler scheduler1) {
+    private static void runOnSchedule(Class<?> initClazz, BLangIdentifier name, Scheduler scheduler) {
         String funcName = cleanupFunctionName(name);
         try {
             final Method method = initClazz.getDeclaredMethod(funcName, Strand.class);
-            Scheduler scheduler = scheduler1;
             //TODO fix following method invoke to scheduler.schedule()
             Function<Object[], Object> func = objects -> {
                 try {
@@ -327,9 +339,9 @@ public class BCompileUtil {
         final String unixFolderSeparator = "/";
         StringBuilder path = new StringBuilder(pathLocation.toAbsolutePath().toString());
         if (pathLocation.endsWith(windowsFolderSeparator)) {
-            path = path.append(windowsFolderSeparator).append(fileName);
+            path.append(windowsFolderSeparator).append(fileName);
         } else {
-            path = path.append(unixFolderSeparator).append(fileName);
+            path.append(unixFolderSeparator).append(fileName);
         }
         return path.toString();
     }
@@ -643,7 +655,7 @@ public class BCompileUtil {
 
     public static boolean jBallerinaTestsEnabled() {
         String value = System.getProperty(ENABLE_JBALLERINA_TESTS);
-        return value != null && Boolean.valueOf(value);
+        return Boolean.parseBoolean(value);
     }
 
     private static CompileResult compileOnJBallerina(String sourceRoot, String packageName,
@@ -698,7 +710,7 @@ public class BCompileUtil {
                 compileResult.getAST()).packageID.orgName.value,
                 ((BLangPackage) compileResult.getAST()).packageID.name.value, MODULE_INIT_CLASS_NAME);
         Class<?> initClazz = compileResult.classLoader.loadClass(initClassName);
-        Method mainMethod = null;
+        Method mainMethod;
         try {
             mainMethod = initClazz.getDeclaredMethod("main", String[].class);
             mainMethod.invoke(null, (Object) args);
@@ -713,10 +725,10 @@ public class BCompileUtil {
 
     }
 
-    private static CompileResult compileOnJBallerina(String sourceFilePath, boolean temp) {
+    private static CompileResult compileOnJBallerina(String sourceFilePath, boolean temp, boolean init) {
         Path sourcePath = Paths.get(sourceFilePath);
         String packageName = sourcePath.getFileName().toString();
         Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
-        return compileOnJBallerina(sourceRoot.toString(), packageName, temp, true);
+        return compileOnJBallerina(sourceRoot.toString(), packageName, temp, init);
     }
 }


### PR DESCRIPTION
## Purpose
The tests were failing because of the lack of a compile only function which was there before jballerina implementation. This adds that function to BCompileUtil and fixes the tests.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/15867

## Approach
> Resolve the said issue to and call the `compileOnly` function to fix the tests

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
