### PR TITLE
Constraint lhs type of table literal expr

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -45,6 +45,7 @@ public enum DiagnosticCode {
     TYPE_NOT_ALLOWED_WITH_PRIMARYKEY("type.not.allowed.with.primarykey"),
     FIELD_NOT_ALLOWED_WITH_TABLE_COLUMN("field.not.allowed.with.table.column"),
     TABLE_CANNOT_BE_CREATED_WITHOUT_CONSTRAINT("table.cannot.be.created.without.constraint"),
+    CANNOT_INFER_TABLE_TYPE("cannot.infer.table.type"),
     TABLE_KEY_EXPECTED("table.key.expected"),
     OBJECT_TYPE_NOT_ALLOWED("object.type.not.allowed"),
     UNDEFINED_STRUCTURE_FIELD_WITH_TYPE("undefined.field.in.structure.with.type"), // TODO: remove Maryam

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -529,6 +529,11 @@ public class TypeChecker extends BLangNodeVisitor {
         if (expType.tag == symTable.semanticError.tag) {
             return;
         }
+        if (expType.getKind() != TypeKind.TABLE) {
+            dlog.error(tableLiteral.pos, DiagnosticCode.CANNOT_INFER_TABLE_TYPE);
+            resultType = symTable.semanticError;
+            return;
+        }
         BType tableConstraint = ((BTableType) expType).getConstraint();
         if (tableConstraint.tag == TypeTags.NONE) {
             dlog.error(tableLiteral.pos, DiagnosticCode.TABLE_CANNOT_BE_CREATED_WITHOUT_CONSTRAINT);

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -640,6 +640,9 @@ error.object.type.not.allowed=\
 error.table.cannot.be.created.without.constraint=\
   table cannot be created without a constraint
 
+error.cannot.infer.table.type=\
+  cannot infer table type
+
 error.table.key.expected=\
   expected token ''key''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralSyntaxTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableLiteralSyntaxTest.java
@@ -474,7 +474,7 @@ public class TableLiteralSyntaxTest {
 
     @Test(description = "Test table remove with function pointer of invalid return type")
     public void testTableReturnNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 18);
+        Assert.assertEquals(resultNegative.getErrorCount(), 19);
         BAssertUtil.validateError(resultNegative, 0, "object type not allowed as the constraint", 39, 11);
         BAssertUtil.validateError(resultNegative, 1, "undefined column 'married2' for table of type 'Person'", 46, 42);
         BAssertUtil.validateError(resultNegative, 2, "undefined field 'married2' in record 'Person'", 47, 10);
@@ -506,6 +506,8 @@ public class TableLiteralSyntaxTest {
                                   "field 'xArr' of type 'xml[]' is not allowed as a table column", 212, 29);
         BAssertUtil.validateError(resultNegative, 17,
                                   "field 'eArr' of type 'error?[]' is not allowed as a table column", 212, 29);
+        BAssertUtil.validateError(resultNegative, 18,
+                                  "cannot infer table type", 223, 14);
     }
 
     @Test(description = "Test table remove with function pointer of invalid return type")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_literal_syntax_negative1.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_literal_syntax_negative1.bal
@@ -217,3 +217,14 @@ function addInvalidArrayData() {
 function isBelow35Invalid(Person p) {
     p.age = 10;
 }
+
+function testTableLiteralWithVar() {
+
+    var t1 = table {
+        { key id, salary, key name, age, married2 },
+        [{ 1, 300.5, "jane",  30, true },
+        { 2, 302.5, "anne",  23, false },
+        { 3, 320.5, "john",  33, true }
+        ]
+    };
+}


### PR DESCRIPTION
## Purpose
LHS type of table literal is constraint to be of a table type.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10914
