### PR TITLE
Fix config-api "=" not recognized issue

### DIFF
--- a/distribution/zip/jballerina/build.gradle
+++ b/distribution/zip/jballerina/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     dist 'org.bouncycastle:bcprov-jdk15on:1.61'
     dist 'org.bouncycastle:bcpkix-jdk15on:1.61'
 
-    dist 'info.picocli:picocli:3.3.0'
+    dist 'info.picocli:picocli:4.0.1'
     dist 'org.apache.kafka:kafka-clients:2.0.0'
     dist 'org.apache.kafka:kafka_2.11:2.0.0'
     dist 'org.apache.james:apache-mime4j-core:0.7.2'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -92,7 +92,7 @@ dependencies {
         implementation 'org.wso2.staxon:staxon-core:1.2.0.wso2v2'
         implementation 'org.quartz-scheduler:quartz:2.3.1'
         
-        implementation 'info.picocli:picocli:3.9.5'
+        implementation 'info.picocli:picocli:4.0.1'
         implementation 'io.ballerina.messaging:broker-common:0.970.5'
         implementation 'io.ballerina.messaging:broker-core:0.970.5'
         implementation 'io.ballerina.messaging:broker-amqp:0.970.5'

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/build.gradle
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'io.swagger.parser.v3:swagger-parser-v2-converter'
     implementation 'io.swagger.parser.v3:swagger-parser-v3'
     implementation 'com.github.jknack:handlebars:4.0.6'
-    implementation 'info.picocli:picocli:3.9.0'
+    implementation 'info.picocli:picocli:4.0.1'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.0'
     implementation project(':ballerina-tool')
     implementation project(':ballerina-lang')

--- a/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigTest.java
+++ b/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigTest.java
@@ -338,10 +338,26 @@ public class ConfigTest {
         Assert.assertEquals(returnVals[0].stringValue(), "Hello\nWorld!!!\n");
     }
 
+    @Test(description = "Test config keys with equals")
+    public void testGetAsStringWithEquals() throws IOException {
+        BString key = new BString("\\\"a=b\\\"");
+        BValue[] inputArg = { key };
+
+        registry.initRegistry(getRuntimeProperties(), customConfigFilePath, ballerinaConfPath);
+
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetAsString", inputArg);
+
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values.");
+        Assert.assertTrue(returnVals[0] instanceof BString);
+        Assert.assertEquals(returnVals[0].stringValue(), "abcd");
+    }
+
     private Map<String, String> getRuntimeProperties() {
         Map<String, String> runtimeConfigs = new HashMap<>();
         runtimeConfigs.put("ballerina.http.host", "10.100.1.201");
         runtimeConfigs.put("http1.port", "8082");
+        runtimeConfigs.put("\\\"a=b\\\"", "abcd");
         return runtimeConfigs;
     }
 }


### PR DESCRIPTION
## Purpose
> Fixing a=b=abcd type value passing for config-api via command line. This type of values need to enclose in double quotation in both command line and key in the ballerina code.

Fixes #13041

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
