### PR TITLE
Move authorization logic into auth module

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinInvocationArgs3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinInvocationArgs3.json
@@ -3369,14 +3369,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
@@ -2092,6 +2092,20 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "REQUEST_METHOD",
+      "kind": "Variable",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "Constant for the request method reference."
+        }
+      },
+      "sortText": "221",
+      "insertText": "REQUEST_METHOD",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "CONNECTION_CLOSURE_ERROR",
       "kind": "Variable",
       "detail": "string",
@@ -3369,14 +3383,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
@@ -980,14 +980,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
@@ -2092,6 +2092,20 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "REQUEST_METHOD",
+      "kind": "Variable",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "Constant for the request method reference."
+        }
+      },
+      "sortText": "221",
+      "insertText": "REQUEST_METHOD",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "CONNECTION_CLOSURE_ERROR",
       "kind": "Variable",
       "detail": "string",
@@ -3369,14 +3383,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
@@ -2092,6 +2092,20 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "REQUEST_METHOD",
+      "kind": "Variable",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "Constant for the request method reference."
+        }
+      },
+      "sortText": "221",
+      "insertText": "REQUEST_METHOD",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "CONNECTION_CLOSURE_ERROR",
       "kind": "Variable",
       "detail": "string",
@@ -3369,14 +3383,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
@@ -2092,6 +2092,20 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "REQUEST_METHOD",
+      "kind": "Variable",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "Constant for the request method reference."
+        }
+      },
+      "sortText": "221",
+      "insertText": "REQUEST_METHOD",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "CONNECTION_CLOSURE_ERROR",
       "kind": "Variable",
       "detail": "string",
@@ -3369,14 +3383,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport2.json
@@ -654,14 +654,14 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "AuthCacheConfig",
+            "label": "AuthzCacheConfig",
             "kind": "Class",
             "detail": "Record",
             "documentation": {
                 "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
             },
             "sortText": "221",
-            "insertText": "AuthCacheConfig",
+            "insertText": "AuthzCacheConfig",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/service/serviceBodyCompletion5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service/serviceBodyCompletion5.json
@@ -2092,6 +2092,20 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "REQUEST_METHOD",
+      "kind": "Variable",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "Constant for the request method reference."
+        }
+      },
+      "sortText": "221",
+      "insertText": "REQUEST_METHOD",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "CONNECTION_CLOSURE_ERROR",
       "kind": "Variable",
       "detail": "string",
@@ -3369,7 +3383,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
@@ -2092,6 +2092,20 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "REQUEST_METHOD",
+      "kind": "Variable",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "Constant for the request method reference."
+        }
+      },
+      "sortText": "221",
+      "insertText": "REQUEST_METHOD",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "CONNECTION_CLOSURE_ERROR",
       "kind": "Variable",
       "detail": "string",
@@ -3369,14 +3383,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AuthCacheConfig",
+      "label": "AuthzCacheConfig",
       "kind": "Class",
       "detail": "Record",
       "documentation": {
         "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
       },
       "sortText": "120",
-      "insertText": "AuthCacheConfig",
+      "insertText": "AuthzCacheConfig",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/topLevelPackageContentAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/topLevelPackageContentAccess.json
@@ -6,6 +6,105 @@
   "source": "toplevel/source/topLevelPackageContentAccess.bal",
   "items": [
     {
+      "label": "authorizeFromCache(string authzCacheKey, (cache:Cache|()) positiveAuthzCache, (cache:Cache|()) negativeAuthzCache)((boolean|()))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nTries to retrieve authorization decision from the cached information, if any.\n  \n**Params**  \n- `string` authzCacheKey: Cache key  \n- `(cache:Cache|())` positiveAuthzCache: The cache for positive authorizations(Defaultable)  \n- `(cache:Cache|())` positiveAuthzCache: The cache for positive authorizations  \n- `(cache:Cache|())` negativeAuthzCache: The cache for negative authorizations(Defaultable)  \n- `(cache:Cache|())` negativeAuthzCache: The cache for negative authorizations  \n  \n**Returns** `(boolean|())`   \n- `true` or `false` in case of a cache hit, `()` in case of a cache miss  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "authorizeFromCache(${1})",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/http;\n"
+        }
+      ],
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cacheAuthzResult(boolean authorized, string authzCacheKey, (cache:Cache|()) positiveAuthzCache, (cache:Cache|()) negativeAuthzCache)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCached the authorization result.\n  \n**Params**  \n- `boolean` authorized: boolean flag to indicate the authorization decision  \n- `string` authzCacheKey: Cache key  \n- `(cache:Cache|())` positiveAuthzCache: The cache for positive authorizations(Defaultable)  \n- `(cache:Cache|())` positiveAuthzCache: The cache for positive authorizations  \n- `(cache:Cache|())` negativeAuthzCache: The cache for negative authorizations(Defaultable)  \n- `(cache:Cache|())` negativeAuthzCache: The cache for negative authorizations"
+        }
+      },
+      "sortText": "130",
+      "insertText": "cacheAuthzResult(${1});",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/http;\n"
+        }
+      ],
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "checkForScopeMatch((string[]|string[][]) resourceScopes, string[] userScopes)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nCheck whether the scopes of the user and scopes of resource matches.\n  \n**Params**  \n- `(string[]|string[][])` resourceScopes: Scopes of resource  \n- `string[]` userScopes: Scopes of user  \n  \n**Returns** `boolean`   \n- true if there is a match between resource and user scopes, else false  \n  \n"
+        }
+      },
+      "sortText": "130",
+      "insertText": "checkForScopeMatch(${1})",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/http;\n"
+        }
+      ],
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
       "label": "extractAuthorizationHeaderValue(http:Request req)(string)",
       "kind": "Function",
       "detail": "Function",
@@ -419,6 +518,32 @@
       ]
     },
     {
+      "label": "AuthzCacheConfig",
+      "kind": "Class",
+      "detail": "Record",
+      "documentation": {
+        "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
+      },
+      "sortText": "120",
+      "insertText": "AuthzCacheConfig",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/http;\n"
+        }
+      ]
+    },
+    {
       "label": "CacheConfig",
       "kind": "Class",
       "detail": "Record",
@@ -605,7 +730,7 @@
       "kind": "Class",
       "detail": "Record",
       "documentation": {
-        "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+        "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
       },
       "sortText": "120",
       "insertText": "FollowRedirects",
@@ -1311,32 +1436,6 @@
       },
       "sortText": "120",
       "insertText": "ListenerSecureSocket",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
-      "label": "AuthCacheConfig",
-      "kind": "Class",
-      "detail": "Record",
-      "documentation": {
-        "left": "Provides a set of configurations for controlling the authorization caching behaviour of the endpoint.\n"
-      },
-      "sortText": "120",
-      "insertText": "AuthCacheConfig",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {

--- a/stdlib/auth/src/main/ballerina/src/auth/utils.bal
+++ b/stdlib/auth/src/main/ballerina/src/auth/utils.bal
@@ -91,7 +91,8 @@ public function setAuthenticationContext(string scheme, string authToken) {
 # + username - Username of the authenticated user.
 # + claims - Claims of the authenticated user.
 # + scopes - Authenticated user scopes.
-public function setPrincipal(public string? userId = (), public string? username = (), public string[]? scopes = (), public map<any>? claims = ()) {
+public function setPrincipal(public string? userId = (), public string? username = (), public string[]? scopes = (),
+                             public map<any>? claims = ()) {
     runtime:InvocationContext invocationContext = runtime:getInvocationContext();
     if (!(userId is ())) {
         invocationContext.principal.userId = userId;
@@ -143,7 +144,8 @@ public function checkForScopeMatch(string[]|string[][] resourceScopes, string[] 
 # + positiveAuthzCache - The cache for positive authorizations
 # + negativeAuthzCache - The cache for negative authorizations
 # + return - `true` or `false` in case of a cache hit, `()` in case of a cache miss
-function authorizeFromCache(string authzCacheKey, cache:Cache? positiveAuthzCache, cache:Cache? negativeAuthzCache) returns boolean? {
+function authorizeFromCache(string authzCacheKey, cache:Cache? positiveAuthzCache,
+                            cache:Cache? negativeAuthzCache) returns boolean? {
     cache:Cache? pCache = positiveAuthzCache;
     if (pCache is cache:Cache) {
         var positiveCacheResponse = pCache.get(authzCacheKey);
@@ -168,7 +170,8 @@ function authorizeFromCache(string authzCacheKey, cache:Cache? positiveAuthzCach
 # + authzCacheKey - Cache key
 # + positiveAuthzCache - The cache for positive authorizations
 # + negativeAuthzCache - The cache for negative authorizations
-function cacheAuthzResult(boolean authorized, string authzCacheKey, cache:Cache? positiveAuthzCache, cache:Cache? negativeAuthzCache) {
+function cacheAuthzResult(boolean authorized, string authzCacheKey, cache:Cache? positiveAuthzCache,
+                          cache:Cache? negativeAuthzCache) {
     if (authorized) {
         cache:Cache? pCache = positiveAuthzCache;
         if (pCache is cache:Cache) {

--- a/stdlib/auth/src/main/ballerina/src/auth/utils.bal
+++ b/stdlib/auth/src/main/ballerina/src/auth/utils.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/cache;
 import ballerina/encoding;
 import ballerina/internal;
 import ballerina/log;
@@ -104,4 +105,82 @@ public function setPrincipal(public string? userId = (), public string? username
     if (!(claims is ())) {
         invocationContext.principal.claims = claims;
     }
+}
+
+# Tries to retrieve authorization decision from the cached information, if any.
+#
+# + authzCacheKey - Cache key
+# + positiveAuthzCache - The cache for positive authorizations
+# + negativeAuthzCache - The cache for negative authorizations
+# + return - `true` or `false` in case of a cache hit, `()` in case of a cache miss
+public function authorizeFromCache(string authzCacheKey, cache:Cache? positiveAuthzCache, cache:Cache? negativeAuthzCache) returns boolean? {
+    cache:Cache? pCache = positiveAuthzCache;
+    if (pCache is cache:Cache) {
+        var positiveCacheResponse = pCache.get(authzCacheKey);
+        if (positiveCacheResponse is boolean) {
+            return true;
+        }
+    }
+
+    cache:Cache? nCache = negativeAuthzCache;
+    if (nCache is cache:Cache) {
+        var negativeCacheResponse = nCache.get(authzCacheKey);
+        if (negativeCacheResponse is boolean) {
+            return false;
+        }
+    }
+    return ();
+}
+
+# Cached the authorization result.
+#
+# + authorized - boolean flag to indicate the authorization decision
+# + authzCacheKey - Cache key
+# + positiveAuthzCache - The cache for positive authorizations
+# + negativeAuthzCache - The cache for negative authorizations
+public function cacheAuthzResult(boolean authorized, string authzCacheKey, cache:Cache? positiveAuthzCache, cache:Cache? negativeAuthzCache) {
+    if (authorized) {
+        cache:Cache? pCache = positiveAuthzCache;
+        if (pCache is cache:Cache) {
+            pCache.put(authzCacheKey, authorized);
+        }
+    } else {
+        cache:Cache? nCache = negativeAuthzCache;
+         if (nCache is cache:Cache) {
+            nCache.put(authzCacheKey, authorized);
+         }
+    }
+}
+
+# Check whether the scopes of the user and scopes of resource matches.
+#
+# + resourceScopes - Scopes of resource
+# + userScopes - Scopes of user
+# + return - true if there is a match between resource and user scopes, else false
+public function checkForScopeMatch(string[]|string[][] resourceScopes, string[] userScopes) returns boolean {
+    boolean authorized = true;
+    if (resourceScopes is string[]) {
+        authorized = matchScopes(resourceScopes, userScopes);
+    } else {
+        foreach string[] resourceScope in resourceScopes {
+            authorized = authorized && matchScopes(resourceScope, userScopes);
+        }
+    }
+    return authorized;
+}
+
+# Tries to find a match between the two scope arrays.
+#
+# + resourceScopes - Scopes of resource
+# + userScopes - Scopes of the user
+# + return - true if one of the resourceScopes can be found at userScopes, else false
+function matchScopes(string[] resourceScopes, string[] userScopes) returns boolean {
+    foreach var resourceScope in resourceScopes {
+        foreach var userScope in userScopes {
+            if (resourceScope == userScope) {
+                return true;
+            }
+        }
+    }
+    return false;
 }

--- a/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
@@ -63,9 +63,11 @@ public type AuthzHandler object {
         if (principal is runtime:Principal) {
             string username = principal?.username ?: "";    // this is already validated at `canProcess` function
             string[] userScopes = principal?.scopes ?: [];
-            string authzCacheKey = generateAuthzCacheKey(username, userScopes, serviceName, resourceName, requestMethod);
+            string authzCacheKey = generateAuthzCacheKey(username, userScopes, serviceName, resourceName,
+                                   requestMethod);
 
-            boolean authorized = auth:checkForScopeMatch(scopes, userScopes, authzCacheKey, self.positiveAuthzCache, self.negativeAuthzCache);
+            boolean authorized = auth:checkForScopeMatch(scopes, userScopes, authzCacheKey, self.positiveAuthzCache,
+                                                         self.negativeAuthzCache);
 
             if (authorized) {
                 log:printDebug(function () returns string {

--- a/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
@@ -61,7 +61,7 @@ public type AuthzHandler object {
 
         runtime:Principal? principal = runtime:getInvocationContext()?.principal;
         if (principal is runtime:Principal) {
-            string username = principal?.username ?: "";
+            string username = principal?.username ?: "";    // this is already validated at `canProcess` function
             string[] userScopes = principal?.scopes ?: [];
             string authzCacheKey = generateAuthzCacheKey(username, userScopes, serviceName, resourceName, requestMethod);
 
@@ -77,7 +77,7 @@ public type AuthzHandler object {
                 });
             }
         }
-        // This block will never execute, since `canProcess` method has validated the
+        // This block will never execute, since `canProcess` function has validated the
         // `runtime:getInvocationContext()?.principal` is `runtime:Principal`
         return false;
     }

--- a/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
@@ -61,14 +61,9 @@ public type AuthzHandler object {
 
         runtime:Principal? principal = runtime:getInvocationContext()?.principal;
         if (principal is runtime:Principal) {
-            string authzCacheKey = (principal?.username ?: "") + "-" + serviceName + "-" + resourceName + "-" + requestMethod;
+            string username = principal?.username ?: "";
             string[] userScopes = principal?.scopes ?: [];
-            if (userScopes.length() > 0) {
-                authzCacheKey += "-";
-                foreach var userScope in userScopes {
-                    authzCacheKey += userScope + ",";
-                }
-            }
+            string authzCacheKey = generateAuthzCacheKey(username, userScopes, serviceName, resourceName, requestMethod);
 
             boolean authorized = auth:checkForScopeMatch(scopes, userScopes, authzCacheKey, self.positiveAuthzCache, self.negativeAuthzCache);
 
@@ -87,3 +82,15 @@ public type AuthzHandler object {
         return false;
     }
 };
+
+function generateAuthzCacheKey(string username, string[] userScopes, string serviceName, string resourceName,
+                               string requestMethod) returns string {
+    string authzCacheKey = username + "-" + serviceName + "-" + resourceName + "-" + requestMethod;
+    if (userScopes.length() > 0) {
+        authzCacheKey += "-";
+        foreach var userScope in userScopes {
+            authzCacheKey += userScope + ",";
+        }
+    }
+    return authzCacheKey;
+}

--- a/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
@@ -41,138 +41,30 @@ public type AuthzHandler object {
         runtime:Principal? principal = runtime:getInvocationContext()?.principal;
         if (principal is runtime:Principal) {
             if (principal?.username is ()) {
-                return prepareAuthorizationError("Username not set in auth context. Unable to authorize.");
+                return prepareAuthorizationError("Username not set in runtime:Principal. Unable to authorize.");
             }
             return true;
         }
-        return prepareAuthorizationError("Username not set in auth context. Unable to authorize.");
+        return prepareAuthorizationError("runtime:Principal is not set in runtime:InvocationContext. Unable to authorize.");
     }
 
     # Tries to authorize the request.
     #
-    # + username - User name
-    # + serviceName - `Service` name
-    # + resourceName - `Resource` name
-    # + method - HTTP method name
+    # + authzCacheKey - Authorization cache key
+    # + authCtxtScopes - Scopes set at the `runtime:Principal` of `runtime:InvocationContext`
     # + scopes - Array of scopes or Array of arrays of scopes
     # + return - true if authorization check is a success, else false
-    function process(string username, string serviceName, string resourceName, string method,
-                     string[]|string[][] scopes) returns boolean {
-        runtime:Principal? principal = runtime:getInvocationContext()?.principal;
-        if (principal is runtime:Principal) {
-            // first, check in the cache. cache key is <username>-<service>-<resource>-<http method>-<scopes-separated-by-comma>,
-            // since different resources can have different scopes
-            string authzCacheKey = (principal?.userId ?: "") + "-" + serviceName + "-" + resourceName + "-" + method;
-            string[] authCtxtScopes = principal?.scopes ?: [];
-            if (authCtxtScopes.length() > 0) {
-                authzCacheKey += "-";
-                foreach var authCtxtScope in authCtxtScopes {
-                    authzCacheKey += authCtxtScope + ",";
-                }
-            }
-
-            var authorizedFromCache = self.authorizeFromCache(authzCacheKey);
-            if (authorizedFromCache is boolean) {
-                return authorizedFromCache;
-            } else {
-                // if there are scopes set in the AuthenticationContext already from a previous authentication phase,
-                // try to match against those.
-                if (authCtxtScopes.length() > 0) {
-                    boolean authorized = checkForScopeMatch(scopes, authCtxtScopes, resourceName, method);
-                    // cache authz result
-                    self.cacheAuthzResult(authzCacheKey, authorized);
-                    return authorized;
-                }
-            }
-        }
-        return false;
-    }
-
-    # Tries to retrieve authorization decision from the cached information, if any.
-    #
-    # + authzCacheKey - Cache key
-    # + return - true or false in case of a cache hit, nil in case of a cache miss
-    function authorizeFromCache(string authzCacheKey) returns boolean? {
-        cache:Cache? pCache = self.positiveAuthzCache;
-
-        if (pCache is cache:Cache) {
-            var positiveCacheResponse = pCache.get(authzCacheKey);
-            if (positiveCacheResponse is boolean) {
-                return true;
-            }
-        }
-
-        cache:Cache? nCache = self.negativeAuthzCache;
-
-        if (nCache is cache:Cache) {
-            var negativeCacheResponse = nCache.get(authzCacheKey);
-            if (negativeCacheResponse is boolean) {
-                return false;
-            }
-        }
-        return ();
-    }
-
-    # Cached the authorization result.
-    #
-    # + authzCacheKey - Cache key
-    # + authorized - boolean flag to indicate the authorization decision
-    function cacheAuthzResult(string authzCacheKey, boolean authorized) {
-        if (authorized) {
-            cache:Cache? pCache = self.positiveAuthzCache;
-            if (pCache is cache:Cache) {
-                pCache.put(authzCacheKey, authorized);
-            }
+    function process(string authzCacheKey, string[] authCtxtScopes, string[]|string[][] scopes) returns boolean {
+        var authorizedFromCache = auth:authorizeFromCache(authzCacheKey, self.positiveAuthzCache, self.negativeAuthzCache);
+        if (authorizedFromCache is boolean) {
+            return authorizedFromCache;
         } else {
-            cache:Cache? nCache = self.negativeAuthzCache;
-             if (nCache is cache:Cache) {
-                nCache.put(authzCacheKey, authorized);
-             }
+            if (authCtxtScopes.length() > 0) {
+                boolean authorized = auth:checkForScopeMatch(scopes, authCtxtScopes);
+                auth:cacheAuthzResult(authorized, authzCacheKey, self.positiveAuthzCache, self.negativeAuthzCache);
+                return authorized;
+            }
+            return false;
         }
     }
 };
-
-# Check whether the scopes of the user and scopes of resource matches.
-#
-# + resourceScopes - Scopes of resource
-# + userScopes - Scopes of user
-# + resourceName - Name of the `resource`
-# + method - HTTP method name
-# + return - true if there is a match between resource and user scopes, else false
-function checkForScopeMatch(string[]|string[][] resourceScopes, string[] userScopes, string resourceName,
-                            string method) returns boolean {
-    boolean authorized = true;
-    if (resourceScopes is string[]) {
-        authorized = matchScopes(resourceScopes, userScopes);
-    } else {
-        foreach string[] resourceScope in resourceScopes {
-            authorized = authorized && matchScopes(resourceScope, userScopes);
-        }
-    }
-    if (authorized) {
-        log:printDebug(function () returns string {
-            return "Successfully authorized to access resource: " + resourceName + ", method: " + method;
-        });
-    } else {
-        log:printDebug(function () returns string {
-            return "Authorization failure for resource: " + resourceName + ", method: " + method;
-        });
-    }
-    return authorized;
-}
-
-# Tries to find a match between the two scope arrays.
-#
-# + resourceScopes - Scopes of resource
-# + userScopes - Scopes of the user
-# + return - true if one of the resourceScopes can be found at userScopes, else false
-function matchScopes(string[] resourceScopes, string[] userScopes) returns boolean {
-    foreach var resourceScope in resourceScopes {
-        foreach var userScope in userScopes {
-            if (resourceScope == userScope) {
-                return true;
-            }
-        }
-    }
-    return false;
-}

--- a/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
@@ -78,6 +78,7 @@ public type AuthzHandler object {
                     return "Authorization failure for resource: " + serviceName + ", method: " + requestMethod;
                 });
             }
+            return authorized;
         }
         // This block will never execute, since `canProcess` function has validated the
         // `runtime:getInvocationContext()?.principal` is `runtime:Principal`

--- a/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/authz_handler.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/auth;
 import ballerina/cache;
 import ballerina/io;
 import ballerina/log;

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -253,6 +253,8 @@ public const KEEPALIVE_NEVER = "NEVER";
 public const SERVICE_NAME = "SERVICE_NAME";
 # Constant for the resource name reference.
 public const RESOURCE_NAME = "RESOURCE_NAME";
+# Constant for the request method reference.
+public const REQUEST_METHOD = "REQUEST_METHOD";
 
 # Adds authentication and authorization filters.
 #
@@ -312,6 +314,7 @@ type AttributeFilter object {
     public function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
         runtime:getInvocationContext().attributes[SERVICE_NAME] = context.getServiceName();
         runtime:getInvocationContext().attributes[RESOURCE_NAME] = context.getResourceName();
+        runtime:getInvocationContext().attributes[REQUEST_METHOD] = request.method;
         return true;
     }
 };

--- a/stdlib/ldap/build.gradle
+++ b/stdlib/ldap/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     baloImplementation project(path: ':ballerina-config-api', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-io', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-system', configuration: 'baloImplementation')
+    baloImplementation project(path: ':ballerina-cache', configuration: 'baloImplementation')
+    baloImplementation project(path: ':ballerina-task', configuration: 'baloImplementation')
 }
 
 configurations.all {


### PR DESCRIPTION
## Purpose
This PR move the authorization logic into `ballerina/auth` module while exposing authorization common logic as APIs in `ballerina/auth` module. The HTTP specific authorization implementation is at `http:AuthzFilter` and `http:AuthzHandler`.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/14399

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
