### PR TITLE
[IntelliJ Plugin] Add ballerina module creation support

### DIFF
--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/actions/BallerinaCreateFileAction.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/actions/BallerinaCreateFileAction.java
@@ -52,8 +52,8 @@ public class BallerinaCreateFileAction extends CreateFileFromTemplateAction impl
                                @NotNull CreateFileFromTemplateDialog.Builder builder) {
 
         if (directory.getName().equals(BALLERINA_SRC_DIR_NAME)) {
-            Messages.showWarningDialog("Ballerina project files can only exist inside ballerina modules under" +
-                    " src directory.", "Warning");
+            Messages.showWarningDialog("In a project, ballerina source files can only reside within ballerina " +
+                    "modules.", "Warning");
         }
         builder.setTitle(NEW_BALLERINA_FILE).addKind(BALLERINA_MAIN, BallerinaIcons.ICON, BALLERINA_MAIN)
                 .addKind(BALLERINA_SERVICE, BallerinaIcons.ICON, BALLERINA_SERVICE)
@@ -68,7 +68,7 @@ public class BallerinaCreateFileAction extends CreateFileFromTemplateAction impl
 
     @NotNull
     @Override
-    protected String getActionName(PsiDirectory directory, String newName, String templateName) {
+    protected String getActionName(PsiDirectory directory, @NotNull String newName, String templateName) {
         return NEW_BALLERINA_FILE;
     }
 

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/actions/BallerinaCreateFileAction.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/actions/BallerinaCreateFileAction.java
@@ -20,6 +20,7 @@ import com.intellij.ide.actions.CreateFileFromTemplateAction;
 import com.intellij.ide.actions.CreateFileFromTemplateDialog;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
 import icons.BallerinaIcons;
@@ -28,8 +29,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
+import static io.ballerina.plugins.idea.BallerinaConstants.BALLERINA_SRC_DIR_NAME;
+
 /**
- * Handles creating new Ballerina file.
+ * Handles creating new Ballerina files.
  */
 public class BallerinaCreateFileAction extends CreateFileFromTemplateAction implements DumbAware {
 
@@ -37,7 +40,7 @@ public class BallerinaCreateFileAction extends CreateFileFromTemplateAction impl
     private static final String BALLERINA_MAIN = "Ballerina Main";
     private static final String BALLERINA_SERVICE = "Ballerina Service";
 
-    private static final String NEW_BALLERINA_FILE = "New Ballerina File";
+    private static final String NEW_BALLERINA_FILE = "Ballerina File";
     private static final String DEFAULT_BALLERINA_TEMPLATE_PROPERTY = "Empty file";
 
     public BallerinaCreateFileAction() {
@@ -47,6 +50,11 @@ public class BallerinaCreateFileAction extends CreateFileFromTemplateAction impl
     @Override
     protected void buildDialog(Project project, PsiDirectory directory,
                                @NotNull CreateFileFromTemplateDialog.Builder builder) {
+
+        if (directory.getName().equals(BALLERINA_SRC_DIR_NAME)) {
+            Messages.showWarningDialog("Ballerina project files can only exist inside ballerina modules under" +
+                    " src directory.", "Warning");
+        }
         builder.setTitle(NEW_BALLERINA_FILE).addKind(BALLERINA_MAIN, BallerinaIcons.ICON, BALLERINA_MAIN)
                 .addKind(BALLERINA_SERVICE, BallerinaIcons.ICON, BALLERINA_SERVICE)
                 .addKind(BALLERINA_EMPTY_FILE, BallerinaIcons.ICON, BALLERINA_EMPTY_FILE);

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/actions/BallerinaCreateModuleAction.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/actions/BallerinaCreateModuleAction.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.ballerina.plugins.idea.actions;
+
+import com.intellij.ide.IdeBundle;
+import com.intellij.ide.IdeView;
+import com.intellij.ide.actions.CreateDirectoryOrPackageAction;
+import com.intellij.ide.actions.CreateDirectoryOrPackageHandler;
+import com.intellij.ide.util.DirectoryChooserUtil;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiElement;
+import icons.BallerinaIcons;
+import org.jetbrains.annotations.NotNull;
+
+import static io.ballerina.plugins.idea.BallerinaConstants.BALLERINA_CONFIG_FILE_NAME;
+import static io.ballerina.plugins.idea.BallerinaConstants.BALLERINA_SRC_DIR_NAME;
+
+/**
+ * Handles creating new Ballerina modules.
+ */
+public class BallerinaCreateModuleAction extends CreateDirectoryOrPackageAction implements DumbAware {
+
+    public BallerinaCreateModuleAction() {
+        super();
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        final IdeView view = event.getData(LangDataKeys.IDE_VIEW);
+        final Project project = event.getData(CommonDataKeys.PROJECT);
+        if (view == null || project == null) {
+            return;
+        }
+
+        PsiDirectory dir = DirectoryChooserUtil.getOrChooseDirectory(view);
+        if (dir == null) {
+            return;
+        }
+
+        // This action is visible only for ballerina project root directory and src directory.
+        if ((dir.findFile(BALLERINA_CONFIG_FILE_NAME) == null || dir.findSubdirectory(BALLERINA_SRC_DIR_NAME) == null)
+                && !dir.getName().equals(BALLERINA_SRC_DIR_NAME)) {
+            return;
+        }
+
+        // If user tries to create new module in the project root level.
+        if (dir.findFile(BALLERINA_CONFIG_FILE_NAME) != null && dir.findSubdirectory(BALLERINA_SRC_DIR_NAME) != null) {
+            dir = dir.findSubdirectory(BALLERINA_SRC_DIR_NAME);
+        }
+
+        final CreateDirectoryOrPackageHandler validator;
+        final String message, title;
+        validator = new CreateDirectoryOrPackageHandler(project, dir, true, "\\/");
+        message = IdeBundle.message("prompt.enter.new.directory.name");
+        title = IdeBundle.message("title.new.directory");
+        String initialText = "";
+        Messages.showInputDialog(project, message, title, null, initialText, validator,
+                TextRange.from(initialText.length(), 0));
+
+        final PsiElement result = validator.getCreatedElement();
+        if (result != null) {
+            view.selectElement(result);
+        }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        Presentation presentation = event.getPresentation();
+
+        Project project = event.getData(CommonDataKeys.PROJECT);
+        if (project == null) {
+            presentation.setEnabledAndVisible(false);
+            return;
+        }
+
+        IdeView view = event.getData(LangDataKeys.IDE_VIEW);
+        if (view == null) {
+            presentation.setEnabledAndVisible(false);
+            return;
+        }
+
+        final PsiDirectory dir = view.getOrChooseDirectory();
+        if (dir == null) {
+            presentation.setEnabledAndVisible(false);
+            return;
+        }
+
+        // This action is visible only for ballerina project root directory and src directory.
+        if ((dir.findFile(BALLERINA_CONFIG_FILE_NAME) == null || dir.findSubdirectory(BALLERINA_SRC_DIR_NAME) == null)
+                && !dir.getName().equals(BALLERINA_SRC_DIR_NAME)) {
+            presentation.setEnabledAndVisible(false);
+            return;
+        }
+
+        presentation.setEnabledAndVisible(true);
+        presentation.setText("Ballerina Module");
+        presentation.setIcon(BallerinaIcons.ICON);
+    }
+}
+

--- a/tool-plugins/intellij/src/main/resources/META-INF/plugin.xml
+++ b/tool-plugins/intellij/src/main/resources/META-INF/plugin.xml
@@ -220,9 +220,12 @@
         </group>
         <action id="NewBallerinaFile" class="io.ballerina.plugins.idea.actions.BallerinaCreateFileAction"
                 text="Ballerina File" description="Create new Ballerina file">
-            <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+            <add-to-group group-id="NewGroup" anchor="first"/>
         </action>
-
+        <action id="NewBallerinaModule" class="io.ballerina.plugins.idea.actions.BallerinaCreateModuleAction"
+                text="Ballerina Module" description="Create new Ballerina module">
+            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewBallerinaFile"/>
+        </action>
         <action class="org.wso2.lsp4intellij.actions.LSPReformatAction" id="ReformatCode"
                 use-shortcut-of="ReformatCode"
                 overrides="true" text="Reformat Code"/>

--- a/tool-plugins/intellij/src/main/resources/META-INF/plugin.xml
+++ b/tool-plugins/intellij/src/main/resources/META-INF/plugin.xml
@@ -218,7 +218,7 @@
                     icon="BallerinaIcons.Layout.PREVIEW_ONLY">
             </action>
         </group>
-        <action id="Ballerina.NewBallerinaFile" class="io.ballerina.plugins.idea.actions.BallerinaCreateFileAction"
+        <action id="NewBallerinaFile" class="io.ballerina.plugins.idea.actions.BallerinaCreateFileAction"
                 text="Ballerina File" description="Create new Ballerina file">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
         </action>


### PR DESCRIPTION
## Purpose
This PR adds menu item to create ballerina modules in IntelliJ IDEA. This menu item only appears for the ballerina project root directory and `src` directory. 

In addition, now the plugin also gives warning when user is trying to create src level bal files.

Fixes #17751,  #17816.

## Samples
Please refer the following usages.
![Peek 2019-08-19 13-24](https://user-images.githubusercontent.com/29032600/63248842-d31f6600-c285-11e9-8660-17d14d6d9fb9.gif)

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
