### PR TITLE
Fix faulty unique symbol check

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -168,7 +168,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         // if a symbol is found, then check whether it is unique
-        return !isSameSymbol(pos, symbol, foundSym);
+        return !isDuplicateSymbol(pos, symbol, foundSym);
     }
 
     public boolean checkForUniqueSymbol(SymbolEnv env, BSymbol symbol, int expSymTag) {
@@ -176,7 +176,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         if (foundSym == symTable.notFoundSymbol) {
             return true;
         }
-        return !isSameSymbol(symbol, foundSym);
+        return !isDuplicateSymbol(symbol, foundSym);
     }
 
     /**
@@ -200,7 +200,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         //if a symbol is found, then check whether it is unique
-        return !isSameSymbol(pos, symbol, foundSym);
+        return !isDuplicateSymbol(pos, symbol, foundSym);
     }
 
     /**
@@ -212,7 +212,7 @@ public class SymbolResolver extends BLangNodeVisitor {
      * @param foundSym symbol that is found from the scope.
      * @return true if the symbol is unique, false otherwise.
      */
-    private boolean isSameSymbol(DiagnosticPos pos, BSymbol symbol, BSymbol foundSym) {
+    private boolean isDuplicateSymbol(DiagnosticPos pos, BSymbol symbol, BSymbol foundSym) {
         // It is allowed to have a error constructor symbol with the same name as a type def.
         if (symbol.tag == SymTag.CONSTRUCTOR && foundSym.tag == SymTag.ERROR) {
             return true;
@@ -221,20 +221,20 @@ public class SymbolResolver extends BLangNodeVisitor {
         // Type names should be unique and cannot be shadowed
         if ((foundSym.tag & SymTag.TYPE) == SymTag.TYPE) {
             dlog.error(pos, DiagnosticCode.REDECLARED_SYMBOL, symbol.name);
-            return false;
+            return true;
         }
 
         if (isSymbolDefinedInRootPkgLvl(foundSym)) {
             dlog.error(pos, DiagnosticCode.REDECLARED_BUILTIN_SYMBOL, symbol.name);
-            return false;
+            return true;
         }
 
         if (hasSameOwner(symbol, foundSym)) {
             dlog.error(pos, DiagnosticCode.REDECLARED_SYMBOL, symbol.name);
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /**
@@ -245,7 +245,7 @@ public class SymbolResolver extends BLangNodeVisitor {
      * @param foundSym symbol that is found from the scope.
      * @return true if the symbol is unique, false otherwise.
      */
-    private boolean isSameSymbol(BSymbol symbol, BSymbol foundSym) {
+    private boolean isDuplicateSymbol(BSymbol symbol, BSymbol foundSym) {
         // It is allowed to have a error constructor symbol with the same name as a type def.
         if (symbol.tag == SymTag.CONSTRUCTOR && foundSym.tag == SymTag.ERROR) {
             return true;
@@ -253,11 +253,11 @@ public class SymbolResolver extends BLangNodeVisitor {
 
         // Type names should be unique and cannot be shadowed
         if ((foundSym.tag & SymTag.TYPE) == SymTag.TYPE) {
-            return false;
+            return true;
         }
 
         if (isSymbolDefinedInRootPkgLvl(foundSym)) {
-            return false;
+            return true;
         }
 
         return hasSameOwner(symbol, foundSym);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -168,7 +168,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         // if a symbol is found, then check whether it is unique
-        return isSameSymbol(pos, symbol, foundSym);
+        return !isSameSymbol(pos, symbol, foundSym);
     }
 
     public boolean checkForUniqueSymbol(SymbolEnv env, BSymbol symbol, int expSymTag) {
@@ -176,7 +176,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         if (foundSym == symTable.notFoundSymbol) {
             return true;
         }
-        return isSameSymbol(symbol, foundSym);
+        return !isSameSymbol(symbol, foundSym);
     }
 
     /**
@@ -200,7 +200,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         //if a symbol is found, then check whether it is unique
-        return isSameSymbol(pos, symbol, foundSym);
+        return !isSameSymbol(pos, symbol, foundSym);
     }
 
     /**
@@ -223,7 +223,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return false;
         }
 
-        if (!isSymbolOwnersSame(symbol, foundSym)) {
+        if (isSymbolOwnersSame(symbol, foundSym)) {
             dlog.error(pos, DiagnosticCode.REDECLARED_SYMBOL, symbol.name);
             return false;
         }
@@ -255,11 +255,17 @@ public class SymbolResolver extends BLangNodeVisitor {
 
     private boolean isSymbolOwnersSame(BSymbol symbol, BSymbol foundSym) {
         // check whether the given symbol owner is same as found symbol's owner
-        if ((foundSym.tag & SymTag.TYPE) == SymTag.TYPE || foundSym.owner == symbol.owner) {
+        if (foundSym.owner == symbol.owner) {
+            return true;
+        }
+
+        if ((foundSym.tag & SymTag.TYPE) == SymTag.TYPE) {
             return false;
         }
 
-        return !Symbols.isFlagOn(Flags.LAMBDA, symbol.flags) ||
+        // If the symbol being defined is inside a lambda and the existing symbol is defined inside a function, both
+        // symbols are in the same block scope.
+        return Symbols.isFlagOn(symbol.owner.flags, Flags.LAMBDA) &&
                 ((foundSym.owner.tag & SymTag.INVOKABLE) != SymTag.INVOKABLE);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -168,7 +168,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         // if a symbol is found, then check whether it is unique
-        return !isDuplicateSymbol(pos, symbol, foundSym);
+        return isDistinctSymbol(pos, symbol, foundSym);
     }
 
     public boolean checkForUniqueSymbol(SymbolEnv env, BSymbol symbol, int expSymTag) {
@@ -176,7 +176,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         if (foundSym == symTable.notFoundSymbol) {
             return true;
         }
-        return !isDuplicateSymbol(symbol, foundSym);
+        return isDistinctSymbol(symbol, foundSym);
     }
 
     /**
@@ -200,7 +200,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         //if a symbol is found, then check whether it is unique
-        return !isDuplicateSymbol(pos, symbol, foundSym);
+        return isDistinctSymbol(pos, symbol, foundSym);
     }
 
     /**
@@ -212,29 +212,29 @@ public class SymbolResolver extends BLangNodeVisitor {
      * @param foundSym symbol that is found from the scope.
      * @return true if the symbol is unique, false otherwise.
      */
-    private boolean isDuplicateSymbol(DiagnosticPos pos, BSymbol symbol, BSymbol foundSym) {
+    private boolean isDistinctSymbol(DiagnosticPos pos, BSymbol symbol, BSymbol foundSym) {
         // It is allowed to have a error constructor symbol with the same name as a type def.
         if (symbol.tag == SymTag.CONSTRUCTOR && foundSym.tag == SymTag.ERROR) {
-            return true;
+            return false;
         }
 
         // Type names should be unique and cannot be shadowed
         if ((foundSym.tag & SymTag.TYPE) == SymTag.TYPE) {
             dlog.error(pos, DiagnosticCode.REDECLARED_SYMBOL, symbol.name);
-            return true;
+            return false;
         }
 
         if (isSymbolDefinedInRootPkgLvl(foundSym)) {
             dlog.error(pos, DiagnosticCode.REDECLARED_BUILTIN_SYMBOL, symbol.name);
-            return true;
+            return false;
         }
 
         if (hasSameOwner(symbol, foundSym)) {
             dlog.error(pos, DiagnosticCode.REDECLARED_SYMBOL, symbol.name);
-            return true;
+            return false;
         }
 
-        return false;
+        return true;
     }
 
     /**
@@ -245,22 +245,22 @@ public class SymbolResolver extends BLangNodeVisitor {
      * @param foundSym symbol that is found from the scope.
      * @return true if the symbol is unique, false otherwise.
      */
-    private boolean isDuplicateSymbol(BSymbol symbol, BSymbol foundSym) {
+    private boolean isDistinctSymbol(BSymbol symbol, BSymbol foundSym) {
         // It is allowed to have a error constructor symbol with the same name as a type def.
         if (symbol.tag == SymTag.CONSTRUCTOR && foundSym.tag == SymTag.ERROR) {
-            return true;
+            return false;
         }
 
         // Type names should be unique and cannot be shadowed
         if ((foundSym.tag & SymTag.TYPE) == SymTag.TYPE) {
-            return true;
+            return false;
         }
 
         if (isSymbolDefinedInRootPkgLvl(foundSym)) {
-            return true;
+            return false;
         }
 
-        return hasSameOwner(symbol, foundSym);
+        return !hasSameOwner(symbol, foundSym);
     }
 
 


### PR DESCRIPTION
## Purpose
> Fixes an issue in the check for unique symbols. Not adding any new tests since the tests for this are already in place. The faulty logic still worked since in the current language semantics it's not possible to write code which exposes this fault.

Fixes #17992

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
