### PR TITLE
Fix following bugs in diagram

### DIFF
--- a/composer/packages/diagram/src/diagram/diagram.tsx
+++ b/composer/packages/diagram/src/diagram/diagram.tsx
@@ -104,6 +104,8 @@ export class Diagram extends React.Component<DiagramProps, DiagramState> {
         // Calculate dimention of AST Nodes.
         ASTUtil.traversNode(ast, sizingVisitor);
         // Calculate positions of the AST Nodes.
+        (ast.viewState as ViewState).bBox.x = 0;
+        (ast.viewState as ViewState).bBox.y = 0;
         ASTUtil.traversNode(ast, positioningVisitor);
         // Get React components for AST Nodes.
         children.push(DiagramUtils.getComponents(ast));

--- a/composer/packages/diagram/src/diagram/diagram.tsx
+++ b/composer/packages/diagram/src/diagram/diagram.tsx
@@ -6,9 +6,6 @@ import { DefaultConfig } from "../config/default";
 import { CompilationUnitViewState, ViewState } from "../view-model/index";
 import { SvgCanvas } from "../views";
 import { visitor as hiddenBlockVisitor } from "../visitors/hidden-block-visitor";
-import { visitor as initVisitor } from "../visitors/init-visitor";
-import { setMaxInvocationDepth, setProjectAST, visitor as invocationVisitor
-    } from "../visitors/invocation-expanding-visitor";
 import { visitor as interactionModeVisitor } from "../visitors/mode-visitors/interaction-mode-visitor";
 import { visitor as statementModeVisitor } from "../visitors/mode-visitors/statement-mode-visitor";
 import { visitor as positioningVisitor } from "../visitors/positioning-visitor";
@@ -97,11 +94,6 @@ export class Diagram extends React.Component<DiagramProps, DiagramState> {
         cuViewState.container.w = diagramWidth;
         cuViewState.container.h = diagramHeight;
 
-        // Initialize AST node view state
-        ASTUtil.traversNode(ast, initVisitor);
-        setProjectAST(projectAst);
-        setMaxInvocationDepth(this.props.maxInvocationDepth === undefined ? -1 : this.props.maxInvocationDepth);
-        ASTUtil.traversNode(ast, invocationVisitor);
         if (this.props.mode === DiagramMode.INTERACTION) {
             ASTUtil.traversNode(ast, interactionModeVisitor);
         } else {

--- a/composer/packages/diagram/src/diagram/overview.tsx
+++ b/composer/packages/diagram/src/diagram/overview.tsx
@@ -115,10 +115,12 @@ export class Overview extends React.Component<OverviewProps, OverviewState> {
 
     public selectConstruct({moduleName, constructName, subConstructName}: ConstructIdentifier) {
         this.setState({
+            maxInvocationDepth: -1,
             selectedConstruct: {
                 constructName, moduleName, subConstructName
-            }
+            },
         });
+        this.handleReset();
     }
 
     public componentDidMount() {

--- a/composer/packages/diagram/src/diagram/overview.tsx
+++ b/composer/packages/diagram/src/diagram/overview.tsx
@@ -4,6 +4,9 @@ import { PanZoom } from "panzoom";
 import React from "react";
 import { DropdownItemProps, List, ListItemProps, Loader } from "semantic-ui-react";
 import { visitor as expandingResettingVisitor } from "../visitors/expandings-undoing-visitor";
+import { visitor as initVisitor } from "../visitors/init-visitor";
+import { getReachedInvocationDepth, setMaxInvocationDepth, setProjectAST, visitor as invocationVisitor
+    } from "../visitors/invocation-expanding-visitor";
 import { CommonDiagramProps, Diagram } from "./diagram";
 import { DiagramMode } from "./diagram-context";
 import { DiagramUtils } from "./diagram-utils";
@@ -139,6 +142,14 @@ export class Overview extends React.Component<OverviewProps, OverviewState> {
             selectedUri,
         } = this.getSelected(this.state.selectedConstruct);
 
+        if (selectedAST) {
+            // Initialize AST node view state
+            ASTUtil.traversNode(selectedAST, initVisitor);
+            setProjectAST(modules);
+            setMaxInvocationDepth(this.state.maxInvocationDepth === undefined ? -1 : this.state.maxInvocationDepth);
+            ASTUtil.traversNode(selectedAST, invocationVisitor);
+        }
+
         return (
             <div style={{height: "100%"}}>
                 <TopMenu
@@ -156,6 +167,7 @@ export class Overview extends React.Component<OverviewProps, OverviewState> {
                     handleReset={this.handleReset}
                     handleDepthSelect={this.setMaxInvocationDepth}
                     maxInvocationDepth={this.state.maxInvocationDepth}
+                    reachedInvocationDepth={getReachedInvocationDepth()}
                 />
                 <Diagram ast={selectedAST}
                     langClient={this.props.langClient}

--- a/composer/packages/diagram/src/diagram/top-menu.tsx
+++ b/composer/packages/diagram/src/diagram/top-menu.tsx
@@ -19,6 +19,7 @@ export interface TopMenuProps {
     handleReset: () => void;
     handleDepthSelect: (depth: number) => void;
     maxInvocationDepth: number;
+    reachedInvocationDepth: number;
     zoomFactor: number;
 }
 
@@ -37,6 +38,7 @@ export const TopMenu = (props: TopMenuProps) => {
         openedState,
         zoomFactor = 1,
         maxInvocationDepth,
+        reachedInvocationDepth,
     } = props;
 
     return (
@@ -104,15 +106,22 @@ export const TopMenu = (props: TopMenuProps) => {
                     </Grid.Column>
                     <Grid.Column className="selection-row" width={9}>
                         <Dropdown
-                            text={maxInvocationDepth === -1 ? "All" : maxInvocationDepth.toString()}
+                            text={maxInvocationDepth === -1 ?
+                                reachedInvocationDepth.toString() : maxInvocationDepth.toString()}
                             className="menu-dropdown-small"
                         >
                             <Dropdown.Menu>
-                                <Dropdown.Item onClick={() => handleDepthSelect(0)} text={0} />
-                                <Dropdown.Item onClick={() => handleDepthSelect(1)} text={1} />
-                                <Dropdown.Item onClick={() => handleDepthSelect(2)} text={2} />
-                                <Dropdown.Item onClick={() => handleDepthSelect(3)} text={3} />
-                                <Dropdown.Item onClick={() => handleDepthSelect(-1)} text={"All"} />
+                                {
+                                    (() => {
+                                        const items = [];
+
+                                        for (let i = 0; i < reachedInvocationDepth + 1; i++) {
+                                            items.push(<Dropdown.Item onClick={() => handleDepthSelect(i)} text={i} />);
+                                        }
+
+                                        return items;
+                                    })()
+                                }
                             </Dropdown.Menu>
                         </Dropdown>
                         <Popup

--- a/composer/packages/diagram/src/diagram/top-menu.tsx
+++ b/composer/packages/diagram/src/diagram/top-menu.tsx
@@ -50,7 +50,8 @@ export const TopMenu = (props: TopMenuProps) => {
                 </div>
                 <div onClick={handleOpened} className="status-wrapper">
                     Zoom : <Label> {`${Math.floor(zoomFactor * 100)}%`} </Label>
-                    Depth : <Label>{maxInvocationDepth === -1 ? "All" : maxInvocationDepth.toString()}</Label>
+                    Depth : <Label>{maxInvocationDepth === -1 ?
+                        reachedInvocationDepth : maxInvocationDepth.toString()}</Label>
                     Design : <Label>{selectedModeText}</Label>
                 </div>
             </div> :

--- a/composer/packages/diagram/src/views/components/svg-canvas.tsx
+++ b/composer/packages/diagram/src/views/components/svg-canvas.tsx
@@ -11,7 +11,7 @@ export const SvgCanvas: React.StatelessComponent<{
     return (
         <DiagramContext.Consumer>
             {(diagContext) => {
-                const viewBox =  `-20 -20 1000 1000`;
+                const viewBox =  `-20 -20 605 605`;
                 return (
                     <DiagramContext.Provider value={{ ...diagContext, overlayGroupRef }} >
                         <svg

--- a/composer/packages/diagram/src/views/components/worker.tsx
+++ b/composer/packages/diagram/src/views/components/worker.tsx
@@ -19,7 +19,7 @@ export const Worker: React.SFC<WorkerProps> = ({ model, startY, client }) => {
     const functionNode = lambda.functionNode;
     return <g>
         <StartInvocation client={client} worker={workerViewState.lifeline}
-            y={startY} label="start" />
+            y={startY}/>
         <LifeLine title={workerViewState.name} icon="worker"
             model={workerViewState.lifeline.bBox} astModel={model} />
         {functionNode.body && <Block model={functionNode.body}

--- a/composer/packages/diagram/src/visitors/invocation-expanding-visitor.ts
+++ b/composer/packages/diagram/src/visitors/invocation-expanding-visitor.ts
@@ -161,6 +161,7 @@ function getExpandedSubTree(invocation: Invocation): {node: BalFunction, uri: st
 export function setProjectAST(ast: ProjectAST) {
     projectAST = ast;
     invocationDepth = 0;
+    reachedInvocationDepth = 0;
 }
 
 export function setMaxInvocationDepth(depth: number) {

--- a/composer/packages/diagram/src/visitors/invocation-expanding-visitor.ts
+++ b/composer/packages/diagram/src/visitors/invocation-expanding-visitor.ts
@@ -12,6 +12,7 @@ let projectAST: ProjectAST;
 let envEndpoints: VisibleEndpoint[] = [];
 let invocationDepth = 0;
 let maxInvocationDepth = 0;
+let reachedInvocationDepth = 0;
 
 // This function processes endpoint parameters of expanded functions
 // so that actions to these parameters can be drawn to the original endpoint passed to them
@@ -83,6 +84,10 @@ function handleExpanding(expression: ASTNode, viewState: StmntViewState) {
     ASTUtil.traversNode(viewState.expandContext.expandedSubTree, initVisitor);
 
     invocationDepth += 1;
+    if (invocationDepth > reachedInvocationDepth) {
+        reachedInvocationDepth = invocationDepth;
+    }
+
     ASTUtil.traversNode(viewState.expandContext.expandedSubTree, visitor);
     invocationDepth -= 1;
 
@@ -160,6 +165,10 @@ export function setProjectAST(ast: ProjectAST) {
 
 export function setMaxInvocationDepth(depth: number) {
     maxInvocationDepth = depth;
+}
+
+export function getReachedInvocationDepth() {
+    return reachedInvocationDepth;
 }
 
 export const visitor: Visitor = {

--- a/tool-plugins/vscode/src/overview/activator.ts
+++ b/tool-plugins/vscode/src/overview/activator.ts
@@ -106,7 +106,7 @@ function openWebView(context: ExtensionContext, langClient: ExtendedLangClient, 
 		}
 
 		const newCurrentFilePath = activeEditor.document.fileName;
-		const newSourceRoot = getSourceRoot(currentFilePath, path.parse(currentFilePath).root);
+		const newSourceRoot = getSourceRoot(newCurrentFilePath, path.parse(newCurrentFilePath).root);
 	
 		const newOptions : {
 			currentUri: string,
@@ -119,6 +119,7 @@ function openWebView(context: ExtensionContext, langClient: ExtendedLangClient, 
 		let shouldRerender = false;
 		if (newSourceRoot) {
 			shouldRerender = sourceRoot !== newSourceRoot;
+			newOptions.sourceRootUri = Uri.file(newSourceRoot).toString();
 		} else {
 			shouldRerender = currentFilePath !== newCurrentFilePath;
 		}


### PR DESCRIPTION
## Purpose
Fix following bugs in the diagram. (Changes are in separate commits)
* Fix bug where diagram breaks when switching from a single .bal file to a project
* Remove "start" label from worker arrow. Its confusing with the `start fnName()` syntax
* Show the depth dropdown according to the maximum depth reached in the program
* Reset state when switching between constructs. This will reset the zoom positioning and maximum depth when diagram switches between constructs.
## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
