### PR TITLE
Allow panic on union of errors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2232,9 +2232,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangPanic panicNode) {
         this.typeChecker.checkExpr(panicNode.expr, env, symTable.errorType);
-        if (panicNode.expr.type.tag != TypeTags.ERROR) {
-            dlog.error(panicNode.expr.pos, DiagnosticCode.INCOMPATIBLE_TYPES, symTable.errorType, panicNode.expr.type);
-        }
     }
 
     BType analyzeNode(BLangNode node, SymbolEnv env, BType expType, DiagnosticCode diagCode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2800,6 +2800,17 @@ public class TypeChecker extends BLangNodeVisitor {
 
     private void checkErrorConstructorInvocation(BLangInvocation iExpr) {
         BType expectedType = this.expType;
+
+        if (expType.getKind() == TypeKind.UNION) {
+            BType[] errorMembers = ((BUnionType) expectedType).getMemberTypes()
+                    .stream()
+                    .filter(memberType -> types.isAssignable(memberType, symTable.errorType))
+                    .toArray(BType[]::new);
+            if (errorMembers.length > 0) {
+                expectedType = BUnionType.create(null, errorMembers);
+            }
+        }
+
         if (expType.getKind() == TypeKind.UNION && iExpr.symbol.type == symTable.errorType) {
             BUnionType unionType = (BUnionType) expType;
             long count = unionType.getMemberTypes().stream()

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -237,7 +237,7 @@ public class ErrorTest {
 
     @Test
     public void testErrorNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 15);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 16);
         BAssertUtil.validateError(negativeCompileResult, 0,
                                   "incompatible types: expected 'reason one|reason two', found 'string'", 26, 31);
         BAssertUtil.validateError(negativeCompileResult, 1,
@@ -265,6 +265,8 @@ public class ErrorTest {
                 "cannot infer reason from error constructor: 'RNError'", 96, 18);
         BAssertUtil.validateError(negativeCompileResult, 14,
                 "cannot infer reason from error constructor: 'RNStrError'", 97, 21);
+        BAssertUtil.validateError(negativeCompileResult, 15,
+                "incompatible types: expected 'error', found '(error|int)'", 102, 11);
     }
     @DataProvider(name = "userDefTypeAsReasonTests")
     public Object[][] userDefTypeAsReasonTests() {
@@ -335,5 +337,24 @@ public class ErrorTest {
                 "error: array index out of range: index: 4, size: 2 \n\t" +
                         "at ballerina.lang_array:slice(array.bal:124)\n\t" +
                         "   error_test:testStackTraceInNative(error_test.bal:286)");
+    }
+
+    @Test
+    public void testPanicOnErrorUnion() {
+        BValue[] args = new BValue[] { new BInteger(0) };
+        BValue[] result = BRunUtil.invoke(errorTestResult, "testPanicOnErrorUnion", args);
+        Assert.assertEquals(result[0].stringValue(), "str");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp = "error: x.*")
+    public void testPanicOnErrorUnionCustomError() {
+        BValue[] args = new BValue[] { new BInteger(1) };
+        BRunUtil.invoke(errorTestResult, "testPanicOnErrorUnion", args);
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp = "error: y code=4.*")
+    public void testPanicOnErrorUnionCustomError2() {
+        BValue[] args = new BValue[] { new BInteger(2) };
+        BRunUtil.invoke(errorTestResult, "testPanicOnErrorUnion", args);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -285,3 +285,27 @@ public function testStackTraceInNative() {
     string[] array = ["apple", "orange"];
     _ = array.slice(1, 4);
 }
+
+const C1 = "x";
+const C2 = "y";
+
+type C1E error<C1, record {| string message?; error cause?; |}>;
+type C2E error<C2, record {| string message?; error cause?; int code; |}>;
+
+public function testPanicOnErrorUnion(int i) returns string {
+    var res = testFunc(i);
+    if (res is string) {
+        return res;
+    } else {
+        panic res;
+    }
+}
+
+function testFunc(int i) returns string|E1|E2 { // fails even if one of the errors is `error`
+    if (i == 0) {
+        return "str";
+    } else if (i == 1) {
+        return C1E();
+    }
+    return C2E(code=4);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -96,3 +96,8 @@ function testIndirectErrorDestructuring() {
     RNError e2 = RNError(message="Msg", fatal=false, other="k");
     RNStrError e3 = RNStrError(message="Msg", fatal=false, other="k");
 }
+
+function panicOnNonErrorMemberUnion() {
+    error|int e = 5;
+    panic e;
+}


### PR DESCRIPTION
## Purpose
$subject 

```ballerina
const C1 = "x";
const C2 = "y";

type C1E error<C1, record {| string message?; error cause?; |}>;
type C2E error<C2, record {| string message?; error cause?; int code; |}>;

public function testPanicOnErrorUnion(int i) returns string {
    C1E|C2E|string res = testFunc(i);
    if (res is string) {
        return res;
    } else {
        // res is (C1E|C2E)
        panic res;
    }
}

```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/17262

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
