### PR TITLE
Support using same name for a field and method in objects

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -211,7 +211,6 @@ public enum DiagnosticCode {
     DOES_NOT_RETURN_VALUE("does.not.return.value"),
     FUNC_DEFINED_ON_NOT_SUPPORTED_TYPE("func.defined.on.not.supported.type"),
     FUNC_DEFINED_ON_NON_LOCAL_TYPE("func.defined.on.non.local.type"),
-    OBJECT_FIELD_AND_FUNC_WITH_SAME_NAME("object.field.and.func.with.same.name"),
     INVALID_OBJECT_CONSTRUCTOR("invalid.object.constructor"),
     RECORD_INITIALIZER_INVOKED("explicit.invocation.of.record.init.is.not.allowed"),
     PKG_ALIAS_NOT_ALLOWED_HERE("pkg.alias.not.allowed.here"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1607,6 +1607,9 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         BInvokableType funcType = (BInvokableType) funcSymbol.type;
         BObjectTypeSymbol objectSymbol = (BObjectTypeSymbol) funcNode.receiver.type.tsymbol;
+        symResolver.lookupMemberSymbol(funcNode.receiver.pos, objectSymbol.scope, invokableEnv,
+                names.fromIdNode(funcNode.name), SymTag.VARIABLE);
+
         BAttachedFunction attachedFunc = new BAttachedFunction(
                 names.fromIdNode(funcNode.name), funcSymbol, funcType);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1607,14 +1607,6 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         BInvokableType funcType = (BInvokableType) funcSymbol.type;
         BObjectTypeSymbol objectSymbol = (BObjectTypeSymbol) funcNode.receiver.type.tsymbol;
-        BSymbol symbol = symResolver.lookupMemberSymbol(funcNode.receiver.pos, objectSymbol.scope, invokableEnv,
-                names.fromIdNode(funcNode.name), SymTag.VARIABLE);
-        if (symbol != symTable.notFoundSymbol) {
-            dlog.error(funcNode.pos, DiagnosticCode.OBJECT_FIELD_AND_FUNC_WITH_SAME_NAME,
-                    funcNode.name.value, funcNode.receiver.type.toString());
-            return;
-        }
-
         BAttachedFunction attachedFunc = new BAttachedFunction(
                 names.fromIdNode(funcNode.name), funcSymbol, funcType);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1583,9 +1583,9 @@ public class SymbolEnter extends BLangNodeVisitor {
         // Check whether there exists a struct field with the same name as the function name.
         if (isValidAttachedFunc) {
             if (typeSymbol.tag == SymTag.OBJECT) {
-                validateFunctionsAttachedToObject(funcNode, funcSymbol, invokableEnv);
+                validateFunctionsAttachedToObject(funcNode, funcSymbol);
             } else if (typeSymbol.tag == SymTag.RECORD) {
-                validateFunctionsAttachedToRecords(funcNode, funcSymbol, invokableEnv);
+                validateFunctionsAttachedToRecords(funcNode, funcSymbol);
             }
         }
 
@@ -1593,8 +1593,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         funcSymbol.receiverSymbol = funcNode.receiver.symbol;
     }
 
-    private void validateFunctionsAttachedToRecords(BLangFunction funcNode, BInvokableSymbol funcSymbol,
-                                                    SymbolEnv invokableEnv) {
+    private void validateFunctionsAttachedToRecords(BLangFunction funcNode, BInvokableSymbol funcSymbol) {
         BInvokableType funcType = (BInvokableType) funcSymbol.type;
         BRecordTypeSymbol recordSymbol = (BRecordTypeSymbol) funcNode.receiver.type.tsymbol;
 
@@ -1602,14 +1601,10 @@ public class SymbolEnter extends BLangNodeVisitor {
                 names.fromIdNode(funcNode.name), funcSymbol, funcType);
     }
 
-    private void validateFunctionsAttachedToObject(BLangFunction funcNode, BInvokableSymbol funcSymbol,
-                                                   SymbolEnv invokableEnv) {
+    private void validateFunctionsAttachedToObject(BLangFunction funcNode, BInvokableSymbol funcSymbol) {
 
         BInvokableType funcType = (BInvokableType) funcSymbol.type;
         BObjectTypeSymbol objectSymbol = (BObjectTypeSymbol) funcNode.receiver.type.tsymbol;
-        symResolver.lookupMemberSymbol(funcNode.receiver.pos, objectSymbol.scope, invokableEnv,
-                names.fromIdNode(funcNode.name), SymTag.VARIABLE);
-
         BAttachedFunction attachedFunc = new BAttachedFunction(
                 names.fromIdNode(funcNode.name), funcSymbol, funcType);
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -431,9 +431,6 @@ error.func.defined.on.not.supported.type=\
 error.func.defined.on.non.local.type=\
   function ''{0}'' defined on non-local type ''{1}''
 
-error.object.field.and.func.with.same.name=\
-  function and field named ''{0}'' in object ''{1}''
-
 error.invalid.object.constructor=\
   invalid object constructor for ''{0}'': expected sub-type of ''error?'', but found ''{1}''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
@@ -712,9 +712,22 @@ public class ObjectTest {
 
     @Test(description = "Test field name and method name in different namespaces")
     public void testFieldWithSameNameAsMethod() {
-        CompileResult objectTypeUnion = BCompileUtil.compile(
+        CompileResult compileResult = BCompileUtil.compile(
                 "test-src/object/object_field_with_same_name_as_method.bal");
-        BValue[] result = BRunUtil.invoke(objectTypeUnion, "testFieldWithSameNameAsMethod");
+        BValue[] result = BRunUtil.invoke(compileResult, "testFieldWithSameNameAsMethod");
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 13);
+        Assert.assertEquals(((BInteger) result[1]).intValue(), 23);
+        Assert.assertEquals(((BInteger) result[2]).intValue(), 23);
+        Assert.assertEquals(((BFloat) result[3]).floatValue(), 1.1);
+        Assert.assertEquals(((BFloat) result[4]).floatValue(), 2.2);
+        Assert.assertEquals(((BFloat) result[5]).floatValue(), 1.1);
+        Assert.assertEquals(((BFloat) result[6]).floatValue(), 2.2);
+    }
+
+    @Test(description = "Test field name and method name in different namespaces from balo")
+    public void testFieldWithSameNameAsMethodFromBalo() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/object/ObjectProject", "pkg2");
+        BValue[] result = BRunUtil.invoke(compileResult, "testBaloWithFieldWithSameNameAsMethod");
         Assert.assertEquals(((BInteger) result[0]).intValue(), 13);
         Assert.assertEquals(((BInteger) result[1]).intValue(), 23);
         Assert.assertEquals(((BInteger) result[2]).intValue(), 23);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.object;
 
+import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
@@ -707,5 +708,19 @@ public class ObjectTest {
                 {"test-src/object/object_with_missing_native_impl.bal"},
                 {"test-src/object/object_with_missing_native_impl_2.bal"}
         };
+    }
+
+    @Test(description = "Test field name and method name in different namespaces")
+    public void testFieldWithSameNameAsMethod() {
+        CompileResult objectTypeUnion = BCompileUtil.compile(
+                "test-src/object/object_field_with_same_name_as_method.bal");
+        BValue[] result = BRunUtil.invoke(objectTypeUnion, "testFieldWithSameNameAsMethod");
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 13);
+        Assert.assertEquals(((BInteger) result[1]).intValue(), 23);
+        Assert.assertEquals(((BInteger) result[2]).intValue(), 23);
+        Assert.assertEquals(((BFloat) result[3]).floatValue(), 1.1);
+        Assert.assertEquals(((BFloat) result[4]).floatValue(), 2.2);
+        Assert.assertEquals(((BFloat) result[5]).floatValue(), 1.1);
+        Assert.assertEquals(((BFloat) result[6]).floatValue(), 2.2);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg1/pkg1.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg1/pkg1.bal
@@ -16,3 +16,27 @@ public type Employee object {
         return self.email;
     }
 };
+
+public type SameFieldAndMethodObject object {
+    public int someInt = 13;
+    public float someFloat = 1.1;
+
+    public function someInt() returns int {
+        self.someInt += 10;
+        return self.someInt;
+    }
+
+    public function someFloat() returns float {
+        return 2.2;
+    }
+
+    public function getInt() returns int {
+        return self.someInt;
+    }
+
+    public function testFloat() returns [float, float] {
+        float f1 = self.someFloat;
+        float f2 = self.someFloat();
+        return [f1, f2];
+    }
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg2/pkg2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg2/pkg2.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.package internal;
+
+import pkg1;
+
+function testBaloWithFieldWithSameNameAsMethod() returns [int, int, int, float, float, float, float] {
+    pkg1:SameFieldAndMethodObject obj = new();
+    int a = obj.someInt;
+    int b = obj.someInt();
+    int c = obj.getInt();
+
+    [float, float] [d, e] = obj.testFloat();
+    float f = obj.someFloat;
+    float g = obj.someFloat();
+
+    return [a, b, c, d, e, f, g];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_field_with_same_name_as_method.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_field_with_same_name_as_method.bal
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.package internal;
+
+public type ObjectA object {
+    int someInt = 13;
+    float someFloat = 1.1;
+
+    function someInt() returns int {
+        self.someInt += 10;
+        return self.someInt;
+    }
+
+    function someFloat() returns float {
+        return 2.2;
+    }
+
+    function getInt() returns int {
+        return self.someInt;
+    }
+
+    function testFloat() returns [float, float] {
+        float f1 = self.someFloat;
+        float f2 = self.someFloat();
+        return [f1, f2];
+    }
+};
+
+function testFieldWithSameNameAsMethod() returns [int, int, int, float, float, float, float] {
+    ObjectA obj = new();
+    int a = obj.someInt;
+    int b = obj.someInt();
+    int c = obj.getInt();
+
+    [float, float] [d, e] = obj.testFloat();
+    float f = obj.someFloat;
+    float g = obj.someFloat();
+
+    return [a, b, c, d, e, f, g];
+}


### PR DESCRIPTION
## Purpose
Object fields and methods can have the same name now

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/13340

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
