### PR TITLE
Validate resource function return types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -161,6 +161,7 @@ public enum DiagnosticCode {
     REMOTE_FUNCTION_IN_NON_CLIENT_OBJECT("remote.function.in.non.client.object"),
     RESOURCE_FUNCTION_IN_NON_SERVICE_OBJECT("resource.function.in.non.service.object"),
     RESOURCE_FUNCTION_WITH_VISIBILITY_QUALIFIER("resource.function.with.visibility.qualifier"),
+    RESOURCE_FUNCTION_INVALID_RETURN_TYPE("resource.function.invalid.return.type"),
     REMOTE_IN_NON_OBJECT_FUNCTION("remote.in.non.object.function"),
     REMOTE_ON_NON_REMOTE_FUNCTION("remote.on.non.remote.function"),
     REMOTE_REQUIRED_ON_REMOTE_FUNCTION("remote.required.on.remote.function"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1646,7 +1646,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        dlog.error(objectInitFn.pos, DiagnosticCode.INVALID_OBJECT_CONSTRUCTOR, objectInitFn.receiver.type.toString(),
+        dlog.error(objectInitFn.returnTypeNode.pos, DiagnosticCode.INVALID_OBJECT_CONSTRUCTOR,
                    objectInitFn.returnTypeNode.type.toString());
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1627,27 +1627,26 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        validateObjectInitFnReturnSignature(funcNode);
+        validateErrorOrNilReturn(funcNode, DiagnosticCode.INVALID_OBJECT_CONSTRUCTOR);
         objectSymbol.initializerFunc = attachedFunc;
     }
 
-    private void validateObjectInitFnReturnSignature(BLangFunction objectInitFn) {
-        BType returnType = objectInitFn.returnTypeNode.type;
-
-        if (returnType.tag == TypeTags.UNION) {
-            Set<BType> memberTypes = ((BUnionType) returnType).getMemberTypes();
-            if (memberTypes.stream().noneMatch(type -> type.tag != TypeTags.NIL && type.tag != TypeTags.ERROR)
-                    && memberTypes.contains(symTable.nilType)) {
-                return;
-            }
-        }
+    private void validateErrorOrNilReturn(BLangFunction function, DiagnosticCode diagnosticCode) {
+        BType returnType = function.returnTypeNode.type;
 
         if (returnType.tag == TypeTags.NIL) {
             return;
         }
 
-        dlog.error(objectInitFn.returnTypeNode.pos, DiagnosticCode.INVALID_OBJECT_CONSTRUCTOR,
-                   objectInitFn.returnTypeNode.type.toString());
+        if (returnType.tag == TypeTags.UNION) {
+            Set<BType> memberTypes = ((BUnionType) returnType).getMemberTypes();
+            if (returnType.isNullable() &&
+                    memberTypes.stream().allMatch(type -> type.tag == TypeTags.NIL || type.tag == TypeTags.ERROR)) {
+                return;
+            }
+        }
+
+        dlog.error(function.returnTypeNode.pos, diagnosticCode, function.returnTypeNode.type.toString());
     }
 
     private void validateRemoteFunctionAttachedToObject(BLangFunction funcNode, BObjectTypeSymbol objectSymbol) {
@@ -1675,6 +1674,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (!Symbols.isFlagOn(objectSymbol.flags, Flags.SERVICE)) {
             this.dlog.error(funcNode.pos, DiagnosticCode.RESOURCE_FUNCTION_IN_NON_SERVICE_OBJECT);
         }
+
+        validateErrorOrNilReturn(funcNode, DiagnosticCode.RESOURCE_FUNCTION_INVALID_RETURN_TYPE);
     }
 
     private StatementNode createAssignmentStmt(BLangSimpleVariable variable, BVarSymbol varSym, BSymbol fieldVar) {

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -572,6 +572,9 @@ error.resource.function.in.non.service.object=\
 error.resource.function.with.visibility.qualifier=\
   a resource function cannot have an explicit visibility qualifier
 
+error.resource.function.invalid.return.type=\
+  invalid resource function return type ''{0}'', expected a subtype of ''error?'' containing ''()''
+
 error.remote.in.non.object.function=\
   remote modifier not allowed in non-object attached function {0}
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -435,7 +435,7 @@ error.object.field.and.func.with.same.name=\
   function and field named ''{0}'' in object ''{1}''
 
 error.invalid.object.constructor=\
-  invalid object constructor for ''{0}'': expected sub-type of ''error?'', but found ''{1}''
+  invalid object constructor return type ''{0}'', expected a subtype of ''error?'' containing ''()''
 
 error.explicit.invocation.of.record.init.is.not.allowed=\
   explicit invocation of ''{0}'' record initializer is not allowed

--- a/stdlib/grpc/src/test/java/org/ballerinalang/net/grpc/ResourceReturnTypeTest.java
+++ b/stdlib/grpc/src/test/java/org/ballerinalang/net/grpc/ResourceReturnTypeTest.java
@@ -48,6 +48,7 @@ public class ResourceReturnTypeTest {
         CompileResult result = BCompileUtil.compile(serviceBalPath.toAbsolutePath().toString());
         Assert.assertEquals(result.getErrorCount(), 5);
         Assert.assertEquals(result.getDiagnostics().length, 5);
-        Assert.assertEquals(result.getDiagnostics()[0].getMessage(), "Invalid return type: expected error?");
+        Assert.assertEquals(result.getDiagnostics()[0].getMessage(), "invalid resource function return type " +
+                "'int', expected a subtype of 'error?' containing '()'");
     }
 }

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
@@ -108,8 +108,8 @@ public class SignatureTest {
                 "test-src/services/signature/invalid-return.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
-                            "invalid return type: expected error?");
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(), "invalid resource function return" +
+                " type 'int', expected a subtype of 'error?' containing '()'");
     }
 
     @Test

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
@@ -167,7 +167,8 @@ public class WebSocketCompilationTest {
         CompileResult compileResult = BCompileUtil.compileOnly(TEST_PATH + "resource_return.bal");
 
         assertExpectedDiagnosticsLength(compileResult, 1);
-        BAssertUtil.validateError(compileResult, 0, "Invalid return type: expected error?", 21, 5);
+        BAssertUtil.validateError(compileResult, 0, "invalid resource function return type 'int', expected a subtype " +
+                "of 'error?' containing '()'", 21, 80);
     }
 
     private void assertExpectedDiagnosticsLength(CompileResult compileResult, int expectedLength) {

--- a/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/compiler/KafkaServiceCompilerTest.java
+++ b/stdlib/messaging/kafka/src/test/java/org/ballerinalang/messaging/kafka/compiler/KafkaServiceCompilerTest.java
@@ -37,7 +37,7 @@ public class KafkaServiceCompilerTest {
 
     @Test(description = "Test endpoint bind to a service returning invalid return type")
     public void testKafkaServiceInvalidReturnType() {
-        String msg = "Invalid return type for the resource function:Expected error? or subset of error? but found: int";
+        String msg = "invalid resource function return type 'int', expected a subtype of 'error?' containing '()'";
         compileResult = BCompileUtil.compile(getFilePath(
                 Paths.get(TEST_SRC, TEST_COMPILER, "kafka_service_invalid_return_type.bal")));
         validateCompilerErrors(compileResult, msg);

--- a/stdlib/websub/src/test/java/org.ballerinalang.net.websub/WebSubCompilationTest.java
+++ b/stdlib/websub/src/test/java/org.ballerinalang.net.websub/WebSubCompilationTest.java
@@ -36,7 +36,7 @@ public class WebSubCompilationTest {
     public void setup() {
         negativeCompilationResult =
                 BCompileUtil.compile("test-src/compilation/test_compilation_failure.bal");
-        Assert.assertEquals(negativeCompilationResult.getDiagnostics().length, 13);
+        Assert.assertEquals(negativeCompilationResult.getDiagnostics().length, 12);
     }
 
     @Test(description = "Test specifying > 1 SubscriberServiceConfig annotations")
@@ -108,14 +108,16 @@ public class WebSubCompilationTest {
                                   110, 5);
     }
 
-    @Test(description = "Test invalid resource return type")
-    public void testInvalidResourceReturnType() {
-        BAssertUtil.validateError(negativeCompilationResult, 11, "invalid return type: expected error?", 121, 5);
-    }
-
     @Test(description = "Test subscriber without SubscriberServiceConfig")
     public void testNoSubscriberServiceConfig() {
-        BAssertUtil.validateError(negativeCompilationResult, 12, "'SubscriberServiceConfig' annotation is compulsory",
-                                  127, 1);
+        BAssertUtil.validateError(negativeCompilationResult, 11, "'SubscriberServiceConfig' annotation is compulsory",
+                                  115, 1);
+    }
+
+    @Test(description = "Test invalid resource return type")
+    public void testInvalidResourceReturnType() {
+        CompileResult negativeResult = BCompileUtil.compile("test-src/compilation/test_invalid_return_negative.bal");
+        BAssertUtil.validateError(negativeResult, 0, "invalid resource function return type 'int?', expected a " +
+                "subtype of 'error?' containing '()'", 26, 80);
     }
 }

--- a/stdlib/websub/src/test/resources/test-src/compilation/test_compilation_failure.bal
+++ b/stdlib/websub/src/test/resources/test-src/compilation/test_compilation_failure.bal
@@ -112,18 +112,6 @@ service {
 };
 
 service websubSubscriberEight =
-@websub:SubscriberServiceConfig {
-    path: "/websub",
-    subscribeOnStartUp: true,
-    target: ["http://websubpubhubtwo.com", "http://websubpubtopictwo.com"]
-}
-service {
-    resource function onNotification (websub:Notification notification) returns int? {
-        return 10;
-    }
-};
-
-service websubSubscriberNine =
 service {
     resource function noSubscriberServiceConfig (websub:Notification notification) {
     }

--- a/stdlib/websub/src/test/resources/test-src/compilation/test_invalid_return_negative.bal
+++ b/stdlib/websub/src/test/resources/test-src/compilation/test_invalid_return_negative.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websub;
+
+service websubSubscriber =
+@websub:SubscriberServiceConfig {
+    path: "/websub",
+    subscribeOnStartUp: true,
+    target: ["http://websubpubhubtwo.com", "http://websubpubtopictwo.com"]
+}
+service {
+    resource function onNotification(websub:Notification notification) returns int? {
+        return 10;
+    }
+};

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ServiceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ServiceTest.java
@@ -18,13 +18,14 @@
 package org.ballerinalang.test.endpoint;
 
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.util.BAssertUtil.validateError;
 
 /**
  * Services test.
@@ -62,18 +63,23 @@ public class ServiceTest {
     public void testServiceBasicsNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/endpoint/new/service_basic_negative.bal");
         int errIdx = 0;
-        BAssertUtil
-                .validateError(compileResult, errIdx++, "resource function can not be invoked with in a service", 9, 9);
-        BAssertUtil.validateError(compileResult, errIdx++, "redeclared symbol 'name1'", 19, 9);
-        BAssertUtil.validateError(compileResult, errIdx++,
+        validateError(compileResult, errIdx++, "resource function can not be invoked with in a service", 9, 9);
+        validateError(compileResult, errIdx++, "redeclared symbol 'name1'", 19, 9);
+        validateError(compileResult, errIdx++,
                 "incompatible types: expected 'AbstractListener', found 'string'", 19, 18);
-        BAssertUtil.validateError(compileResult, errIdx++, "invalid listener attachment", 19, 18);
-        BAssertUtil.validateError(compileResult, errIdx++, "redeclared symbol 'MyService$$service$2.foo'", 30, 14);
-        BAssertUtil.validateError(compileResult, errIdx++, "undefined symbol 'invalidVar'", 58, 12);
-        BAssertUtil.validateError(compileResult, errIdx++,
+        validateError(compileResult, errIdx++, "invalid listener attachment", 19, 18);
+        validateError(compileResult, errIdx++, "redeclared symbol 'MyService$$service$2.foo'", 30, 14);
+        validateError(compileResult, errIdx++, "undefined symbol 'invalidVar'", 58, 12);
+        validateError(compileResult, errIdx++,
                                   "a resource function cannot have an explicit visibility qualifier", 64, 5);
-        BAssertUtil.validateError(compileResult, errIdx++,
+        validateError(compileResult, errIdx++,
                                   "a resource function cannot have an explicit visibility qualifier", 68, 5);
+        validateError(compileResult, errIdx++, "invalid resource function return type 'string?', expected a subtype " +
+                "of 'error?' containing '()'", 74, 37);
+        validateError(compileResult, errIdx++, "invalid resource function return type 'error', expected a subtype of " +
+                "'error?' containing '()'", 78, 37);
+        validateError(compileResult, errIdx++, "invalid resource function return type '(FooErr|BarErr)', expected a " +
+                "subtype of 'error?' containing '()'", 90, 37);
         Assert.assertEquals(compileResult.getErrorCount(), errIdx);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -83,16 +83,14 @@ public class ObjectInitializerTest {
                       "object initializer function can not be declared as private", 27, 4);
         validateError(result, 2, "incompatible types: expected 'Person', found '(Person|error)'", 47, 17);
         validateError(result, 3, "incompatible types: expected 'Person', found '(Person|error)'", 48, 17);
-        validateError(result, 4,
-                      "invalid object constructor for 'Person2': expected sub-type of 'error?', but found 'string?'",
-                      54, 5);
+        validateError(result, 4, "invalid object constructor return type 'string?', " +
+                              "expected a subtype of 'error?' containing '()'", 54, 31);
         validateError(result, 5,
-                      "invalid object constructor for 'Person3': expected sub-type of 'error?', but found 'error'",
-                      63, 5);
+                      "invalid object constructor return type 'error', expected a subtype of 'error?' containing '()'",
+                      63, 31);
         validateError(result, 6,
-                      "invalid object constructor for 'Person4': expected sub-type of 'error?', but found " +
-                              "'(FooErr|BarErr)'",
-                      89, 5);
+                      "invalid object constructor return type '(FooErr|BarErr)', expected a subtype of 'error?' " +
+                              "containing '()'", 89, 31);
     }
 
     @Test(description = "Test object initializer invocation")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtNegativeTest.java
@@ -178,8 +178,8 @@ public class ReturnStmtNegativeTest {
         CompileResult result = BCompileUtil.compile("test-src/statements/returnstmt/return-in-resource-with-" +
                 "mismatching-types.bal");
         Assert.assertEquals(result.getErrorCount(), 3);
-        BAssertUtil.validateError(result, 0, "incompatible types: expected 'string', found 'int'", 22, 16);
-        BAssertUtil.validateError(result, 1, "incompatible types: expected 'int', found 'string'", 26, 16);
+        BAssertUtil.validateError(result, 0, "incompatible types: expected 'error?', found 'int'", 22, 16);
+        BAssertUtil.validateError(result, 1, "incompatible types: expected '()', found 'string'", 26, 16);
         BAssertUtil.validateError(result, 2, "incompatible types: expected '()', found 'string'", 30, 16);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access.bal
@@ -138,8 +138,8 @@ service ser on lis {
     @v5 {
         val: "54"
     }
-    resource function res(@v6 { foo: "v64" } int intVal) returns @v7 string {
-        return "";
+    resource function res(@v6 { foo: "v64" } int intVal) returns @v7 () {
+        return;
     }
 }
 
@@ -170,8 +170,8 @@ service serTwo = @v8 {
     @v5 {
         val: "542"
     }
-    resource function res(@v6 { foo: "v642" } int intVal) returns @v7 int {
-        return 1;
+    resource function res(@v6 { foo: "v642" } int intVal) returns @v7 error? {
+        return;
     }
 };
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access_via_reflect.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access_via_reflect.bal
@@ -46,8 +46,8 @@ service ser on lis {
         path: "testPath"
     }
     resource function res(@v2 int intVal, string strVal) returns
-                            @v3 { foo: "v41" }  @v3 { foo: "v42", bar: 2 } string {
-        return "";
+                            @v3 { foo: "v41" }  @v3 { foo: "v42", bar: 2 } () {
+        return;
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments.bal
@@ -104,8 +104,8 @@ service ser on lis {
     @v5 {
         val: "54"
     }
-    resource function res(@v6 { val: "v64" } int intVal) returns @v7 string {
-        return "";
+    resource function res(@v6 { val: "v64" } int intVal) returns @v7 error? {
+        return;
     }
 }
 
@@ -116,8 +116,8 @@ service serTwo = @v8 {
     @v5 {
         val: "542"
     }
-    resource function res(@v6 { val: "v642" } int intVal) returns @v7 int {
-        return 1;
+    resource function res(@v6 { val: "v642" } int intVal) returns @v7 () {
+        return;
     }
 };
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/endpoint/new/service_basic_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/endpoint/new/service_basic_negative.bal
@@ -69,3 +69,25 @@ service ser2 on ex {
 
     }
 }
+
+service ser3 on ex {
+    resource function foo() returns string? {
+
+    }
+
+    resource function bar() returns error {
+        return error("dummy error");
+    }
+}
+
+const R1 = "reason 1";
+const R2 = "reason 2";
+
+type FooErr error<R1>;
+type BarErr error<R2, record { string message?; error cause?; int code; }>;
+
+service ser4 = service {
+    resource function foo() returns FooErr|BarErr {
+        return FooErr();
+    }
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/extern_resource_function_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/extern_resource_function_negative.bal
@@ -16,7 +16,7 @@
 
 service x =
 service {
-    resource function foo() returns int = external;
+    resource function foo() returns error? = external;
 
     resource function bar() = external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/returnstmt/return-in-resource-with-mismatching-types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/returnstmt/return-in-resource-with-mismatching-types.bal
@@ -18,11 +18,11 @@ import ballerina/http;
 
 service helloWorld on new http:Listener(9090) {
 
-    resource function sayHelloWithString(int x) returns string {
+    resource function sayHelloWithString(int x) returns error? {
         return x;
     }
 
-    resource function sayHelloWithInt(string x) returns int {
+    resource function sayHelloWithInt(string x) returns () {
         return x;
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/returnstmt/return-in-resource.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/returnstmt/return-in-resource.bal
@@ -15,12 +15,12 @@
 // under the License.
 
 service helloWorld = service {
-    resource function sayHelloWithString(string x) returns string {
-        return x;
+    resource function sayHelloWithString(string x) returns error? {
+        return error("dummy err");
     }
 
-    resource function sayHelloWithInt(int x) returns int {
-        return x;
+    resource function sayHelloWithInt(int x) returns error? {
+        return;
     }
 
     resource function sayHelloWithNil1(string x) {


### PR DESCRIPTION
## Purpose
$title. Validates that the return type is a subtype of `error?` and contains `()`.
This PR does not remove existing std lib specific validation code (which should be redundant for most services now).

This PR also improves the error message on invalid object `__init()` return types.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/17940
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/17916

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
