### PR TITLE
Improve tuple assignment type check logic

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
@@ -122,9 +122,34 @@ public class BasicTupleTest {
         Assert.assertEquals(((BFloat) returns[3]).intValue(), 0);
     }
 
+    @Test(description = "Test tuple to array assignment")
+    public void testTupleToArrayAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testTupleToArrayAssignment", new BValue[]{});
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(returns[0].stringValue(), "a");
+        Assert.assertEquals(returns[1].stringValue(), "b");
+        Assert.assertEquals(returns[2].stringValue(), "c");
+    }
+
+    @Test(description = "Test array to tuple assignment")
+    public void testArrayToTupleAssignment() {
+        BValue[] returns = BRunUtil.invoke(result, "testArrayToTupleAssignment1", new BValue[]{});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(returns[0].stringValue(), "[\"a\", \"b\", \"c\"]");
+
+        returns = BRunUtil.invoke(result, "testArrayToTupleAssignment2", new BValue[]{});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(returns[0].stringValue(), "[\"a\", \"b\", \"c\"]");
+
+        returns = BRunUtil.invoke(result, "testArrayToTupleAssignment3", new BValue[]{});
+        Assert.assertEquals(returns.length, 2);
+        Assert.assertEquals(returns[0].stringValue(), "a");
+        Assert.assertEquals(returns[1].stringValue(), "[\"b\", \"c\"]");
+    }
+
     @Test(description = "Test negative scenarios of assigning tuple literals")
     public void testNegativeTupleLiteralAssignments() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 18);
+        Assert.assertEquals(resultNegative.getErrorCount(), 21);
         BAssertUtil.validateError(
                 resultNegative, 0, "tuple and expression size does not match", 18, 25);
         BAssertUtil.validateError(
@@ -133,6 +158,17 @@ public class BasicTupleTest {
                 resultNegative, 2, "ambiguous type '([int,boolean,string]|[any,boolean,string])?'", 34, 63);
         BAssertUtil.validateError(
                 resultNegative, 3, "ambiguous type '([Person,int]|[Employee,int])?'", 38, 47);
+    }
+
+    @Test(description = "Test negative scenarios of assigning tuples and arrays")
+    public void testNegativeTupleArrayAssignments() {
+        Assert.assertEquals(resultNegative.getErrorCount(), 21);
+        BAssertUtil.validateError(
+                resultNegative, 4, "incompatible types: expected 'int[]', found '[string...]'", 43, 15);
+        BAssertUtil.validateError(
+                resultNegative, 5, "incompatible types: expected '[int...]', found 'string[]'", 49, 18);
+        BAssertUtil.validateError(
+                resultNegative, 6, "incompatible types: expected '[int,string...]', found '(int|string)[]'", 55, 26);
     }
 
     @Test(enabled = false, description = "Test negatives of index based access of tuple type")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -149,3 +149,27 @@ function testDefaultValuesInTuples () returns [string, int, boolean, float] {
     [boolean, int, string, float] x = [false, 0, "", 0.0];
     return [x[2], x[1], x[0], x[3]];
 }
+
+function testTupleToArrayAssignment() returns string[] {
+    [string...] x = ["a", "b", "c"];
+    string[] y = x;
+    return y;
+}
+
+function testArrayToTupleAssignment1() returns [string...] {
+    string[] x = ["a", "b", "c"];
+    [string...] y = x;
+    return y;
+}
+
+function testArrayToTupleAssignment2() returns [string, string...] {
+    string[] x = ["a", "b", "c"];
+    [string, string...] y = x;
+    return y;
+}
+
+function testArrayToTupleAssignment3() returns [string, string[]] {
+    string[] x = ["a", "b", "c"];
+    [string, string...] [i, ...j] = x;
+    return [i, j];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_negative_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_negative_test.bal
@@ -38,6 +38,24 @@ function invalidTupleAssignmentToUnion() {
     [Person, int] | [Employee, int] | () k3 = [p, 3]; // ambiguous
 }
 
+function testTupleToArrayAssignmentNegative() returns int[] {
+    [string...] x = ["a", "b", "c"];
+    int[] y = x;
+    return y;
+}
+
+function testArrayToTupleAssignmentNegative() returns [int...] {
+    string[] x = ["a", "b", "c"];
+    [int...] y = x;
+    return y;
+}
+
+function testArrayToTupleAssignmentNegative2() returns [int, string...] {
+    (int|string)[] x = [1, "b", "c"];
+    [int, string...] y = x;
+    return y;
+}
+
 function tupleAssignmentToAnyAndVar () {
     var x1 = (1); // brace hence valid
     any x2 = (1); // brace hence valid


### PR DESCRIPTION
## Purpose
This pr will $subject and fixes #17201.

## Samples
```ballerina
function testTupleToArrayAssignment() returns string[] {
    [string...] x = ["a", "b", "c"];
    string[] y = x;
    return y;
}

function testArrayToTupleAssignment1() returns [string...] {
    string[] x = ["a", "b", "c"];
    [string...] y = x;
    return y;
}

function testArrayToTupleAssignment2() returns [string, string...] {
    string[] x = ["a", "b", "c"];
    [string, string...] y = x;
    return y;
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
