### PR TITLE
Keep project tree when moving to diagram tab

### DIFF
--- a/composer/packages/diagram/src/visitors/init-visitor.ts
+++ b/composer/packages/diagram/src/visitors/init-visitor.ts
@@ -117,6 +117,9 @@ export const visitor: Visitor = {
 
     beginVisitVariableDef(node: VariableDef) {
         if (ASTUtil.isWorker(node)) {
+            if (!node.viewState) {
+                node.viewState = new WorkerViewState();
+            }
             currentWorker = node;
         }
     },


### PR DESCRIPTION
## Purpose
* Avoid the project tree view dissapearing when project overview tab is focused
* Fix diagram not rendering for fork statementsFix diagram not rendering for fork statements

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
