### PR TITLE
Execute select on same connection as other operations in a transaction

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableResourceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TableResourceManager.java
@@ -36,12 +36,11 @@ public class TableResourceManager {
     private Connection connection;
     private Statement statement;
     private Set<ResultSet> resultSets;
-    // Connection is closable if the table associated with the connection was retrieved through a select operation,
-    // because for select operations a separate db connection is obtained which independent of the connection used for
-    // rest of the operations in case of a transaction.
-    // If the table was retrieved through a call operation the connection will not be closable as the connection is
-    // shared with all the operations inside the transaction except for the select operations. In this case, connection
-    // closure happens through the {@code TransactionResourceManager} at the end of the transaction.
+
+    // Connection is closable only if the operation is not inside of a transaction because the connection is shared
+    // with all the operations inside the transaction.
+    // In the case where connection is not closable, connection closure happens through the
+    // {@code TransactionResourceManager} at the end of the transaction.
     private boolean connectionClosable;
 
     public TableResourceManager(Connection conn, Statement stmt, boolean connectionClosable) {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/AbstractSQLStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/AbstractSQLStatement.java
@@ -349,26 +349,11 @@ public abstract class AbstractSQLStatement implements SQLStatement {
         notifyTxMarkForAbort(strand, transactionLocalContext);
     }
 
-    Connection getDatabaseConnection(Strand strand, ObjectValue client, SQLDatasource datasource,
-                                     boolean isSelectQuery) throws SQLException {
+    Connection getDatabaseConnection(Strand strand, ObjectValue client, SQLDatasource datasource) throws SQLException {
         Connection conn;
         try {
             boolean isInTransaction = strand.isInTransaction();
-            // Here when isSelectQuery condition is true i.e. in case of a select operation, we allow
-            // it to use a normal database connection. This is because,
-            // 1. In mysql (and possibly some other databases) another operation cannot be performed over a connection
-            // which has an open result set on top of it
-            // 2. But inside a transaction we use the same connection to perform all the db operation, so unless the
-            // result set is fully iterated, it won't be possible to perform rest of the operations inside the 
-            // transaction
-            // 3. Therefore, we allow select operations to be performed on separate db connections inside transactions
-            // (XA or general transactions)
-            // 4. However for call operations, despite of the fact that they could output resultsets
-            // (as OUT params or return values) we do not use a separate connection, because,
-            // call operations can contain UPDATE actions as well inside the procedure which may require to happen 
-            // in the
-            // same scope as any other individual UPDATE actions
-            if (!isInTransaction || isSelectQuery) {
+            if (!isInTransaction) {
                 conn = datasource.getSQLConnection();
                 return conn;
             } else {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/BatchUpdateStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/BatchUpdateStatement.java
@@ -83,7 +83,7 @@ public class BatchUpdateStatement extends AbstractSQLStatement {
         boolean isInTransaction = strand.isInTransaction();
         String errorMessagePrefix = "Failed to execute batch update";
         try {
-            conn = getDatabaseConnection(strand, client, datasource, false);
+            conn = getDatabaseConnection(strand, client, datasource);
             stmt = conn.prepareStatement(query, PreparedStatement.RETURN_GENERATED_KEYS);
             conn.setAutoCommit(false);
             if (paramArrayCount == 0) {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/CallStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/CallStatement.java
@@ -95,7 +95,7 @@ public class CallStatement extends AbstractSQLStatement {
         String errorMessagePrefix = "Failed to execute stored procedure: ";
         try {
             ArrayValue generatedParams = constructParameters(parameters);
-            conn = getDatabaseConnection(strand, client, datasource, false);
+            conn = getDatabaseConnection(strand, client, datasource);
             stmt = getPreparedCall(conn, datasource, query, generatedParams);
             ProcessedStatement processedStatement = new ProcessedStatement(conn, stmt, generatedParams,
                     datasource.getDatabaseProductName());

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/SelectStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/SelectStatement.java
@@ -67,14 +67,14 @@ public class SelectStatement extends AbstractSQLStatement {
         String errorMessagePrefix = "Failed to execute select query: ";
         try {
             ArrayValue generatedParams = constructParameters(parameters);
-            conn = getDatabaseConnection(strand, client, datasource, true);
+            conn = getDatabaseConnection(strand, client, datasource);
             String processedQuery = createProcessedQueryString(query, generatedParams);
             stmt = getPreparedStatement(conn, datasource, processedQuery);
             ProcessedStatement processedStatement = new ProcessedStatement(conn, stmt, generatedParams,
                     datasource.getDatabaseProductName());
             stmt = processedStatement.prepare();
             rs = stmt.executeQuery();
-            TableResourceManager rm = new TableResourceManager(conn, stmt, true);
+            TableResourceManager rm = new TableResourceManager(conn, stmt, !strand.isInTransaction());
             List<ColumnDefinition> columnDefinitions = getColumnDefinitions(rs);
             rm.addResultSet(rs);
             return constructTable(rm, rs, structType, columnDefinitions, datasource.getDatabaseProductName());

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/UpdateStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/UpdateStatement.java
@@ -74,7 +74,7 @@ public class UpdateStatement extends AbstractSQLStatement {
         String errorMessagePrefix = "Failed to execute update query: ";
         try {
             ArrayValue generatedParams = constructParameters(parameters);
-            conn = getDatabaseConnection(strand, client, datasource, false);
+            conn = getDatabaseConnection(strand, client, datasource);
             String processedQuery = createProcessedQueryString(query, generatedParams);
             stmt = conn.prepareStatement(processedQuery, Statement.RETURN_GENERATED_KEYS);
             ProcessedStatement processedStatement = new ProcessedStatement(conn, stmt, generatedParams,

--- a/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/transaction/LocalTransactionsTest.java
+++ b/stdlib/jdbc/src/test/java/org/ballerinax/jdbc/transaction/LocalTransactionsTest.java
@@ -218,6 +218,30 @@ public class LocalTransactionsTest {
     }
 
     @Test(groups = TRANSACTION_TEST_GROUP)
+    public void testLocalTransactionWithUpdateAfterSelectAndForeachIteration() {
+        BValue[] returns = BRunUtil
+                .invoke(result, "testLocalTransactionWithUpdateAfterSelectAndForeachIteration", args);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 3);
+    }
+
+    @Test(groups = TRANSACTION_TEST_GROUP)
+    public void testLocalTransactionWithUpdateAfterSelectAndBreakingWhileIteration() {
+        BValue[] returns = BRunUtil
+                .invoke(result, "testLocalTransactionWithUpdateAfterSelectAndBreakingWhileIteration", args);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 3);
+    }
+
+    @Test(groups = TRANSACTION_TEST_GROUP)
+    public void testLocalTransactionWithUpdateAfterSelectAndTableClosure() {
+        BValue[] returns = BRunUtil
+                .invoke(result, "testLocalTransactionWithUpdateAfterSelectAndTableClosure", args);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 3);
+    }
+
+    @Test(groups = TRANSACTION_TEST_GROUP)
     public void testLocalTransactionWithSelectAndHasNextIteration() {
         BValue[] returns = BRunUtil.invoke(result, "testLocalTransactionWithSelectAndHasNextIteration", args);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 0);


### PR DESCRIPTION
Purpose
Fixes #18183

When executing operations following a select inside a transaction, on a MySQL database, set `clobberStreamingResults` property to true so that, 'streaming' ResultSet to be automatically closed, and any outstanding data still streaming from the server to be discarded if another query is executed before all the data has been read from the server.

```ballerina
jdbc:Client testDB = new({
    url: "jdbc:mysql://localhost:3306/testdb",
    username: "root",
    password: "123",
    poolOptions: { maximumPoolSize: 5 },
    dbOptions: { useSSL: false, clobberStreamingResults: true }
});
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
