### PR TITLE
Improve type checking in tuple types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -643,9 +643,6 @@ public class TypeChecker extends BLangNodeVisitor {
                             actType = checkExpr(listConstructor.exprs.get(i), env, expType);
                             results.add(expType.tag != TypeTags.NONE ? expType : actType);
                         } else {
-                            // TODO: 8/21/19 The fix below is a temporary one. The rest type should be NoType if
-                            //  absent. Should be able to simply pass tupleType.restType as the expType.
-                            //  https://github.com/ballerina-platform/ballerina-lang/issues/18074
                             if (tupleType.restType != null) {
                                 restType = checkExpr(listConstructor.exprs.get(i), env, tupleType.restType);
                             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -646,8 +646,15 @@ public class TypeChecker extends BLangNodeVisitor {
                             // TODO: 8/21/19 The fix below is a temporary one. The rest type should be NoType if
                             //  absent. Should be able to simply pass tupleType.restType as the expType.
                             //  https://github.com/ballerina-platform/ballerina-lang/issues/18074
-                            BType expRestType = tupleType.restType != null ? tupleType.restType : symTable.noType;
-                            restType = checkExpr(listConstructor.exprs.get(i), env, expRestType);
+                            if (tupleType.restType != null) {
+                                restType = checkExpr(listConstructor.exprs.get(i), env, tupleType.restType);
+                            } else {
+                                // tuple type size != list constructor exprs
+                                dlog.error(listConstructor.pos, DiagnosticCode.SYNTAX_ERROR,
+                                        "tuple and expression size does not match");
+                                resultType = symTable.semanticError;
+                                return;
+                            }
                         }
                     }
                     actualType = new BTupleType(results);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleRestDescriptorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleRestDescriptorTest.java
@@ -117,8 +117,10 @@ public class TupleRestDescriptorTest {
                 19, 24);
         BAssertUtil.validateError(resultNegative, i++, "incompatible types: expected 'boolean', found 'int'",
                 19, 33);
-        BAssertUtil.validateError(resultNegative, i, "incompatible types: expected 'boolean', found 'string'",
+        BAssertUtil.validateError(resultNegative, i++, "incompatible types: expected 'boolean', found 'string'",
                 19, 36);
+        BAssertUtil.validateError(resultNegative, i++, "tuple and expression size does not match",
+                24, 12);
     }
 
 }


### PR DESCRIPTION
## Purpose
$subject, to check tuple size.

Fixes #18076 

## Samples
```ballerina
function testTupleInUnionReturn() returns [string, int, boolean]|string {
    return ["", 5, true, false]; // this should fail
}
```

## Remarks
#18076 
#17192
#18074