### PR TITLE
Add a flag to avoid reloading langlibs when reusing compiler contexts

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -49,6 +49,7 @@ public class Compiler {
     private final BLangDiagnosticLog dlog;
     private final PackageLoader pkgLoader;
     private final Manifest manifest;
+    private boolean langLibsLoaded;
     private PrintStream outStream;
 
     private Compiler(CompilerContext context) {
@@ -61,6 +62,7 @@ public class Compiler {
         this.pkgLoader = PackageLoader.getInstance(context);
         this.manifest = ManifestProcessor.getInstance(context).getManifest();
         this.outStream = System.out;
+        this.langLibsLoaded = false;
     }
 
     public static Compiler getInstance(CompilerContext context) {
@@ -151,8 +153,10 @@ public class Compiler {
     // private methods
 
     private List<BLangPackage> compilePackages(List<PackageID> pkgIdList) {
-
-        this.compilerDriver.loadLangModules(pkgIdList);
+        if (!this.langLibsLoaded) {
+            this.compilerDriver.loadLangModules(pkgIdList);
+            this.langLibsLoaded = true;
+        }
         this.compilerDriver.loadUtilsPackage();
 
         // 1) Load all source packages. i.e. source-code -> BLangPackageNode

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageCache.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSPackageCache.java
@@ -22,6 +22,7 @@ import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.List;
 import java.util.Map;
@@ -128,14 +129,24 @@ public class LSPackageCache {
         public void remove(PackageID packageID) {
             if (packageID != null) {
                 this.packageMap.forEach((key, value) -> {
-                    String alias = packageID.getName().toString();
-                    if (key.contains(alias + ":") || key.contains(alias)) {
+                    String[] split = key.split("/");
+                    String alias = (split.length > 1) ? split[1] : key;
+                    String orgName = (split.length > 1) ? split[0] : "";
+                    String name = packageID.getName().value;
+                    boolean isLangLib = Names.BALLERINA_ORG.value.equals(orgName) &&
+                            alias.startsWith(Names.LANG.value + ".");
+                    if (!isLangLib && (alias.contains(name + ":") || alias.contains(name))) {
                         this.packageMap.remove(key);
                     }
                 });
                 this.packageSymbolMap.forEach((key, value) -> {
-                    String alias = packageID.getName().toString();
-                    if (key.contains(alias + ":") || key.contains(alias)) {
+                    String[] split = key.split("/");
+                    String alias = (split.length > 1) ? split[1] : key;
+                    String orgName = (split.length > 1) ? split[0] : "";
+                    String name = packageID.getName().value;
+                    boolean isLangLib = Names.BALLERINA_ORG.value.equals(orgName) &&
+                            alias.startsWith(Names.LANG.value + ".");
+                    if (!isLangLib && (alias.contains(name + ":") || alias.contains(name))) {
                         this.packageSymbolMap.remove(key);
                     }
                 });


### PR DESCRIPTION
## Purpose
> Add a flag to avoid reloading langlibs when reusing compiler contexts

Fixes #18118

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
