### PR TITLE
Use a new instance of Positioning Visitor for each expanded function

### DIFF
--- a/composer/packages/diagram/src/visitors/positioning-visitor.ts
+++ b/composer/packages/diagram/src/visitors/positioning-visitor.ts
@@ -181,7 +181,7 @@ class PositioningVisitor implements Visitor {
                     expandedFunctionVS.bBox.x = elViewState.bBox.x;
                     expandedFunctionVS.bBox.y = elViewState.bBox.y;
 
-                    ASTUtil.traversNode(expandedSubTree, this);
+                    ASTUtil.traversNode(expandedSubTree, new PositioningVisitor());
                 }
             }
             if (elViewState.hiddenBlockContext && elViewState.hiddenBlockContext.expanded) {


### PR DESCRIPTION
## Purpose
$title
This fixes a bug where positioning of endpoints is wrong when expanded function invocations are present.

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/3872221/62525598-4fad5000-b855-11e9-9552-cd6a19a8b45f.png">

Fixes #17432

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
