### PR TITLE
Enable task timer attachment test after fix intermittant failure cause

### DIFF
--- a/stdlib/task/src/test/java/org/ballerinalang/stdlib/task/scheduler/TimerSchedulerTest.java
+++ b/stdlib/task/src/test/java/org/ballerinalang/stdlib/task/scheduler/TimerSchedulerTest.java
@@ -52,11 +52,11 @@ public class TimerSchedulerTest {
         });
     }
 
-    @Test(description = "Test service parameter passing", enabled = false)
+    @Test(description = "Test service parameter passing")
     public void testTimerAttachment() {
-        CompileResult compileResult = BCompileUtil.compile("scheduler/timer/service_parameter.bal");
+        CompileResult compileResult = BCompileUtil.compile("scheduler/timer/timer_attachment.bal");
         BRunUtil.invoke(compileResult, "attachTimer");
-        String expectedResult = "Sam is 10 years old";
+        String expectedResult = "Sam is 5 years old";
         try {
             await().atMost(10000, TimeUnit.MILLISECONDS).until(() -> {
                 BValue[] result = BRunUtil.invoke(compileResult, "getResult");

--- a/stdlib/task/src/test/resources/scheduler/timer/timer_attachment.bal
+++ b/stdlib/task/src/test/resources/scheduler/timer/timer_attachment.bal
@@ -27,7 +27,7 @@ function attachTimer() {
         age: 0
     };
 
-    task:Scheduler timer = new({ intervalInMillis: 100, initialDelayInMillis: 1000 });
+    task:Scheduler timer = new({ intervalInMillis: 2000, initialDelayInMillis: 1000 });
     var attachResult = timer.attach(timerService, person);
     if (attachResult is error) {
         panic attachResult;


### PR DESCRIPTION
## Purpose
> Enable the tasks `timer_attachment1` test after fixing the root cause for the intermittent failures.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
