### PR TITLE
Fix intermittent test failures in Kafka tests

### DIFF
--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerAssignTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerAssignTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 
 /**
@@ -44,15 +45,15 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath
  */
 public class KafkaConsumerAssignTest {
     private CompileResult result;
-    private static File dataDir;
     private static KafkaCluster kafkaCluster;
+    private File dataDir;
 
     @BeforeClass
     public void setup() throws IOException {
+        dataDir =  Testing.Files.createTestingDirectory("kafka-consumer-assign-test");
         result = BCompileUtil.compile(
                 getFilePath(Paths.get(TEST_SRC, TEST_CONSUMER, "kafka_consumer_assign.bal")));
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        kafkaCluster = createKafkaCluster(dataDir, 14001, 14101).addBrokers(1).startup();
         kafkaCluster.createTopic("test-1", 1, 1);
     }
 
@@ -89,14 +90,5 @@ public class KafkaConsumerAssignTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-assign-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14001, 14101);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerManualCommitTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerManualCommitTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -57,8 +58,8 @@ public class KafkaConsumerManualCommitTest {
 
     @BeforeClass
     public void setup() throws IOException {
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-manual-commit-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14002, 14102).addBrokers(1).startup();
         result = BCompileUtil.compile(
                 getFilePath(Paths.get(TEST_SRC, TEST_CONSUMER, "kafka_consumer_manual_commit.bal")));
     }
@@ -128,14 +129,5 @@ public class KafkaConsumerManualCommitTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-manual-commit-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14002, 14102);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerPauseTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerPauseTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -55,8 +56,8 @@ public class KafkaConsumerPauseTest {
     @BeforeClass
     public void setup() throws IOException {
         result = BCompileUtil.compile(getFilePath(Paths.get(TEST_SRC, TEST_CONSUMER, "kafka_consumer_pause.bal")));
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).deleteDataUponShutdown(true)
-                .addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-pause-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14003, 14103).addBrokers(1).startup();
         kafkaCluster.createTopic("test", 1, 1);
     }
 
@@ -120,14 +121,5 @@ public class KafkaConsumerPauseTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-pause-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14003, 14103);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerSeekTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerSeekTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -53,8 +54,8 @@ public class KafkaConsumerSeekTest {
     @BeforeClass
     public void setup() throws IOException {
         result = BCompileUtil.compile(getFilePath(Paths.get(TEST_SRC, TEST_CONSUMER, "kafka_consumer_seek.bal")));
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).deleteDataUponShutdown(true)
-                .addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-seek-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14004, 14104).addBrokers(1).startup();
         kafkaCluster.createTopic("test", 1, 1);
     }
 
@@ -126,14 +127,5 @@ public class KafkaConsumerSeekTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-seek-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14004, 14104);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerSubscribePartitionRebalanceTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerSubscribePartitionRebalanceTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -52,8 +53,8 @@ public class KafkaConsumerSubscribePartitionRebalanceTest {
 
     @BeforeClass
     public void setup() throws IOException {
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-subscribe-to-pattern-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14005, 14105).addBrokers(1).startup();
     }
 
     @Test(description = "Test functionality of subscribeWithPartitionRebalance() function")
@@ -102,14 +103,5 @@ public class KafkaConsumerSubscribePartitionRebalanceTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-subscribe-to-pattern-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14005, 14105);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerSubscribeToPatternTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerSubscribeToPatternTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 
 /**
@@ -50,8 +51,8 @@ public class KafkaConsumerSubscribeToPatternTest {
 
     @BeforeClass
     public void setup() throws IOException {
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-subscribe-to-pattern-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14006, 14106).addBrokers(1).startup();
     }
 
     @Test(description = "Test functionality of getAvailableTopics() function")
@@ -110,14 +111,5 @@ public class KafkaConsumerSubscribeToPatternTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-subscribe-to-pattern-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14006, 14106);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -60,8 +61,8 @@ public class KafkaConsumerTest {
 
     @BeforeClass
     public void setup() throws IOException {
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14007, 14107).addBrokers(1).startup();
         kafkaCluster.createTopic(TOPIC, 1, 1);
         result = BCompileUtil.compile(getFilePath(Paths.get(TEST_SRC, TEST_CONSUMER, "kafka_consumer.bal")));
     }
@@ -133,14 +134,4 @@ public class KafkaConsumerTest {
             }
         }
     }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14007, 14107);
-        return kafkaCluster;
-    }
-
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerTopicsTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/consumer/KafkaConsumerTopicsTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -57,8 +58,8 @@ public class KafkaConsumerTopicsTest {
     @BeforeClass
     public void setup() throws IOException {
         result = BCompileUtil.compile(getFilePath(Paths.get(TEST_SRC, TEST_CONSUMER, "kafka_consumer_topics.bal")));
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-get-available-topics-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14008, 14108).addBrokers(1).startup();
     }
 
     @Test(description = "Test Kafka getAvailableTopics function")
@@ -128,14 +129,5 @@ public class KafkaConsumerTopicsTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-get-available-topics-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14008, 14108);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/producer/KafkaProducerTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/producer/KafkaProducerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_PRODUCER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 
 /**
@@ -56,8 +57,8 @@ public class KafkaProducerTest {
     @BeforeClass
     public void setup() throws IOException {
         result = BCompileUtil.compile(getFilePath(Paths.get(TEST_SRC, TEST_PRODUCER, "kafka_producer.bal")));
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-producer-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14009, 14109).addBrokers(1).startup();
     }
 
     @Test(description = "Test Basic produce")
@@ -144,14 +145,4 @@ public class KafkaProducerTest {
             }
         }
     }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-producer-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14009, 14109);
-        return kafkaCluster;
-    }
-
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/services/KafkaServiceTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/services/KafkaServiceTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SERVICES;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.produceToKafkaCluster;
 
@@ -53,8 +54,8 @@ public class KafkaServiceTest {
 
     @BeforeClass
     public void setup() throws IOException {
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).deleteDataUponShutdown(true)
-                .addBrokers(1).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-service-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14010, 14110).addBrokers(1).startup();
     }
 
     @Test(description = "Test endpoint bind to a service")
@@ -123,14 +124,5 @@ public class KafkaServiceTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    private static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-consumer-service-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14010, 14110);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/ssl/KafkaConsumerAndProducerWithSSLTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/ssl/KafkaConsumerAndProducerWithSSLTest.java
@@ -180,6 +180,8 @@ public class KafkaConsumerAndProducerWithSSLTest {
         prop.put("ssl.truststore.location", resourceDir + File.separator + keystoresAndTruststores + File.separator
                 + "kafka.server.truststore.jks");
         prop.put("ssl.truststore.password", "test1234");
+        prop.put("zookeeper.session.timeout.ms", "20000");
+        prop.put("zookeeper.connection.timeout.ms", "20000");
 
         return prop;
     }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/transactions/KafkaProducerTransactionsTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/transactions/KafkaProducerTransactionsTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_SRC;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.TEST_TRANSACTIONS;
+import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.createKafkaCluster;
 import static org.ballerinalang.messaging.kafka.utils.KafkaTestUtils.getFilePath;
 
 /**
@@ -53,8 +54,8 @@ public class KafkaProducerTransactionsTest {
 
     @BeforeClass
     public void setup() throws IOException {
-        kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true)
-                .deleteDataUponShutdown(true).addBrokers(3).startup();
+        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-transaction-test");
+        kafkaCluster = createKafkaCluster(dataDir, 14012, 14112).addBrokers(3).startup();
     }
 
     @Test(description = "Test Kafka producer send function within transaction")
@@ -145,14 +146,5 @@ public class KafkaProducerTransactionsTest {
                 dataDir.deleteOnExit();
             }
         }
-    }
-
-    protected static KafkaCluster kafkaCluster() {
-        if (kafkaCluster != null) {
-            throw new IllegalStateException();
-        }
-        dataDir = Testing.Files.createTestingDirectory("cluster-kafka-transaction-test");
-        kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(14012, 14112);
-        return kafkaCluster;
     }
 }

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/utils/KafkaTestUtils.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/utils/KafkaTestUtils.java
@@ -19,7 +19,10 @@
 package org.ballerinalang.messaging.kafka.utils;
 
 import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Collect;
+import kafka.server.KafkaConfig;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
@@ -53,5 +56,15 @@ public class KafkaTestUtils {
         } catch (Exception ex) {
             //Ignore
         }
+    }
+
+    public static KafkaCluster createKafkaCluster(File dataDir, int zkPort, int brokerPort) {
+        String timeout = "20000";
+        return new KafkaCluster()
+                .usingDirectory(dataDir)
+                .deleteDataPriorToStartup(true)
+                .deleteDataUponShutdown(true)
+                .withKafkaConfiguration(Collect.propertiesOf(KafkaConfig.ZkSessionTimeoutMsProp(), timeout))
+                .withPorts(zkPort, brokerPort);
     }
 }

--- a/stdlib/messaging/kafka/src/test/resources/testng.xml
+++ b/stdlib/messaging/kafka/src/test/resources/testng.xml
@@ -28,11 +28,9 @@
             <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerTest"/>
             <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerManualCommitTest"/>
             <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerPauseTest"/>
+            <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerSubscribePartitionRebalanceTest"/>
             <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerSubscribeToPatternTest"/>
             <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerSeekTest"/>
-
-            <!-- FAILING TESTS -->
-            <class name="org.ballerinalang.messaging.kafka.consumer.KafkaConsumerSubscribePartitionRebalanceTest"/>
         </classes>
     </test>
     <test name="ballerina-kafka-producer-tests">
@@ -42,25 +40,26 @@
         </classes>
     </test>
     <test name="ballerina-kafka-service-tests">
-        <!-- Kafka service related tests -->
+        <!-- Service-Related tests -->
         <classes>
             <class name="org.ballerinalang.messaging.kafka.services.KafkaServiceTest"/>
         </classes>
     </test>
     <test name="ballerina-kafka-compiler-test">
+        <!-- Compiler plugin validation tests -->
         <classes>
             <class name="org.ballerinalang.messaging.kafka.compiler.KafkaServiceCompilerTest"/>
         </classes>
     </test>
     <test name="ballerina-kafka-transactions-test">
         <classes>
-            <!-- Kafka transactions related tests -->
+            <!-- Transactions-Related tests -->
             <class name="org.ballerinalang.messaging.kafka.transactions.KafkaProducerTransactionsTest"/>
         </classes>
     </test>
     <test name="ballerina-kafka-ssl-tests">
         <classes>
-            <!-- Kafka SSL related tests -->
+            <!-- SSL-Based Consumer/Producer-Related tests -->
             <class name="org.ballerinalang.messaging.kafka.ssl.KafkaConsumerAndProducerWithSSLTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
> $subject

Fixes #18209 

## Approach
> The Kafka zookeeper connection time out is increased to 20000ms, (from the default of 6000ms). This will fix the intermittent failures.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples