### PR TITLE
Update LDAP connection initialization API

### DIFF
--- a/stdlib/ldap/src/main/ballerina/src/ldap/inbound_ldap_auth_provider.bal
+++ b/stdlib/ldap/src/main/ballerina/src/ldap/inbound_ldap_auth_provider.bal
@@ -38,7 +38,12 @@ public type InboundLdapAuthProvider object {
     public function __init(LdapConnectionConfig ldapConnectionConfig, string instanceId) {
         self.instanceId = instanceId;
         self.ldapConnectionConfig = ldapConnectionConfig;
-        self.ldapConnection = initLdapConnectionContext(self.ldapConnectionConfig, instanceId);
+        var ldapConnection = initLdapConnectionContext(self.ldapConnectionConfig, instanceId);
+        if (ldapConnection is LdapConnection) {
+            self.ldapConnection = ldapConnection;
+        } else {
+            panic ldapConnection;
+        }
     }
 
     # Authenticate with username and password.
@@ -153,6 +158,6 @@ public function doAuthenticate(LdapConnection ldapConnection, string username, s
 #
 # + ldapConnectionConfig - `LdapConnectionConfig` instance
 # + instanceId - Unique id generated to identify an endpoint
-# + return - `LdapConnection` instance
+# + return - `LdapConnection` instance, or `Error` if error occurred
 public function initLdapConnectionContext(LdapConnectionConfig ldapConnectionConfig, string instanceId)
-                                          returns LdapConnection = external;
+                                          returns LdapConnection|Error = external;

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/InitLdapConnectionContext.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/InitLdapConnectionContext.java
@@ -54,8 +54,8 @@ import javax.net.ssl.SSLContext;
         functionName = "initLdapConnectionContext", isPublic = true)
 public class InitLdapConnectionContext {
 
-    public static MapValue<String, Object> initLdapConnectionContext(Strand strand, MapValue<?, ?> authProviderConfig,
-                                                                     String instanceId) {
+    public static Object initLdapConnectionContext(Strand strand, MapValue<?, ?> authProviderConfig,
+                                                   String instanceId) {
         CommonLdapConfiguration commonLdapConfiguration = new CommonLdapConfiguration();
 
         commonLdapConfiguration.setDomainName(authProviderConfig.getStringValue(LdapConstants.DOMAIN_NAME));
@@ -116,7 +116,7 @@ public class InitLdapConnectionContext {
             return ldapConnectionRecord;
         } catch (KeyStoreException | KeyManagementException | NoSuchAlgorithmException
                 | CertificateException | NamingException | IOException e) {
-            throw LdapUtils.createError(e.getMessage());
+            return LdapUtils.createError(e.getMessage());
         } finally {
             if (sslConfig != null) {
                 LdapUtils.removeServiceName();


### PR DESCRIPTION
## Purpose
This PR updates the LDAP connection initialization API with a return type of `ldap:Error`. But the issue https://github.com/ballerina-platform/ballerina-lang/issues/17774 is applicable for here also.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/17353

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
