### PR TITLE
Change openapi module structure to match ballerina

### DIFF
--- a/misc/openapi-ballerina/modules/ballerina-to-openapi-generator/src/main/java/org/ballerinalang/ballerina/openapi/convertor/service/OpenApiConverterUtils.java
+++ b/misc/openapi-ballerina/modules/ballerina-to-openapi-generator/src/main/java/org/ballerinalang/ballerina/openapi/convertor/service/OpenApiConverterUtils.java
@@ -503,6 +503,7 @@ public class OpenApiConverterUtils {
         Files.createFile(path);
         try (PrintWriter writer = new PrintWriter(path.toString(), "UTF-8")) {
             writer.print(content);
+            outStream.println("Successfully generated the ballerina contract at location \n" + path.toAbsolutePath());
         }
     }
 

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/CodeGenerator.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/CodeGenerator.java
@@ -55,6 +55,7 @@ import java.util.regex.Pattern;
 
 import static org.ballerinalang.openapi.model.GenSrcFile.GenFileType;
 import static org.ballerinalang.openapi.utils.GeneratorConstants.GenType.GEN_CLIENT;
+import static org.ballerinalang.openapi.utils.GeneratorConstants.MODULE_MD;
 
 /**
  * This class generates Ballerina Services/Clients for a provided OAS definition.
@@ -289,7 +290,18 @@ public class CodeGenerator {
         if (srcPackage != null && !srcPackage.isEmpty() && Files.exists(srcPath)) {
             final File[] listFiles = new File(String.valueOf(srcPath)).listFiles();
             if (listFiles != null) {
-                Arrays.stream(listFiles).forEach(File::delete);
+                Arrays.stream(listFiles).forEach(file -> {
+                    boolean deleteStatus = true;
+                    if (!file.isDirectory() && !file.getName().equals(MODULE_MD)) {
+                        deleteStatus = file.delete();
+                    }
+
+                    //Capture return value of file.delete() since if
+                    //unable to delete returns false from file.delete() without an exception.
+                    if (!deleteStatus) {
+                        outStream.println("Unable to clean module directory.");
+                    }
+                });
             }
 
         }
@@ -311,10 +323,10 @@ public class CodeGenerator {
         }
 
         //This will print the generated files to the console
-        outStream.println("Service generated successfully. Following files were created. \n" +
+        outStream.println("Service generated successfully and the OpenApi contract is copied to " + srcPackage
+                + "/resources. this location will be referenced throughout the ballerina project.");
+        outStream.println(" Following files were created. \n" +
                 "src/ \n- " + srcPackage);
-        outStream.println("The OpenApi contract is copied to " + srcPackage + "/resources this location will be" +
-                " referenced throughout the ballerina project.");
         Iterator<GenSrcFile> iterator = sources.iterator();
         while (iterator.hasNext()) {
             outStream.println("-- " + iterator.next().getFileName());

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/OpenApiMesseges.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/OpenApiMesseges.java
@@ -47,9 +47,12 @@ public class OpenApiMesseges {
     public static final String MODULE_DIRECTORY_EXCEPTION = "Unable to create module directory. File system error " +
                                                             "occured.";
     public static final String RESOURCE_DIRECTORY_EXCEPTION = "Unable to create resource directory. File system error" +
-            " occured.";
+                                                            " occured.";
+    public static final String TESTS_DIRECTORY_EXCEPTION = "Unable to create tests directory. File system error " +
+                                                           "occured";
     public static final String SOURCE_DIRECTORY_EXCEPTION = "Unable to create source directory. File system error " +
-            "occured.";
+                                                            "occured.";
+    public static final String MODULE_MD_EXCEPTION = "Unable to create moudle.md file. File system error occured.";
     public static final String DEFINITION_EXISTS = "There is already an OpenApi contract in the location.";
 
     private OpenApiMesseges() {

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/cmd/OpenApiGenServiceCmd.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/cmd/OpenApiGenServiceCmd.java
@@ -19,8 +19,10 @@ import static org.ballerinalang.openapi.OpenApiMesseges.DEFINITION_EXISTS;
 import static org.ballerinalang.openapi.OpenApiMesseges.GEN_SERVICE_MODULE_REQUIRED;
 import static org.ballerinalang.openapi.OpenApiMesseges.GEN_SERVICE_PROJECT_ROOT;
 import static org.ballerinalang.openapi.OpenApiMesseges.MODULE_DIRECTORY_EXCEPTION;
+import static org.ballerinalang.openapi.OpenApiMesseges.MODULE_MD_EXCEPTION;
 import static org.ballerinalang.openapi.OpenApiMesseges.RESOURCE_DIRECTORY_EXCEPTION;
 import static org.ballerinalang.openapi.OpenApiMesseges.SOURCE_DIRECTORY_EXCEPTION;
+import static org.ballerinalang.openapi.OpenApiMesseges.TESTS_DIRECTORY_EXCEPTION;
 
 /**
  * Class to implement "openapi gen-service" command for ballerina.
@@ -100,6 +102,7 @@ public class OpenApiGenServiceCmd implements BLauncherCmd {
         final Path sourceDirectory = projectRoot.resolve("src");
         final Path moduleDirectory = sourceDirectory.resolve(moduleArgs.get(0));
         final Path resourcesDirectory = Paths.get(moduleDirectory + "/resources");
+        final Path testsDirectory = Paths.get(moduleDirectory + "/tests");
         final File openApiFile = new File(argList.get(0));
         final String openApiFilePath = openApiFile.getPath();
         Path resourcePath = Paths.get(resourcesDirectory + "/" + openApiFile.getName());
@@ -130,12 +133,37 @@ public class OpenApiGenServiceCmd implements BLauncherCmd {
                 }
             }
 
-            // Check for resources folder in ballerina project root
+            // Check for resources folder in ballerina module root
             if (Files.notExists(resourcesDirectory)) {
                 try {
                     Files.createDirectory(resourcesDirectory);
                 } catch (IOException e) {
                     throw LauncherUtils.createLauncherException(RESOURCE_DIRECTORY_EXCEPTION + "\n"
+                            + e.getLocalizedMessage());
+                }
+            }
+
+            File moduleMd = new File(moduleDirectory + "/Module.md");
+            if (!moduleMd.exists()) {
+                try {
+                    boolean createMd = true;
+                    createMd = moduleMd.createNewFile();
+
+                    if (!createMd) {
+                        throw LauncherUtils.createLauncherException(MODULE_MD_EXCEPTION);
+                    }
+                } catch (IOException e) {
+                    throw LauncherUtils.createLauncherException(MODULE_MD_EXCEPTION + "\n"
+                            + e.getLocalizedMessage());
+                }
+            }
+
+            // Check for tests folder in ballerina module root
+            if (Files.notExists(testsDirectory)) {
+                try {
+                    Files.createDirectory(testsDirectory);
+                } catch (IOException e) {
+                    throw LauncherUtils.createLauncherException(TESTS_DIRECTORY_EXCEPTION + "\n"
                             + e.getLocalizedMessage());
                 }
             }

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/GeneratorConstants.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/GeneratorConstants.java
@@ -63,6 +63,7 @@ public class GeneratorConstants {
     public static final String DEFAULT_CLIENT_PKG = "client";
     public static final String DEFAULT_MOCK_PKG = "mock";
     public static final String OAS_PATH_SEPARATOR = "/";
+    public static final String MODULE_MD = "Module.md";
 
     public static final String UNTITLED_SERVICE = "UntitledAPI";
     public static final List<String> RESERVED_KEYWORDS = Collections.unmodifiableList(


### PR DESCRIPTION
## Purpose
> This PR will change the module structure which is created while generating a service using the openapi tool to match the ballerina module structure which is generated using the `ballerina add` command.