### PR TITLE
Fix panics generated from langlib string cause 'ballerina run' command to break 

### DIFF
--- a/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/Substring.java
+++ b/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/Substring.java
@@ -16,10 +16,10 @@
 
 package org.ballerinalang.langlib.string;
 
+import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BLangExceptionHelper;
 import org.ballerinalang.jvm.util.exceptions.BallerinaErrorReasons;
-import org.ballerinalang.jvm.util.exceptions.BallerinaException;
 import org.ballerinalang.jvm.util.exceptions.RuntimeErrors;
 import org.ballerinalang.langlib.string.utils.StringUtils;
 import org.ballerinalang.model.types.TypeKind;
@@ -53,9 +53,9 @@ public class Substring {
         }
 
         if (startIndex < 0 || endIndex > value.length()) {
-            throw new BallerinaException(BallerinaErrorReasons.STRING_OPERATION_ERROR,
-                    "String index out of range. Actual:" + value.length() + " requested: " + startIndex + " to " +
-                            endIndex);
+            throw BallerinaErrors.createError(BallerinaErrorReasons.STRING_OPERATION_ERROR,
+                                              "String index out of range. Actual:" + value.length() + " requested: " +
+                                                      startIndex + " to " + endIndex);
         }
         return value.substring((int) startIndex, (int) endIndex);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -128,6 +129,14 @@ public class StringTest {
         BValue[] returns = BRunUtil.invoke(result, "substring", args);
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(), "testValue");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = "error: \\{ballerina\\}StringOperationError message=String index out of "
+                  + "range. Actual:4 requested: 5 to 9.*")
+    public void testSubStringIndexOut() {
+        BValue[] args = { new BString("test"), new BInteger(5), new BInteger(9) };
+        BRunUtil.invoke(result, "substring", args);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
$Subject

Fixes #18141

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
