### PR TITLE
Add ballerina home command

### DIFF
--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/BallerinaCliCommands.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/BallerinaCliCommands.java
@@ -35,4 +35,5 @@ public class BallerinaCliCommands {
     public static final String PULL = "pull";
     public static final String USE = "use";
     public static final String REMOVE = "remove";
+    public static final String HOME = "home";
 }

--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/Main.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/Main.java
@@ -100,6 +100,11 @@ public class Main {
             cmdParser.addSubcommand(BallerinaCliCommands.VERSION, versionCmd);
             versionCmd.setParentCmdParser(cmdParser);
 
+            // Ballerina Home Command
+            HomeCmd homeCmd = new HomeCmd();
+            cmdParser.addSubcommand(BallerinaCliCommands.HOME, homeCmd);
+            homeCmd.setParentCmdParser(cmdParser);
+
             EncryptCmd encryptCmd = new EncryptCmd();
             cmdParser.addSubcommand(BallerinaCliCommands.ENCRYPT, encryptCmd);
             encryptCmd.setParentCmdParser(cmdParser);
@@ -184,6 +189,15 @@ public class Main {
         } catch (Throwable ignore) {
             // Exception is ignored
             throw LauncherUtils.createUsageExceptionWithHelp("version info not available");
+        }
+    }
+
+    private static void printBallerinaDistPath() {
+        try {
+            outStream.print(ToolUtil.getCurrentDist() + "\n");
+        } catch (Throwable ignore) {
+            // Exception is ignored
+            throw LauncherUtils.createUsageExceptionWithHelp("home info not available");
         }
     }
 
@@ -307,6 +321,62 @@ public class Main {
         @Override
         public void printUsage(StringBuilder out) {
             out.append("  ballerina version\n");
+        }
+
+        @Override
+        public void setParentCmdParser(CommandLine parentCmdParser) {
+            this.parentCmdParser = parentCmdParser;
+        }
+    }
+
+    /**
+     * This class represents the "home" command and it holds arguments and flags specified by the user.
+     *
+     * @since 1.0.0
+     */
+    @CommandLine.Command(name = "home", description = "Prints the path of current Ballerina dist")
+    private static class HomeCmd implements BLauncherCmd {
+
+        @CommandLine.Parameters(description = "Command name")
+        private List<String> homeCommands;
+
+        @CommandLine.Option(names = {"--help", "-h", "?"}, hidden = true)
+        private boolean helpFlag;
+
+        private CommandLine parentCmdParser;
+
+        public void execute() {
+            if (helpFlag) {
+                printUsageInfo(BallerinaCliCommands.HOME);
+                return;
+            }
+
+            if (homeCommands == null) {
+                printBallerinaDistPath();
+                return;
+            } else if (homeCommands.size() > 1) {
+                throw LauncherUtils.createUsageExceptionWithHelp("too many arguments given");
+            }
+
+            String userCommand = homeCommands.get(0);
+            if (parentCmdParser.getSubcommands().get(userCommand) == null) {
+                throw LauncherUtils.createUsageExceptionWithHelp("unknown command `" + userCommand + "`");
+            }
+        }
+
+        @Override
+        public String getName() {
+            return BallerinaCliCommands.HOME;
+        }
+
+        @Override
+        public void printLongDesc(StringBuilder out) {
+
+        }
+
+        @Override
+        public void printUsage(StringBuilder out) {
+            out.append("  ballerina home\n");
         }
 
         @Override

--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/Main.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/Main.java
@@ -193,15 +193,13 @@ public class Main {
     }
 
     private static void printBallerinaDistPath() {
-        try {
-            outStream.print(ToolUtil.getCurrentDist() + "\n");
-        } catch (Throwable ignore) {
-            // Exception is ignored
+        String balHome = System.getProperty("ballerina.home");
+        if (balHome != null) {
+            outStream.print(balHome + "\n");
+        } else {
             throw LauncherUtils.createUsageExceptionWithHelp("home info not available");
         }
     }
-
-
 
     private static String getMessageForInternalErrors() {
         String errorMsg;

--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/util/ToolUtil.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/util/ToolUtil.java
@@ -100,17 +100,6 @@ public class ToolUtil {
         }
     }
 
-
-    /**
-     * Provide the path of currently configured Ballerina Distribution.
-     * @return Used Ballerina distribution path
-     */
-    public static String getCurrentDist() throws IOException {
-        String currentBallerinaVersion = getCurrentBallerinaVersion();
-        return OSUtils.getDistributionsPath() + File.separator + currentBallerinaVersion;
-//      return System.getProperty("ballerina.home");
-    }
-
     /**
      * Provides used Ballerina version.
      * @return Used Ballerina version

--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/util/ToolUtil.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/util/ToolUtil.java
@@ -100,6 +100,17 @@ public class ToolUtil {
         }
     }
 
+
+    /**
+     * Provide the path of currently configured Ballerina Distribution.
+     * @return Used Ballerina distribution path
+     */
+    public static String getCurrentDist() throws IOException {
+        String currentBallerinaVersion = getCurrentBallerinaVersion();
+        return OSUtils.getDistributionsPath() + File.separator + currentBallerinaVersion;
+//      return System.getProperty("ballerina.home");
+    }
+
     /**
      * Provides used Ballerina version.
      * @return Used Ballerina version

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-home.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-home.help
@@ -1,0 +1,12 @@
+NAME
+    Ballerina home - Print the path of current Ballerina distribution
+
+SYNOPSIS
+    ballerina <home>
+
+DESCRIPTION
+     Ballerina home command prints the path of current Ballerina Distribution in use.
+
+EXAMPLES
+     What is the path of Ballerina distribution currently configured on your machine?
+     $ ballerina home

--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -25,7 +25,7 @@ import {
 } from "vscode";
 import {
     INVALID_HOME_MSG, INSTALL_BALLERINA, DOWNLOAD_BALLERINA, MISSING_SERVER_CAPABILITY,
-    CONFIG_CHANGED, OLD_BALLERINA_VERSION, OLD_PLUGIN_VERSION, UNKNOWN_ERROR, INVALID_FILE,
+    CONFIG_CHANGED, OLD_BALLERINA_VERSION, OLD_PLUGIN_VERSION, UNKNOWN_ERROR, INVALID_FILE, INSTALL_NEW_BALLERINA,
 } from "./messages";
 import * as path from 'path';
 import * as fs from 'fs';
@@ -37,7 +37,7 @@ import { info, getOutputChannel } from '../utils/index';
 import { AssertionError } from "assert";
 import { OVERRIDE_BALLERINA_HOME, BALLERINA_HOME, ALLOW_EXPERIMENTAL, ENABLE_DEBUG_LOG, ENABLE_TRACE_LOG } from "./preferences";
 import TelemetryReporter from "vscode-extension-telemetry";
-import { createTelemetryReporter, TM_EVENT_ERROR_INVALID_BAL_HOME_CONFIGURED, TM_EVENT_ERROR_INVALID_BAL_HOME_DETECTED, TM_EVENT_OLD_BAL_HOME, TM_EVENT_OLD_BAL_PLUGIN } from "../telemetry";
+import { createTelemetryReporter, TM_EVENT_ERROR_INVALID_BAL_HOME_CONFIGURED, TM_EVENT_ERROR_INVALID_BAL_HOME_DETECTED, TM_EVENT_OLD_BAL_HOME, TM_EVENT_OLD_BAL_PLUGIN, TM_EVENT_ERROR_OLD_BAL_HOME_DETECTED } from "../telemetry";
 
 export const EXTENSION_ID = 'ballerina.ballerina';
 
@@ -97,12 +97,18 @@ export class BallerinaExtension {
             } else {
                 info("Auto detecting Ballerina home.");
                 // If ballerina home is not set try to auto detect ballerina home.
-                // TODO If possible try to update the setting page.
-                this.ballerinaHome = this.autoDetectBallerinaHome();
-                if (!this.ballerinaHome) {
+                const { isBallerinaNotFound, isOldBallerinaDist, home } = this.autoDetectBallerinaHome();
+                this.ballerinaHome = home;
+
+                if (isBallerinaNotFound) {
                     this.showMessageInstallBallerina();
                     info("Unable to auto detect Ballerina home.");
                     this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_INVALID_BAL_HOME_DETECTED);
+                    return Promise.resolve();
+                } else if (isOldBallerinaDist) {
+                    this.showMessageInstallLatestBallerina();
+                    info("Found an incompatible Ballerina installation.");
+                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_OLD_BAL_HOME_DETECTED);
                     return Promise.resolve();
                 }
             }
@@ -299,6 +305,19 @@ export class BallerinaExtension {
         });
     }
 
+    showMessageInstallLatestBallerina(): any {
+        const download: string = 'Download';
+        const openSettings: string = 'Open Settings';
+        window.showWarningMessage(INSTALL_NEW_BALLERINA, download, openSettings).then((selection) => {
+            if (openSettings === selection) {
+                commands.executeCommand('workbench.action.openGlobalSettings');
+            }
+            if (download === selection) {
+                commands.executeCommand('vscode.open', Uri.parse(DOWNLOAD_BALLERINA));
+            }
+        });
+    }
+
     showMessageInvalidBallerinaHome(): void {
         const action = 'Open Settings';
         window.showWarningMessage(INVALID_HOME_MSG, action).then((selection) => {
@@ -380,58 +399,29 @@ export class BallerinaExtension {
         return <boolean>workspace.getConfiguration().get(ENABLE_TRACE_LOG);
     }
 
-    autoDetectBallerinaHome(): string {
-        // try to detect the environment.
-        const platform: string = process.platform;
-        let ballerinaPath = '';
-        switch (platform) {
-            case 'win32': // Windows
-                if (process.env.BALLERINA_HOME) {
-                    return process.env.BALLERINA_HOME;
-                }
-                try {
-                    ballerinaPath = execSync('where ballerina.bat').toString().trim();
-                } catch (error) {
-                    return ballerinaPath;
-                }
-                if (ballerinaPath) {
-                    ballerinaPath = ballerinaPath.replace(/bin\\ballerina.bat$/, '');
-                }
-                break;
-            case 'darwin': // Mac OS
-                try {
-                    const output = execSync('which ballerina');
-                    ballerinaPath = fs.realpathSync(output.toString().trim());
-                    // remove ballerina bin from ballerinaPath
-                    if (ballerinaPath) {
-                        ballerinaPath = ballerinaPath.replace(/bin\/ballerina$/, '');
-                        // For homebrew installations ballerina executable is in libexcec
-                        const homebrewBallerinaPath = path.join(ballerinaPath, 'libexec');
-                        if (fs.existsSync(homebrewBallerinaPath)) {
-                            ballerinaPath = homebrewBallerinaPath;
-                        }
-                    }
-                } catch {
-                    return ballerinaPath;
-                }
-                break;
-            case 'linux': // Linux
-                // lets see where the ballerina command is.
-                try {
-                    const output = execSync('which ballerina');
-                    ballerinaPath = fs.realpathSync(output.toString().trim());
-                    // remove ballerina bin from path
-                    if (ballerinaPath) {
-                        ballerinaPath = ballerinaPath.replace(/bin\/ballerina$/, '');
-                    }
-                } catch {
-                    return ballerinaPath;
-                }
-                break;
+    autoDetectBallerinaHome(): { home: string, isOldBallerinaDist: boolean, isBallerinaNotFound: boolean } {
+        let balHomeOutput = "",
+            isBallerinaNotFound = false,
+            isOldBallerinaDist = false;
+        try {
+            balHomeOutput = execSync('ballerina home').toString().trim();
+            // specially handle unknown ballerina command scenario for windows
+            if (balHomeOutput === "" && process.platform === "win32") {
+                isOldBallerinaDist = true;
+            }
+        } catch ({ message }) {
+            // ballerina is installed, but ballerina home command is not found
+            isOldBallerinaDist = message.includes("ballerina: unknown command ''home''");
+            // ballerina is not installed
+            isBallerinaNotFound = message.includes('command not found')
+                || message.includes('is not recognized as an internal or external command');
         }
-
-        // If we cannot find ballerina home return empty.
-        return ballerinaPath;
+       
+        return {
+            home: isBallerinaNotFound || isOldBallerinaDist ? '' : balHomeOutput,
+            isBallerinaNotFound,
+            isOldBallerinaDist
+        };
     }
 
     private overrideBallerinaHome(): boolean {

--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -33,7 +33,7 @@ import { exec, execSync } from 'child_process';
 import { LanguageClientOptions, State as LS_STATE, RevealOutputChannelOn, DidChangeConfigurationParams } from "vscode-languageclient";
 import { getServerOptions } from '../server/server';
 import { ExtendedLangClient } from './extended-language-client';
-import { info, getOutputChannel } from '../utils/index';
+import { log, getOutputChannel } from '../utils/index';
 import { AssertionError } from "assert";
 import { OVERRIDE_BALLERINA_HOME, BALLERINA_HOME, ALLOW_EXPERIMENTAL, ENABLE_DEBUG_LOG, ENABLE_TRACE_LOG } from "./preferences";
 import TelemetryReporter from "vscode-extension-telemetry";
@@ -76,48 +76,51 @@ export class BallerinaExtension {
         this.context = context;
     }
 
-    init(onBeforeInit: Function): Promise<any> {
+    init(onBeforeInit: Function): Promise<void> {
         try {
             // Register pre init handlers.
             this.registerPreInitHandlers();
 
             // Check if ballerina home is set.
             if (this.overrideBallerinaHome()) {
-                info("Ballerina home is configured in settings.");
+                log("Ballerina home is configured in settings.");
                 this.ballerinaHome = this.getConfiguredBallerinaHome();
                 // Lets check if ballerina home is valid.
                 if (!this.isValidBallerinaHome(this.ballerinaHome)) {
-                    info("Configured Ballerina home is not valid.");
+                    const msg = "Configured Ballerina home is not valid.";
+                    log(msg);
                     // Ballerina home in setting is invalid show message and quit.
                     // Prompt to correct the home. // TODO add auto detection.
                     this.showMessageInvalidBallerinaHome();
-                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_INVALID_BAL_HOME_CONFIGURED);
-                    return Promise.resolve();
+                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_INVALID_BAL_HOME_CONFIGURED, { error: msg });
+                    return Promise.reject(msg);
                 }
             } else {
-                info("Auto detecting Ballerina home.");
+                log("Auto detecting Ballerina home.");
                 // If ballerina home is not set try to auto detect ballerina home.
                 const { isBallerinaNotFound, isOldBallerinaDist, home } = this.autoDetectBallerinaHome();
                 this.ballerinaHome = home;
 
                 if (isBallerinaNotFound) {
                     this.showMessageInstallBallerina();
-                    info("Unable to auto detect Ballerina home.");
-                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_INVALID_BAL_HOME_DETECTED);
-                    return Promise.resolve();
+                    const msg = "Unable to auto detect Ballerina home.";
+                    log(msg);
+                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_INVALID_BAL_HOME_DETECTED, { error: msg });
+                    return Promise.reject(msg);
                 } else if (isOldBallerinaDist) {
                     this.showMessageInstallLatestBallerina();
-                    info("Found an incompatible Ballerina installation.");
-                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_OLD_BAL_HOME_DETECTED);
-                    return Promise.resolve();
+                    const msg = "Found an incompatible Ballerina installation.";
+                    log(msg);
+                    this.telemetryReporter.sendTelemetryEvent(TM_EVENT_ERROR_OLD_BAL_HOME_DETECTED, { error: msg });
+                    return Promise.reject(msg);
                 }
             }
-            info("Using " + this.ballerinaHome + " as the Ballerina home.");
+            log("Using " + this.ballerinaHome + " as the Ballerina home.");
             // Validate the ballerina version.
             const pluginVersion = this.extension.packageJSON.version.split('-')[0];
             return this.getBallerinaVersion(this.ballerinaHome).then(ballerinaVersion => {
                 ballerinaVersion = ballerinaVersion.split('-')[0];
-                info(`Plugin version: ${pluginVersion}\nBallerina version: ${ballerinaVersion}`);
+                log(`Plugin version: ${pluginVersion}\nBallerina version: ${ballerinaVersion}`);
                 this.checkCompatibleVersion(pluginVersion, ballerinaVersion);
                 // if Home is found load Language Server.
                 this.langClient = new ExtendedLangClient('ballerina-vscode', 'Ballerina LS Client',
@@ -132,7 +135,7 @@ export class BallerinaExtension {
                 // Following was put in to handle server startup failures.
                 const disposeDidChange = this.langClient.onDidChangeState(stateChangeEvent => {
                     if (stateChangeEvent.newState === LS_STATE.Stopped) {
-                        info("Couldn't establish language server connection.");
+                        log("Couldn't establish language server connection.");
                         this.showPluginActivationError();
                     }
                 });
@@ -144,18 +147,17 @@ export class BallerinaExtension {
                     this.context!.subscriptions.push(disposable);
                 });
             }).catch(e => {
-                const msg = 'Error when checking ballerina version.';
-                info(`${msg} Error: ${e}`);
+                const msg = `Error when checking ballerina version. ${e.message}`;
+                log(msg);
                 this.telemetryReporter.sendTelemetryException(e, { error: msg });
+                throw new Error(msg);
             });
-
         } catch (ex) {
-            const msg = "Error while activating plugin.";
-            info(msg + " Error: " + (ex.message ? ex.message : ex));
+            const msg = "Error while activating plugin. " + (ex.message ? ex.message : ex);
             // If any failure occurs while initializing show an error message
             this.showPluginActivationError();
             this.telemetryReporter.sendTelemetryException(ex, { error: msg });
-            return Promise.resolve();
+            return Promise.reject(msg);
         }
     }
 
@@ -308,7 +310,7 @@ export class BallerinaExtension {
     showMessageInstallLatestBallerina(): any {
         const download: string = 'Download';
         const openSettings: string = 'Open Settings';
-        window.showWarningMessage(INSTALL_NEW_BALLERINA, download, openSettings).then((selection) => {
+        window.showWarningMessage(ballerinaExtInstance.getVersion() + INSTALL_NEW_BALLERINA, download, openSettings).then((selection) => {
             if (openSettings === selection) {
                 commands.executeCommand('workbench.action.openGlobalSettings');
             }

--- a/tool-plugins/vscode/src/core/messages.ts
+++ b/tool-plugins/vscode/src/core/messages.ts
@@ -21,8 +21,8 @@ import { BALLERINA_HOME } from "./preferences";
  *
  */
 export const INVALID_HOME_MSG: string = "Ballerina Home is invalid, please check `" + BALLERINA_HOME + "` in settings";
-export const INSTALL_BALLERINA: string = "Unable to auto detect ballerina in your environment. Please download and install Ballerina or provide ballerina home path in settings.";
-export const INSTALL_NEW_BALLERINA: string = "This version of Ballerina VSCode extension only supports Ballerina v1.0.0-beta or later. Please download and install the latest version or point ```ballerina.home``` in settings to a latest Ballerina distribution.";
+export const INSTALL_BALLERINA: string = "Unable to auto detect ballerina in your environment. Please download and install Ballerina or configure `" + BALLERINA_HOME + "` in settings.";
+export const INSTALL_NEW_BALLERINA: string = " version of Ballerina VSCode extension only supports Ballerina v1.0.0-beta or later. Please download and install the latest version or point `" + BALLERINA_HOME + "` in settings to a latest Ballerina distribution.";
 export const DOWNLOAD_BALLERINA: string = "https://ballerina.io/downloads/";
 export const CONFIG_CHANGED: string = "Ballerina plugin configuration changed. Please restart vscode for changes to take effect.";
 export const OLD_BALLERINA_VERSION: string ="Your Ballerina version does not match the Ballerina vscode plugin version. Some features may not work properly. Please download the latest Ballerina distribution.";

--- a/tool-plugins/vscode/src/core/messages.ts
+++ b/tool-plugins/vscode/src/core/messages.ts
@@ -22,6 +22,7 @@ import { BALLERINA_HOME } from "./preferences";
  */
 export const INVALID_HOME_MSG: string = "Ballerina Home is invalid, please check `" + BALLERINA_HOME + "` in settings";
 export const INSTALL_BALLERINA: string = "Unable to auto detect ballerina in your environment. Please download and install Ballerina or provide ballerina home path in settings.";
+export const INSTALL_NEW_BALLERINA: string = "This version of Ballerina VSCode extension only supports Ballerina v1.0.0-beta or later. Please download and install the latest version or point ```ballerina.home``` in settings to a latest Ballerina distribution.";
 export const DOWNLOAD_BALLERINA: string = "https://ballerina.io/downloads/";
 export const CONFIG_CHANGED: string = "Ballerina plugin configuration changed. Please restart vscode for changes to take effect.";
 export const OLD_BALLERINA_VERSION: string ="Your Ballerina version does not match the Ballerina vscode plugin version. Some features may not work properly. Please download the latest Ballerina distribution.";

--- a/tool-plugins/vscode/src/debugger/config-provider.ts
+++ b/tool-plugins/vscode/src/debugger/config-provider.ts
@@ -13,7 +13,7 @@ import { ExtendedLangClient } from '../core/extended-language-client';
 import { BALLERINA_HOME } from '../core/preferences';
 import { isUnix } from "./osUtils";
 import { TM_EVENT_START_DEBUG_SESSION } from '../telemetry';
-import { info, log as debugLog} from "../utils";
+import { log, debug as debugLog} from "../utils";
 
 const debugConfigProvider: DebugConfigurationProvider = {
     resolveDebugConfiguration(folder: WorkspaceFolder, config: DebugConfiguration)
@@ -104,14 +104,14 @@ class BallerinaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFa
             port.toString()
         ]);
 
-        info("Starting debug adapter: " + startScriptPath);
+        log("Starting debug adapter: " + startScriptPath);
         
         return new Promise((resolve)=>{
             serverProcess.stdout.on('data', (data) => {
                 if (data.toString().includes('Debug server started')) {
                     resolve();
                 }
-                info(`${data}`);
+                log(`${data}`);
             });
     
             serverProcess.stderr.on('data', (data) => {

--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -31,6 +31,7 @@ import { activate as activateProjectFeatures } from './project';
 import { activate as activateOverview } from './overview';
 import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities } from 'vscode-languageclient';
 import { ExtendedLangClient } from './core/extended-language-client';
+import { log } from './utils';
 
 // TODO initializations should be contributions from each component
 function onBeforeInit(langClient: ExtendedLangClient) {
@@ -80,5 +81,7 @@ export function activate(context: ExtensionContext): Promise<any> {
         activateOverview(ballerinaExtInstance);
         // Enable Ballerina Project Overview
         activateTreeView(ballerinaExtInstance);
+    }).catch((e) => {
+        log("Failed to activate Ballerina extension. " + (e.message ? e.message : e));
     });
 }

--- a/tool-plugins/vscode/src/server/server.ts
+++ b/tool-plugins/vscode/src/server/server.ts
@@ -18,11 +18,11 @@
  *
  */
 import * as path from 'path';
-import { log } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { ServerOptions, ExecutableOptions } from 'vscode-languageclient';
 
 export function getServerOptions(ballerinaHome: string, experimental: boolean, debugLogsEnabled: boolean, traceLogsEnabled: boolean) : ServerOptions {
-    log(`Using Ballerina installation at ${ballerinaHome} for Language server.`);
+    debug(`Using Ballerina installation at ${ballerinaHome} for Language server.`);
 
     let cmd;
     const cwd = path.join(ballerinaHome, 'lib', 'tools', 'lang-server', 'launcher');
@@ -40,7 +40,7 @@ export function getServerOptions(ballerinaHome: string, experimental: boolean, d
         opt.env.BALLERINA_HOME = ballerinaHome;
     }
     if (process.env.LSDEBUG === "true") {
-        log('Language Server is starting in debug mode.');
+        debug('Language Server is starting in debug mode.');
         args.push('--debug');
     }
     if (debugLogsEnabled || traceLogsEnabled) {
@@ -53,7 +53,7 @@ export function getServerOptions(ballerinaHome: string, experimental: boolean, d
             str.push('trace');
             opt.env.TRACE_LOG = traceLogsEnabled;
         }
-        log('Language Server ' + str.join(', ') +' logs enabled.');
+        debug('Language Server ' + str.join(', ') +' logs enabled.');
     }
     if (process.env.LS_CUSTOM_CLASSPATH) {
         args.push('--classpath', process.env.LS_CUSTOM_CLASSPATH);

--- a/tool-plugins/vscode/src/telemetry/exceptions.ts
+++ b/tool-plugins/vscode/src/telemetry/exceptions.ts
@@ -1,6 +1,7 @@
 // error events
 export const TM_EVENT_ERROR_INVALID_BAL_HOME_CONFIGURED = "invalid.ballerina.home.configured";
 export const TM_EVENT_ERROR_INVALID_BAL_HOME_DETECTED = "invalid.ballerina.home.detected";
+export const TM_EVENT_ERROR_OLD_BAL_HOME_DETECTED = "old.ballerina.home.detected";
 export const TM_EVENT_ERROR_INCOMPATIBLE_PLUGIN_VERSION = "incompatible.plugin.version";
 
 export const TM_EVENT_OLD_BAL_HOME = "old.ballerina.home";

--- a/tool-plugins/vscode/src/utils/logger.ts
+++ b/tool-plugins/vscode/src/utils/logger.ts
@@ -30,7 +30,7 @@ function withNewLine(value: string) {
 }
 
 // This function will log the value to the Ballerina output channel only if debug log is enabled
-export function log(value: string) : void {
+export function debug(value: string) : void {
     const output = withNewLine(value);
     console.log(output);
     if (logLevelDebug) {
@@ -39,7 +39,7 @@ export function log(value: string) : void {
 }
 
 // This function will log the value to the Ballerina output channel
-export function info(value: string) : void {
+export function log(value: string) : void {
     const output = withNewLine(value);
     console.log(output);
     outputChannel.append(output);

--- a/tool-plugins/vscode/test/core/ballerina-extention.test.ts
+++ b/tool-plugins/vscode/test/core/ballerina-extention.test.ts
@@ -41,9 +41,9 @@ suite("Ballerina Extension Core Tests", function () {
 
     test("Test autoDetectBallerinaHome", function () {
         // Following should not throw an error all times.
-        const path = ballerinaExtInstance.autoDetectBallerinaHome();
-        if (path) {
-            assert.equal(ballerinaExtInstance.isValidBallerinaHome(path), true);
+        const { home } = ballerinaExtInstance.autoDetectBallerinaHome();
+        if (home) {
+            assert.equal(ballerinaExtInstance.isValidBallerinaHome(home), true);
         }
     });
 


### PR DESCRIPTION
## Purpose
This adds a new subcommand called ```ballerina home``` to ballerina cli tool. It will print currently configured Ballerina Distribution Path.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
