### PR TITLE
 Add functionality to specify the depth level in system:readDir()

### DIFF
--- a/stdlib/system/src/main/ballerina/src/system/system.bal
+++ b/stdlib/system/src/main/ballerina/src/system/system.bal
@@ -92,8 +92,9 @@ public function getFileInfo(@untainted string path) returns FileInfo|Error = ext
 # Reads the directory and returns a list of files and directories # inside the specified directory
 #
 # + path - String value of directory path.
+# + maxDepth - The maximum number of directory levels to visit. -1 to indicate that all levels should be visited.
 # + return - Returns FileInfo array or an `Error` if there is an error while changing the mode.
-public function readDir(@untainted string path) returns FileInfo[]|Error = external;
+public function readDir(@untainted string path, int maxDepth = -1) returns FileInfo[]|Error = external;
 
 # Copy file/directory in old path to new path.
 # If new path already exists, this replaces the file.

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/Copy.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/Copy.java
@@ -60,7 +60,7 @@ public class Copy {
 
         if (Files.notExists(srcPath)) {
             return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR,
-                    "File doesn't exist in path " + sourcePath);
+                    "File not found: " + sourcePath);
         }
         try {
             Files.walkFileTree(srcPath, new RecursiveFileCopyVisitor(srcPath, destPath, replaceExisting));

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/GetFileInfo.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/GetFileInfo.java
@@ -48,7 +48,7 @@ public class GetFileInfo {
         File inputFile = Paths.get(path).toAbsolutePath().toFile();
         if (!inputFile.exists()) {
             return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR,
-                    "File doesn't exist in path " + path);
+                    "File not found: " + path);
         }
         try {
             return SystemUtils.getFileInfo(inputFile);

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/ReadDir.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/ReadDir.java
@@ -50,7 +50,7 @@ public class ReadDir {
 
     private static BType fileInfoType;
 
-    public static Object readDir(Strand strand, String path) {
+    public static Object readDir(Strand strand, String path, long maxDepth) {
         File inputFile = Paths.get(path).toAbsolutePath().toFile();
 
         if (!inputFile.exists()) {
@@ -62,8 +62,22 @@ public class ReadDir {
             return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR,
                     "File in path " + path + " is not a directory");
         }
+
+        if (maxDepth == SystemConstants.DEFAULT_MAX_DEPTH) {
+            // If the user has not given a value, read all levels
+            return readFileTree(inputFile, Integer.MAX_VALUE);
+        } else if (maxDepth > SystemConstants.DEFAULT_MAX_DEPTH && maxDepth < Integer.MAX_VALUE) {
+            // If the user has given a valid depth level, read up-to that level
+            return readFileTree(inputFile, Math.toIntExact(maxDepth));
+        } else {
+            return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR,
+                    "Invalid maxDepth value " + maxDepth);
+        }
+    }
+
+    private static Object readFileTree(File inputFile, int maxDepth) {
         ObjectValue[] results;
-        try (Stream<Path> walk = Files.walk(inputFile.toPath())) {
+        try (Stream<Path> walk = Files.walk(inputFile.toPath(), maxDepth)) {
             results = walk.map(x -> {
                 try {
                     ObjectValue objectValue = SystemUtils.getFileInfo(x.toFile());

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/ReadDir.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/ReadDir.java
@@ -55,7 +55,7 @@ public class ReadDir {
 
         if (!inputFile.exists()) {
             return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR, "" +
-                    "File doesn't exist in path " + path);
+                    "File not found: " + path);
         }
 
         if (!inputFile.isDirectory()) {

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/Remove.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/Remove.java
@@ -60,7 +60,7 @@ public class Remove {
 
             if (!removeFile.exists()) {
                 return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR,
-                        "File doesn't exist in path " + removeFile.getCanonicalPath());
+                        "File not found: " + removeFile.getCanonicalPath());
             }
 
             if (recursive) {

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/Rename.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/nativeimpl/Rename.java
@@ -48,7 +48,7 @@ public class Rename {
 
         if (Files.notExists(oldFilePath)) {
             return SystemUtils.getBallerinaError(SystemConstants.INVALID_OPERATION_ERROR,
-                    "File doesn't exist in path " + oldFilePath.toAbsolutePath());
+                    "File not found: " + oldFilePath.toAbsolutePath());
         }
 
         try {

--- a/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/utils/SystemConstants.java
+++ b/stdlib/system/src/main/java/org/ballerinalang/stdlib/system/utils/SystemConstants.java
@@ -57,6 +57,9 @@ public class SystemConstants {
     static final String ERROR_DETAILS = "Detail";
     static final String ERROR_MESSAGE = "message";
 
+    // System constant fields
+    public static final int DEFAULT_MAX_DEPTH = -1;
+
     private SystemConstants() {
     }
 }

--- a/stdlib/system/src/test/java/org/ballerinalang/stdlib/system/FileSystemTest.java
+++ b/stdlib/system/src/test/java/org/ballerinalang/stdlib/system/FileSystemTest.java
@@ -198,6 +198,20 @@ public class FileSystemTest {
         assertTrue(returns[0].getType() instanceof BObjectType);
     }
 
+    @Test(description = "Test for retrieving files inside directory specifying the depth level - 0")
+    public void testReadDirWithMaxDepth() {
+        BValue[] args = {new BString(srcDirPath.toString()), new BInteger(0)};
+        BValue[] returns = BRunUtil.invoke(compileResult, "testReadDirWithMaxDepth", args);
+        assertTrue(returns[0].getType() instanceof BObjectType);
+    }
+
+    @Test(description = "Test for retrieving files inside directory specifying the depth level - 1")
+    public void testReadDirWithMaxDepth1() {
+        BValue[] args = {new BString(srcDirPath.toString()), new BInteger(1)};
+        BValue[] returns = BRunUtil.invoke(compileResult, "testReadDirWithMaxDepth", args);
+        assertTrue(returns[0].getType() instanceof BObjectType);
+    }
+
     @Test(description = "Test for reading file info from non existence directory")
     public void testReadNonExistDirectory() throws IOException {
         Path filepath = tempDirPath.resolve("dest-dir");

--- a/stdlib/system/src/test/java/org/ballerinalang/stdlib/system/FileSystemTest.java
+++ b/stdlib/system/src/test/java/org/ballerinalang/stdlib/system/FileSystemTest.java
@@ -167,7 +167,7 @@ public class FileSystemTest {
         assertTrue(returns[0] instanceof BError);
         BError error = (BError) returns[0];
         assertEquals(error.getReason(), SystemConstants.INVALID_OPERATION_ERROR);
-        assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("File doesn't exist in path "));
+        assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("File not found: "));
     }
 
     @Test(description = "Test for retrieving file info from system")
@@ -188,7 +188,7 @@ public class FileSystemTest {
         assertTrue(returns[0] instanceof BError);
         BError error = (BError) returns[0];
         assertEquals(error.getReason(), SystemConstants.INVALID_OPERATION_ERROR);
-        assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("File doesn't exist in path "));
+        assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("File not found: "));
     }
 
     @Test(description = "Test for retrieving files inside directory")
@@ -221,7 +221,7 @@ public class FileSystemTest {
         assertTrue(returns[0] instanceof BError);
         BError error = (BError) returns[0];
         assertEquals(error.getReason(), SystemConstants.INVALID_OPERATION_ERROR);
-        assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("File doesn't exist in path"));
+        assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("File not found: "));
     }
 
     @Test(description = "Test for reading file info from non existence directory")
@@ -359,7 +359,7 @@ public class FileSystemTest {
             BError error = (BError) returns[0];
             assertEquals(error.getReason(), SystemConstants.INVALID_OPERATION_ERROR);
             assertTrue(((BMap) error.getDetails()).get("message").stringValue()
-                    .contains("File doesn't exist in path "));
+                    .contains("File not found: "));
         } finally {
             Files.deleteIfExists(tempDestPath);
         }

--- a/stdlib/system/src/test/resources/test-src/file-system-test.bal
+++ b/stdlib/system/src/test/resources/test-src/file-system-test.bal
@@ -32,6 +32,10 @@ function testReadDir(string path) returns system:FileInfo[]|error {
     return system:readDir(path);
 }
 
+function testReadDirWithMaxDepth(string path, int maxDepth) returns system:FileInfo[]|error {
+    return system:readDir(path, maxDepth);
+}
+
 function testGetFileInfo(string path) returns system:FileInfo|error {
     return system:getFileInfo(path);
 }


### PR DESCRIPTION
## Purpose
The `maxDepth` parameter is the maximum number of levels of directories to visit. A value of 0 means that only the starting file is visited. The default value, -1 is used to indicate that all levels should be visited. 

Fixes #17786
Fixes #17781

## Samples

Read directories with a depth level of 1:

```ballerina
    string[] fileNames = [];
    var files = system:readDir(path, 1);
    if (files is system:FileInfo[]) {
        foreach system:FileInfo file in files {
            fileNames.push(file.getName());
        }
        io:println(fileNames);
    } else {
        io:println(files);
    }
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
