### PR TITLE
Limit constants from using '_' as identifier

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2280,6 +2280,9 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangConstant constant) {
+        if (names.fromIdNode(constant.name) == Names.IGNORE) {
+            dlog.error(constant.name.pos, DiagnosticCode.UNDERSCORE_NOT_ALLOWED);
+        }
         if (constant.typeNode != null && !types.isAllowedConstantType(constant.typeNode.type)) {
             dlog.error(constant.typeNode.pos, DiagnosticCode.CANNOT_DEFINE_CONSTANT_WITH_TYPE, constant.typeNode);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1055,6 +1055,10 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
+        if (constant.symbol.name == Names.IGNORE) {
+            // Avoid symbol definition for constants with name '_'
+            return;
+        }
         // Add the symbol to the enclosing scope.
         env.scope.define(constantSymbol.name, constantSymbol);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantNegativeTest.java
@@ -32,7 +32,7 @@ public class SimpleConstantNegativeTest {
     public void testNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/constant/" +
                 "simple-literal-constant-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 57);
+        Assert.assertEquals(compileResult.getErrorCount(), 59);
 
         int index = 0;
         int offset = 1;
@@ -48,6 +48,10 @@ public class SimpleConstantNegativeTest {
                 offset += 1, 29);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected 'string', found 'int'",
                 offset += 1, 27);
+        BAssertUtil.validateError(compileResult, index++, "underscore is not allowed here",
+                offset += 3, 14);
+        BAssertUtil.validateError(compileResult, index++, "underscore is not allowed here",
+                offset += 1, 7);
         BAssertUtil.validateError(compileResult, index++, "cannot update constant value", offset += 14, 5);
         BAssertUtil.validateError(compileResult, index++, "cannot update constant value", offset += 1, 5);
         BAssertUtil.validateError(compileResult, index++, "cannot update constant value", offset += 6, 9);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/simple-literal-constant-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/simple-literal-constant-negative.bal
@@ -5,6 +5,10 @@ const float someFloat = true; // Invalid RHS value.
 const decimal someDeciaml = true; // Invalid RHS value.
 const string someString = 120; // Invalid RHS value.
 
+// Invalid identifier
+const string _ = "PUT";
+const _ = 11;
+
 // Assigning var ref.
 string s = "Ballerina";
 public const string name2 = "";


### PR DESCRIPTION
## Purpose
$title

Fixes #18157

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
