### PR TITLE
Add formatting support for xml attribute and element and PI literals

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
@@ -6502,8 +6502,36 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatXmlAttributeNode(JsonObject node) {
-        // TODO: fix formatting for XML Attribute.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+            boolean useParentIdentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
+
+            this.preserveHeight(ws, useParentIdentation ? indentationOfParent : indentation);
+
+            for (JsonElement wsItem : ws) {
+                JsonObject currentWS = wsItem.getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                    if (text.equals(Tokens.EQUAL)) {
+                        currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                    }
+                }
+            }
+
+            if (node.has(FormattingConstants.NAME)) {
+                node.getAsJsonObject(FormattingConstants.NAME).add(FormattingConstants.FORMATTING_CONFIG, formatConfig);
+            }
+
+            if (node.has(FormattingConstants.VALUE)) {
+                node.getAsJsonObject(FormattingConstants.VALUE).add(FormattingConstants.FORMATTING_CONFIG,
+                        this.getFormattingConfig(0, 0, 0, false,
+                                this.getWhiteSpaceCount(indentationOfParent), true));
+            }
+        }
     }
 
     /**
@@ -6531,8 +6559,68 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatXmlElementLiteralNode(JsonObject node) {
-        // TODO: fix formatting for XML Element Literal.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+            boolean useParentIndentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
+
+            this.preserveHeight(ws, useParentIndentation ? indentationOfParent : indentation);
+
+            String startLiteral = "";
+            if (node.has("startLiteral")) {
+                startLiteral = node.get("startLiteral").getAsString();
+            }
+
+            for (JsonElement wsItem : ws) {
+                JsonObject currentWS = wsItem.getAsJsonObject();
+                String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                if (text.equals(startLiteral)) {
+                    currentWS.addProperty(FormattingConstants.TEXT, Tokens.XML_LITERAL_START);
+                }
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    if (text.equals(startLiteral)) {
+                        currentWS.addProperty(FormattingConstants.WS,
+                                this.getWhiteSpaces(formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                    } else {
+                        currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                    }
+                }
+            }
+
+            if (node.has("startTagName")) {
+                node.getAsJsonObject("startTagName").add(FormattingConstants.FORMATTING_CONFIG,
+                        this.getFormattingConfig(0, 0, 0, false,
+                                this.getWhiteSpaceCount(indentationOfParent), true));
+            }
+
+            if (node.has("attributes")) {
+                JsonArray attributes = node.getAsJsonArray("attributes");
+                for (JsonElement attributeItem : attributes) {
+                    JsonObject attribute = attributeItem.getAsJsonObject();
+                    attribute.add(FormattingConstants.FORMATTING_CONFIG,
+                            this.getFormattingConfig(0, 1, 0, false,
+                                    this.getWhiteSpaceCount(indentationOfParent), true));
+                }
+            }
+
+            if (node.has("content")) {
+                JsonArray contents = node.getAsJsonArray("content");
+                for (JsonElement contentItem : contents) {
+                    JsonObject content = contentItem.getAsJsonObject();
+                    content.add(FormattingConstants.FORMATTING_CONFIG,
+                            this.getFormattingConfig(0, 0, 0, false,
+                                    this.getWhiteSpaceCount(indentationOfParent), true));
+                }
+            }
+
+            if (node.has("endTagName")) {
+                node.getAsJsonObject("endTagName").add(FormattingConstants.FORMATTING_CONFIG,
+                        this.getFormattingConfig(0, 0, 0, false,
+                                this.getWhiteSpaceCount(indentationOfParent), true));
+            }
+        }
     }
 
     /**
@@ -6592,8 +6680,52 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatXmlPiLiteralNode(JsonObject node) {
-        // TODO: fix formatting for XML PI Literal.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+            boolean useParentIndentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
+
+            this.preserveHeight(ws, useParentIndentation ? indentationOfParent : indentation);
+
+            String startLiteral = "";
+            if (node.has("startLiteral")) {
+                startLiteral = node.get("startLiteral").getAsString();
+            }
+
+            for (JsonElement wsItem : ws) {
+                JsonObject currentWS = wsItem.getAsJsonObject();
+                String text = currentWS.get(FormattingConstants.TEXT).getAsString();
+                if (text.equals(startLiteral)) {
+                    currentWS.addProperty(FormattingConstants.TEXT, Tokens.XML_LITERAL_START);
+                }
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    if (text.equals(startLiteral)) {
+                        currentWS.addProperty(FormattingConstants.WS,
+                                this.getWhiteSpaces(formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                    } else {
+                        currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                    }
+                }
+            }
+
+            if (node.has("target")) {
+                node.getAsJsonObject("target").add(FormattingConstants.FORMATTING_CONFIG,
+                        this.getFormattingConfig(0, 0, 0, false,
+                                this.getWhiteSpaceCount(indentationOfParent), true));
+            }
+
+            if (node.has("dataTextFragments")) {
+                JsonArray dataTextFragments = node.getAsJsonArray("dataTextFragments");
+                for (JsonElement textFragmentItem : dataTextFragments) {
+                    JsonObject textFragment = textFragmentItem.getAsJsonObject();
+                    textFragment.add(FormattingConstants.FORMATTING_CONFIG, this.getFormattingConfig(0,
+                            0, 0, false, this.getWhiteSpaceCount(indentationOfParent),
+                            true));
+                }
+            }
+        }
     }
 
     /**
@@ -6602,8 +6734,27 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatXmlQnameNode(JsonObject node) {
-        // TODO: fix formatting for XML Qname.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.WS) && node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
+            String indentation = this.getIndentation(formatConfig, false);
+            String indentationOfParent = this.getParentIndentation(formatConfig);
+            boolean useParentIndentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
+
+            this.preserveHeight(ws, useParentIndentation ? indentationOfParent : indentation);
+
+            for (int i = 0; i < ws.size(); i++) {
+                JsonObject currentWS = ws.get(i).getAsJsonObject();
+                if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
+                    if (i == 0) {
+                        currentWS.addProperty(FormattingConstants.WS,
+                                this.getWhiteSpaces(formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                    } else {
+                        currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -6612,8 +6763,16 @@ public class FormattingNodeTree {
      * @param node {JsonObject} node as json object
      */
     public void formatXmlQuotedStringNode(JsonObject node) {
-        // TODO: fix formatting for XML Quoted String.
-        this.skipFormatting(node, true);
+        if (node.has(FormattingConstants.FORMATTING_CONFIG)) {
+            JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
+            if (node.has("textFragments")) {
+                JsonArray textFragments = node.getAsJsonArray("textFragments");
+                for (JsonElement textFragmentItem : textFragments) {
+                    JsonObject textFragment = textFragmentItem.getAsJsonObject();
+                    textFragment.add(FormattingConstants.FORMATTING_CONFIG, formatConfig);
+                }
+            }
+        }
     }
 
     /**
@@ -6656,7 +6815,7 @@ public class FormattingNodeTree {
                 JsonObject currentWS = wsItem.getAsJsonObject();
                 String text = currentWS.get(FormattingConstants.TEXT).getAsString();
                 if (text.equals(startLiteral)) {
-                    currentWS.addProperty(FormattingConstants.TEXT, "xml `");
+                    currentWS.addProperty(FormattingConstants.TEXT, Tokens.XML_LITERAL_START);
                 }
                 if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
                     if (text.equals(startLiteral)) {

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/Tokens.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/Tokens.java
@@ -118,4 +118,5 @@ public class Tokens {
     public static final String VERSION = "version";
     public static final String TYPEDESC = "typedesc";
     public static final String XMLNS = "xmlns";
+    public static final String XML_LITERAL_START = "xml `";
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -160,6 +160,9 @@ public class FormattingTest {
                 {"expectedXmlns.bal", "xmlns.bal"},
                 {"expectedXMLTextLiteral.bal", "xmlTextLiteral.bal"},
                 {"expectedXMLCommentLiteral.bal", "xmlCommentLiteral.bal"},
+                {"expectedXMLPILiteral.bal", "xmlPILiteral.bal"},
+                {"expectedXMLElementLiteral.bal", "xmlElementLiteral.bal"},
+                {"expectedXMLAttribute.bal", "xmlAttribute.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedXMLAttribute.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedXMLAttribute.bal
@@ -1,0 +1,83 @@
+function testExpressionAsAttributeValue() returns [xml, xml, xml, xml, xml] {
+    string v0 = "\"zzz\"";
+    string v1 = "zzz";
+    string v2 = "33>22";
+    xml x1 = xml `<foo bar="${v0}"/>`;
+    xml x2 = xml `<foo bar="aaa${v1}bb'b${v2}ccc?"/>`;
+    xml x3 = xml `<foo bar="}aaa${v1}bbb${v2}ccc{d{}e}{f{"/>`;
+    xml x4 = xml `<foo bar1='aaa{${v1}}b\${b"b${v2}c\}cc{d{}e}{f{' bar2='aaa{${v1}}b\${b"b${v2}c\}cc{d{}e}{f{'/>`;
+    xml x5 = xml `<foo bar=""/>`;
+    return [x1, x2, x3, x4, x5];
+}
+
+function testExpressionAsAttributeValue1() returns [xml, xml, xml, xml, xml] {
+    string v0 = "\"zzz\"";
+    string v1 = "zzz";
+    string v2 = "33>22";
+    xml x1 =
+    xml `<
+    foo
+    bar
+    =
+    "${
+    v0
+    }"/>`
+    ;
+    xml x2 =
+    xml `<
+    foo
+    bar
+    =
+    "aaa${
+    v1
+    }bb'b${
+    v2
+    }ccc?"/>`
+    ;
+    xml x3 =
+    xml `<
+    foo
+    bar
+    =
+    "}aaa${
+    v1
+    }}bbb${
+    v2
+    }ccc{d{}e}{f{"/>`
+    ;
+    xml x4 =
+    xml `<foo
+    bar1
+    ='aaa{${v1
+    }}b\${b"b${
+    v2
+    }c\}cc{d{}e}{f{' bar2='aaa{${
+    v1
+    }}b\${b"b${
+    v2
+    }c\}cc{d{}e}{f{'/>`
+    ;
+    xml x5 = xml `<foo
+    bar=
+    ""/>`
+    ;
+    return [x1, x2, x3, x4, x5];
+}
+
+function testDefineInlineNamespace() returns (xml) {
+    xml x1 = xml `<foo foo="http://wso2.com">hello</foo>`;
+    return x1;
+}
+
+function testDefineInlineNamespace1() returns (xml) {
+    xml x1 =
+    xml `<
+    foo
+    foo
+    =
+    "http://wso2.com"
+    >hello</
+    foo>`
+    ;
+    return x1;
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedXMLElementLiteral.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedXMLElementLiteral.bal
@@ -1,0 +1,123 @@
+xmlns "http://ballerina.com/b" as ns1;
+
+function testElementLiteralWithNamespaces() returns [xml, xml] {
+    xmlns "http://ballerina.com/";
+    xmlns "http://ballerina.com/a" as ns0;
+    xmlns "http://ballerina.com/c" as ns1;
+
+    xml x1 = xml `<root ns0:id="456"><foo>123</foo><bar ns1:status="complete"></bar></root>`;
+    xml x2 = x1.*;
+    return [x1, x2];
+}
+
+function testElementLiteralWithNamespaces1() returns [xml, xml] {
+    xmlns "http://ballerina.com/";
+    xmlns "http://ballerina.com/a" as ns0;
+    xmlns "http://ballerina.com/c" as ns1;
+
+    xml x1 =
+    xml `<root
+    ns0
+    :
+    id
+    =
+    "456"><foo>123</foo><bar
+    ns1
+    :
+    status
+    =
+    "complete"></bar></root>`
+    ;
+    xml x2 =
+    x1
+    .
+    *
+    ;
+    return [x1, x2];
+}
+
+function testElementWithQualifiedName() returns [xml, xml, xml] {
+
+    xml x1 = xml `<root>hello</root>`;
+
+    xmlns "http://ballerina.com/";
+    xml x2 = xml `<root>hello</root>`;
+
+    xml x3 = xml `<ns1:root>hello</ns1:root>`;
+
+    return [x1, x2, x3];
+}
+
+function testElementWithQualifiedName1() returns [xml, xml, xml] {
+
+    xml x1 =
+    xml `<root>hello</root>`
+    ;
+
+    xmlns "http://ballerina.com/";
+    xml x2 =
+    xml `<root>hello</root>`
+    ;
+
+    xml x3 =
+    xml `<ns1:root>hello</ns1:root>`
+    ;
+
+    return [x1, x2, x3];
+}
+
+function testElementLiteralWithTemplateChildren() returns [xml, xml] {
+    string v2 = "aaa<bbb";
+    xml x1 = xml `<fname>John</fname>`;
+    xml x2 = xml `<lname>Doe</lname>`;
+
+    xml x3 = xml `<root>hello ${v2} good morning ${x1} ${x2}. Have a nice day!<foo>123</foo><bar></bar></root>`;
+    xml x4 = x3.*;
+    return [x3, x4];
+}
+
+function testElementLiteralWithTemplateChildren1() returns [xml, xml] {
+    string v2 = "aaa<bbb";
+    xml x1 =
+    xml `<fname>John</fname>`;
+    xml x2 =
+    xml `<
+    lname
+    >Doe</
+    lname
+    >`
+    ;
+
+    xml x3 =
+    xml `<
+    root
+    >hello ${
+    v2
+    } good morning ${
+    x1
+    } ${
+    x2
+    }. Have a nice day!<
+    foo
+    >123</
+    foo
+    ><
+    bar
+    ></
+    bar
+    ></
+    root
+    >`
+    ;
+    xml x4 =
+    x3
+    .
+    *
+    ;
+    return [
+    x3
+    ,
+    x4
+    ]
+    ;
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedXMLPILiteral.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedXMLPILiteral.bal
@@ -1,0 +1,53 @@
+function testXMLPILiteral() returns [xml, xml, xml, xml, xml] {
+    int v1 = 11;
+    string v2 = "22";
+    string v3 = "33";
+    xml x1 = xml `<?foo ?>`;
+    xml x2 =
+    xml `<?foo ${
+    v1
+    }?>`;
+    xml x3 = xml `<?foo aaa${v1}bbb${v2}ccc?>`;
+    xml x4 = xml `<?foo <aaa${v1}bbb${v2}ccc??d?e>?f<<{>>>?>`;
+    xml x5 = xml `<?foo ?a?aa${
+    v1
+    }b\${bb${
+    v2
+    }c\}cc{d{}e}{f{?>`
+    ;
+
+    return [x1, x2, x3, x4, x5];
+}
+
+function testXMLPILiteral1() returns [xml, xml, xml, xml, xml] {
+    int v1 = 11;
+    string v2 = "22";
+    string v3 = "33";
+    xml x1 =
+    xml `<?foo ?>`;
+    xml x2 =
+    xml `<?foo ${
+    v1
+    }?>`;
+    xml x3 =
+    xml `<?foo aaa${
+    v1
+    }bbb${
+    v2
+    }ccc?>`
+    ;
+    xml x4 =
+    xml `<?foo <aaa${
+    v1
+    }bbb${
+    v2
+    }ccc??d?e>?f<<{>>>?>`
+    ;
+    xml x5 = xml `<?foo ?a?aa${
+    v1
+    }b\${bb${
+    v2}c\}cc{d{}e}{f{?>`
+    ;
+
+    return [x1, x2, x3, x4, x5];
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/xmlAttribute.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/xmlAttribute.bal
@@ -1,0 +1,82 @@
+function testExpressionAsAttributeValue() returns [xml, xml, xml, xml, xml] {
+    string v0 = "\"zzz\"";
+    string v1 = "zzz";
+    string v2 = "33>22";
+    xml  x1=xml    `<foo  bar   = "${  v0 }"/>`   ;xml x2 = xml     `< foo    bar  ="aaa${  v1}bb'b${v2   }ccc?" />` ;
+          xml x3=xml`< foo bar = "}aaa${   v1   }bbb${    v2   }ccc{d{}e}{f{" />`   ;
+  xml x4=   xml    `< foo bar1 = 'aaa{${ v1}}b\${b"b${v2}c\}cc{d{}e}{f{'    bar2 =  'aaa{${ v1  }}b\${b"b${ v2 }c\}cc{d{}e}{f{'/>` ;
+       xml    x5=   xml`< foo   bar = "" />` ;
+    return [x1, x2, x3, x4, x5];
+}
+
+function testExpressionAsAttributeValue1() returns [xml, xml, xml, xml, xml] {
+    string v0 = "\"zzz\"";
+    string v1 = "zzz";
+    string v2 = "33>22";
+    xml x1 =
+    xml`<
+ foo
+        bar
+    =
+        "${
+ v0
+       }"/>`
+  ;
+    xml  x2  =
+       xml  `<
+  foo
+         bar
+ =
+    "aaa${
+          v1
+ }bb'b${
+        v2
+        }ccc?"/>`
+      ;
+    xml x3   =
+xml     `<
+  foo
+       bar
+    =
+       "}aaa${
+    v1
+ }}bbb${
+          v2
+         }ccc{d{}e}{f{"/>`
+         ;
+    xml   x4=
+           xml `<foo
+ bar1
+           =   'aaa{${ v1
+          }}b\${b"b${
+         v2
+ }c\}cc{d{}e}{f{' bar2='aaa{${
+ v1
+       }}b\${b"b${
+ v2
+        }c\}cc{d{}e}{f{'/>`
+        ;
+    xml    x5 =    xml`<   foo
+ bar    =
+         ""/>`
+    ;
+    return [x1, x2, x3, x4, x5];
+}
+
+function testDefineInlineNamespace() returns (xml) {
+    xml x1 =   xml`< foo  foo = "http://wso2.com"  >hello</ foo >` ;
+    return x1;
+}
+
+function testDefineInlineNamespace1() returns (xml) {
+    xml x1 =
+    xml `<
+ foo
+          foo
+        =
+       "http://wso2.com"
+    >hello</
+         foo>`
+ ;
+        return x1;
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/xmlElementLiteral.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/xmlElementLiteral.bal
@@ -1,0 +1,122 @@
+xmlns "http://ballerina.com/b" as ns1;
+
+function testElementLiteralWithNamespaces() returns [xml, xml] {
+    xmlns "http://ballerina.com/";
+    xmlns "http://ballerina.com/a" as ns0;
+    xmlns "http://ballerina.com/c" as ns1;
+
+ xml    x1=xml    `<   root ns0 : id = "456" >< foo >123</ foo >< bar ns1 : status  =  "complete" ></ bar ></ root >` ;xml x2  =  x1  .  *  ;
+     return  [ x1 , x2 ];
+}
+
+function testElementLiteralWithNamespaces1() returns [xml, xml] {
+    xmlns "http://ballerina.com/";
+    xmlns "http://ballerina.com/a" as ns0;
+    xmlns "http://ballerina.com/c" as ns1;
+
+    xml x1 =
+           xml        `<root
+         ns0
+  :
+            id
+    =
+          "456"><foo>123</foo><bar
+             ns1
+         :
+ status
+          =
+ "complete"></bar></root>`
+        ;
+              xml x2 =
+           x1
+        .
+ *
+       ;
+    return [x1, x2];
+}
+
+function testElementWithQualifiedName() returns [xml, xml, xml] {
+
+    xml x1 =     xml      `< root >hello</ root >`     ;
+
+        xmlns      "http://ballerina.com/";
+ xml    x2 =    xml       `< root >hello</ root >`;
+
+              xml x3  =xml    `< ns1 : root >hello</ ns1 : root >`       ;
+
+ return    [  x1 , x2 , x3 ]   ;
+}
+
+function testElementWithQualifiedName1() returns [xml, xml, xml] {
+
+    xml x1 =
+        xml    `< root >hello</ root >`
+ ;
+
+    xmlns"http://ballerina.com/" ;
+               xml   x2=
+       xml      `< root >hello</root>`
+        ;
+
+  xml    x3=
+        xml     `< ns1 : root >hello</ ns1 : root >`
+      ;
+
+    return [x1, x2, x3];
+}
+
+function testElementLiteralWithTemplateChildren() returns [xml, xml] {
+    string v2 = "aaa<bbb";
+    xml x1 =xml`< fname >John</ fname >`  ;
+    xml x2 =    xml   `< lname >Doe</ lname >`  ;
+
+ xml   x3=xml     `< root >hello ${  v2 } good morning ${ x1 } ${ x2 }. Have a nice day!< foo >123</ foo >< bar ></ bar ></ root >` ;
+    xml    x4=    x3 . * ;
+    return  [ x3,x4];
+}
+
+function testElementLiteralWithTemplateChildren1() returns [xml, xml] {
+    string v2 = "aaa<bbb";
+    xml x1 =
+    xml`<fname>John</fname>`;
+    xml x2    =
+xml       `<
+          lname
+>Doe</
+ lname
+         >`
+ ;
+
+  xml    x3 =
+       xml     `<
+        root
+  >hello ${
+          v2
+  } good morning ${
+        x1
+ } ${
+        x2
+ }. Have a nice day!<
+            foo
+ >123</
+         foo
+        ><
+       bar
+       ></
+  bar
+        ></
+       root
+  >`
+        ;
+    xml x4 =
+    x3
+    .
+    *
+    ;
+    return [
+    x3
+    ,
+    x4
+    ]
+    ;
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/xmlPILiteral.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/xmlPILiteral.bal
@@ -1,0 +1,52 @@
+function testXMLPILiteral() returns [xml, xml, xml, xml, xml] {
+    int v1 = 11;
+    string v2 = "22";
+    string v3 = "33";
+       xml  x1  =  xml`<?foo ?>`   ;xml   x2  =
+xml   `<?foo ${
+        v1
+        }?>`;
+           xml x3 =    xml      `<?foo aaa${ v1  }bbb${v2    }ccc?>`;
+           xml x4 =xml       `<?foo <aaa${    v1  }bbb${    v2}ccc??d?e>?f<<{>>>?>`;
+    xml x5 = xml`<?foo ?a?aa${
+        v1
+        }b\${bb${
+            v2
+            }c\}cc{d{}e}{f{?>`
+            ;
+
+    return [x1, x2, x3, x4, x5];
+}
+
+function testXMLPILiteral1() returns [xml, xml, xml, xml, xml] {
+    int v1 = 11;
+    string v2 = "22";
+    string v3 = "33";
+    xml x1 =
+     xml     `<?foo ?>`    ;
+ xml     x2 =
+         xml       `<?foo ${
+              v1
+        }?>`    ;
+           xml    x3    =
+ xml`<?foo aaa${
+                 v1
+ }bbb${
+           v2
+          }ccc?>`
+ ;
+            xml   x4  =
+ xml       `<?foo <aaa${
+            v1
+                   }bbb${
+ v2
+ }ccc??d?e>?f<<{>>>?>`
+         ;
+ xml     x5    =    xml     `<?foo ?a?aa${
+ v1
+    }b\${bb${
+           v2   }c\}cc{d{}e}{f{?>`
+        ;
+
+    return [x1, x2, x3, x4, x5];
+}


### PR DESCRIPTION
## Purpose
This will add formatting support for xml attribute, element literals and PI literals.

Related Issue 
https://github.com/ballerina-platform/ballerina-lang/issues/13280

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
