### PR TITLE
Fix Hover and Completions help text not omitting first param for langlibs based

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
@@ -18,10 +18,8 @@ package org.ballerinalang.langserver.common.constants;
 import org.ballerinalang.langserver.compiler.LSContext;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
 import org.ballerinalang.model.elements.PackageID;
-import org.eclipse.lsp4j.Location;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 
-import java.util.List;
 import java.util.Stack;
 
 /**
@@ -48,12 +46,10 @@ public class NodeContextKeys {
             = new LSContext.Key<>();
     public static final LSContext.Key<String> VAR_NAME_OF_NODE_KEY
             = new LSContext.Key<>();
-    public static final LSContext.Key<List<Location>> REFERENCE_RESULTS_KEY
-            = new LSContext.Key<>();
-    public static final LSContext.Key<List<PackageID>> REFERENCE_PKG_IDS_KEY
-            = new LSContext.Key<>();
     public static final LSContext.Key<String> NODE_NAME_KEY
             = new LSContext.Key<>();
     public static final LSContext.Key<SymbolReferencesModel> REFERENCES_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Integer> INVOCATION_TOKEN_TYPE_KEY
             = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BFunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BFunctionCompletionItemBuilder.java
@@ -95,16 +95,18 @@ public final class BFunctionCompletionItemBuilder {
         item.setInsertTextFormat(InsertTextFormat.Snippet);
         item.setDetail(ItemResolverConstants.FUNCTION_TYPE);
         item.setKind(CompletionItemKind.Function);
-        List<String> funcArguments = FunctionGenerator.getFuncArguments(bSymbol, ctx);
-        if (bSymbol != null && !funcArguments.isEmpty()) {
-            Command cmd = new Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints");
-            item.setCommand(cmd);
-        }
-        int invocationType = (ctx == null || ctx.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY) == null) ? -1
-                : ctx.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY);
-        boolean skipFirstParam = CommonUtil.skipFirstParam(bSymbol, invocationType);
-        if (bSymbol != null && bSymbol.markdownDocumentation != null) {
-            item.setDocumentation(getDocumentation(bSymbol, skipFirstParam, ctx));
+        if (bSymbol != null) {
+            List<String> funcArguments = FunctionGenerator.getFuncArguments(bSymbol, ctx);
+            if (!funcArguments.isEmpty()) {
+                Command cmd = new Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints");
+                item.setCommand(cmd);
+            }
+            int invocationType = (ctx == null || ctx.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY) == null) ? -1
+                    : ctx.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY);
+            boolean skipFirstParam = CommonUtil.skipFirstParam(bSymbol, invocationType);
+            if (bSymbol.markdownDocumentation != null) {
+                item.setDocumentation(getDocumentation(bSymbol, skipFirstParam, ctx));
+            }
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BFunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BFunctionCompletionItemBuilder.java
@@ -19,7 +19,9 @@ package org.ballerinalang.langserver.completions.builder;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.FunctionGenerator;
 import org.ballerinalang.langserver.compiler.LSContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.model.elements.MarkdownDocAttachment;
 import org.eclipse.lsp4j.Command;
@@ -39,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 /**
@@ -88,17 +91,25 @@ public final class BFunctionCompletionItemBuilder {
         return item;
     }
 
-    private static void setMeta(CompletionItem item, BInvokableSymbol bSymbol, LSContext context) {
+    private static void setMeta(CompletionItem item, BInvokableSymbol bSymbol, LSContext ctx) {
         item.setInsertTextFormat(InsertTextFormat.Snippet);
         item.setDetail(ItemResolverConstants.FUNCTION_TYPE);
         item.setKind(CompletionItemKind.Function);
-        item.setCommand(new Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints"));
+        List<String> funcArguments = FunctionGenerator.getFuncArguments(bSymbol, ctx);
+        if (bSymbol != null && !funcArguments.isEmpty()) {
+            Command cmd = new Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints");
+            item.setCommand(cmd);
+        }
+        int invocationType = (ctx == null || ctx.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY) == null) ? -1
+                : ctx.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY);
+        boolean skipFirstParam = CommonUtil.skipFirstParam(bSymbol, invocationType);
         if (bSymbol != null && bSymbol.markdownDocumentation != null) {
-            item.setDocumentation(getDocumentation(bSymbol, context));
+            item.setDocumentation(getDocumentation(bSymbol, skipFirstParam, ctx));
         }
     }
 
-    private static Either<String, MarkupContent> getDocumentation(BInvokableSymbol bInvokableSymbol, LSContext ctx) {
+    private static Either<String, MarkupContent> getDocumentation(BInvokableSymbol bInvokableSymbol,
+                                                                  boolean skipFirstParam, LSContext ctx) {
         String pkgID = bInvokableSymbol.pkgID.toString();
 
         MarkdownDocAttachment docAttachment = bInvokableSymbol.getMarkdownDocAttachment();
@@ -115,24 +126,28 @@ public final class BFunctionCompletionItemBuilder {
         MarkupContent docMarkupContent = new MarkupContent();
         docMarkupContent.setKind(CommonUtil.MARKDOWN_MARKUP_KIND);
         String documentation = "**Package:** " + "_" + pkgID + "_" + CommonUtil.MD_LINE_SEPARATOR
-                + CommonUtil.MD_LINE_SEPARATOR + description
-                + CommonUtil.MD_LINE_SEPARATOR + "**Params**"
-                + CommonUtil.MD_LINE_SEPARATOR
-                + parameters.stream()
-                .map(parameter -> {
-                    Optional<BVarSymbol> defaultVal = defaultParams.stream()
-                            .filter(bVarSymbol -> bVarSymbol.getName().getValue().equals(parameter.getName()))
-                            .findFirst();
-                    String type = (!types.isEmpty() && types.get(parameter.name) != null) ?
-                            "`" + CommonUtil.getBTypeName(types.get(parameter.name), ctx) + "` " : "";
-                    String paramDescription = "- " + type + parameter.getName() + ": " + parameter.getDescription();
-                    if (defaultVal.isPresent()) {
-                        return paramDescription + "(Defaultable)";
-                    }
-                    return paramDescription;
-                })
-                .collect(Collectors.joining(CommonUtil.MD_LINE_SEPARATOR));
-
+                + CommonUtil.MD_LINE_SEPARATOR + description + CommonUtil.MD_LINE_SEPARATOR;
+        StringJoiner joiner = new StringJoiner(CommonUtil.MD_LINE_SEPARATOR);
+        for (int i = 0; i < parameters.size(); i++) {
+            MarkdownDocAttachment.Parameter parameter = parameters.get(i);
+            if (i == 0 && skipFirstParam) {
+                continue;
+            }
+            Optional<BVarSymbol> defaultVal = defaultParams.stream()
+                    .filter(bVarSymbol -> bVarSymbol.getName().getValue().equals(parameter.getName()))
+                    .findFirst();
+            String type = (!types.isEmpty() && types.get(parameter.name) != null) ?
+                    "`" + CommonUtil.getBTypeName(types.get(parameter.name), ctx) + "` " : "";
+            String paramDescription = "- " + type + parameter.getName() + ": " + parameter.getDescription();
+            if (defaultVal.isPresent()) {
+                joiner.add(paramDescription + "(Defaultable)");
+            }
+            joiner.add(paramDescription);
+        }
+        String paramsStr = joiner.toString();
+        if (!paramsStr.isEmpty()) {
+            documentation += "**Params**" + CommonUtil.MD_LINE_SEPARATOR + paramsStr;
+        }
         if (!(bInvokableSymbol.retType instanceof BNilType)
                 && bInvokableSymbol.retType != null
                 && bInvokableSymbol.retType.tsymbol != null) {
@@ -142,7 +157,7 @@ public final class BFunctionCompletionItemBuilder {
                 desc = "- " + reader.lines().map(String::trim)
                         .collect(Collectors.joining(CommonUtil.MD_LINE_SEPARATOR)) + CommonUtil.MD_LINE_SEPARATOR;
             }
-            documentation = documentation + CommonUtil.MD_LINE_SEPARATOR + CommonUtil.MD_LINE_SEPARATOR + "**Returns**"
+            documentation += CommonUtil.MD_LINE_SEPARATOR + CommonUtil.MD_LINE_SEPARATOR + "**Returns**"
                     + " `" + CommonUtil.getBTypeName(bInvokableSymbol.retType, ctx) + "` " +
                     CommonUtil.MD_LINE_SEPARATOR + desc + CommonUtil.MD_LINE_SEPARATOR;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -100,7 +100,7 @@ public class HoverUtil {
         Map<String, List<MarkdownDocAttachment.Parameter>> filterAttributes =
                 filterDocumentationAttributes(docAttachment, symbol);
 
-        if (!docAttachment.description.isEmpty()) {
+        if (docAttachment.description != null && !docAttachment.description.isEmpty()) {
             String description =
                     CommonUtil.MD_LINE_SEPARATOR + docAttachment.description.trim() + CommonUtil.MD_LINE_SEPARATOR;
             content.append(getFormattedHoverDocContent(ContextConstants.DESCRIPTION, description));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesSubRuleParser.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesSubRuleParser.java
@@ -48,6 +48,14 @@ class ReferencesSubRuleParser {
         TokenStream tokenStream = parser.getTokenStream();
         List<Token> tokenList = new ArrayList<>(((CommonTokenStream) tokenStream).getTokens());
         Optional<Token> tokenAtCursor = searchTokenAtCursor(tokenList, pos.getLine(), pos.getCharacter(), true);
-        tokenAtCursor.ifPresent(token -> context.put(NodeContextKeys.NODE_NAME_KEY, token.getText()));
+        tokenAtCursor.ifPresent(token -> {
+            context.put(NodeContextKeys.NODE_NAME_KEY, token.getText());
+            int tokenIndex = token.getTokenIndex() - 1;
+            int tokenType = -1;
+            if (tokenIndex > 0) {
+                tokenType = tokenList.get(tokenIndex).getType();
+            }
+            context.put(NodeContextKeys.INVOCATION_TOKEN_TYPE_KEY, tokenType);
+        });
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/annotationBodyCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/annotationBodyCompletion3.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "helloFunction(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "helloFunction()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "helloService",
@@ -75,7 +71,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -89,7 +85,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -121,7 +117,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -135,7 +131,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -167,7 +163,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -181,7 +177,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -397,7 +393,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -411,7 +407,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -604,7 +600,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -618,7 +614,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -627,7 +623,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -641,7 +637,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -765,7 +761,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -779,7 +775,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -834,7 +830,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -848,7 +844,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -880,7 +876,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -894,7 +890,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -949,7 +945,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -963,7 +959,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -972,7 +968,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -986,7 +982,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -995,7 +991,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1009,7 +1005,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1018,7 +1014,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1032,7 +1028,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1041,7 +1037,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1055,7 +1051,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/anonFunctionSnippetSuggestion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/anonFunctionSnippetSuggestion1.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testAnonFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testAnonFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "ballerinax/java.jdbc",
@@ -51,7 +47,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -65,7 +61,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -97,7 +93,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -111,7 +107,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -143,7 +139,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -157,7 +153,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -396,7 +392,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -410,7 +406,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -603,7 +599,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -617,7 +613,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -626,7 +622,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -640,7 +636,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -764,7 +760,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -778,7 +774,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -833,7 +829,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -847,7 +843,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -902,7 +898,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -916,7 +912,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -971,7 +967,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -985,7 +981,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -994,7 +990,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1008,7 +1004,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1017,7 +1013,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1031,7 +1027,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1040,7 +1036,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1054,7 +1050,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1063,7 +1059,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1077,7 +1073,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },
@@ -1145,11 +1141,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "function (string param1, \u003e\u003c param2, \u003e\u003c param3, \u003e\u003c param4) returns (\u003e\u003c) ",
+      "label": "function (string param1, >< param2, >< param3, >< param4) returns (><) ",
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "function (string ${1:param1}, \u003e\u003c ${2:param2}, \u003e\u003c ${3:param3}, \u003e\u003c ${4:param4}) returns (\u003e\u003c) {\n\treturn ();\n};",
+      "insertText": "function (string ${1:param1}, >< ${2:param2}, >< ${3:param3}, >< ${4:param4}) returns (><) {\n\treturn ();\n};",
       "insertTextFormat": "Snippet"
     },
     {
@@ -1157,7 +1153,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "(${1:param1}, ${2:param2}, ${3:param3}, ${4:param4})  \u003d\u003e ${5:()};",
+      "insertText": "(${1:param1}, ${2:param2}, ${3:param3}, ${4:param4})  => ${5:()};",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/anonFunctionSnippetSuggestion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/anonFunctionSnippetSuggestion2.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testAnonFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testAnonFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "ballerinax/java.jdbc",
@@ -51,7 +47,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -65,7 +61,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -97,7 +93,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -111,7 +107,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -143,7 +139,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -157,7 +153,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -396,7 +392,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -410,7 +406,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -603,7 +599,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -617,7 +613,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -626,7 +622,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -640,7 +636,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -764,7 +760,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -778,7 +774,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -833,7 +829,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -847,7 +843,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -902,7 +898,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -916,7 +912,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -971,7 +967,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -985,7 +981,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -994,7 +990,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1008,7 +1004,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1017,7 +1013,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1031,7 +1027,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1040,7 +1036,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1054,7 +1050,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1063,7 +1059,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1077,7 +1073,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },
@@ -1145,11 +1141,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "function (string param1, \u003e\u003c param2, \u003e\u003c param3, \u003e\u003c param4) ",
+      "label": "function (string param1, >< param2, >< param3, >< param4) ",
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "function (string ${1:param1}, \u003e\u003c ${2:param2}, \u003e\u003c ${3:param3}, \u003e\u003c ${4:param4}) {\n\t${5}\n};",
+      "insertText": "function (string ${1:param1}, >< ${2:param2}, >< ${3:param3}, >< ${4:param4}) {\n\t${5}\n};",
       "insertTextFormat": "Snippet"
     },
     {
@@ -1157,7 +1153,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "(${1:param1}, ${2:param2}, ${3:param3}, ${4:param4})  \u003d\u003e ${5};",
+      "insertText": "(${1:param1}, ${2:param2}, ${3:param3}, ${4:param4})  => ${5};",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/anonFunctionSnippetSuggestion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/anonFunctionSnippetSuggestion3.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testAnonFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testAnonFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "ballerinax/java.jdbc",
@@ -51,7 +47,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -65,7 +61,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -97,7 +93,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -111,7 +107,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -143,7 +139,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -157,7 +153,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -396,7 +392,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -410,7 +406,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -603,7 +599,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -617,7 +613,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -626,7 +622,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -640,7 +636,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -764,7 +760,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -778,7 +774,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -833,7 +829,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -847,7 +843,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -902,7 +898,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -916,7 +912,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -971,7 +967,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -985,7 +981,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -994,7 +990,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1008,7 +1004,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1017,7 +1013,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1031,7 +1027,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1040,7 +1036,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1054,7 +1050,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1063,7 +1059,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1077,7 +1073,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },
@@ -1145,11 +1141,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "function () returns (\u003e\u003c) ",
+      "label": "function () returns (><) ",
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "function () returns (\u003e\u003c) {\n\treturn ();\n};",
+      "insertText": "function () returns (><) {\n\treturn ();\n};",
       "insertTextFormat": "Snippet"
     },
     {
@@ -1157,7 +1153,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "()  \u003d\u003e ${1:()};",
+      "insertText": "()  => ${1:()};",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion1.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "130",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "130",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "130",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion2.json
@@ -6,253 +6,16 @@
   "source": "function/source/chainCompletion2.bal",
   "items": [
     {
-      "label": "setContentType(string mediaType)((()|mime:InvalidContentTypeError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content-type to entity.\n  \n  \n---    \n**Parameters**  \n- _mediaType_  \n    Content type that needs to be set to the entity  \n  \n  \n**Return**  \nballerina/mime:InvalidContentTypeError?"
-        }
-      },
-      "insertText": "setContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentType()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content type of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentId(string contentId)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content ID of the entity.\n  \n  \n---    \n**Parameters**  \n- _contentId_  \n    Content ID that needs to be set to entity  \n"
-        }
-      },
-      "insertText": "setContentId(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentId()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content ID of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentId(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentLength(int contentLength)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content length of the entity.\n  \n  \n---    \n**Parameters**  \n- _contentLength_  \n    Content length that needs to be set to entity  \n"
-        }
-      },
-      "insertText": "setContentLength(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentLength()((int|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content length of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
-        }
-      },
-      "insertText": "getContentLength(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentDisposition(mime:ContentDisposition contentDisposition)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content disposition of the entity.\n  \n  \n---    \n**Parameters**  \n- _contentDisposition_  \n    Content disposition that needs to be set to entity  \n"
-        }
-      },
-      "insertText": "setContentDisposition(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentDisposition()(mime:ContentDisposition)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content disposition of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:ContentDisposition"
-        }
-      },
-      "insertText": "getContentDisposition(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBody((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) entityBody)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given content.\n  \n  \n---    \n**Parameters**  \n- _entityBody_  \n    Entity body can be of type `string`,`xml`,`json`,`byte[]`,`io:ReadableByteChannel` or `Entity[]`  \n"
-        }
-      },
-      "insertText": "setBody(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setFileAsEntityBody(string filePath, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with a given file. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _filePath_  \n    Represents the path to the file  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setFileAsEntityBody(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setJson(json jsonContent, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given `json` content. This method overrides any existing `content-type` headers\nwith the default content type `application/json`. The default value `application/json` can be overridden\nby passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _jsonContent_  \n    JSON content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter. `application/json`\n                is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setJson(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getJson()((json|mime:ParserError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nExtracts JSON body from the entity. If the entity body is not a JSON, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getJson(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setXml(xml xmlContent, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given XML content. This method overrides any existing content-type headers\nwith the default content-type `application/xml`. The default value `application/xml` can be overridden\nby passing the content-type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _xmlContent_  \n    XML content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter. `application/xml`\n                is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setXml(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getXml()((xml|mime:ParserError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nExtracts `xml` body from the entity. If the entity body is not an XML, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(xml|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getXml(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "setText(string textContent, string contentType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given text content. This method overrides any existing content-type headers\nwith the default content-type `text/plain`. The default value `text/plain` can be overridden\nby passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _textContent_  \n    Text content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter. `text/plain`\n                is used as the default value.  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given text content. This method overrides any existing content-type headers\nwith the default content-type `text/plain`. The default value `text/plain` can be overridden\nby passing the content type as an optional parameter.\n  \n**Params**  \n- `string` textContent: Text content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `text/plain`\n                is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `text/plain`\n                is used as the default value."
         }
       },
+      "sortText": "130",
       "insertText": "setText(${1});",
       "insertTextFormat": "Snippet",
       "command": {
@@ -267,10 +30,39 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nExtracts text body from the entity. If the entity body is not text compatible an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(string|ballerina/mime:ParserError)"
+          "value": "**Package:** _ballerina/mime_  \n  \nExtracts text body from the entity. If the entity body is not text compatible an error is returned.\n  \n  \n  \n**Returns** `(string|mime:ParserError)`   \n- `string` data extracted from the the entity body or `ParserError` in case of errors.  \n  \n"
         }
       },
-      "insertText": "getText(${1})",
+      "sortText": "130",
+      "insertText": "getText()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentLength()((int|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content length of entity.\n  \n  \n  \n**Returns** `(int|error)`   \n- Content length as an `int`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentLength()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the given header value against the existing header. If a header already exists, its value is replaced\nwith the given header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: Represents the header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setHeader(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -278,16 +70,31 @@
       }
     },
     {
-      "label": "setByteArray(byte[] blobContent, string contentType)",
+      "label": "getJson()((json|mime:ParserError))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte[] content. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _blobContent_  \n    byte[] content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/mime_  \n  \nExtracts JSON body from the entity. If the entity body is not a JSON, an error is returned.\n  \n  \n  \n**Returns** `(json|mime:ParserError)`   \n- `json` data extracted from the the entity body. An `ParserError` record is returned in case of  \nerrors.  \n  \n"
         }
       },
-      "insertText": "setByteArray(${1});",
+      "sortText": "130",
+      "insertText": "getJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentDisposition(mime:ContentDisposition contentDisposition)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content disposition of the entity.\n  \n**Params**  \n- `mime:ContentDisposition` contentDisposition: Content disposition that needs to be set to entity"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentDisposition(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -295,55 +102,12 @@
       }
     },
     {
-      "label": "getByteArray()((byte[]|mime:ParserError))",
+      "label": "__init()",
       "kind": "Function",
       "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a `byte[]`. If the entity size is considerably large consider\nusing getByteChannel() method instead.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(byte[]|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getByteArray(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setByteChannel(io:ReadableByteChannel byteChannel, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte channel content. This method overrides any existing content-type headers\nwith the default content-type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content-type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _byteChannel_  \n    Byte channel that needs to be set to entity  \n  \n- _contentType_  \n    Content-type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setByteChannel(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getByteChannel()((io:ReadableByteChannel|mime:ParserError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a byte channel.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getByteChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getBodyParts()((mime:Entity[]|mime:ParserError))",
@@ -352,78 +116,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets its body parts. If the entity body is not a set of body parts an error will be returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity[]|ballerina/mime:ParserError)"
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets its body parts. If the entity body is not a set of body parts an error will be returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|mime:ParserError)`   \n- An array of body parts(`Entity[]`) extracted from the entity body. An `ParserError` record will be  \nreturned in case of errors.  \n  \n"
         }
       },
-      "insertText": "getBodyParts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getBodyPartsAsChannel()((io:ReadableByteChannel|mime:ParserError))",
+      "label": "setBody((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) entityBody)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the body parts as a byte channel.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/mime:ParserError)"
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the body of the entity with the given content. Note that any string value is set as `text/plain`. To send a\nJSON-compatible string, set the content-type header to `application/json` or use the `setJsonPayload` method instead.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` entityBody: Entity body can be of the type `string`,`xml`,`json`,`byte[]`,`io:ReadableByteChannel`, or `Entity[]`."
         }
       },
-      "insertText": "getBodyPartsAsChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets body parts to entity. This method overrides any existing `content-type` headers\nwith the default content type `multipart/form-data`. The default value `multipart/form-data` can be overridden\nby passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _bodyParts_  \n    Represents the body parts that needs to be set to the entity  \n  \n- _contentType_  \n    Content-type to be used with the payload. This is an optional parameter.\n                `multipart/form-data` is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBodyParts(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeader(string headerName)(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the header value associated with the given header name.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    Represents header name  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaders(string headerName)(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets all the header values associated with the given header name.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaders(${1})",
+      "sortText": "130",
+      "insertText": "setBody(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -437,10 +148,245 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets all header names.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/mime_  \n  \nGets all header names.\n  \n  \n  \n**Returns** `string[]`   \n- All header names as a `string[]`  \n  \n"
         }
       },
-      "insertText": "getHeaderNames(${1})",
+      "sortText": "130",
+      "insertText": "getHeaderNames()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeHeader(string headerName)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nRemoves the given header from the entity.\n  \n**Params**  \n- `string` headerName: Represents the header name"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentId(string contentId)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content ID of the entity.\n  \n**Params**  \n- `string` contentId: Content ID that needs to be set to entity"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentId(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXml()((xml|mime:ParserError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nExtracts `xml` body from the entity. If the entity body is not an XML, an error is returned.\n  \n  \n  \n**Returns** `(xml|mime:ParserError)`   \n- `xml` data extracted from the the entity body. An `ParserError` record is returned in case of  \nerrors.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getXml()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentId()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content ID of entity.\n  \n  \n  \n**Returns** `string`   \n- Content ID as a `string`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentId()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cLength",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "cLength",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyPartsAsChannel()((io:ReadableByteChannel|mime:ParserError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the body parts as a byte channel.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|mime:ParserError)`   \n- Body parts as a byte channel  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBodyPartsAsChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasHeader(string headerName)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `boolean`   \n- True if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setXml(xml xmlContent, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given XML content. This method overrides any existing content-type headers\nwith the default content-type `application/xml`. The default value `application/xml` can be overridden\nby passing the content-type as an optional parameter.\n  \n**Params**  \n- `xml` xmlContent: XML content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/xml`\n                is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/xml`\n                is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setXml(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cId",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "cId",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setFileAsEntityBody(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with a given file. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n**Params**  \n- `string` filePath: Represents the path to the file  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setFileAsEntityBody(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content type of entity.\n  \n  \n  \n**Returns** `string`   \n- Content type as a `string`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nRemoves all headers associated with the entity.  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAllHeaders();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel byteChannel, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte channel content. This method overrides any existing content-type headers\nwith the default content-type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content-type as an optional parameter.\n  \n**Params**  \n- `io:ReadableByteChannel` byteChannel: Byte channel that needs to be set to entity  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.(Defaultable)  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cType",
+      "kind": "Variable",
+      "detail": "mime:MediaType",
+      "sortText": "120",
+      "insertText": "cType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentLength(int contentLength)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content length of the entity.\n  \n**Params**  \n- `int` contentLength: Content length that needs to be set to entity"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentLength(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeaders(string headerName)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets all the header values associated with the given header name.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string[]`   \n- All the header values associated with the given header name as a `string[]`. An exception is thrown  \nif no header is found. Use `hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaders(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -454,9 +400,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nAdds the given header value against the given header.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    Represents the header value to be added  \n"
+          "value": "**Package:** _ballerina/mime_  \n  \nAdds the given header value against the given header.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: Represents the header value to be added"
         }
       },
+      "sortText": "130",
       "insertText": "addHeader(${1});",
       "insertTextFormat": "Snippet",
       "command": {
@@ -465,111 +412,144 @@
       }
     },
     {
-      "label": "setHeader(string headerName, string headerValue)",
+      "label": "getByteChannel()((io:ReadableByteChannel|mime:ParserError))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the given header value against the existing header. If a header already exists, its value is replaced\nwith the given header value.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    Represents the header value  \n"
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a byte channel.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|mime:ParserError)`   \n- An `io:ReadableByteChannel`. An `ParserError` record will be returned in case of errors  \n  \n"
         }
       },
-      "insertText": "setHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeHeader(string headerName)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nRemoves the given header from the entity.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    Represents the header name  \n"
-        }
-      },
-      "insertText": "removeHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAllHeaders()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nRemoves all headers associated with the entity.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAllHeaders(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasHeader(string headerName)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nChecks whether the requested header key exists in the header map.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "__init()",
-      "kind": "Function",
-      "detail": "Function",
-      "insertText": "__init(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cType",
-      "kind": "Variable",
-      "detail": "mime:MediaType",
-      "insertText": "cType",
+      "sortText": "130",
+      "insertText": "getByteChannel()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cId",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "cId",
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets body parts to entity. This method overrides any existing `content-type` headers\nwith the default content type `multipart/form-data`. The default value `multipart/form-data` can be overridden\nby passing the content type as an optional parameter.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: Represents the body parts that needs to be set to the entity  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `multipart/form-data` is used as the default value.(Defaultable)  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `multipart/form-data` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentDisposition()(mime:ContentDisposition)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content disposition of entity.\n  \n  \n  \n**Returns** `mime:ContentDisposition`   \n- A `ContentDisposition` object  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentDisposition()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cLength",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "cLength",
+      "label": "getByteArray()((byte[]|mime:ParserError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a `byte[]`. If the entity size is considerably large consider\nusing getByteChannel() method instead.\n  \n  \n  \n**Returns** `(byte[]|mime:ParserError)`   \n- `byte[]` data extracted from the the entity body. An `ParserError` record is returned in case of  \nerrors.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getByteArray()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteArray(byte[] blobContent, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte[] content. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n**Params**  \n- `byte[]` blobContent: byte[] content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteArray(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeader(string headerName)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the header value associated with the given header name.\n  \n**Params**  \n- `string` headerName: Represents header name  \n  \n**Returns** `string`   \n- Header value associated with the given header name as a `string`. If multiple header values are  \npresent, then the first value is returned. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string mediaType)((()|mime:InvalidContentTypeError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content-type to entity.\n  \n**Params**  \n- `string` mediaType: Content type that needs to be set to the entity  \n  \n**Returns** `(()|mime:InvalidContentTypeError)`   \n- Nil if successful, error in case of invalid media-type  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "cDisposition",
       "kind": "Variable",
       "detail": "mime:ContentDisposition",
+      "sortText": "120",
       "insertText": "cDisposition",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setJson(json jsonContent, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given `json` content. This method overrides any existing `content-type` headers\nwith the default content type `application/json`. The default value `application/json` can be overridden\nby passing the content type as an optional parameter.\n  \n**Params**  \n- `json` jsonContent: JSON content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/json`\n                is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/json`\n                is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setJson(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion3.json
@@ -6,253 +6,16 @@
   "source": "function/source/chainCompletion3.bal",
   "items": [
     {
-      "label": "setContentType(string mediaType)((()|mime:InvalidContentTypeError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content-type to entity.\n  \n  \n---    \n**Parameters**  \n- _mediaType_  \n    Content type that needs to be set to the entity  \n  \n  \n**Return**  \nballerina/mime:InvalidContentTypeError?"
-        }
-      },
-      "insertText": "setContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentType()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content type of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentId(string contentId)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content ID of the entity.\n  \n  \n---    \n**Parameters**  \n- _contentId_  \n    Content ID that needs to be set to entity  \n"
-        }
-      },
-      "insertText": "setContentId(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentId()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content ID of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentId(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentLength(int contentLength)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content length of the entity.\n  \n  \n---    \n**Parameters**  \n- _contentLength_  \n    Content length that needs to be set to entity  \n"
-        }
-      },
-      "insertText": "setContentLength(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentLength()((int|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content length of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
-        }
-      },
-      "insertText": "getContentLength(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentDisposition(mime:ContentDisposition contentDisposition)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the content disposition of the entity.\n  \n  \n---    \n**Parameters**  \n- _contentDisposition_  \n    Content disposition that needs to be set to entity  \n"
-        }
-      },
-      "insertText": "setContentDisposition(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentDisposition()(mime:ContentDisposition)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the content disposition of entity.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:ContentDisposition"
-        }
-      },
-      "insertText": "getContentDisposition(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBody((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) entityBody)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given content.\n  \n  \n---    \n**Parameters**  \n- _entityBody_  \n    Entity body can be of type `string`,`xml`,`json`,`byte[]`,`io:ReadableByteChannel` or `Entity[]`  \n"
-        }
-      },
-      "insertText": "setBody(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setFileAsEntityBody(string filePath, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with a given file. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _filePath_  \n    Represents the path to the file  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setFileAsEntityBody(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setJson(json jsonContent, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given `json` content. This method overrides any existing `content-type` headers\nwith the default content type `application/json`. The default value `application/json` can be overridden\nby passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _jsonContent_  \n    JSON content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter. `application/json`\n                is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setJson(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getJson()((json|mime:ParserError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nExtracts JSON body from the entity. If the entity body is not a JSON, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getJson(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setXml(xml xmlContent, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given XML content. This method overrides any existing content-type headers\nwith the default content-type `application/xml`. The default value `application/xml` can be overridden\nby passing the content-type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _xmlContent_  \n    XML content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter. `application/xml`\n                is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setXml(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getXml()((xml|mime:ParserError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nExtracts `xml` body from the entity. If the entity body is not an XML, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(xml|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getXml(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "setText(string textContent, string contentType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given text content. This method overrides any existing content-type headers\nwith the default content-type `text/plain`. The default value `text/plain` can be overridden\nby passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _textContent_  \n    Text content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter. `text/plain`\n                is used as the default value.  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given text content. This method overrides any existing content-type headers\nwith the default content-type `text/plain`. The default value `text/plain` can be overridden\nby passing the content type as an optional parameter.\n  \n**Params**  \n- `string` textContent: Text content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `text/plain`\n                is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `text/plain`\n                is used as the default value."
         }
       },
+      "sortText": "130",
       "insertText": "setText(${1});",
       "insertTextFormat": "Snippet",
       "command": {
@@ -267,10 +30,39 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nExtracts text body from the entity. If the entity body is not text compatible an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(string|ballerina/mime:ParserError)"
+          "value": "**Package:** _ballerina/mime_  \n  \nExtracts text body from the entity. If the entity body is not text compatible an error is returned.\n  \n  \n  \n**Returns** `(string|mime:ParserError)`   \n- `string` data extracted from the the entity body or `ParserError` in case of errors.  \n  \n"
         }
       },
-      "insertText": "getText(${1})",
+      "sortText": "130",
+      "insertText": "getText()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentLength()((int|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content length of entity.\n  \n  \n  \n**Returns** `(int|error)`   \n- Content length as an `int`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentLength()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the given header value against the existing header. If a header already exists, its value is replaced\nwith the given header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: Represents the header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setHeader(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -278,16 +70,31 @@
       }
     },
     {
-      "label": "setByteArray(byte[] blobContent, string contentType)",
+      "label": "getJson()((json|mime:ParserError))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte[] content. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _blobContent_  \n    byte[] content that needs to be set to entity  \n  \n- _contentType_  \n    Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/mime_  \n  \nExtracts JSON body from the entity. If the entity body is not a JSON, an error is returned.\n  \n  \n  \n**Returns** `(json|mime:ParserError)`   \n- `json` data extracted from the the entity body. An `ParserError` record is returned in case of  \nerrors.  \n  \n"
         }
       },
-      "insertText": "setByteArray(${1});",
+      "sortText": "130",
+      "insertText": "getJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentDisposition(mime:ContentDisposition contentDisposition)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content disposition of the entity.\n  \n**Params**  \n- `mime:ContentDisposition` contentDisposition: Content disposition that needs to be set to entity"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentDisposition(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -295,55 +102,12 @@
       }
     },
     {
-      "label": "getByteArray()((byte[]|mime:ParserError))",
+      "label": "__init()",
       "kind": "Function",
       "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a `byte[]`. If the entity size is considerably large consider\nusing getByteChannel() method instead.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(byte[]|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getByteArray(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setByteChannel(io:ReadableByteChannel byteChannel, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte channel content. This method overrides any existing content-type headers\nwith the default content-type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content-type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _byteChannel_  \n    Byte channel that needs to be set to entity  \n  \n- _contentType_  \n    Content-type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setByteChannel(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getByteChannel()((io:ReadableByteChannel|mime:ParserError))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a byte channel.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/mime:ParserError)"
-        }
-      },
-      "insertText": "getByteChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getBodyParts()((mime:Entity[]|mime:ParserError))",
@@ -352,78 +116,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets its body parts. If the entity body is not a set of body parts an error will be returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity[]|ballerina/mime:ParserError)"
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets its body parts. If the entity body is not a set of body parts an error will be returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|mime:ParserError)`   \n- An array of body parts(`Entity[]`) extracted from the entity body. An `ParserError` record will be  \nreturned in case of errors.  \n  \n"
         }
       },
-      "insertText": "getBodyParts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getBodyPartsAsChannel()((io:ReadableByteChannel|mime:ParserError))",
+      "label": "setBody((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) entityBody)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the body parts as a byte channel.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/mime:ParserError)"
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the body of the entity with the given content. Note that any string value is set as `text/plain`. To send a\nJSON-compatible string, set the content-type header to `application/json` or use the `setJsonPayload` method instead.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` entityBody: Entity body can be of the type `string`,`xml`,`json`,`byte[]`,`io:ReadableByteChannel`, or `Entity[]`."
         }
       },
-      "insertText": "getBodyPartsAsChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets body parts to entity. This method overrides any existing `content-type` headers\nwith the default content type `multipart/form-data`. The default value `multipart/form-data` can be overridden\nby passing the content type as an optional parameter.\n  \n  \n---    \n**Parameters**  \n- _bodyParts_  \n    Represents the body parts that needs to be set to the entity  \n  \n- _contentType_  \n    Content-type to be used with the payload. This is an optional parameter.\n                `multipart/form-data` is used as the default value.  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBodyParts(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeader(string headerName)(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets the header value associated with the given header name.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    Represents header name  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaders(string headerName)(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets all the header values associated with the given header name.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaders(${1})",
+      "sortText": "130",
+      "insertText": "setBody(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -437,10 +148,245 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nGets all header names.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/mime_  \n  \nGets all header names.\n  \n  \n  \n**Returns** `string[]`   \n- All header names as a `string[]`  \n  \n"
         }
       },
-      "insertText": "getHeaderNames(${1})",
+      "sortText": "130",
+      "insertText": "getHeaderNames()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeHeader(string headerName)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nRemoves the given header from the entity.\n  \n**Params**  \n- `string` headerName: Represents the header name"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentId(string contentId)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content ID of the entity.\n  \n**Params**  \n- `string` contentId: Content ID that needs to be set to entity"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentId(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXml()((xml|mime:ParserError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nExtracts `xml` body from the entity. If the entity body is not an XML, an error is returned.\n  \n  \n  \n**Returns** `(xml|mime:ParserError)`   \n- `xml` data extracted from the the entity body. An `ParserError` record is returned in case of  \nerrors.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getXml()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentId()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content ID of entity.\n  \n  \n  \n**Returns** `string`   \n- Content ID as a `string`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentId()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cLength",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "cLength",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyPartsAsChannel()((io:ReadableByteChannel|mime:ParserError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the body parts as a byte channel.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|mime:ParserError)`   \n- Body parts as a byte channel  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBodyPartsAsChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasHeader(string headerName)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `boolean`   \n- True if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setXml(xml xmlContent, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given XML content. This method overrides any existing content-type headers\nwith the default content-type `application/xml`. The default value `application/xml` can be overridden\nby passing the content-type as an optional parameter.\n  \n**Params**  \n- `xml` xmlContent: XML content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/xml`\n                is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/xml`\n                is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setXml(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cId",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "cId",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setFileAsEntityBody(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with a given file. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n**Params**  \n- `string` filePath: Represents the path to the file  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setFileAsEntityBody(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content type of entity.\n  \n  \n  \n**Returns** `string`   \n- Content type as a `string`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nRemoves all headers associated with the entity.  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAllHeaders();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel byteChannel, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte channel content. This method overrides any existing content-type headers\nwith the default content-type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content-type as an optional parameter.\n  \n**Params**  \n- `io:ReadableByteChannel` byteChannel: Byte channel that needs to be set to entity  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.(Defaultable)  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cType",
+      "kind": "Variable",
+      "detail": "mime:MediaType",
+      "sortText": "120",
+      "insertText": "cType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentLength(int contentLength)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content length of the entity.\n  \n**Params**  \n- `int` contentLength: Content length that needs to be set to entity"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentLength(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeaders(string headerName)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets all the header values associated with the given header name.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string[]`   \n- All the header values associated with the given header name as a `string[]`. An exception is thrown  \nif no header is found. Use `hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaders(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -454,9 +400,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nAdds the given header value against the given header.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    Represents the header value to be added  \n"
+          "value": "**Package:** _ballerina/mime_  \n  \nAdds the given header value against the given header.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: Represents the header value to be added"
         }
       },
+      "sortText": "130",
       "insertText": "addHeader(${1});",
       "insertTextFormat": "Snippet",
       "command": {
@@ -465,111 +412,144 @@
       }
     },
     {
-      "label": "setHeader(string headerName, string headerValue)",
+      "label": "getByteChannel()((io:ReadableByteChannel|mime:ParserError))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nSets the given header value against the existing header. If a header already exists, its value is replaced\nwith the given header value.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    Represents the header value  \n"
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a byte channel.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|mime:ParserError)`   \n- An `io:ReadableByteChannel`. An `ParserError` record will be returned in case of errors  \n  \n"
         }
       },
-      "insertText": "setHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeHeader(string headerName)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nRemoves the given header from the entity.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    Represents the header name  \n"
-        }
-      },
-      "insertText": "removeHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAllHeaders()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nRemoves all headers associated with the entity.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAllHeaders(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasHeader(string headerName)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/mime_  \n  \nChecks whether the requested header key exists in the header map.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "__init()",
-      "kind": "Function",
-      "detail": "Function",
-      "insertText": "__init(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cType",
-      "kind": "Variable",
-      "detail": "mime:MediaType",
-      "insertText": "cType",
+      "sortText": "130",
+      "insertText": "getByteChannel()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cId",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "cId",
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets body parts to entity. This method overrides any existing `content-type` headers\nwith the default content type `multipart/form-data`. The default value `multipart/form-data` can be overridden\nby passing the content type as an optional parameter.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: Represents the body parts that needs to be set to the entity  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `multipart/form-data` is used as the default value.(Defaultable)  \n- `string` contentType: Content-type to be used with the payload. This is an optional parameter.\n                `multipart/form-data` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentDisposition()(mime:ContentDisposition)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the content disposition of entity.\n  \n  \n  \n**Returns** `mime:ContentDisposition`   \n- A `ContentDisposition` object  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentDisposition()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cLength",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "cLength",
+      "label": "getByteArray()((byte[]|mime:ParserError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGiven an entity, gets the entity body as a `byte[]`. If the entity size is considerably large consider\nusing getByteChannel() method instead.\n  \n  \n  \n**Returns** `(byte[]|mime:ParserError)`   \n- `byte[]` data extracted from the the entity body. An `ParserError` record is returned in case of  \nerrors.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getByteArray()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteArray(byte[] blobContent, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given byte[] content. This method overrides any existing `content-type` headers\nwith the default content type `application/octet-stream`. The default value `application/octet-stream`\ncan be overridden by passing the content type as an optional parameter.\n  \n**Params**  \n- `byte[]` blobContent: byte[] content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter.\n                `application/octet-stream` is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteArray(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeader(string headerName)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nGets the header value associated with the given header name.\n  \n**Params**  \n- `string` headerName: Represents header name  \n  \n**Returns** `string`   \n- Header value associated with the given header name as a `string`. If multiple header values are  \npresent, then the first value is returned. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string mediaType)((()|mime:InvalidContentTypeError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the content-type to entity.\n  \n**Params**  \n- `string` mediaType: Content type that needs to be set to the entity  \n  \n**Returns** `(()|mime:InvalidContentTypeError)`   \n- Nil if successful, error in case of invalid media-type  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "cDisposition",
       "kind": "Variable",
       "detail": "mime:ContentDisposition",
+      "sortText": "120",
       "insertText": "cDisposition",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setJson(json jsonContent, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/mime_  \n  \nSets the entity body with the given `json` content. This method overrides any existing `content-type` headers\nwith the default content type `application/json`. The default value `application/json` can be overridden\nby passing the content type as an optional parameter.\n  \n**Params**  \n- `json` jsonContent: JSON content that needs to be set to entity  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/json`\n                is used as the default value.(Defaultable)  \n- `string` contentType: Content type to be used with the payload. This is an optional parameter. `application/json`\n                is used as the default value."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setJson(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion4.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "shift(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "shift()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(int i)((any|error))",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    index of member to be removed  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n**Params**  \n- `int` i: index of member to be removed  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "pop(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "pop()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "iterator()()",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeAll()",
@@ -84,16 +72,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "slice(int startIndex, int endIndex)((any|error)[])",
@@ -102,7 +86,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _startIndex_  \n    index of first member to include in the slice  \n  \n- _endIndex_  \n    index of first member not to include in the slice  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n**Params**  \n- `int` startIndex: index of first member to include in the slice  \n- `int` endIndex: index of first member not to include in the slice  \n  \n**Returns** `(any|error)[]`   \n- array slice within specified range  \n  \n"
         }
       },
       "sortText": "130",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base16 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase16(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase16()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "enumerate()([int,(any|error)][])",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n[int,(any|error)][]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n  \n**Returns** `[int,(any|error)][]`   \n- array of position, member pair  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "enumerate(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "enumerate()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map(function ((any|error)) returns ((any|error)) func)((any|error)[])",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `(any|error)[]`   \n- new array containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `\u003d\u003d`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _val_  \n    member to search for  \n  \n- _startIndex_  \n    index to start the search from  \n(Default Parameter)  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `==`\n  \n**Params**  \n- `(anydata|error)` val: member to search for  \n- `int` startIndex: index to start the search from(Defaultable)  \n- `int` startIndex: index to start the search from  \n  \n**Returns** `(int|())`   \n- index of the member if found, else `()`  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,7 +168,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    combining function  \n  \n- _initial_  \n    initial value to first evaluation of combining function `func`  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the array  \n  \nExample: Emulating sum function.  \n```  \n# var ar = [1, 2, 3];  \n# var a = ar.reduce(function (int i, int j) returns int { return i + j; }, 0);  \n# ```  \n  \nExample: Emulating map behavior.  \n```  \n# var ar = [1, 2, 3];  \n# int[] newArr = [];  \n# int[] a = ar.reduce(function (int[] a, int j) returns int[] { a.push(j*2); return a; }, newArr);  \n# ```  \n  \n"
         }
       },
       "sortText": "130",
@@ -210,16 +186,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `\u003d`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `=`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base64 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase64(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase64()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "forEach(function ((any|error)) returns () func)",
@@ -228,7 +200,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
       "sortText": "130",
@@ -246,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "sort(function ((any|error),(any|error)) returns (int) func)((any|error)[])",
@@ -264,7 +232,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    comparator function  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns (int)` func: comparator function  \n  \n**Returns** `(any|error)[]`   \n- sorted `arr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -282,16 +250,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array to be reversed  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- reversed `arr`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "reverse(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "reverse()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "push(...(any|error))",
@@ -300,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the end of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n**Params**  \n- vals: values to add to the end of the array"
         }
       },
       "sortText": "130",
@@ -318,7 +282,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of \u0027arr\u0027 for which `func` returns true.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a predicate to apply to each element to determine if it should be included  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of 'arr' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `(any|error)[]`   \n- new array only containig members which evaluate function 'func' to true  \n  \n"
         }
       },
       "sortText": "130",
@@ -336,7 +300,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    new length  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n**Params**  \n- `int` i: new length"
         }
       },
       "sortText": "130",
@@ -354,16 +318,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "unshift(...(any|error))",
@@ -372,7 +332,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the start of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n**Params**  \n- vals: values to add to the start of the array"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion5.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "shift(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "shift()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(int i)((any|error))",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    index of member to be removed  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n**Params**  \n- `int` i: index of member to be removed  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "pop(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "pop()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "iterator()()",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeAll()",
@@ -84,16 +72,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "slice(int startIndex, int endIndex)((any|error)[])",
@@ -102,7 +86,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _startIndex_  \n    index of first member to include in the slice  \n  \n- _endIndex_  \n    index of first member not to include in the slice  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n**Params**  \n- `int` startIndex: index of first member to include in the slice  \n- `int` endIndex: index of first member not to include in the slice  \n  \n**Returns** `(any|error)[]`   \n- array slice within specified range  \n  \n"
         }
       },
       "sortText": "130",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base16 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase16(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase16()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "enumerate()([int,(any|error)][])",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n[int,(any|error)][]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n  \n**Returns** `[int,(any|error)][]`   \n- array of position, member pair  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "enumerate(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "enumerate()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map(function ((any|error)) returns ((any|error)) func)((any|error)[])",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `(any|error)[]`   \n- new array containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `\u003d\u003d`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _val_  \n    member to search for  \n  \n- _startIndex_  \n    index to start the search from  \n(Default Parameter)  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `==`\n  \n**Params**  \n- `(anydata|error)` val: member to search for  \n- `int` startIndex: index to start the search from(Defaultable)  \n- `int` startIndex: index to start the search from  \n  \n**Returns** `(int|())`   \n- index of the member if found, else `()`  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,7 +168,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    combining function  \n  \n- _initial_  \n    initial value to first evaluation of combining function `func`  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the array  \n  \nExample: Emulating sum function.  \n```  \n# var ar = [1, 2, 3];  \n# var a = ar.reduce(function (int i, int j) returns int { return i + j; }, 0);  \n# ```  \n  \nExample: Emulating map behavior.  \n```  \n# var ar = [1, 2, 3];  \n# int[] newArr = [];  \n# int[] a = ar.reduce(function (int[] a, int j) returns int[] { a.push(j*2); return a; }, newArr);  \n# ```  \n  \n"
         }
       },
       "sortText": "130",
@@ -210,16 +186,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `\u003d`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `=`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base64 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase64(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase64()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "forEach(function ((any|error)) returns () func)",
@@ -228,7 +200,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
       "sortText": "130",
@@ -246,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "sort(function ((any|error),(any|error)) returns (int) func)((any|error)[])",
@@ -264,7 +232,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    comparator function  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns (int)` func: comparator function  \n  \n**Returns** `(any|error)[]`   \n- sorted `arr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -282,16 +250,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array to be reversed  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- reversed `arr`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "reverse(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "reverse()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "push(...(any|error))",
@@ -300,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the end of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n**Params**  \n- vals: values to add to the end of the array"
         }
       },
       "sortText": "130",
@@ -318,7 +282,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of \u0027arr\u0027 for which `func` returns true.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a predicate to apply to each element to determine if it should be included  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of 'arr' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `(any|error)[]`   \n- new array only containig members which evaluate function 'func' to true  \n  \n"
         }
       },
       "sortText": "130",
@@ -336,7 +300,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    new length  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n**Params**  \n- `int` i: new length"
         }
       },
       "sortText": "130",
@@ -354,16 +318,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "unshift(...(any|error))",
@@ -372,7 +332,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the start of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n**Params**  \n- vals: values to add to the start of the array"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf1.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -106,7 +106,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -191,16 +191,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testElseAndElseIf(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testElseAndElseIf();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "error",
@@ -329,7 +325,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -343,7 +339,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -375,7 +371,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -389,7 +385,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -421,7 +417,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -435,7 +431,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -674,7 +670,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -688,7 +684,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -881,7 +877,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -895,7 +891,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -904,7 +900,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -918,7 +914,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1042,7 +1038,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1056,7 +1052,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1111,7 +1107,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1125,7 +1121,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1180,7 +1176,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1194,7 +1190,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1249,7 +1245,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1263,7 +1259,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1272,7 +1268,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1286,7 +1282,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1295,7 +1291,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1309,7 +1305,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1318,7 +1314,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1332,7 +1328,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1341,7 +1337,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1355,7 +1351,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf2.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -106,7 +106,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -199,16 +199,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testElseAndElseIf(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testElseAndElseIf();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "error",
@@ -337,7 +333,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -351,7 +347,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -383,7 +379,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -397,7 +393,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -429,7 +425,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -443,7 +439,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -682,7 +678,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -696,7 +692,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -889,7 +885,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -903,7 +899,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -912,7 +908,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -926,7 +922,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1050,7 +1046,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1064,7 +1060,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1119,7 +1115,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1133,7 +1129,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1188,7 +1184,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1202,7 +1198,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1257,7 +1253,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1271,7 +1267,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1280,7 +1276,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1294,7 +1290,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1303,7 +1299,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1317,7 +1313,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1326,7 +1322,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1340,7 +1336,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1349,7 +1345,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1363,7 +1359,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeIfElse.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeIfElse.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -116,7 +116,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -177,7 +177,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -254,16 +254,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -421,7 +417,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -435,7 +431,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -467,7 +463,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -481,7 +477,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -513,7 +509,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -527,7 +523,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -766,7 +762,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -780,7 +776,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -950,7 +946,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -964,7 +960,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -973,7 +969,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -987,7 +983,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1111,7 +1107,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1125,7 +1121,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1180,7 +1176,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1194,7 +1190,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1226,7 +1222,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1240,7 +1236,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1272,7 +1268,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1286,7 +1282,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1295,7 +1291,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1309,7 +1305,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1318,7 +1314,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1332,7 +1328,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1341,7 +1337,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1355,7 +1351,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1364,7 +1360,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1378,7 +1374,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeWhile.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeWhile.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -106,7 +106,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -132,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -193,7 +193,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -270,16 +270,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -437,7 +433,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -451,7 +447,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -483,7 +479,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -497,7 +493,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -529,7 +525,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -543,7 +539,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -782,7 +778,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -796,7 +792,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -966,7 +962,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -980,7 +976,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -989,7 +985,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1003,7 +999,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1127,7 +1123,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1141,7 +1137,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1196,7 +1192,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1210,7 +1206,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1242,7 +1238,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1256,7 +1252,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1288,7 +1284,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1302,7 +1298,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1311,7 +1307,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1325,7 +1321,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1334,7 +1330,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1348,7 +1344,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1357,7 +1353,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1371,7 +1367,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1380,7 +1376,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1394,7 +1390,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElse.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElse.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -108,7 +108,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -169,7 +169,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -246,16 +246,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -413,7 +409,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -427,7 +423,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -459,7 +455,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -473,7 +469,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -505,7 +501,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -519,7 +515,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -758,7 +754,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -772,7 +768,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -942,7 +938,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -956,7 +952,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -965,7 +961,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -979,7 +975,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1103,7 +1099,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1117,7 +1113,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1172,7 +1168,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1186,7 +1182,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1218,7 +1214,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1232,7 +1228,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1264,7 +1260,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1278,7 +1274,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1287,7 +1283,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1301,7 +1297,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1310,7 +1306,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1324,7 +1320,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1333,7 +1329,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1347,7 +1343,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1356,7 +1352,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1370,7 +1366,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElseIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElseIf.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -108,7 +108,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -169,7 +169,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -246,16 +246,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -413,7 +409,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -427,7 +423,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -459,7 +455,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -473,7 +469,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -505,7 +501,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -519,7 +515,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -758,7 +754,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -772,7 +768,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -942,7 +938,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -956,7 +952,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -965,7 +961,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -979,7 +975,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1103,7 +1099,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1117,7 +1113,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1172,7 +1168,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1186,7 +1182,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1218,7 +1214,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1232,7 +1228,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1264,7 +1260,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1278,7 +1274,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1287,7 +1283,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1301,7 +1297,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1310,7 +1306,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1324,7 +1320,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1333,7 +1329,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1347,7 +1343,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1356,7 +1352,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1370,7 +1366,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinIf.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -108,7 +108,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -169,7 +169,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -246,16 +246,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -413,7 +409,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -427,7 +423,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -459,7 +455,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -473,7 +469,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -505,7 +501,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -519,7 +515,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -758,7 +754,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -772,7 +768,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -942,7 +938,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -956,7 +952,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -965,7 +961,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -979,7 +975,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1103,7 +1099,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1117,7 +1113,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1172,7 +1168,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1186,7 +1182,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1218,7 +1214,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1232,7 +1228,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1264,7 +1260,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1278,7 +1274,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1287,7 +1283,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1301,7 +1297,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1310,7 +1306,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1324,7 +1320,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1333,7 +1329,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1347,7 +1343,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1356,7 +1352,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1370,7 +1366,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinInvocationArgs8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinInvocationArgs8.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testFunction(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testFunction()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "testO",
@@ -75,7 +71,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -89,7 +85,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -121,7 +117,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -135,7 +131,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -167,7 +163,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -181,7 +177,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -397,7 +393,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -411,7 +407,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -604,7 +600,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -618,7 +614,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -627,7 +623,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -641,7 +637,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -765,7 +761,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -779,7 +775,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -834,7 +830,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -848,7 +844,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -903,7 +899,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -917,7 +913,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -972,7 +968,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -986,7 +982,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -995,7 +991,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1009,7 +1005,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1018,7 +1014,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1032,7 +1028,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1041,7 +1037,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1055,7 +1051,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1064,7 +1060,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1078,7 +1074,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinTransaction.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinTransaction.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -106,7 +106,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -124,7 +124,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -193,7 +193,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -262,16 +262,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -429,7 +425,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -443,7 +439,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -475,7 +471,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -489,7 +485,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -521,7 +517,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -535,7 +531,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -774,7 +770,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -788,7 +784,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -958,7 +954,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -972,7 +968,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -981,7 +977,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -995,7 +991,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1119,7 +1115,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1133,7 +1129,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1188,7 +1184,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1202,7 +1198,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1234,7 +1230,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1248,7 +1244,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1280,7 +1276,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1294,7 +1290,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1303,7 +1299,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1317,7 +1313,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1326,7 +1322,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1340,7 +1336,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1349,7 +1345,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1363,7 +1359,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1372,7 +1368,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1386,7 +1382,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinTransactionOnRetry.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinTransactionOnRetry.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -116,7 +116,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -185,7 +185,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -254,16 +254,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -413,7 +409,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -427,7 +423,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -459,7 +455,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -473,7 +469,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -505,7 +501,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -519,7 +515,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -758,7 +754,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -772,7 +768,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -942,7 +938,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -956,7 +952,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -965,7 +961,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -979,7 +975,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1103,7 +1099,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1117,7 +1113,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1172,7 +1168,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1186,7 +1182,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1218,7 +1214,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1232,7 +1228,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1264,7 +1260,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1278,7 +1274,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1287,7 +1283,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1301,7 +1297,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1310,7 +1306,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1324,7 +1320,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1333,7 +1329,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1347,7 +1343,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1356,7 +1352,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1370,7 +1366,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWhile.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWhile.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -106,7 +106,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -124,7 +124,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -185,7 +185,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -262,16 +262,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -429,7 +425,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -443,7 +439,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -475,7 +471,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -489,7 +485,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -521,7 +517,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -535,7 +531,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -774,7 +770,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -788,7 +784,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -958,7 +954,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -972,7 +968,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -981,7 +977,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -995,7 +991,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1119,7 +1115,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1133,7 +1129,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1188,7 +1184,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1202,7 +1198,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1234,7 +1230,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1248,7 +1244,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1280,7 +1276,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1294,7 +1290,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1303,7 +1299,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1317,7 +1313,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1326,7 +1322,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1340,7 +1336,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1349,7 +1345,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1363,7 +1359,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1372,7 +1368,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1386,7 +1382,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWorkersInResource.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWorkersInResource.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -108,7 +108,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
@@ -138,7 +138,7 @@
     {
       "label": "w1",
       "kind": "Unit",
-      "detail": "future\u003c()\u003e",
+      "detail": "future<()>",
       "sortText": "120",
       "insertText": "w1",
       "insertTextFormat": "Snippet"
@@ -146,7 +146,7 @@
     {
       "label": "w2",
       "kind": "Unit",
-      "detail": "future\u003c()\u003e",
+      "detail": "future<()>",
       "sortText": "120",
       "insertText": "w2",
       "insertTextFormat": "Snippet"
@@ -193,7 +193,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `(int|error)`   \n  \n"
         }
       },
       "sortText": "130",
@@ -278,16 +278,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "functionForkJoin(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "functionForkJoin()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map",
@@ -437,7 +433,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -451,7 +447,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -483,7 +479,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -497,7 +493,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -529,7 +525,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -543,7 +539,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -782,7 +778,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -796,7 +792,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -966,7 +962,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -980,7 +976,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -989,7 +985,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1003,7 +999,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1127,7 +1123,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1141,7 +1137,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1196,7 +1192,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1210,7 +1206,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1242,7 +1238,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1256,7 +1252,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1288,7 +1284,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1302,7 +1298,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1311,7 +1307,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1325,7 +1321,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1334,7 +1330,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1348,7 +1344,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1357,7 +1353,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1371,7 +1367,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1380,7 +1376,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1394,7 +1390,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource2.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "130",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "130",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "130",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/emptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/emptyLineCompletion.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -205,16 +205,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function4(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function4();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "function3(int a, string b)",
@@ -223,7 +219,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
@@ -249,16 +245,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function2(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "function1(int param1, int param2)",
@@ -267,7 +259,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
@@ -453,7 +445,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -467,7 +459,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -499,7 +491,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -513,7 +505,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -545,7 +537,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -559,7 +551,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -798,7 +790,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -812,7 +804,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -982,7 +974,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -996,7 +988,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -1005,7 +997,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1019,7 +1011,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1143,7 +1135,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1157,7 +1149,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1212,7 +1204,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1226,7 +1218,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1281,7 +1273,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1295,7 +1287,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1350,7 +1342,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1364,7 +1356,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1373,7 +1365,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1387,7 +1379,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1396,7 +1388,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1410,7 +1402,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1419,7 +1411,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1433,7 +1425,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1442,7 +1434,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1456,7 +1448,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/errorLiftingSuggestions1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/errorLiftingSuggestions1.json
@@ -6,186 +6,39 @@
   "source": "function/source/errorLiftingSuggestions1.bal",
   "items": [
     {
-      "label": "createNewEntity()(mime:Entity)",
+      "label": "setLastModified()",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
         }
       },
-      "insertText": "createNewEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "setLastModified();",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getEntity()((mime:Entity|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "label": "server",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "server",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getEntityWithoutBody()(mime:Entity)",
+      "label": "setTextPayload(string payload, string contentType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`"
         }
       },
-      "insertText": "getEntityWithoutBody(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setEntity(mime:Entity e)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n  \n---    \n**Parameters**  \n- _e_  \n    The `Entity` to be set to the response  \n"
-        }
-      },
-      "insertText": "setEntity(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasHeader(string headerName)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeader(string headerName)(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "addHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "addHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaders(string headerName)(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaders(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "setHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeHeader(string key)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n  \n---    \n**Parameters**  \n- _key_  \n    The header name  \n"
-        }
-      },
-      "insertText": "removeHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAllHeaders()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAllHeaders(${1});",
+      "sortText": "130",
+      "insertText": "setTextPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -199,197 +52,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
         }
       },
-      "insertText": "getHeaderNames(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getHeaderNames()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "setContentType(string contentType)",
+      "label": "setEntity(mime:Entity e)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n  \n---    \n**Parameters**  \n- _contentType_  \n    Content type value to be set as the `content-type` header  \n"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
         }
       },
-      "insertText": "setContentType(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentType()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getJsonPayload()((json|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getJsonPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getXmlPayload()((xml|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(xml|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getXmlPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getTextPayload()((string|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(string|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getTextPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getByteChannel()((io:ReadableByteChannel|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getByteChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getBinaryPayload()((byte[]|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(byte[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getBinaryPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getBodyParts()((mime:Entity[]|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getBodyParts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setETag((json|xml|string|byte[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The payload for which the ETag should be set  \n"
-        }
-      },
-      "insertText": "setETag(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setLastModified()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "setLastModified(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setJsonPayload(json payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `json` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `json`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setJsonPayload(${1});",
+      "sortText": "130",
+      "insertText": "setEntity(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -403,112 +84,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `xml` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`"
         }
       },
+      "sortText": "130",
       "insertText": "setXmlPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setTextPayload(string payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `string` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `string`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setTextPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBinaryPayload(byte[] payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `byte[]` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBinaryPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n  \n---    \n**Parameters**  \n- _bodyParts_  \n    The entities which make up the message body  \n  \n- _contentType_  \n    The content type of the top level message. Set this to override the default\n                `content-type` header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBodyParts(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setFileAsPayload(string filePath, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n  \n---    \n**Parameters**  \n- _filePath_  \n    Path to the file to be set as the payload  \n  \n- _contentType_  \n    The content type of the specified file. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setFileAsPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    A `ByteChannel` through which the message payload can be read  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setByteChannel(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)  \n"
-        }
-      },
-      "insertText": "setPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -522,10 +102,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/http_  \n  \n  \n"
         }
       },
-      "insertText": "__init(${1});",
+      "sortText": "130",
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBinaryPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -533,59 +128,447 @@
       }
     },
     {
-      "label": "statusCode",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "statusCode",
+      "label": "getHeaders(string headerName)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|error)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBinaryPayload()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reasonPhrase",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "reasonPhrase",
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "createNewEntity()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the response  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "createNewEntity()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "server",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "server",
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXmlPayload()((xml|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|error)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasHeader(string headerName)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|error)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntity()((mime:Entity|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|error)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAllHeaders();",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "resolvedRequestedURI",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "resolvedRequestedURI",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setETag((json|xml|string|byte[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setETag(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentType()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "cacheControl",
       "kind": "Variable",
       "detail": "(http:ResponseCacheControl|())",
+      "sortText": "120",
       "insertText": "cacheControl",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "receivedTime",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "receivedTime",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "requestTime",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "120",
       "insertText": "requestTime",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|error)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \nconstructing the body parts from the response  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|error)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentType(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "receivedTime",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "receivedTime",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reasonPhrase",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "reasonPhrase",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getTextPayload()((string|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|error)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntityWithoutBody()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntityWithoutBody()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "entity",
       "kind": "Variable",
       "detail": "mime:Entity",
+      "sortText": "120",
       "insertText": "entity",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "statusCode",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "statusCode",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/errorLiftingSuggestions2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/errorLiftingSuggestions2.json
@@ -9,6 +9,10 @@
       "label": "anydataType",
       "kind": "Keyword",
       "detail": "Anydata",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "anydataType",
       "insertTextFormat": "Snippet"
     },
@@ -19,15 +23,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "keys()(string[])",
@@ -36,15 +37,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- list of all keys  \n  \n"
         }
       },
-      "insertText": "keys(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(string k)((any|error))",
@@ -53,9 +51,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +66,25 @@
       "label": "Type1",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "Type1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAll();",
       "insertTextFormat": "Snippet"
     },
     {
@@ -77,32 +94,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAll()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -111,15 +108,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "get(string k)((any|error))",
@@ -128,9 +122,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map m with key k.\nPanics if m does not have a member with key k.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nPanics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member matching key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -145,9 +140,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<(any|error)>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturn a map with the result of applying function `func` to each member of map `m`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -162,15 +158,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -179,27 +172,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReduce operate on each member of `m` using combining function `func` to produce\na new value combining all members of `m`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the map  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "reduce(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasKey(string k)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -210,13 +187,33 @@
       "label": "a",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "a",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "b",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "b",
       "insertTextFormat": "Snippet"
     },
@@ -224,6 +221,10 @@
       "label": "PureType",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "PureType",
       "insertTextFormat": "Snippet"
     },
@@ -234,27 +235,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
+      "sortText": "130",
       "insertText": "forEach(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cloneReadOnly()(anydata)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "cloneReadOnly(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -268,20 +253,32 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the map  \n  \n"
         }
       },
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "MapIterator",
       "kind": "Class",
       "detail": "Object",
+      "sortText": "120",
       "insertText": "MapIterator",
       "insertTextFormat": "Snippet"
     },
@@ -292,9 +289,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<(any|error)>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a new map constructed from those elements of 'm' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containig members which evaluate function 'func' to true  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -303,28 +301,29 @@
       }
     },
     {
-      "label": "Type",
-      "kind": "Enum",
-      "detail": "Union",
-      "insertText": "Type",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "entries()(map<[string,(any|error)]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<[string,(any|error)]>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- map of [key, member] pairs  \n  \n"
         }
       },
-      "insertText": "entries(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
+      "insertText": "Type",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "mergeJson(json j2)((json|error))",
@@ -333,9 +332,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\nIf the merge fails, then return an error.\nThe merge of j1 with j2 is defined as follows:\n- if j1 is (), then the result is j2\n- if j2 is nil, then the result is j1\n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,\n  set j1[k] to the merge of j1[k] with j\n    - if j1[k] is undefined, then set j1[k] to j\n    - if any merge fails, then the merge of j1 with j2 fails\n    - otherwise, the result is j1.\n- otherwise, the merge fails  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "mergeJson(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -350,15 +350,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -367,15 +364,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key=value for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `==` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion2.json
@@ -202,16 +202,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testConditionFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testConditionFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "ballerinax/java.jdbc",
@@ -241,7 +237,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -255,7 +251,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -287,7 +283,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -301,7 +297,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -333,7 +329,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -347,7 +343,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -586,7 +582,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -600,7 +596,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -793,7 +789,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -807,7 +803,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -816,7 +812,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -830,7 +826,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -954,7 +950,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -968,7 +964,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1023,7 +1019,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1037,7 +1033,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1092,7 +1088,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1106,7 +1102,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1161,7 +1157,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1175,7 +1171,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1184,7 +1180,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1198,7 +1194,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1207,7 +1203,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1221,7 +1217,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1230,7 +1226,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1244,7 +1240,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1253,7 +1249,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1267,7 +1263,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion5.json
@@ -202,16 +202,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testConditionFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testConditionFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "http",
@@ -249,7 +245,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -263,7 +259,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -295,7 +291,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -309,7 +305,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -341,7 +337,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -355,7 +351,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -594,7 +590,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -608,7 +604,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -801,7 +797,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -815,7 +811,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -824,7 +820,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -838,7 +834,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -962,7 +958,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -976,7 +972,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1031,7 +1027,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1045,7 +1041,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1077,7 +1073,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1091,7 +1087,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1146,7 +1142,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1160,7 +1156,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1169,7 +1165,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1183,7 +1179,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1192,7 +1188,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1206,7 +1202,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1215,7 +1211,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1229,7 +1225,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1238,7 +1234,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1252,7 +1248,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation1.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "shift(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "shift()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(int i)((any|error))",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    index of member to be removed  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n**Params**  \n- `int` i: index of member to be removed  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "pop(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "pop()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "iterator()()",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeAll()",
@@ -84,16 +72,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -102,16 +86,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "slice(int startIndex, int endIndex)((any|error)[])",
@@ -120,7 +100,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _startIndex_  \n    index of first member to include in the slice  \n  \n- _endIndex_  \n    index of first member not to include in the slice  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n**Params**  \n- `int` startIndex: index of first member to include in the slice  \n- `int` endIndex: index of first member not to include in the slice  \n  \n**Returns** `(any|error)[]`   \n- array slice within specified range  \n  \n"
         }
       },
       "sortText": "130",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base16 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase16(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase16()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "enumerate()([int,(any|error)][])",
@@ -156,16 +132,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n[int,(any|error)][]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n  \n**Returns** `[int,(any|error)][]`   \n- array of position, member pair  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "enumerate(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "enumerate()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map(function ((any|error)) returns ((any|error)) func)((any|error)[])",
@@ -174,7 +146,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `(any|error)[]`   \n- new array containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,7 +164,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `\u003d\u003d`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _val_  \n    member to search for  \n  \n- _startIndex_  \n    index to start the search from  \n(Default Parameter)  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `==`\n  \n**Params**  \n- `(anydata|error)` val: member to search for  \n- `int` startIndex: index to start the search from(Defaultable)  \n- `int` startIndex: index to start the search from  \n  \n**Returns** `(int|())`   \n- index of the member if found, else `()`  \n  \n"
         }
       },
       "sortText": "130",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -228,7 +196,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    combining function  \n  \n- _initial_  \n    initial value to first evaluation of combining function `func`  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the array  \n  \nExample: Emulating sum function.  \n```  \n# var ar = [1, 2, 3];  \n# var a = ar.reduce(function (int i, int j) returns int { return i + j; }, 0);  \n# ```  \n  \nExample: Emulating map behavior.  \n```  \n# var ar = [1, 2, 3];  \n# int[] newArr = [];  \n# int[] a = ar.reduce(function (int[] a, int j) returns int[] { a.push(j*2); return a; }, newArr);  \n# ```  \n  \n"
         }
       },
       "sortText": "130",
@@ -246,16 +214,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `\u003d`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `=`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base64 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase64(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase64()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "forEach(function ((any|error)) returns () func)",
@@ -264,7 +228,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
       "sortText": "130",
@@ -282,16 +246,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -300,16 +260,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "sort(function ((any|error),(any|error)) returns (int) func)((any|error)[])",
@@ -318,7 +274,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    comparator function  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns (int)` func: comparator function  \n  \n**Returns** `(any|error)[]`   \n- sorted `arr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -336,16 +292,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array to be reversed  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- reversed `arr`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "reverse(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "reverse()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "push(...(any|error))",
@@ -354,7 +306,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the end of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n**Params**  \n- vals: values to add to the end of the array"
         }
       },
       "sortText": "130",
@@ -372,7 +324,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of \u0027arr\u0027 for which `func` returns true.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a predicate to apply to each element to determine if it should be included  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of 'arr' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `(any|error)[]`   \n- new array only containig members which evaluate function 'func' to true  \n  \n"
         }
       },
       "sortText": "130",
@@ -390,7 +342,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    new length  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n**Params**  \n- `int` i: new length"
         }
       },
       "sortText": "130",
@@ -408,7 +360,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -426,16 +378,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -444,16 +392,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "unshift(...(any|error))",
@@ -462,7 +406,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the start of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n**Params**  \n- vals: values to add to the start of the array"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation2.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "shift(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "shift()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(int i)((any|error))",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    index of member to be removed  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n**Params**  \n- `int` i: index of member to be removed  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "pop(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "pop()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "iterator()()",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeAll()",
@@ -84,16 +72,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -102,16 +86,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "slice(int startIndex, int endIndex)((any|error)[])",
@@ -120,7 +100,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _startIndex_  \n    index of first member to include in the slice  \n  \n- _endIndex_  \n    index of first member not to include in the slice  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n**Params**  \n- `int` startIndex: index of first member to include in the slice  \n- `int` endIndex: index of first member not to include in the slice  \n  \n**Returns** `(any|error)[]`   \n- array slice within specified range  \n  \n"
         }
       },
       "sortText": "130",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base16 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase16(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase16()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "enumerate()([int,(any|error)][])",
@@ -156,16 +132,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n[int,(any|error)][]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n  \n**Returns** `[int,(any|error)][]`   \n- array of position, member pair  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "enumerate(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "enumerate()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map(function ((any|error)) returns ((any|error)) func)((any|error)[])",
@@ -174,7 +146,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `(any|error)[]`   \n- new array containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,7 +164,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `\u003d\u003d`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _val_  \n    member to search for  \n  \n- _startIndex_  \n    index to start the search from  \n(Default Parameter)  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `==`\n  \n**Params**  \n- `(anydata|error)` val: member to search for  \n- `int` startIndex: index to start the search from(Defaultable)  \n- `int` startIndex: index to start the search from  \n  \n**Returns** `(int|())`   \n- index of the member if found, else `()`  \n  \n"
         }
       },
       "sortText": "130",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -228,7 +196,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    combining function  \n  \n- _initial_  \n    initial value to first evaluation of combining function `func`  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the array  \n  \nExample: Emulating sum function.  \n```  \n# var ar = [1, 2, 3];  \n# var a = ar.reduce(function (int i, int j) returns int { return i + j; }, 0);  \n# ```  \n  \nExample: Emulating map behavior.  \n```  \n# var ar = [1, 2, 3];  \n# int[] newArr = [];  \n# int[] a = ar.reduce(function (int[] a, int j) returns int[] { a.push(j*2); return a; }, newArr);  \n# ```  \n  \n"
         }
       },
       "sortText": "130",
@@ -246,16 +214,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `\u003d`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `=`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base64 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase64(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase64()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "forEach(function ((any|error)) returns () func)",
@@ -264,7 +228,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
       "sortText": "130",
@@ -282,16 +246,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -300,16 +260,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "sort(function ((any|error),(any|error)) returns (int) func)((any|error)[])",
@@ -318,7 +274,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    comparator function  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns (int)` func: comparator function  \n  \n**Returns** `(any|error)[]`   \n- sorted `arr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -336,16 +292,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array to be reversed  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- reversed `arr`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "reverse(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "reverse()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "push(...(any|error))",
@@ -354,7 +306,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the end of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n**Params**  \n- vals: values to add to the end of the array"
         }
       },
       "sortText": "130",
@@ -372,7 +324,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of \u0027arr\u0027 for which `func` returns true.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a predicate to apply to each element to determine if it should be included  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of 'arr' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `(any|error)[]`   \n- new array only containig members which evaluate function 'func' to true  \n  \n"
         }
       },
       "sortText": "130",
@@ -390,7 +342,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    new length  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n**Params**  \n- `int` i: new length"
         }
       },
       "sortText": "130",
@@ -408,7 +360,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -426,16 +378,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -444,16 +392,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "unshift(...(any|error))",
@@ -462,7 +406,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the start of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n**Params**  \n- vals: values to add to the start of the array"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation3.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet the text value of a XML. If the XML is a sequence, concatenation of the text values of the members of the\nsequence is returned. If the XML is an element, then the text value of the sequence of children is returned. If\nthe XML is a text item, then the text is returned. Otherwise, an empty string is returned.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet the text value of a XML. If the XML is a sequence, concatenation of the text values of the members of the\nsequence is returned. If the XML is an element, then the text value of the sequence of children is returned. If\nthe XML is a text item, then the text is returned. Otherwise, an empty string is returned.\n  \n  \n  \n**Returns** `string`   \n- Text value of the xml  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getTextValue(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getTextValue()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "setName(string xName)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nChange the name of element `elmem` to `xName`.\n  \n  \n---    \n**Parameters**  \n- _elem_  \n    xml element  \n  \n- _xName_  \n    new name  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nChange the name of element `elmem` to `xName`.\n  \n**Params**  \n- `string` xName: new name"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is a singleton xml sequence consisting of a comment item.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is a singleton xml sequence consisting of a comment item.\n  \n  \n  \n**Returns** `boolean`   \n- true if `x` is a xml comment item  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isComment(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isComment()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "select(string qname)(xml)",
@@ -66,7 +58,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet all the items that are of element type, and matches the given qualified name, in an XML sequence.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _qname_  \n    Qualified name of the element  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet all the items that are of element type, and matches the given qualified name, in an XML sequence.\n  \n**Params**  \n- `string` qname: Qualified name of the element  \n  \n**Returns** `xml`   \n- All the elements-type items in the given XML sequence, that matches the qualified name  \n  \n"
         }
       },
       "sortText": "130",
@@ -84,16 +76,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns a string giving the expanded name of `elem`.\n  \n  \n---    \n**Parameters**  \n- _elem_  \n    xml element  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns a string giving the expanded name of `elem`.\n  \n  \n  \n**Returns** `string`   \n- element name  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getName(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getName()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeChildren(string qname)",
@@ -102,7 +90,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nRemove children matching the given name from an XML. This operation has no effect\nif the XML is not an element type XML.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _qname_  \n    Namespace qualified name of the children to be removed  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nRemove children matching the given name from an XML. This operation has no effect\nif the XML is not an element type XML.\n  \n**Params**  \n- `string` qname: Namespace qualified name of the children to be removed"
         }
       },
       "sortText": "130",
@@ -120,25 +108,21 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the content of a text or processing instruction or comment item.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml item  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the content of a text or processing instruction or comment item.\n  \n  \n  \n**Returns** `string`   \n- content of `x`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getContent(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getContent()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "setAttributes(map\u003cany\u003e attributes)",
+      "label": "setAttributes(map<any> attributes)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nSets the attributes to the provided attributes map.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _attributes_  \n    Attributes map  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nSets the attributes to the provided attributes map.\n  \n**Params**  \n- `map<any>` attributes: Attributes map"
         }
       },
       "sortText": "130",
@@ -156,16 +140,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet the fully qualified name of the element as a string. Returns an empty string if the XML is not a singleton.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet the fully qualified name of the element as a string. Returns an empty string if the XML is not a singleton.\n  \n  \n  \n**Returns** `string`   \n- Qualified name of the XML as a string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getElementName(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getElementName()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "iterator()()",
@@ -174,16 +154,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml item to iterate  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getTarget()(string)",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the target part of the processing instruction.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml processing instruction item  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the target part of the processing instruction.\n  \n  \n  \n**Returns** `string`   \n- target potion of `x`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getTarget(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getTarget()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "strip()(xml)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nStrips any text items from an XML sequence that are all whitespace.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nStrips any text items from an XML sequence that are all whitespace.\n  \n  \n  \n**Returns** `xml`   \n- Striped sequence  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "strip(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "strip()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -228,16 +196,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "slice(int startIndex, int endIndex)(xml)",
@@ -246,7 +210,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nSlice and return a subsequence of the an XML sequence.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _startIndex_  \n    Start index, inclusive  \n  \n- _endIndex_  \n    End index, exclusive  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nSlice and return a subsequence of the an XML sequence.\n  \n**Params**  \n- `int` startIndex: Start index, inclusive  \n- `int` endIndex: End index, exclusive  \n  \n**Returns** `xml`   \n- Sliced sequence  \n  \n"
         }
       },
       "sortText": "130",
@@ -264,16 +228,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nMake a deep copy of an XML.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nMake a deep copy of an XML.\n  \n  \n  \n**Returns** `xml`   \n- A Copy of the XML  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "copy(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "copy()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeAttribute(string qname)",
@@ -282,7 +242,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nRemove an attribute from an XML.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _qname_  \n    Qualified name of the attribute  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nRemove an attribute from an XML.\n  \n**Params**  \n- `string` qname: Qualified name of the attribute"
         }
       },
       "sortText": "130",
@@ -300,7 +260,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nFor xml sequence returns the result of applying function `func` to each member of sequence `item`.\nFor xml element returns the result of applying function `funct` to `item`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the x  \n  \n- _func_  \n    a function to apply to each child or `item`  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nFor xml sequence returns the result of applying function `func` to each member of sequence `item`.\nFor xml element returns the result of applying function `funct` to `item`.\n  \n**Params**  \n- `function ((xml|string)) returns ((xml|string))` func: a function to apply to each child or `item`  \n  \n**Returns** `xml`   \n- new xml value containing result of applying function `func` to each child or `item`  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +286,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is an xml sequence consisting of one or more character items.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is an xml sequence consisting of one or more character items.\n  \n  \n  \n**Returns** `boolean`   \n- true if `x` is a sequence containing any charactor items  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isText(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isText()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "selectDescendants(string qname)(xml)",
@@ -344,7 +300,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nSearches in children recursively for elements matching the qualified name and returns a sequence containing them\nall. Does not search within a matched result.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _qname_  \n    Qualified name of the element  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nSearches in children recursively for elements matching the qualified name and returns a sequence containing them\nall. Does not search within a matched result.\n  \n**Params**  \n- `string` qname: Qualified name of the element  \n  \n**Returns** `xml`   \n- All the descendants that matches the given qualified name, as a sequence  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,34 +318,26 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is a singleton xml sequence consisting of a processing instruction item.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is a singleton xml sequence consisting of a processing instruction item.\n  \n  \n  \n**Returns** `boolean`   \n- true if `x` is a xml processing instruction  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isProcessingInstruction(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isProcessingInstruction()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getAttributes()(map\u003cstring\u003e)",
+      "label": "getAttributes()(map<string>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the map representing the attributes of `elem`.\nThis includes namespace attributes.\nThe keys in the map are the expanded name of the attribute.\nPanics if `isElement(elem)` is not true.\nThere is no setAttributes function.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml element  \n  \n  \n**Return**  \nmap\u003cstring\u003e"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the map representing the attributes of `elem`.\nThis includes namespace attributes.\nThe keys in the map are the expanded name of the attribute.\nPanics if `isElement(elem)` is not true.\nThere is no setAttributes function.\n  \n  \n  \n**Returns** `map<string>`   \n- attributes of `x`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getAttributes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getAttributes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "appendChildren(xml children)",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nAppend children to an XML if its an element type XML. Error otherwise.\nNew children will be appended at the end of the existing children.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n- _children_  \n    children  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nAppend children to an XML if its an element type XML. Error otherwise.\nNew children will be appended at the end of the existing children.\n  \n**Params**  \n- `xml` children: children"
         }
       },
       "sortText": "130",
@@ -416,16 +364,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is a singleton xml sequence consisting of an element item.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns true if `x` is a singleton xml sequence consisting of an element item.\n  \n  \n  \n**Returns** `boolean`   \n- true if `x` is an xml element item  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isElement(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isElement()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "forEach(function ((xml|string)) returns () func)",
@@ -434,7 +378,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nFor xml sequence apply the `func` to children of `item`.\nFor xml element apply the `func` to `item`.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    the xml value  \n  \n- _func_  \n    a function to apply to each child or `item`  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nFor xml sequence apply the `func` to children of `item`.\nFor xml element apply the `func` to `item`.\n  \n**Params**  \n- `function ((xml|string)) returns ()` func: a function to apply to each child or `item`"
         }
       },
       "sortText": "130",
@@ -452,16 +396,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -470,16 +410,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns number of XML items in `x`.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml item  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns number of XML items in `x`.\n  \n  \n  \n**Returns** `int`   \n- number of XML items in `x`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isEmpty()(boolean)",
@@ -488,16 +424,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nCheck whether the XML sequence is empty.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nCheck whether the XML sequence is empty.\n  \n  \n  \n**Returns** `boolean`   \n- Boolean flag indicating whether the XML sequence is empty  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isEmpty(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isEmpty()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isSingleton()(boolean)",
@@ -506,16 +438,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nCheck whether the XML sequence contains only a single element.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nCheck whether the XML sequence contains only a single element.\n  \n  \n  \n**Returns** `boolean`   \n- Boolean flag indicating whether the XML sequence contains only a single element  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isSingleton(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isSingleton()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getItemType()(string)",
@@ -524,16 +452,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet the type of a XML as a string. If the XML is singleton, type can be one of \u0027element\u0027, \u0027text\u0027, \u0027comment\u0027 or \u0027pi\u0027.\nReturns an empty string if the XML is not a singleton.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet the type of a XML as a string. If the XML is singleton, type can be one of 'element', 'text', 'comment' or 'pi'.\nReturns an empty string if the XML is not a singleton.\n  \n  \n  \n**Returns** `string`   \n- Type of the XML as a string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getItemType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getItemType()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...(xml|string))(xml)",
@@ -542,7 +466,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nConcatenate all the `xs`. Empty xml sequence if empty.\n  \n  \n---    \n**Parameters**  \n- _xs_  \n    xml or string items to concat  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nConcatenate all the `xs`. Empty xml sequence if empty.\n  \n  \n  \n**Returns** `xml`   \n- xml sequence containing `xs`  \n  \n"
         }
       },
       "sortText": "130",
@@ -560,7 +484,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nFor xml sequence returns a new xml sequence constructed from children of `x` for which `func` returns true.\nFor xml element returns a new xml sequence constructed from `x` if `x` applied to `funct` returns true, else\nreturns an empty sequence.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    xml value  \n  \n- _func_  \n    a predicate to apply to each child to determine if it should be included  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nFor xml sequence returns a new xml sequence constructed from children of `x` for which `func` returns true.\nFor xml element returns a new xml sequence constructed from `x` if `x` applied to `funct` returns true, else\nreturns an empty sequence.\n  \n**Params**  \n- `function ((xml|string)) returns (boolean)` func: a predicate to apply to each child to determine if it should be included  \n  \n**Returns** `xml`   \n- new xml sequence containing filtered children  \n  \n"
         }
       },
       "sortText": "130",
@@ -578,16 +502,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the children of `elem`.\nPanics if `isElement(elem)` is not true.\n  \n  \n---    \n**Parameters**  \n- _elem_  \n    xml element  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nReturns the children of `elem`.\nPanics if `isElement(elem)` is not true.\n  \n  \n  \n**Returns** `xml`   \n- children of `elem`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getChildren(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getChildren()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "elements()(xml)",
@@ -596,16 +516,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet all the items that are of element type in an XML sequence.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    The xml source  \n  \n  \n**Return**  \nxml"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nGet all the items that are of element type in an XML sequence.\n  \n  \n  \n**Returns** `xml`   \n- All the elements-type items in the given XML sequence  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "elements(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "elements()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "clone()(anydata)",
@@ -614,16 +530,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -632,16 +544,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "setChildren((xml|string) children)",
@@ -650,7 +558,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml_  \n  \nSets the children of `elem` to `children`.\nPanics if `isElement(elem)` is not true.\n  \n  \n---    \n**Parameters**  \n- _elem_  \n    xml element  \n  \n- _children_  \n    xml or string to set as children  \n"
+          "value": "**Package:** _ballerina/lang.xml_  \n  \nSets the children of `elem` to `children`.\nPanics if `isElement(elem)` is not true.\n  \n**Params**  \n- `(xml|string)` children: xml or string to set as children"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation4.json
@@ -9,6 +9,10 @@
       "label": "anydataType",
       "kind": "Keyword",
       "detail": "Anydata",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "anydataType",
       "insertTextFormat": "Snippet"
     },
@@ -19,15 +23,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "keys()(string[])",
@@ -36,15 +37,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- list of all keys  \n  \n"
         }
       },
-      "insertText": "keys(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(string k)((any|error))",
@@ -53,9 +51,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +66,25 @@
       "label": "Type1",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "Type1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAll();",
       "insertTextFormat": "Snippet"
     },
     {
@@ -77,32 +94,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAll()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -111,15 +108,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "get(string k)((any|error))",
@@ -128,9 +122,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map m with key k.\nPanics if m does not have a member with key k.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nPanics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member matching key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -145,9 +140,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<(any|error)>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturn a map with the result of applying function `func` to each member of map `m`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -162,15 +158,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -179,9 +172,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReduce operate on each member of `m` using combining function `func` to produce\na new value combining all members of `m`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the map  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -196,9 +190,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -210,6 +205,10 @@
       "label": "PureType",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "PureType",
       "insertTextFormat": "Snippet"
     },
@@ -220,27 +219,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
+      "sortText": "130",
       "insertText": "forEach(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cloneReadOnly()(anydata)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "cloneReadOnly(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -254,20 +237,32 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the map  \n  \n"
         }
       },
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "MapIterator",
       "kind": "Class",
       "detail": "Object",
+      "sortText": "120",
       "insertText": "MapIterator",
       "insertTextFormat": "Snippet"
     },
@@ -278,9 +273,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<(any|error)>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a new map constructed from those elements of 'm' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containig members which evaluate function 'func' to true  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -289,28 +285,29 @@
       }
     },
     {
-      "label": "Type",
-      "kind": "Enum",
-      "detail": "Union",
-      "insertText": "Type",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "entries()(map<[string,(any|error)]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<[string,(any|error)]>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- map of [key, member] pairs  \n  \n"
         }
       },
-      "insertText": "entries(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
+      "insertText": "Type",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "mergeJson(json j2)((json|error))",
@@ -319,9 +316,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\nIf the merge fails, then return an error.\nThe merge of j1 with j2 is defined as follows:\n- if j1 is (), then the result is j2\n- if j2 is nil, then the result is j1\n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,\n  set j1[k] to the merge of j1[k] with j\n    - if j1[k] is undefined, then set j1[k] to j\n    - if any merge fails, then the merge of j1 with j2 fails\n    - otherwise, the result is j1.\n- otherwise, the merge fails  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "mergeJson(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -336,15 +334,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -353,15 +348,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key=value for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `==` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation6.json
@@ -12,7 +12,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nRemove data from the table.\n  \n  \n---    \n**Parameters**  \n- _func_  \n    The function pointer for delete crieteria  \n  \n  \n**Return**  \n(int|error)"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nRemove data from the table.\n  \n  \n  \n**Returns** `(int|error)`   \n- An `int` the number of deleted record count or `error` if any error occurred during removing data  \n  \n"
         }
       },
       "sortText": "130",
@@ -38,16 +38,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nReturns an iterator over the members of `tbl`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $map0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nReturns an iterator over the members of `tbl`.  \n  \n  \n**Returns** ``   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -56,16 +52,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "TableConfig",
@@ -85,16 +77,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nReleases the database connection. If the table data is fully iterated, it will be automatically closed. This explicit\nclose is required only if it is not fully iterated.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nReleases the database connection. If the table data is fully iterated, it will be automatically closed. This explicit\nclose is required only if it is not fully iterated.  \n"
         }
       },
       "sortText": "130",
-      "insertText": "close(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "close();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "add(any data)((()|error))",
@@ -103,7 +91,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nAdd record to the table.\n  \n  \n---    \n**Parameters**  \n- _data_  \n    A record with data  \n  \n  \n**Return**  \nerror?"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nAdd record to the table.\n  \n  \n  \n**Returns** `(()|error)`   \n- An `error` will be returned if there is any error occurred during adding data or else nil is returned  \n  \n"
         }
       },
       "sortText": "130",
@@ -121,16 +109,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -139,16 +123,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nReturns the number of members in `tbl`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nReturns the number of members in `tbl`.  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "hasNext()(boolean)",
@@ -157,16 +137,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nChecks for a new row in the given table. If a new row is found, moves the cursor to it.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nChecks for a new row in the given table. If a new row is found, moves the cursor to it.\n  \n  \n  \n**Returns** `boolean`   \n- True if there is a new row; false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "hasNext(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "hasNext()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getNext()(any)",
@@ -175,16 +151,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.table_  \n  \nRetrives the current row and return a record with the data in the columns.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nany"
+          "value": "**Package:** _ballerina/lang.table_  \n  \nRetrives the current row and return a record with the data in the columns.\n  \n  \n  \n**Returns** `any`   \n- The resulting row as a record  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "getNext(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "getNext()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "clone()(anydata)",
@@ -193,16 +165,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -211,16 +179,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions3.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "130",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "130",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "130",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion1.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nObjectName"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `ObjectName`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "get(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "get()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "testFunction()",
@@ -30,16 +26,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "http",
@@ -77,7 +69,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -91,7 +83,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -123,7 +115,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -137,7 +129,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -169,7 +161,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -183,7 +175,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -422,7 +414,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -436,7 +428,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -629,7 +621,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -643,7 +635,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -652,7 +644,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -666,7 +658,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -790,7 +782,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -804,7 +796,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -859,7 +851,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -873,7 +865,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -905,7 +897,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -919,7 +911,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -974,7 +966,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -988,7 +980,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -997,7 +989,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1011,7 +1003,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1020,7 +1012,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1034,7 +1026,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1043,7 +1035,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1057,7 +1049,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1066,7 +1058,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1080,7 +1072,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },
@@ -1154,7 +1146,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion2.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "http",
@@ -59,7 +55,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -73,7 +69,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -105,7 +101,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -119,7 +115,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -151,7 +147,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -165,7 +161,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -404,7 +400,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -418,7 +414,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -611,7 +607,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -625,7 +621,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -634,7 +630,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -648,7 +644,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -772,7 +768,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -786,7 +782,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -841,7 +837,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -855,7 +851,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -887,7 +883,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -901,7 +897,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -956,7 +952,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -970,7 +966,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -979,7 +975,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -993,7 +989,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1002,7 +998,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1016,7 +1012,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1025,7 +1021,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1039,7 +1035,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1048,7 +1044,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1062,7 +1058,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },
@@ -1135,11 +1131,7 @@
       "detail": "Function",
       "sortText": "130",
       "insertText": "new();",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion3.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testFunction(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "http",
@@ -59,7 +55,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -73,7 +69,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -105,7 +101,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -119,7 +115,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -151,7 +147,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -165,7 +161,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -404,7 +400,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -418,7 +414,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -611,7 +607,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -625,7 +621,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -634,7 +630,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -648,7 +644,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -772,7 +768,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -786,7 +782,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -841,7 +837,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -855,7 +851,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -887,7 +883,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -901,7 +897,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -956,7 +952,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -970,7 +966,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -979,7 +975,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -993,7 +989,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1002,7 +998,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1016,7 +1012,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1025,7 +1021,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1039,7 +1035,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1048,7 +1044,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1062,7 +1058,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },
@@ -1136,7 +1132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCreate a redirect client with the given configurations.\n  \n  \n---    \n**Parameters**  \n- _url_  \n    Target service url  \n  \n- _config_  \n    HTTP ClientEndpointConfig to be used for HTTP client invocation  \n  \n- _redirectConfig_  \n    Configurations associated with redirect  \n  \n- _httpClient_  \n    HTTP client for outbound HTTP requests  \n"
+          "value": "**Package:** _ballerina/http_  \n  \nCreate a redirect client with the given configurations.\n  \n**Params**  \n- `string` url: Target service url  \n- `http:ClientEndpointConfig` config: HTTP ClientEndpointConfig to be used for HTTP client invocation  \n- `http:FollowRedirects` redirectConfig: Configurations associated with redirect  \n- `http:HttpClient` httpClient: HTTP client for outbound HTTP requests"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/nonEmptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/nonEmptyLineCompletion.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -205,16 +205,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function4(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function4();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "function3(int a, string b)",
@@ -223,7 +219,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
@@ -249,16 +245,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function2(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "function1(int param1, int param2)",
@@ -267,7 +259,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
@@ -453,7 +445,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -467,7 +459,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -499,7 +491,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -513,7 +505,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -545,7 +537,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -559,7 +551,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -798,7 +790,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -812,7 +804,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -982,7 +974,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -996,7 +988,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -1005,7 +997,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1019,7 +1011,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1143,7 +1135,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1157,7 +1149,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1212,7 +1204,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1226,7 +1218,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1281,7 +1273,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1295,7 +1287,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1350,7 +1342,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1364,7 +1356,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1373,7 +1365,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1387,7 +1379,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1396,7 +1388,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1410,7 +1402,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1419,7 +1411,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1433,7 +1425,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1442,7 +1434,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1456,7 +1448,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions1.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int_  \n  \nReturns representation of `n` as hexdecimal string.\nThere is no `0x` prefix. Lowercase letters a-f are used.\nNegative numbers will have a `-` prefix. No sign for\nnon-negative numbers.\n  \n  \n---    \n**Parameters**  \n- _x_  \n    int value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.int_  \n  \nReturns representation of `n` as hexdecimal string.\nThere is no `0x` prefix. Lowercase letters a-f are used.\nNegative numbers will have a `-` prefix. No sign for\nnon-negative numbers.\n  \n  \n  \n**Returns** `string`   \n- hexadecimal string representation of int value  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toHexString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toHexString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "max(...int)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int_  \n  \nMaximum of all the arguments.\n  \n  \n---    \n**Parameters**  \n- _n_  \n    first argument to check for max value  \n  \n- _ns_  \n    rest of the argument to check for max value  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.int_  \n  \nMaximum of all the arguments.\n  \n**Params**  \n- ns: rest of the argument to check for max value  \n  \n**Returns** `int`   \n- maximum value of all provided values  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "sum(...int)(int)",
@@ -66,7 +58,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int_  \n  \nSum of all the arguments.\n0 if no args\n  \n  \n---    \n**Parameters**  \n- _ns_  \n    int values to sum  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.int_  \n  \nSum of all the arguments.\n0 if no args\n  \n  \n  \n**Returns** `int`   \n- sum of arguments  \n  \n"
         }
       },
       "sortText": "130",
@@ -84,16 +76,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "abs()(int)",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int_  \n  \nReturn absolute value of `n`.\n  \n  \n---    \n**Parameters**  \n- _n_  \n    int value  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.int_  \n  \nReturn absolute value of `n`.\n  \n  \n  \n**Returns** `int`   \n- absolute value of `n`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "abs(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "abs()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "min(...int)(int)",
@@ -120,7 +104,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int_  \n  \nMinimum of all the arguments.\n  \n  \n---    \n**Parameters**  \n- _n_  \n    first argument to check for min value  \n  \n- _ns_  \n    rest of the argument to check for min value  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.int_  \n  \nMinimum of all the arguments.\n  \n**Params**  \n- ns: rest of the argument to check for min value  \n  \n**Returns** `int`   \n- min value of all provided values  \n  \n"
         }
       },
       "sortText": "130",
@@ -138,7 +122,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -156,16 +140,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -174,16 +154,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions2.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "130",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "130",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "130",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions3.json
@@ -6,186 +6,39 @@
   "source": "function/source/typeGuardSuggestions3.bal",
   "items": [
     {
-      "label": "createNewEntity()(mime:Entity)",
+      "label": "setLastModified()",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
         }
       },
-      "insertText": "createNewEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "setLastModified();",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getEntity()((mime:Entity|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "label": "server",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "server",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getEntityWithoutBody()(mime:Entity)",
+      "label": "setTextPayload(string payload, string contentType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`"
         }
       },
-      "insertText": "getEntityWithoutBody(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setEntity(mime:Entity e)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n  \n---    \n**Parameters**  \n- _e_  \n    The `Entity` to be set to the response  \n"
-        }
-      },
-      "insertText": "setEntity(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasHeader(string headerName)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeader(string headerName)(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "addHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "addHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaders(string headerName)(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaders(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "setHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeHeader(string key)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n  \n---    \n**Parameters**  \n- _key_  \n    The header name  \n"
-        }
-      },
-      "insertText": "removeHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAllHeaders()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAllHeaders(${1});",
+      "sortText": "130",
+      "insertText": "setTextPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -199,197 +52,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
         }
       },
-      "insertText": "getHeaderNames(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getHeaderNames()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "setContentType(string contentType)",
+      "label": "setEntity(mime:Entity e)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n  \n---    \n**Parameters**  \n- _contentType_  \n    Content type value to be set as the `content-type` header  \n"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
         }
       },
-      "insertText": "setContentType(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentType()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getJsonPayload()((json|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getJsonPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getXmlPayload()((xml|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(xml|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getXmlPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getTextPayload()((string|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(string|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getTextPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getByteChannel()((io:ReadableByteChannel|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getByteChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getBinaryPayload()((byte[]|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(byte[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getBinaryPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getBodyParts()((mime:Entity[]|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getBodyParts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setETag((json|xml|string|byte[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The payload for which the ETag should be set  \n"
-        }
-      },
-      "insertText": "setETag(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setLastModified()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "setLastModified(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setJsonPayload(json payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `json` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `json`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setJsonPayload(${1});",
+      "sortText": "130",
+      "insertText": "setEntity(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -403,112 +84,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `xml` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`"
         }
       },
+      "sortText": "130",
       "insertText": "setXmlPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setTextPayload(string payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `string` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `string`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setTextPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBinaryPayload(byte[] payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `byte[]` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBinaryPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n  \n---    \n**Parameters**  \n- _bodyParts_  \n    The entities which make up the message body  \n  \n- _contentType_  \n    The content type of the top level message. Set this to override the default\n                `content-type` header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBodyParts(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setFileAsPayload(string filePath, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n  \n---    \n**Parameters**  \n- _filePath_  \n    Path to the file to be set as the payload  \n  \n- _contentType_  \n    The content type of the specified file. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setFileAsPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    A `ByteChannel` through which the message payload can be read  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setByteChannel(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)  \n"
-        }
-      },
-      "insertText": "setPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -522,10 +102,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/http_  \n  \n  \n"
         }
       },
-      "insertText": "__init(${1});",
+      "sortText": "130",
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBinaryPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -533,59 +128,447 @@
       }
     },
     {
-      "label": "statusCode",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "statusCode",
+      "label": "getHeaders(string headerName)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|error)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBinaryPayload()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reasonPhrase",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "reasonPhrase",
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "createNewEntity()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the response  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "createNewEntity()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "server",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "server",
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXmlPayload()((xml|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|error)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasHeader(string headerName)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|error)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntity()((mime:Entity|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|error)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAllHeaders();",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "resolvedRequestedURI",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "resolvedRequestedURI",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setETag((json|xml|string|byte[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setETag(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentType()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "cacheControl",
       "kind": "Variable",
       "detail": "(http:ResponseCacheControl|())",
+      "sortText": "120",
       "insertText": "cacheControl",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "receivedTime",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "receivedTime",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "requestTime",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "120",
       "insertText": "requestTime",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|error)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \nconstructing the body parts from the response  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|error)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentType(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "receivedTime",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "receivedTime",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reasonPhrase",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "reasonPhrase",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getTextPayload()((string|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|error)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntityWithoutBody()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntityWithoutBody()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "entity",
       "kind": "Variable",
       "detail": "mime:Entity",
+      "sortText": "120",
       "insertText": "entity",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "statusCode",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "statusCode",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions4.json
@@ -9,6 +9,10 @@
       "label": "anydataType",
       "kind": "Keyword",
       "detail": "Anydata",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "anydataType",
       "insertTextFormat": "Snippet"
     },
@@ -19,15 +23,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "keys()(string[])",
@@ -36,15 +37,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- list of all keys  \n  \n"
         }
       },
-      "insertText": "keys(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(string k)((any|error))",
@@ -53,9 +51,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +66,25 @@
       "label": "Type1",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "Type1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAll();",
       "insertTextFormat": "Snippet"
     },
     {
@@ -77,32 +94,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAll()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -111,15 +108,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "get(string k)((any|error))",
@@ -128,9 +122,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map m with key k.\nPanics if m does not have a member with key k.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nPanics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member matching key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -145,9 +140,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<(any|error)>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturn a map with the result of applying function `func` to each member of map `m`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -162,15 +158,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -179,9 +172,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReduce operate on each member of `m` using combining function `func` to produce\na new value combining all members of `m`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the map  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -196,9 +190,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -210,6 +205,10 @@
       "label": "PureType",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "PureType",
       "insertTextFormat": "Snippet"
     },
@@ -220,27 +219,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
+      "sortText": "130",
       "insertText": "forEach(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cloneReadOnly()(anydata)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "cloneReadOnly(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -254,20 +237,32 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the map  \n  \n"
         }
       },
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "MapIterator",
       "kind": "Class",
       "detail": "Object",
+      "sortText": "120",
       "insertText": "MapIterator",
       "insertTextFormat": "Snippet"
     },
@@ -278,34 +273,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<(any|error)>"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a new map constructed from those elements of 'm' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containig members which evaluate function 'func' to true  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "filter(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "Type",
-      "kind": "Enum",
-      "detail": "Union",
-      "insertText": "Type",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "entries()(map<[string,(any|error)]>)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap<[string,(any|error)]>"
-        }
-      },
-      "insertText": "entries(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -316,7 +288,33 @@
       "label": "field1",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "120",
       "insertText": "field1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,(any|error)]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
+      "insertText": "Type",
       "insertTextFormat": "Snippet"
     },
     {
@@ -326,9 +324,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\nIf the merge fails, then return an error.\nThe merge of j1 with j2 is defined as follows:\n- if j1 is (), then the result is j2\n- if j2 is nil, then the result is j1\n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,\n  set j1[k] to the merge of j1[k] with j\n    - if j1[k] is undefined, then set j1[k] to j\n    - if any merge fails, then the merge of j1 with j2 fails\n    - otherwise, the result is j1.\n- otherwise, the merge fails  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "mergeJson(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -343,15 +342,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -360,20 +356,18 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key=value for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `==` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "field2",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "field2",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeguardDestruct1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeguardDestruct1.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -274,16 +274,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testTGuard(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testTGuard();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "future",
@@ -345,7 +341,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -359,7 +355,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -391,7 +387,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -405,7 +401,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -437,7 +433,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -451,7 +447,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -690,7 +686,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -704,7 +700,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -897,7 +893,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -911,7 +907,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -920,7 +916,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -934,7 +930,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1058,7 +1054,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1072,7 +1068,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1127,7 +1123,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1141,7 +1137,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1173,7 +1169,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1187,7 +1183,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1242,7 +1238,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1256,7 +1252,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1265,7 +1261,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1279,7 +1275,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1288,7 +1284,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1302,7 +1298,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1311,7 +1307,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1325,7 +1321,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1334,7 +1330,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1348,7 +1344,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeofKWSuggestion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeofKWSuggestion.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "testTypeOfKW(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "testTypeOfKW();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "ballerinax/java.jdbc",
@@ -51,7 +47,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -65,7 +61,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -97,7 +93,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -111,7 +107,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -143,7 +139,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -157,7 +153,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -396,7 +392,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -410,7 +406,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -603,7 +599,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -617,7 +613,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -626,7 +622,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -640,7 +636,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -764,7 +760,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -778,7 +774,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -833,7 +829,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -847,7 +843,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -902,7 +898,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -916,7 +912,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -971,7 +967,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -985,7 +981,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -994,7 +990,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1008,7 +1004,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1017,7 +1013,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1031,7 +1027,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1040,7 +1036,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1054,7 +1050,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1063,7 +1059,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1077,7 +1073,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions1.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "130",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "130",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "130",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions2.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return first element of the array `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "shift(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "shift()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(int i)((any|error))",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    index of member to be removed  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves the member of `arr` and index `i` and returns it.\nPanics if `i` is out of range.\n  \n**Params**  \n- `int` i: index of member to be removed  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemove and return the last member of the `arr`.\n  \n  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "pop(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "pop()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "iterator()()",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns an iterator over the members of `arr`\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "removeAll()",
@@ -84,16 +72,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nRemoves all members of `arr`.\nPanics if any member cannot be removed.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -102,16 +86,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "slice(int startIndex, int endIndex)((any|error)[])",
@@ -120,7 +100,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _startIndex_  \n    index of first member to include in the slice  \n  \n- _endIndex_  \n    index of first member not to include in the slice  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a sub array starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n**Params**  \n- `int` startIndex: index of first member to include in the slice  \n- `int` endIndex: index of first member not to include in the slice  \n  \n**Returns** `(any|error)[]`   \n- array slice within specified range  \n  \n"
         }
       },
       "sortText": "130",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base16.\nThe representation is the same as used by a Ballerina Base16Literal.\nThe result will contain only characters  `0..9`, `a..f`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base16 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase16(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase16()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "enumerate()([int,(any|error)][])",
@@ -156,16 +132,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \n[int,(any|error)][]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array comprising of position and member pairs.\n  \n  \n  \n**Returns** `[int,(any|error)][]`   \n- array of position, member pair  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "enumerate(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "enumerate()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "map(function ((any|error)) returns ((any|error)) func)((any|error)[])",
@@ -174,7 +146,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array applying function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `(any|error)[]`   \n- new array containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,7 +164,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `\u003d\u003d`\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _val_  \n    member to search for  \n  \n- _startIndex_  \n    index to start the search from  \n(Default Parameter)  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found\nEquality is tested using `==`\n  \n**Params**  \n- `(anydata|error)` val: member to search for  \n- `int` startIndex: index to start the search from(Defaultable)  \n- `int` startIndex: index to start the search from  \n  \n**Returns** `(int|())`   \n- index of the member if found, else `()`  \n  \n"
         }
       },
       "sortText": "130",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -228,7 +196,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    combining function  \n  \n- _initial_  \n    initial value to first evaluation of combining function `func`  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReduce operate on each member of `arr` using combining function `func` to produce\na new value combining all members of `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the array  \n  \nExample: Emulating sum function.  \n```  \n# var ar = [1, 2, 3];  \n# var a = ar.reduce(function (int i, int j) returns int { return i + j; }, 0);  \n# ```  \n  \nExample: Emulating map behavior.  \n```  \n# var ar = [1, 2, 3];  \n# int[] newArr = [];  \n# int[] a = ar.reduce(function (int[] a, int j) returns int[] { a.push(j*2); return a; }, newArr);  \n# ```  \n  \n"
         }
       },
       "sortText": "130",
@@ -246,16 +214,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `\u003d`.\nThere will be no whitespace in the returned string.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the string representing `arr` using Base64 encoding.\nThe representation is the same as used by a Ballerina Base64Literal.\nThe result will contain only characters  `A..Z`, `a..z`, `0..9`, `+`, `/` and `=`.\nThere will be no whitespace in the returned string.\n  \n  \n  \n**Returns** `string`   \n- Base64 string representation  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBase64(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBase64()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "forEach(function ((any|error)) returns () func)",
@@ -264,7 +228,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a function to apply to each member  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nApply function `func` to each member of array `arr`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
       "sortText": "130",
@@ -282,16 +246,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -300,16 +260,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns the number of members contained in `arr`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "sort(function ((any|error),(any|error)) returns (int) func)((any|error)[])",
@@ -318,7 +274,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    comparator function  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nSort `arr` using `func` to order members.\nReturns `arr`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns (int)` func: comparator function  \n  \n**Returns** `(any|error)[]`   \n- sorted `arr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -336,16 +292,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array to be reversed  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReverse the order of the members of `arr`.\nReturns `arr`.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- reversed `arr`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "reverse(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "reverse()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "push(...(any|error))",
@@ -354,7 +306,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the end of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to end of the `arr` array.\n  \n**Params**  \n- vals: values to add to the end of the array"
         }
       },
       "sortText": "130",
@@ -372,7 +324,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of \u0027arr\u0027 for which `func` returns true.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _func_  \n    a predicate to apply to each element to determine if it should be included  \n  \n  \n**Return**  \n(any|error)[]"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nReturns a new array constructed from those elements of 'arr' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `(any|error)[]`   \n- new array only containig members which evaluate function 'func' to true  \n  \n"
         }
       },
       "sortText": "130",
@@ -390,7 +342,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _i_  \n    new length  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nIncrease or decrease the length.\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`.\n  \n**Params**  \n- `int` i: new length"
         }
       },
       "sortText": "130",
@@ -408,7 +360,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -426,16 +378,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -444,16 +392,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "unshift(...(any|error))",
@@ -462,7 +406,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n  \n---    \n**Parameters**  \n- _arr_  \n    the array  \n  \n- _vals_  \n    values to add to the start of the array  \n"
+          "value": "**Package:** _ballerina/lang.array_  \n  \nAdd `vals` to beginig of the array `arr`.\n  \n**Params**  \n- vals: values to add to the start of the array"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions3.json
@@ -6,186 +6,39 @@
   "source": "function/source/variableBoundItemSuggestions3.bal",
   "items": [
     {
-      "label": "createNewEntity()(mime:Entity)",
+      "label": "setLastModified()",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
         }
       },
-      "insertText": "createNewEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "setLastModified();",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getEntity()((mime:Entity|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "label": "server",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "server",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getEntityWithoutBody()(mime:Entity)",
+      "label": "setTextPayload(string payload, string contentType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`"
         }
       },
-      "insertText": "getEntityWithoutBody(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setEntity(mime:Entity e)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n  \n---    \n**Parameters**  \n- _e_  \n    The `Entity` to be set to the response  \n"
-        }
-      },
-      "insertText": "setEntity(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasHeader(string headerName)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeader(string headerName)(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "addHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "addHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaders(string headerName)(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaders(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "setHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeHeader(string key)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n  \n---    \n**Parameters**  \n- _key_  \n    The header name  \n"
-        }
-      },
-      "insertText": "removeHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAllHeaders()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAllHeaders(${1});",
+      "sortText": "130",
+      "insertText": "setTextPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -199,197 +52,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
         }
       },
-      "insertText": "getHeaderNames(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getHeaderNames()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "setContentType(string contentType)",
+      "label": "setEntity(mime:Entity e)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n  \n---    \n**Parameters**  \n- _contentType_  \n    Content type value to be set as the `content-type` header  \n"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
         }
       },
-      "insertText": "setContentType(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentType()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getJsonPayload()((json|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getJsonPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getXmlPayload()((xml|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(xml|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getXmlPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getTextPayload()((string|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(string|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getTextPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getByteChannel()((io:ReadableByteChannel|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getByteChannel(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getBinaryPayload()((byte[]|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(byte[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getBinaryPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getBodyParts()((mime:Entity[]|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getBodyParts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setETag((json|xml|string|byte[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The payload for which the ETag should be set  \n"
-        }
-      },
-      "insertText": "setETag(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setLastModified()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "setLastModified(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setJsonPayload(json payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `json` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `json`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setJsonPayload(${1});",
+      "sortText": "130",
+      "insertText": "setEntity(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -403,112 +84,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `xml` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`  \n(Default Parameter)"
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`"
         }
       },
+      "sortText": "130",
       "insertText": "setXmlPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setTextPayload(string payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `string` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `string`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setTextPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBinaryPayload(byte[] payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `byte[]` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBinaryPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n  \n---    \n**Parameters**  \n- _bodyParts_  \n    The entities which make up the message body  \n  \n- _contentType_  \n    The content type of the top level message. Set this to override the default\n                `content-type` header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBodyParts(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setFileAsPayload(string filePath, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n  \n---    \n**Parameters**  \n- _filePath_  \n    Path to the file to be set as the payload  \n  \n- _contentType_  \n    The content type of the specified file. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setFileAsPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    A `ByteChannel` through which the message payload can be read  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setByteChannel(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)  \n"
-        }
-      },
-      "insertText": "setPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -522,10 +102,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/http_  \n  \n  \n"
         }
       },
-      "insertText": "__init(${1});",
+      "sortText": "130",
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBinaryPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -533,59 +128,447 @@
       }
     },
     {
-      "label": "statusCode",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "statusCode",
+      "label": "getHeaders(string headerName)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|error)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBinaryPayload()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reasonPhrase",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "reasonPhrase",
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "createNewEntity()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the response  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "createNewEntity()",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "server",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "server",
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXmlPayload()((xml|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|error)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasHeader(string headerName)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|error)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntity()((mime:Entity|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|error)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAllHeaders();",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "resolvedRequestedURI",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "resolvedRequestedURI",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setETag((json|xml|string|byte[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setETag(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentType()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "cacheControl",
       "kind": "Variable",
       "detail": "(http:ResponseCacheControl|())",
+      "sortText": "120",
       "insertText": "cacheControl",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "receivedTime",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "receivedTime",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "requestTime",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "120",
       "insertText": "requestTime",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|error)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \nconstructing the body parts from the response  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|error)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentType(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "receivedTime",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "receivedTime",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reasonPhrase",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "reasonPhrase",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getTextPayload()((string|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|error)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntityWithoutBody()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntityWithoutBody()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "entity",
       "kind": "Variable",
       "detail": "mime:Entity",
+      "sortText": "120",
       "insertText": "entity",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "statusCode",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "statusCode",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions4.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "130",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "130",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "130",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "130",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "130",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "130",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "130",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "130",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "130",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest1.json
@@ -26,16 +26,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "helloFunction(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "helloFunction()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "STRING_VAL",
@@ -79,7 +75,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -93,7 +89,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -125,7 +121,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -139,7 +135,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -171,7 +167,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -185,7 +181,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -424,7 +420,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -438,7 +434,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -631,7 +627,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -645,7 +641,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -654,7 +650,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -668,7 +664,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -792,7 +788,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -806,7 +802,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -861,7 +857,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -875,7 +871,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -930,7 +926,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -944,7 +940,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -999,7 +995,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1013,7 +1009,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1022,7 +1018,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1036,7 +1032,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1045,7 +1041,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1059,7 +1055,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1068,7 +1064,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1082,7 +1078,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1091,7 +1087,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1105,7 +1101,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest2.json
@@ -9,6 +9,10 @@
       "label": "anydataType",
       "kind": "Keyword",
       "detail": "Anydata",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "anydataType",
       "insertTextFormat": "Snippet"
     },
@@ -19,15 +23,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "keys()(string[])",
@@ -36,15 +37,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- list of all keys  \n  \n"
         }
       },
-      "insertText": "keys(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remove(string k)((any|error))",
@@ -53,9 +51,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +66,25 @@
       "label": "Type1",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "Type1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAll();",
       "insertTextFormat": "Snippet"
     },
     {
@@ -77,32 +94,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAll()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -111,15 +108,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "get(string k)((any|error))",
@@ -128,9 +122,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map m with key k.\nPanics if m does not have a member with key k.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nPanics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member matching key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -145,9 +140,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003c(any|error)\u003e"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturn a map with the result of applying function `func` to each member of map `m`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map\u003c(any|error)\u003e`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -162,15 +158,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
@@ -179,9 +172,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReduce operate on each member of `m` using combining function `func` to produce\na new value combining all members of `m`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the map  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -196,9 +190,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -210,6 +205,10 @@
       "label": "PureType",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "PureType",
       "insertTextFormat": "Snippet"
     },
@@ -220,27 +219,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
+      "sortText": "130",
       "insertText": "forEach(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cloneReadOnly()(anydata)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "cloneReadOnly(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -254,20 +237,32 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the map  \n  \n"
         }
       },
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "MapIterator",
       "kind": "Class",
       "detail": "Object",
+      "sortText": "120",
       "insertText": "MapIterator",
       "insertTextFormat": "Snippet"
     },
@@ -278,9 +273,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003c(any|error)\u003e"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a new map constructed from those elements of \u0027m\u0027 for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `map\u003c(any|error)\u003e`   \n- new map containig members which evaluate function \u0027func\u0027 to true  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -289,28 +285,29 @@
       }
     },
     {
-      "label": "Type",
-      "kind": "Enum",
-      "detail": "Union",
-      "insertText": "Type",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "entries()(map\u003c[string,(any|error)]\u003e)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003c[string,(any|error)]\u003e"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map\u003c[string,(any|error)]\u003e`   \n- map of [key, member] pairs  \n  \n"
         }
       },
-      "insertText": "entries(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
+      "insertText": "Type",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "mergeJson(json j2)((json|error))",
@@ -319,27 +316,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\nIf the merge fails, then return an error.\nThe merge of j1 with j2 is defined as follows:\n- if j1 is (), then the result is j2\n- if j2 is nil, then the result is j1\n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,\n  set j1[k] to the merge of j1[k] with j\n    - if j1[k] is undefined, then set j1[k] to j\n    - if any merge fails, then the merge of j1 with j2 fails\n    - otherwise, the result is j1.\n- otherwise, the merge fails  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "mergeJson(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "clone()(anydata)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "clone(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -350,7 +331,22 @@
       "label": "name",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "name",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
     {
@@ -360,15 +356,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n"
         }
       },
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest3.json
@@ -9,53 +9,52 @@
       "label": "anydataType",
       "kind": "Keyword",
       "detail": "Anydata",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "anydataType",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonString(string str)((json|error))",
+      "label": "fromJsonString()((json|error))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "keys(map\u003c(any|error)\u003e m)(string[])",
+      "label": "keys()(string[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- list of all keys  \n  \n"
         }
       },
-      "insertText": "keys(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(map\u003c(any|error)\u003e m, string k)((any|error))",
+      "label": "remove(string k)((any|error))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves the member of `m` with key `k` and returns it.\nPanics if there is no such member.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- removed member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,70 +66,66 @@
       "label": "Type1",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "Type1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "iterator(map\u003c(any|error)\u003e m)()",
+      "label": "removeAll()",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nobject { public function next () returns (record {| $|0 value; |}?); }"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.\n  \n"
         }
       },
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "removeAll(map\u003c(any|error)\u003e m)",
+      "label": "iterator()()",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of `m`.\nPanics if any member cannot be removed.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over the members of `m`.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
-      "insertText": "removeAll(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "isReadOnly(anydata value)(boolean)",
+      "label": "isReadOnly()(boolean)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(map\u003c(any|error)\u003e m, string k)((any|error))",
+      "label": "get(string k)((any|error))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map m with key k.\nPanics if m does not have a member with key k.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nPanics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member matching key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -142,19 +137,21 @@
       "label": "employer",
       "kind": "Variable",
       "detail": "Person",
+      "sortText": "120",
       "insertText": "employer",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(map\u003c(any|error)\u003e m, function ((any|error)) returns ((any|error)) func)(map\u003c(any|error)\u003e)",
+      "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003c(any|error)\u003e"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturn a map with the result of applying function `func` to each member of map `m`.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -163,32 +160,30 @@
       }
     },
     {
-      "label": "toJsonString(json v)(string)",
+      "label": "toJsonString()(string)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(map\u003c(any|error)\u003e m, function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
+      "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(any|error)"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReduce operate on each member of `m` using combining function `func` to produce\na new value combining all members of `m`.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value to first evaluation of combining function `func`  \n  \n**Returns** `(any|error)`   \n- result of applying combining function to each member of the map  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -197,15 +192,16 @@
       }
     },
     {
-      "label": "hasKey(map\u003c(any|error)\u003e m, string k)(boolean)",
+      "label": "hasKey(string k)(boolean)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTells whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -217,19 +213,24 @@
       "label": "PureType",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `anydata|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "PureType",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "forEach(map\u003c(any|error)\u003e m, function ((any|error)) returns () func)",
+      "label": "forEach(function ((any|error)) returns () func)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies `func` to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
         }
       },
+      "sortText": "130",
       "insertText": "forEach(${1});",
       "insertTextFormat": "Snippet",
       "command": {
@@ -238,56 +239,52 @@
       }
     },
     {
-      "label": "cloneReadOnly(anydata value)(anydata)",
+      "label": "length()(int)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.\n  \n  \n  \n**Returns** `int`   \n- number of members in the map  \n  \n"
         }
       },
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "length(map\u003c(any|error)\u003e m)(int)",
+      "label": "cloneReadOnly()(anydata)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members in `m`.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "MapIterator",
       "kind": "Class",
       "detail": "Object",
+      "sortText": "120",
       "insertText": "MapIterator",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "filter(map\u003c(any|error)\u003e m, function ((any|error)) returns (boolean) func)(map\u003c(any|error)\u003e)",
+      "label": "filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003c(any|error)\u003e"
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a new map constructed from those elements of 'm' for which `func` returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to determine if it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containig members which evaluate function 'func' to true  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -296,57 +293,42 @@
       }
     },
     {
+      "label": "entries()(map<[string,(any|error)]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Type",
       "kind": "Enum",
       "detail": "Union",
+      "documentation": {
+        "left": "A type parameter that is a subtype of `any|error`.\nHas the special semantic that when used in a declaration\nall uses in the declaration must refer to same type."
+      },
+      "sortText": "120",
       "insertText": "Type",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries(map\u003c(any|error)\u003e m)(map\u003c[string,(any|error)]\u003e)",
+      "label": "mergeJson(json j2)((json|error))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003c[string,(any|error)]\u003e"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
-      "insertText": "entries(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "mergeJson(json j1, json j2)((json|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\nIf the merge fails, then return an error.\nThe merge of j1 with j2 is defined as follows:\n- if j1 is (), then the result is j2\n- if j2 is nil, then the result is j1\n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,\n  set j1[k] to the merge of j1[k] with j\n    - if j1[k] is undefined, then set j1[k] to j\n    - if any merge fails, then the merge of j1 with j2 fails\n    - otherwise, the result is j1.\n- otherwise, the merge fails  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|error)"
-        }
-      },
+      "sortText": "130",
       "insertText": "mergeJson(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "clone(anydata value)(anydata)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "clone(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -357,25 +339,37 @@
       "label": "name",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "name",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "toString((any|error) value)(string)",
+      "label": "clone()(anydata)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n- if `value` is a string, then returns `value`\n- if `value` is `()`, then returns an empty string\n- if `value` is boolean, then the string `true` or `false`\n- if `value` is an int, then return `value` represented as a decimal string\n- if `value` is a float or decimal, then return `value` represented as a decimal string,\n  with a decimal point only if necessary, but without any suffix indicating the type of `value`\n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity\n- if `value` is a list, then returns the results toString on each member of the list\n  separated by a space character\n- if `value` is a map, then returns key\u003dvalue for each member separated by a space character\n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)\n- if `value` is table, TBD\n- if `value` is an error, then a string consisting of the following in order\n    1. the string `error`\n    2. a space character\n    3. the reason string\n    4. if the detail record is non-empty\n        1. a space character\n        2. the result of calling toString on the detail record\n- if `value` is an object, then\n    - if `value` provides a `toString` method with a string return type and no required methods,\n      then the result of calling that method on `value`\n    - otherwise, `object` followed by some implementation-dependent string\n- if `value` is any other behavioral type, then the identifier for the behavioral type\n  (`function`, `future`, `service`, `typedesc` or `handle`)\n  followed by some implementation-dependent string\n\nNote that `toString` may produce the same string for two Ballerina values\nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest4.json
@@ -20,16 +20,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "clone()(anydata)",
@@ -38,16 +34,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -56,16 +48,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -74,16 +62,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "field2",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest5.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "clone()(anydata)",
@@ -30,16 +26,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -48,16 +40,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -66,16 +54,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest6.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "clone()(anydata)",
@@ -30,16 +26,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -48,16 +40,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -66,16 +54,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest7.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "clone()(anydata)",
@@ -30,16 +26,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -48,16 +40,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toString()(string)",
@@ -66,16 +54,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion1.json
@@ -12,9 +12,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller.\n  \n  \n---    \n**Parameters**  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller.\n  \n**Params**  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`,\n            `io:ReadableByteChannel` or `mime:Entity[]`(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`,\n            `io:ReadableByteChannel` or `mime:Entity[]`  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "respond(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -29,9 +30,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nPushes a promise to the caller.\n  \n  \n---    \n**Parameters**  \n- _promise_  \n    Push promise message  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nPushes a promise to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n  \n**Returns** `(()|error)`   \n- An `http:ListenerError` in case of failures  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "promise(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -46,9 +48,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends a promised push response to the caller.\n  \n  \n---    \n**Parameters**  \n- _promise_  \n    Push promise message  \n  \n- _response_  \n    The outbound response  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends a promised push response to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n- `http:Response` response: The outbound response  \n  \n**Returns** `(()|error)`   \n- An `http:ListenerError` in case of failures while responding with the promised response  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "pushPromisedResponse(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -57,15 +60,16 @@
       }
     },
     {
-      "label": "acceptWebSocketUpgrade(map\u003cstring\u003e headers)(http:WebSocketCaller)",
+      "label": "acceptWebSocketUpgrade(map<string> headers)(http:WebSocketCaller)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends an upgrade request with custom headers.\n  \n  \n---    \n**Parameters**  \n- _headers_  \n    A `map` of custom headers for handshake  \n  \n  \n**Return**  \nballerina/http:WebSocketCaller"
+          "value": "**Package:** _ballerina/http_  \n  \nSends an upgrade request with custom headers.\n  \n**Params**  \n- `map<string>` headers: A `map` of custom headers for handshake  \n  \n**Returns** `http:WebSocketCaller`   \n- WebSocket service endpoint  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "acceptWebSocketUpgrade(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -80,9 +84,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCancels the handshake.\n  \n  \n---    \n**Parameters**  \n- _status_  \n    Error Status code for cancelling the upgrade and closing the connection.\n           This error status code need to be 4xx or 5xx else the default status code would be 400.  \n  \n- _reason_  \n    Reason for cancelling the upgrade  \n  \n  \n**Return**  \n(ballerina/http:WsConnectionClosureError|ballerina/http:WsInvalidHandshakeError|ballerina/http:WsPayloadTooBigError|ballerina/http:WsProtocolError|ballerina/http:WsConnectionError|ballerina/http:WsInvalidContinuationFrameError|ballerina/http:WsGenericError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nCancels the handshake.\n  \n**Params**  \n- `int` status: Error Status code for cancelling the upgrade and closing the connection.\n           This error status code need to be 4xx or 5xx else the default status code would be 400.  \n- `string` reason: Reason for cancelling the upgrade  \n  \n**Returns** `(()|error)`   \n- An `error` if an error occurs during cancelling the upgrade or nil  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "cancelWebSocketUpgrade(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -97,15 +102,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to send the `100-continue` response  \n  \n"
         }
       },
-      "insertText": "continue(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "continue()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "redirect(http:Response response, (300|301|302|303|304|305|307|308) code, string[] locations)((()|error))",
@@ -114,9 +116,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n  \n---    \n**Parameters**  \n- _response_  \n    Response to be sent to the caller  \n  \n- _code_  \n    The redirect status code to be sent  \n  \n- _locations_  \n    An array of URLs to which the caller can redirect to  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n**Params**  \n- `http:Response` response: Response to be sent to the caller  \n- `(300|301|302|303|304|305|307|308)` code: The redirect status code to be sent  \n- `string[]` locations: An array of URLs to which the caller can redirect to  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to send the redirect response  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "redirect(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,9 +134,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 200 OK.\n  \n  \n---    \n**Parameters**  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 200 OK.\n  \n**Params**  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "ok(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -148,9 +152,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 201 Created.\n  \n  \n---    \n**Parameters**  \n- _uri_  \n    Represents the most specific URI for the newly created resource  \n  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n(Default Parameter)  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 201 Created.\n  \n**Params**  \n- `string` uri: Represents the most specific URI for the newly created resource  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "created(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -165,9 +170,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 202 Accepted.\n  \n  \n---    \n**Parameters**  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n(Default Parameter)  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 202 Accepted.\n  \n**Params**  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "accepted(${1})",
       "insertTextFormat": "Snippet",
       "command": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/actionInvocationSuggestion2.json
@@ -12,9 +12,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller.\n  \n  \n---    \n**Parameters**  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller.\n  \n**Params**  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`,\n            `io:ReadableByteChannel` or `mime:Entity[]`(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`,\n            `io:ReadableByteChannel` or `mime:Entity[]`  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "respond(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -29,9 +30,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nPushes a promise to the caller.\n  \n  \n---    \n**Parameters**  \n- _promise_  \n    Push promise message  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nPushes a promise to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n  \n**Returns** `(()|error)`   \n- An `http:ListenerError` in case of failures  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "promise(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -46,9 +48,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends a promised push response to the caller.\n  \n  \n---    \n**Parameters**  \n- _promise_  \n    Push promise message  \n  \n- _response_  \n    The outbound response  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends a promised push response to the caller.\n  \n**Params**  \n- `http:PushPromise` promise: Push promise message  \n- `http:Response` response: The outbound response  \n  \n**Returns** `(()|error)`   \n- An `http:ListenerError` in case of failures while responding with the promised response  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "pushPromisedResponse(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -57,15 +60,16 @@
       }
     },
     {
-      "label": "acceptWebSocketUpgrade(map\u003cstring\u003e headers)(http:WebSocketCaller)",
+      "label": "acceptWebSocketUpgrade(map<string> headers)(http:WebSocketCaller)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends an upgrade request with custom headers.\n  \n  \n---    \n**Parameters**  \n- _headers_  \n    A `map` of custom headers for handshake  \n  \n  \n**Return**  \nballerina/http:WebSocketCaller"
+          "value": "**Package:** _ballerina/http_  \n  \nSends an upgrade request with custom headers.\n  \n**Params**  \n- `map<string>` headers: A `map` of custom headers for handshake  \n  \n**Returns** `http:WebSocketCaller`   \n- WebSocket service endpoint  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "acceptWebSocketUpgrade(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -80,9 +84,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCancels the handshake.\n  \n  \n---    \n**Parameters**  \n- _status_  \n    Error Status code for cancelling the upgrade and closing the connection.\n           This error status code need to be 4xx or 5xx else the default status code would be 400.  \n  \n- _reason_  \n    Reason for cancelling the upgrade  \n  \n  \n**Return**  \n(ballerina/http:WsConnectionClosureError|ballerina/http:WsInvalidHandshakeError|ballerina/http:WsPayloadTooBigError|ballerina/http:WsProtocolError|ballerina/http:WsConnectionError|ballerina/http:WsInvalidContinuationFrameError|ballerina/http:WsGenericError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nCancels the handshake.\n  \n**Params**  \n- `int` status: Error Status code for cancelling the upgrade and closing the connection.\n           This error status code need to be 4xx or 5xx else the default status code would be 400.  \n- `string` reason: Reason for cancelling the upgrade  \n  \n**Returns** `(()|error)`   \n- An `error` if an error occurs during cancelling the upgrade or nil  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "cancelWebSocketUpgrade(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -97,15 +102,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends a `100-continue` response to the caller.\n  \n  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to send the `100-continue` response  \n  \n"
         }
       },
-      "insertText": "continue(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "continue()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "redirect(http:Response response, (300|301|302|303|304|305|307|308) code, string[] locations)((()|error))",
@@ -114,9 +116,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n  \n---    \n**Parameters**  \n- _response_  \n    Response to be sent to the caller  \n  \n- _code_  \n    The redirect status code to be sent  \n  \n- _locations_  \n    An array of URLs to which the caller can redirect to  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends a redirect response to the user with the specified redirection status code.\n  \n**Params**  \n- `http:Response` response: Response to be sent to the caller  \n- `(300|301|302|303|304|305|307|308)` code: The redirect status code to be sent  \n- `string[]` locations: An array of URLs to which the caller can redirect to  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to send the redirect response  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "redirect(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,9 +134,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 200 OK.\n  \n  \n---    \n**Parameters**  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`  \n  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 200 OK.\n  \n**Params**  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "ok(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -148,9 +152,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 201 Created.\n  \n  \n---    \n**Parameters**  \n- _uri_  \n    Represents the most specific URI for the newly created resource  \n  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n(Default Parameter)  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 201 Created.\n  \n**Params**  \n- `string` uri: Represents the most specific URI for the newly created resource  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "created(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -165,9 +170,10 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 202 Accepted.\n  \n  \n---    \n**Parameters**  \n- _message_  \n    The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n(Default Parameter)  \n  \n**Return**  \n(ballerina/http:GenericListenerError|ballerina/http:InitializingInboundRequestError|ballerina/http:ReadingInboundRequestHeadersError|ballerina/http:ReadingInboundRequestBodyError|ballerina/http:InitializingOutboundResponseError|ballerina/http:WritingOutboundResponseHeadersError|ballerina/http:WritingOutboundResponseBodyError|ballerina/http:Initiating100ContinueResponseError|ballerina/http:Writing100ContinueResponseError)?"
+          "value": "**Package:** _ballerina/http_  \n  \nSends the outbound response to the caller with the status 202 Accepted.\n  \n**Params**  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.(Defaultable)  \n- `(http:Response|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` message: The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`\n            or `mime:Entity[]`. This message is optional.  \n  \n**Returns** `(()|error)`   \n- Returns an `http:ListenerError` if failed to respond  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "accepted(${1})",
       "insertTextFormat": "Snippet",
       "command": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/completionAvoidRemoteFunctions.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/completionAvoidRemoteFunctions.json
@@ -34,12 +34,8 @@
       "kind": "Function",
       "detail": "Function",
       "sortText": "130",
-      "insertText": "__init(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "remoteAddress",

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/completionBeforeUnderscore2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/completionBeforeUnderscore2.json
@@ -6,344 +6,12 @@
   "source": "resource/source/completionBeforeUnderscore2.bal",
   "items": [
     {
-      "label": "createNewEntity()(mime:Entity)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the request.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
-        }
-      },
-      "insertText": "createNewEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setEntity(mime:Entity e)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the request.\n  \n  \n---    \n**Parameters**  \n- _e_  \n    The `Entity` to be set to the request  \n"
-        }
-      },
-      "insertText": "setEntity(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getQueryParams()(map\u003cstring[]\u003e)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the query parameters of the request as a map consisting of a string array.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nmap\u003cstring[]\u003e"
-        }
-      },
-      "insertText": "getQueryParams(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getQueryParamValue(string key)((string|()))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the query param value associated with the given key.\n  \n  \n---    \n**Parameters**  \n- _key_  \n    Represents the query param key  \n  \n  \n**Return**  \nstring?"
-        }
-      },
-      "insertText": "getQueryParamValue(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getQueryParamValues(string key)((string[]|()))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the query param values associated with the given key.\n  \n  \n---    \n**Parameters**  \n- _key_  \n    Represents the query param key  \n  \n  \n**Return**  \nstring[]?"
-        }
-      },
-      "insertText": "getQueryParamValues(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getMatrixParams(string path)(map\u003cany\u003e)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the matrix parameters of the request.\n  \n  \n---    \n**Parameters**  \n- _path_  \n    Path to the location of matrix parameters  \n  \n  \n**Return**  \nmap"
-        }
-      },
-      "insertText": "getMatrixParams(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getEntity()((mime:Entity|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the request.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getEntity(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getEntityWithoutBody()(mime:Entity)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nballerina/mime:Entity"
-        }
-      },
-      "insertText": "getEntityWithoutBody(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasHeader(string headerName)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "hasHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeader(string headerName)(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getHeader(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaders(string headerName)(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaders(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the request. If a mapping already exists for the specified header key, the existing\nheader value is replaced with the specified header value.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "setHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "addHeader(string headerName, string headerValue)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the request. Existing header values are not replaced.\n  \n  \n---    \n**Parameters**  \n- _headerName_  \n    The header name  \n  \n- _headerValue_  \n    The header value  \n"
-        }
-      },
-      "insertText": "addHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeHeader(string key)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the request.\n  \n  \n---    \n**Parameters**  \n- _key_  \n    The header name  \n"
-        }
-      },
-      "insertText": "removeHeader(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "removeAllHeaders()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the request.  \n  \n---    \n**Parameters**  \n"
-        }
-      },
-      "insertText": "removeAllHeaders(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getHeaderNames()(string[])",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the request.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring[]"
-        }
-      },
-      "insertText": "getHeaderNames(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "expects100Continue()(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the client expects a `100-continue` response.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
-        }
-      },
-      "insertText": "expects100Continue(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setContentType(string contentType)((()|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the request.\n  \n  \n---    \n**Parameters**  \n- _contentType_  \n    Content type value to be set as the `content-type` header  \n  \n  \n**Return**  \nerror?"
-        }
-      },
-      "insertText": "setContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getContentType()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the request (i.e: the `content-type` header value).\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nstring"
-        }
-      },
-      "insertText": "getContentType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "getJsonPayload()((json|error))",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `json` payload from the request. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(json|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
-        }
-      },
-      "insertText": "getJsonPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "label": "extraPathInfo",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "extraPathInfo",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getXmlPayload()((xml|error))",
@@ -352,44 +20,47 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the request. If the content type is not XML, an `http:ClientError` is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(xml|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the request. If the content type is not XML, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(xml|error)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
         }
       },
-      "insertText": "getXmlPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getTextPayload()((string|error))",
+      "label": "expects100Continue()(boolean)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the request. If the content type is not of type text, an `http:ClientError` is returned.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(string|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the client expects a `100-continue` response.\n  \n  \n  \n**Returns** `boolean`   \n- Returns true if the client expects a `100-continue` response  \n  \n"
         }
       },
-      "insertText": "getTextPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "expects100Continue()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getByteChannel()((io:ReadableByteChannel|error))",
+      "label": "dirtyRequest",
+      "kind": "Variable",
+      "detail": "boolean",
+      "sortText": "120",
+      "insertText": "dirtyRequest",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `ByteChannel` except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/io:ReadableByteChannel|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value"
         }
       },
-      "insertText": "getByteChannel(${1})",
+      "sortText": "130",
+      "insertText": "setByteChannel(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -403,180 +74,39 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `byte[]`.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(byte[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
+          "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|error)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
         }
       },
-      "insertText": "getBinaryPayload(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getBinaryPayload()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getFormParams()((map\u003cstring\u003e|error))",
+      "label": "getJsonPayload()((json|error))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nGets the form parameters from the HTTP request as a `map` when content type is application/x-www-form-urlencoded.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(map\u003cstring\u003e|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `json` payload from the request. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|error)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
         }
       },
-      "insertText": "getFormParams(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "sortText": "130",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "getBodyParts()((mime:Entity[]|error))",
+      "label": "getQueryParamValue(string key)((string|()))",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the request. If the content type is not a composite media type, an error\nis returned.  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \n(ballerina/mime:Entity[]|ballerina/http:FailoverAllEndpointsFailedError|ballerina/http:FailoverActionFailedError|ballerina/http:UpstreamServiceUnavailableError|ballerina/http:AllLoadBalanceEndpointsFailedError|ballerina/http:AllRetryAttemptsFailed|ballerina/http:IdleTimeoutError|ballerina/http:AuthenticationError|ballerina/http:AuthorizationError|ballerina/http:InitializingOutboundRequestError|ballerina/http:WritingOutboundRequestHeadersError|ballerina/http:WritingOutboundRequestBodyError|ballerina/http:InitializingInboundResponseError|ballerina/http:ReadingInboundResponseHeadersError|ballerina/http:ReadingInboundResponseBodyError|ballerina/http:UnsupportedActionError|ballerina/http:Http2ClientError|ballerina/http:MaximumWaitTimeExceededError|ballerina/http:SslError|ballerina/http:GenericClientError)"
+          "value": "**Package:** _ballerina/http_  \n  \nGets the query param value associated with the given key.\n  \n**Params**  \n- `string` key: Represents the query param key  \n  \n**Returns** `(string|())`   \n- Returns the query param value associated with the given key as a string. If multiple param values are  \npresent, then the first value is returned. Nil is returned if no key is found.  \n  \n"
         }
       },
-      "insertText": "getBodyParts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setJsonPayload(json payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `json` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `json`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setJsonPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setXmlPayload(xml payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `xml` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setXmlPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setTextPayload(string payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `string` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `string`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setTextPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBinaryPayload(byte[] payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    The `byte[]` payload  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBinaryPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n  \n---    \n**Parameters**  \n- _bodyParts_  \n    The entities which make up the message body  \n  \n- _contentType_  \n    The content type of the top level message. Set this to override the default\n                `content-type` header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setBodyParts(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setFileAsPayload(string filePath, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the request.\n  \n  \n---    \n**Parameters**  \n- _filePath_  \n    Path to the file to be set as the payload  \n  \n- _contentType_  \n    The content type of the specified file. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setFileAsPayload(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    A `ByteChannel` through which the message payload can be read  \n  \n- _contentType_  \n    The content type of the payload. Set this to override the default `content-type`\n                header value  \n(Default Parameter)"
-        }
-      },
-      "insertText": "setByteChannel(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nSets the request payload.\n  \n  \n---    \n**Parameters**  \n- _payload_  \n    Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)  \n"
-        }
-      },
-      "insertText": "setPayload(${1});",
+      "sortText": "130",
+      "insertText": "getQueryParamValue(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -590,10 +120,67 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/http_  \n  \n  \n"
         }
       },
-      "insertText": "parseCacheControlHeader(${1});",
+      "sortText": "130",
+      "insertText": "parseCacheControlHeader();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getTextPayload()((string|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the request. If the content type is not of type text, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(string|error)`   \n- The `text` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "createNewEntity()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the request.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the request  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "createNewEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntityWithoutBody()(mime:Entity)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntityWithoutBody()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeader(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -601,16 +188,127 @@
       }
     },
     {
-      "label": "checkEntityBodyAvailability()(boolean)",
+      "label": "setEntity(mime:Entity e)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \nCheck whether the entity body is present.\n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the request.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the request"
         }
       },
-      "insertText": "checkEntityBodyAvailability(${1})",
+      "sortText": "130",
+      "insertText": "setEntity(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the request. If a mapping already exists for the specified header key, the existing\nheader value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `ByteChannel` except in the case of multiparts. To retrieve multiparts, use\n`getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|error)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rawPath",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "rawPath",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "httpVersion",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "120",
+      "insertText": "httpVersion",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "mutualSslHandshake",
+      "kind": "Variable",
+      "detail": "(http:MutualSslHandshake|())",
+      "sortText": "120",
+      "insertText": "mutualSslHandshake",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setTextPayload(string payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setTextPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string contentType)((()|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the request.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header  \n  \n**Returns** `(()|error)`   \n- Nil if successful, error in case of invalid content-type  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setContentType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the request payload. Note that any string value is set as `text/plain`. To send a JSON-compatible string,\nset the content-type header to `application/json` or use the `setJsonPayload` method instead.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel`, or `Entity[]` (i.e., a set\nof body parts)."
+        }
+      },
+      "sortText": "130",
+      "insertText": "setPayload(${1});",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -624,10 +322,25 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/http_  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _ballerina/http_  \n  \n  \n"
         }
       },
-      "insertText": "__init(${1});",
+      "sortText": "130",
+      "insertText": "__init();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getQueryParamValues(string key)((string[]|()))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the query param values associated with the given key.\n  \n**Params**  \n- `string` key: Represents the query param key  \n  \n**Returns** `(string[]|())`   \n- Returns all the query param values associated with the given key as a `string[]`. Nil is returned if no key  \nis found.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getQueryParamValues(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -635,74 +348,336 @@
       }
     },
     {
-      "label": "rawPath",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "rawPath",
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the request.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeAllHeaders()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the request.  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeAllHeaders();",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "method",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "method",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "httpVersion",
+      "label": "addHeader(string headerName, string headerValue)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the request. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "noEntityBody",
       "kind": "Variable",
-      "detail": "string",
-      "insertText": "httpVersion",
+      "detail": "boolean",
+      "sortText": "120",
+      "insertText": "noEntityBody",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getEntity()((mime:Entity|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the request.\n  \n  \n  \n**Returns** `(mime:Entity|error)`   \n- The `Entity` of the request. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getEntity()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "userAgent",
       "kind": "Variable",
       "detail": "string",
+      "sortText": "120",
       "insertText": "userAgent",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "extraPathInfo",
-      "kind": "Variable",
-      "detail": "string",
-      "insertText": "extraPathInfo",
-      "insertTextFormat": "Snippet"
+      "label": "hasHeader(string headerName)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "cacheControl",
       "kind": "Variable",
       "detail": "(http:RequestCacheControl|())",
+      "sortText": "120",
       "insertText": "cacheControl",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "mutualSslHandshake",
-      "kind": "Variable",
-      "detail": "(http:MutualSslHandshake|())",
-      "insertText": "mutualSslHandshake",
+      "label": "setXmlPayload(xml payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload.\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setXmlPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the request.\n  \n**Params**  \n- `string` key: The header name"
+        }
+      },
+      "sortText": "130",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "checkEntityBodyAvailability()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCheck whether the entity body is present.\n  \n  \n  \n**Returns** `boolean`   \n- a boolean indicating entity body availability  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "checkEntityBodyAvailability()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeaderNames()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the request.\n  \n  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaderNames()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getQueryParams()(map<string[]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the query parameters of the request as a map consisting of a string array.\n  \n  \n  \n**Returns** `map<string[]>`   \n- String array map of the query params  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getQueryParams()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the request. If the content type is not a composite media type, an error\nis returned.  \n  \n  \n**Returns** `(mime:Entity[]|error)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \nconstructing the body parts from the request  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the request (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getMatrixParams(string path)(map<any>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the matrix parameters of the request.\n  \n**Params**  \n- `string` path: Path to the location of matrix parameters  \n  \n**Returns** `map<any>`   \n- A map of matrix parameters which can be found for the given path  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getMatrixParams(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getFormParams()((map<string>|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the form parameters from the HTTP request as a `map` when content type is application/x-www-form-urlencoded.\n  \n  \n  \n**Returns** `(map<string>|error)`   \n- The map of form params or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getFormParams()",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "entity",
       "kind": "Variable",
       "detail": "mime:Entity",
+      "sortText": "120",
       "insertText": "entity",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "dirtyRequest",
-      "kind": "Variable",
-      "detail": "boolean",
-      "insertText": "dirtyRequest",
-      "insertTextFormat": "Snippet"
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`"
+        }
+      },
+      "sortText": "130",
+      "insertText": "setBinaryPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
-      "label": "noEntityBody",
-      "kind": "Variable",
-      "detail": "boolean",
-      "insertText": "noEntityBody",
-      "insertTextFormat": "Snippet"
+      "label": "getHeaders(string headerName)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n`hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/emptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/emptyLineCompletion.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -221,16 +221,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function4(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function4();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "string",
@@ -247,16 +243,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function2(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "function1(int a, string b)",
@@ -265,7 +257,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
@@ -443,7 +435,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -457,7 +449,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -489,7 +481,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -503,7 +495,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -535,7 +527,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -549,7 +541,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -788,7 +780,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -802,7 +794,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -995,7 +987,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1009,7 +1001,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -1018,7 +1010,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1032,7 +1024,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1156,7 +1148,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1170,7 +1162,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1225,7 +1217,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1239,7 +1231,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1271,7 +1263,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1285,7 +1277,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1340,7 +1332,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1354,7 +1346,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1363,7 +1355,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1377,7 +1369,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1386,7 +1378,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1400,7 +1392,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1409,7 +1401,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1423,7 +1415,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1432,7 +1424,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1446,7 +1438,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/nonEmptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/nonEmptyLineCompletion.json
@@ -26,7 +26,7 @@
       "kind": "Snippet",
       "detail": "Snippet",
       "sortText": "110",
-      "insertText": "error ${1:name} \u003d error(\"${2:errorCode}\", message \u003d \"${3}\");",
+      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
       "insertTextFormat": "Snippet"
     },
     {
@@ -90,7 +90,7 @@
       "kind": "Snippet",
       "detail": "Statement",
       "sortText": "200",
-      "insertText": "transaction with retries \u003d ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
+      "insertText": "transaction with retries = ${1:0} {\n\t${2}\n} onretry {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -221,16 +221,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function4(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function4();",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "string",
@@ -247,16 +243,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "130",
-      "insertText": "function2(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "function1(int a, string b)",
@@ -265,7 +257,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
       "sortText": "130",
@@ -443,7 +435,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027object",
+      "insertText": "'object",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -457,7 +449,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027object;\n"
+          "newText": "import ballerina/lang.'object;\n"
         }
       ]
     },
@@ -489,7 +481,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027xml",
+      "insertText": "'xml",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -503,7 +495,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027xml;\n"
+          "newText": "import ballerina/lang.'xml;\n"
         }
       ]
     },
@@ -535,7 +527,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027array",
+      "insertText": "'array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -549,7 +541,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027array;\n"
+          "newText": "import ballerina/lang.'array;\n"
         }
       ]
     },
@@ -788,7 +780,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027string",
+      "insertText": "'string",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -802,7 +794,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027string;\n"
+          "newText": "import ballerina/lang.'string;\n"
         }
       ]
     },
@@ -995,7 +987,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027future",
+      "insertText": "'future",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1009,7 +1001,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027future;\n"
+          "newText": "import ballerina/lang.'future;\n"
         }
       ]
     },
@@ -1018,7 +1010,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027value",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1032,7 +1024,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027value;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -1156,7 +1148,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027float",
+      "insertText": "'float",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1170,7 +1162,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027float;\n"
+          "newText": "import ballerina/lang.'float;\n"
         }
       ]
     },
@@ -1225,7 +1217,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027decimal",
+      "insertText": "'decimal",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1239,7 +1231,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027decimal;\n"
+          "newText": "import ballerina/lang.'decimal;\n"
         }
       ]
     },
@@ -1271,7 +1263,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027table",
+      "insertText": "'table",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1285,7 +1277,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027table;\n"
+          "newText": "import ballerina/lang.'table;\n"
         }
       ]
     },
@@ -1340,7 +1332,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027stream",
+      "insertText": "'stream",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1354,7 +1346,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027stream;\n"
+          "newText": "import ballerina/lang.'stream;\n"
         }
       ]
     },
@@ -1363,7 +1355,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027error",
+      "insertText": "'error",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1377,7 +1369,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027error;\n"
+          "newText": "import ballerina/lang.'error;\n"
         }
       ]
     },
@@ -1386,7 +1378,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027typedesc",
+      "insertText": "'typedesc",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1400,7 +1392,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027typedesc;\n"
+          "newText": "import ballerina/lang.'typedesc;\n"
         }
       ]
     },
@@ -1409,7 +1401,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027map",
+      "insertText": "'map",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1423,7 +1415,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027map;\n"
+          "newText": "import ballerina/lang.'map;\n"
         }
       ]
     },
@@ -1432,7 +1424,7 @@
       "kind": "Module",
       "detail": "Package",
       "sortText": "140",
-      "insertText": "\u0027int",
+      "insertText": "'int",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -1446,7 +1438,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.\u0027int;\n"
+          "newText": "import ballerina/lang.'int;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/service/serviceBodyCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service/serviceBodyCompletion4.json
@@ -12,16 +12,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    string representation of json  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParse a string in JSON format and return the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `value` parsed to json or error  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "fromJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "getCodePoint(int i)(int)",
@@ -30,7 +26,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _i_  \n    code point index  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the unicode codepoint at index `i`.\n  \n**Params**  \n- `int` i: code point index  \n  \n**Returns** `int`   \n- code point  \n  \n"
         }
       },
       "sortText": "131",
@@ -48,16 +44,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an array with an int for each code point in `str`.\n  \n  \n  \n**Returns** `int[]`   \n- CodePoint array  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "toCodePointInts(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toUpperAscii()(string)",
@@ -66,16 +58,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn a-z into A-Z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- Ascii upper cased string  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "toUpperAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "substring(int startIndex, int endIndex)(string)",
@@ -84,7 +72,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    source string.  \n  \n- _startIndex_  \n    the beginning index, inclusive.  \n  \n- _endIndex_  \n    the ending index, exclusive.  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a string that is a substring of this string.\n  \n**Params**  \n- `int` startIndex: the beginning index, inclusive.  \n- `int` endIndex: the ending index, exclusive.  \n  \n**Returns** `string`   \n- specified substring.  \n  \n"
         }
       },
       "sortText": "131",
@@ -102,16 +90,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nobject { public function next () returns (record {| string value; |}?); }"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns an iterator over the string\nThe iterator will return the substrings of length 1 in order.\n  \n  \n  \n**Returns** ``   \n- iterator object  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "iterator(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "isReadOnly()(boolean)",
@@ -120,16 +104,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "isReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "trim()(string)",
@@ -138,16 +118,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRemove ASCII white space characters (0x9...0xD, 0x20) from start and end of `str`.\n  \n  \n  \n**Returns** `string`   \n- trimmed string  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "trim(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "join(...string)(string)",
@@ -156,7 +132,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n  \n---    \n**Parameters**  \n- _seperator_  \n    delimiter string  \n  \n- _strs_  \n    strings to join  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns a new string composed of `strs` elements joined together with `separator`.\n  \n**Params**  \n- strs: strings to join  \n  \n**Returns** `string`   \n- joined string  \n  \n"
         }
       },
       "sortText": "131",
@@ -174,7 +150,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string to search for  \n  \n- _start_  \n    index to start search from  \n  \n  \n**Return**  \nint?"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.\n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`   \n- index of first `substr` occurrence or nil  \n  \n"
         }
       },
       "sortText": "131",
@@ -192,16 +168,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturn A-Z into a-z and leave other characters unchanged.\n  \n  \n  \n**Returns** `string`   \n- lower Ascii cased string  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "toLowerAscii(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "toJsonString()(string)",
@@ -210,16 +182,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    json value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "toJsonString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "StringIterator",
@@ -236,16 +204,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nbyte[]"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "toBytes(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "cloneReadOnly()(anydata)",
@@ -254,16 +218,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "cloneReadOnly(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "length()(int)",
@@ -272,16 +232,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- length of the `str`  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "length(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "concat(...string)(string)",
@@ -290,7 +246,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n---    \n**Parameters**  \n- _strs_  \n    strings to concat  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nConcatenate all the `strs`. Empty string if empty.\n  \n  \n  \n**Returns** `string`   \n- concatanated string  \n  \n"
         }
       },
       "sortText": "131",
@@ -308,7 +264,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n  \n---    \n**Parameters**  \n- _j1_  \n    json value  \n  \n- _j2_  \n    json value  \n  \n  \n**Return**  \n(json|error)"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturn the result of merging json value `j1` with `j2`.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- merged json value or error  \n  \nIf the merge fails, then return an error.  \nThe merge of j1 with j2 is defined as follows:  \n- if j1 is (), then the result is j2  \n- if j2 is nil, then the result is j1  \n- if j1 is a mapping and j2 is a mapping, then for each entry [k, j] in j2,  \nset j1[k] to the merge of j1[k] with j  \n- if j1[k] is undefined, then set j1[k] to j  \n- if any merge fails, then the merge of j1 with j2 fails  \n- otherwise, the result is j1.  \n- otherwise, the merge fails  \n  \n"
         }
       },
       "sortText": "131",
@@ -326,16 +282,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `value`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "clone(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "endsWith(string substr)(boolean)",
@@ -344,7 +296,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` end with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` ends with `substr`  \n  \n"
         }
       },
       "sortText": "131",
@@ -362,16 +314,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n---    \n**Parameters**  \n- _value_  \n    source value  \n  \n  \n**Return**  \nstring"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a simple, human-readable representation of `value` as a string.\n  \n  \n  \n**Returns** `string`   \n- simple, human-readable string representation of `value`  \n  \n- if `value` is a string, then returns `value`  \n- if `value` is `()`, then returns an empty string  \n- if `value` is boolean, then the string `true` or `false`  \n- if `value` is an int, then return `value` represented as a decimal string  \n- if `value` is a float or decimal, then return `value` represented as a decimal string,  \nwith a decimal point only if necessary, but without any suffix indicating the type of `value`  \nreturn `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `value` is a list, then returns the results toString on each member of the list  \nseparated by a space character  \n- if `value` is a map, then returns key=value for each member separated by a space character  \n- if `value` is xml, then returns `value` in XML format (as if it occurred within an XML element)  \n- if `value` is table, TBD  \n- if `value` is an error, then a string consisting of the following in order  \n1. the string `error`  \n2. a space character  \n3. the reason string  \n4. if the detail record is non-empty  \n1. a space character  \n2. the result of calling toString on the detail record  \n- if `value` is an object, then  \n- if `value` provides a `toString` method with a string return type and no required methods,  \nthen the result of calling that method on `value`  \n- otherwise, `object` followed by some implementation-dependent string  \n- if `value` is any other behavioral type, then the identifier for the behavioral type  \n(`function`, `future`, `service`, `typedesc` or `handle`)  \nfollowed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
         }
       },
       "sortText": "131",
-      "insertText": "toString(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "codePointCompare(string str2)(int)",
@@ -380,7 +328,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n  \n---    \n**Parameters**  \n- _str1_  \n    string to compare  \n  \n- _str2_  \n    string to compare  \n  \n  \n**Return**  \nint"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nLexicographically compare strings using their Unicode code points.\nThis will allow strings to be ordered in a consistent and well-defined way,\nbut the ordering will not typically be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: string to compare  \n  \n**Returns** `int`   \n- whether `str1` is greater than `str2`  \n  \n"
         }
       },
       "sortText": "131",
@@ -398,7 +346,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n  \n---    \n**Parameters**  \n- _str_  \n    the string  \n  \n- _substr_  \n    sub string  \n  \n  \n**Return**  \nboolean"
+          "value": "**Package:** _ballerina/lang.string_  \n  \nReturns true if `str` starts with `substr`.\n  \n**Params**  \n- `string` substr: sub string  \n  \n**Returns** `boolean`   \n- whether `str` starts with `substr`  \n  \n"
         }
       },
       "sortText": "131",

--- a/language-server/modules/langserver-core/src/test/resources/completion/service/serviceVariableAndFieldsCompletion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service/serviceVariableAndFieldsCompletion1.json
@@ -6,15 +6,24 @@
   "source": "service/source/serviceVariableAndFieldsCompletion1.bal",
   "items": [
     {
+      "label": "testVal",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "120",
+      "insertText": "testVal",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "sayHello(http:Caller caller, http:Request request)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "130",
       "insertText": "sayHello(${1});",
       "insertTextFormat": "Snippet",
       "command": {
@@ -29,21 +38,11 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n---    \n**Parameters**  \n"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "insertText": "serviceFunc(${1});",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "testVal",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "testVal",
+      "sortText": "130",
+      "insertText": "serviceFunc();",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/hover/expected/builtin-function2.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/expected/builtin-function2.json
@@ -2,7 +2,7 @@
     "result": {
         "contents": {
             "kind": "markdown",
-            "value": "**Description**  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.  \n  \n**Params**  \n- `string` str: the string  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`  \n- index of first `substr` occurrence or nil  \n  \n"
+            "value": "**Description**  \n  \nReturns the index of the first occurrence of `substr` in the part of the `str` starting at `startIndex`\nor nil if it does not occur.  \n  \n**Params**  \n- `string` substr: sub string to search for  \n- start: index to start search from  \n  \n**Returns** `(int|())`  \n- index of first `substr` occurrence or nil  \n  \n"
         }
     },
     "id": {


### PR DESCRIPTION
## Purpose
> Fix Hover and Completions help text not omitting first param for langlibs based

Fixes #17517

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
