### PR TITLE
Add service level variable taint analysis support

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -371,10 +371,11 @@ public class TaintedStatusPropagationTest {
     public void testServiceVariablesNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/service-level-variables-negative.bal");
-        Assert.assertEquals(result.getDiagnostics().length, 3);
-        BAssertUtil.validateError(result, 0, "tainted value passed to global variable 'serviceLevelVariable'", 17, 9);
-        BAssertUtil.validateError(result, 1, "tainted value passed to global variable 'globalLevelVariable'", 18, 9);
-        BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 19, 13);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
+        BAssertUtil.validateError(result, 0, "tainted value passed to global variable 'serviceVarStr'", 9, 5);
+        BAssertUtil.validateError(result, 1, "tainted value passed to global variable 'serviceLevelVariable'", 18, 9);
+        BAssertUtil.validateError(result, 2, "tainted value passed to global variable 'globalLevelVariable'", 19, 9);
+        BAssertUtil.validateError(result, 3, "tainted value passed to untainted parameter 'secureIn'", 20, 13);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/foreach.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/foreach.bal
@@ -1,3 +1,6 @@
+const FORWARD_SLASH = "/";
+const EMPTY_STRING = "";
+
 public function main (string... args) {
     string[] fruits = ["apple", "banana", "cherry"];
 
@@ -8,4 +11,25 @@ public function main (string... args) {
 
 public function secureFunction (@untainted string secureIn, string insecureIn) {
     string data = secureIn + insecureIn;
+}
+
+function prepareUrl(string[] paths) returns string {
+    string url = EMPTY_STRING;
+
+    if (paths.length() > 0) {
+        foreach var path in paths {
+            if (!path.startsWith(FORWARD_SLASH)) {
+                url = url + FORWARD_SLASH;
+            }
+            url = url + path;
+        }
+    }
+    secureFunction(url, "");
+    return url;
+}
+
+function usePrepared() {
+    string[] strs = [EMPTY_STRING];
+    string p = prepareUrl(strs);
+    secureFunction(p, p);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/service-level-variables-negative.bal
@@ -6,6 +6,7 @@ any globalLevelVariable = "";
 service sample on helloWorldEP {
     any serviceLevelVariable = "";
     @tainted any taintedServiceVar = "";
+    string serviceVarStr = getTaintedStr();
 
     @http:ResourceConfig {
         methods:["GET"],
@@ -18,9 +19,16 @@ service sample on helloWorldEP {
         globalLevelVariable = foo;
         sen(self.taintedServiceVar);
     }
+
+    function foo() returns @tainted string {
+        return "";
+    }
 }
 
 function sen(@untainted any secureIn) {
 
 }
 
+function getTaintedStr() returns @tainted string {
+    return "";
+}


### PR DESCRIPTION
## Purpose
This pr add taint analysis to service level variable declarations.
Service level variables are considered like global variables are is prohibited to assign tainted values to them, similar to global variable. (except when annotated @tainted, also similar to global var)

This pr fixes https://github.com/ballerina-platform/ballerina-lang/issues/13093