### PR TITLE
Fix bug where ballerina-font icons are not visible in windows

### DIFF
--- a/tool-plugins/vscode/src/utils/webview-utils.ts
+++ b/tool-plugins/vscode/src/utils/webview-utils.ts
@@ -1,5 +1,5 @@
 import { Uri, ExtensionContext, WebviewOptions, WebviewPanelOptions } from "vscode";
-import { join } from "path";
+import { join, sep } from "path";
 import { ballerinaExtInstance } from "../core";
 
 export function getWebViewResourceRoot(): string {
@@ -57,6 +57,11 @@ export function getLibraryWebViewContent(options: WebViewOptions) {
             '<link rel="stylesheet" type="text/css" href="' + cssFile + '" />').join('\n') 
         : '';
 
+    const fontDir = join(getDistributionComposerURI(), 'font');
+
+    // in windows fontdir path contains \ as separator. css does not like this.
+    const fontDirWithSeparatorReplaced = fontDir.split(sep).join("/");
+
     return `
             <!DOCTYPE html>
             <html>
@@ -73,6 +78,13 @@ export function getLibraryWebViewContent(options: WebViewOptions) {
                         left: calc(50% - 20px);
                         top: calc(50% - 20px);
                     }
+                    @font-face{
+                        font-family: font-ballerina;
+                        src: url("${fontDirWithSeparatorReplaced}/font-ballerina.eot");
+                        src: url("${fontDirWithSeparatorReplaced}/font-ballerina.eot?#iefix") format("embedded-opentype"), url("${fontDirWithSeparatorReplaced}/font-ballerina.woff2") format("woff2"), url("${fontDirWithSeparatorReplaced}/font-ballerina.woff") format("woff"), url("${fontDirWithSeparatorReplaced}/font-ballerina.ttf") format("truetype"), url("${fontDirWithSeparatorReplaced}/font-ballerina.svg#font-ballerina") format("svg");
+                        font-weight:normal;
+                        font-style:normal;
+                   }
                     ${styles}
                 </style>
             </head>


### PR DESCRIPTION
## Purpose
$title. The font face was not loading properly in windows.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
