### PR TITLE
Replace few usages from internal module

### DIFF
--- a/cli/ballerina-cli-module-pull/src/main/ballerina/src/module_pull/module_pull.bal
+++ b/cli/ballerina-cli-module-pull/src/main/ballerina/src/module_pull/module_pull.bal
@@ -130,7 +130,7 @@ function pullPackage(http:Client httpEndpoint, string url, string modulePath, st
         panic createError("connection to the remote registry host failed : " + e.reason());
     } else {
         string statusCode = httpResponse.statusCode.toString();
-        if (internal:hasPrefix(statusCode, "5")) {
+        if (statusCode.startsWith("5")) {
             panic createError("remote registry failed for url:" + url);
         } else if (statusCode != "200") {
             var resp = httpResponse.getJsonPayload();

--- a/cli/ballerina-cli-module-push/src/main/ballerina/src/module_push/module_push.bal
+++ b/cli/ballerina-cli-module-push/src/main/ballerina/src/module_push/module_push.bal
@@ -18,7 +18,6 @@ import ballerina/io;
 import ballerina/mime;
 import ballerina/http;
 import ballerina/'lang\.int as lint;
-import ballerina/internal;
 
 # This functions pulls a module from ballerina central.
 #
@@ -45,7 +44,7 @@ function pushPackage (http:Client definedEndpoint, string accessToken, string or
         }
     } else {
         string statusCode = response.statusCode.toString();
-        if (internal:hasPrefix(statusCode, "5")) {
+        if (statusCode.startsWith("5")) {
             panic createError("error occured in remote registry. url: " + url);
         } else if (statusCode != "200") {
             json|error jsonResponse = response.getJsonPayload();

--- a/cli/ballerina-cli-module-search/src/main/ballerina/src/module_search/module_search.bal
+++ b/cli/ballerina-cli-module-search/src/main/ballerina/src/module_search/module_search.bal
@@ -18,7 +18,6 @@ import ballerina/io;
 import ballerina/http;
 import ballerina/time;
 import ballerina/math;
-import ballerina/internal;
 import ballerina/'lang\.int as lint;
 
 # This function searches modules from ballerina central.
@@ -40,7 +39,7 @@ function search (http:Client definedEndpoint, string url, string querySearched, 
         return;
     }
     string statusCode = httpResponse.statusCode.toString();
-    if (internal:hasPrefix(statusCode, "5")) {
+    if (statusCode.startsWith("5")) {
         io:println("remote registry failed for url : " + url + "/" + querySearched);
     } else if (statusCode != "200") {
         var resp = httpResponse.getJsonPayload();

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
@@ -451,7 +451,7 @@ type TerminatorGenerator object {
 
     function visitArg(bir:VarRef? arg) returns boolean {
         bir:VarRef argRef = getVarRef(arg);
-        if (internal:hasPrefix(argRef.variableDcl.name.value, "_")) {
+        if (argRef.variableDcl.name.value.startsWith("_")) {
             loadDefaultValue(self.mv, getVarRef(arg).typeValue);
             return false;
         }

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
@@ -451,7 +451,7 @@ type TerminatorGenerator object {
 
     function visitArg(bir:VarRef? arg) returns boolean {
         bir:VarRef argRef = getVarRef(arg);
-        if (internal:hasPrefix(argRef.variableDcl.name.value, "_")) {
+        if (argRef.variableDcl.name.value.startsWith("_")) {
             loadDefaultValue(self.mv, getVarRef(arg).typeValue);
             return false;
         }

--- a/examples/response-with-multiparts/response_with_multiparts.bal
+++ b/examples/response-with-multiparts/response_with_multiparts.bal
@@ -2,7 +2,6 @@ import ballerina/http;
 import ballerina/io;
 import ballerina/log;
 import ballerina/mime;
-import ballerina/internal;
 
 // Creates an endpoint for the client.
 http:Client clientEP = new("http://localhost:9092");
@@ -89,7 +88,7 @@ service multipartResponseDecoder on multipartEP {
 // Gets the child parts that are nested within the parent.
 function handleNestedParts(mime:Entity parentPart) {
     string contentTypeOfParent = parentPart.getContentType();
-    if (internal:hasPrefix(contentTypeOfParent, "multipart/")) {
+    if (contentTypeOfParent.startsWith("multipart/")) {
         var childParts = parentPart.getBodyParts();
         if (childParts is mime:Entity[]) {
             log:printInfo("Nested Parts Detected!");

--- a/stdlib/auth/src/main/ballerina/src/auth/inbound_basic_auth_provider.bal
+++ b/stdlib/auth/src/main/ballerina/src/auth/inbound_basic_auth_provider.bal
@@ -53,16 +53,16 @@ public type InboundBasicAuthProvider object {
         string passwordFromConfig = readPassword(username);
         boolean authenticated = false;
         // This check is added to avoid having to go through multiple condition evaluations, when value is plain text.
-        if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX)) {
-            if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX_SHA256)) {
+        if (passwordFromConfig.startsWith(CONFIG_PREFIX)) {
+            if (passwordFromConfig.startsWith(CONFIG_PREFIX_SHA256)) {
                 authenticated = internal:equalsIgnoreCase(
                                 encoding:encodeHex(crypto:hashSha256(password.toBytes())),
                                 extractHash(passwordFromConfig));
-            } else if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX_SHA384)) {
+            } else if (passwordFromConfig.startsWith(CONFIG_PREFIX_SHA384)) {
                 authenticated = internal:equalsIgnoreCase(
                                 encoding:encodeHex(crypto:hashSha384(password.toBytes())),
                                 extractHash(passwordFromConfig));
-            } else if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX_SHA512)) {
+            } else if (passwordFromConfig.startsWith(CONFIG_PREFIX_SHA512)) {
                 authenticated = internal:equalsIgnoreCase(
                                 encoding:encodeHex(crypto:hashSha512(password.toBytes())),
                                 extractHash(passwordFromConfig));

--- a/stdlib/auth/src/main/ballerina/src/auth/inbound_basic_auth_provider.bal
+++ b/stdlib/auth/src/main/ballerina/src/auth/inbound_basic_auth_provider.bal
@@ -56,15 +56,15 @@ public type InboundBasicAuthProvider object {
         if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX)) {
             if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX_SHA256)) {
                 authenticated = internal:equalsIgnoreCase(
-                                encoding:encodeHex(crypto:hashSha256(internal:toByteArray(password, DEFAULT_CHARSET))),
+                                encoding:encodeHex(crypto:hashSha256(password.toBytes())),
                                 extractHash(passwordFromConfig));
             } else if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX_SHA384)) {
                 authenticated = internal:equalsIgnoreCase(
-                                encoding:encodeHex(crypto:hashSha384(internal:toByteArray(password, DEFAULT_CHARSET))),
+                                encoding:encodeHex(crypto:hashSha384(password.toBytes())),
                                 extractHash(passwordFromConfig));
             } else if (internal:hasPrefix(passwordFromConfig, CONFIG_PREFIX_SHA512)) {
                 authenticated = internal:equalsIgnoreCase(
-                                encoding:encodeHex(crypto:hashSha512(internal:toByteArray(password, DEFAULT_CHARSET))),
+                                encoding:encodeHex(crypto:hashSha512(password.toBytes())),
                                 extractHash(passwordFromConfig));
             } else {
                 authenticated = password == passwordFromConfig;

--- a/stdlib/http/src/main/ballerina/src/http/auth/basic_auth_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/basic_auth_handler.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/auth;
-import ballerina/internal;
 
 # Defines the Basic Auth header handler for inbound and outbound HTTP traffic.
 #
@@ -38,7 +37,7 @@ public type BasicAuthHandler object {
     public function canProcess(Request req) returns @tainted boolean {
         if (req.hasHeader(AUTH_HEADER)) {
             string headerValue = extractAuthorizationHeaderValue(req);
-            return internal:hasPrefix(headerValue, auth:AUTH_SCHEME_BASIC);
+            return headerValue.startsWith(auth:AUTH_SCHEME_BASIC);
         }
         return false;
     }

--- a/stdlib/http/src/main/ballerina/src/http/auth/bearer_auth_handler.bal
+++ b/stdlib/http/src/main/ballerina/src/http/auth/bearer_auth_handler.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/auth;
-import ballerina/internal;
 
 # Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.
 #
@@ -38,7 +37,7 @@ public type BearerAuthHandler object {
     public function canProcess(Request req) returns @tainted boolean {
         if (req.hasHeader(AUTH_HEADER)) {
             string headerValue = extractAuthorizationHeaderValue(req);
-            return internal:hasPrefix(headerValue, auth:AUTH_SCHEME_BEARER);
+            return headerValue.startsWith(auth:AUTH_SCHEME_BEARER);
         }
         return false;
     }

--- a/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/crypto;
-import ballerina/internal;
 import ballerina/time;
 
 ////////////////////////////////
@@ -349,13 +348,13 @@ public type OutboundAuthConfig record {|
 function initialize(string serviceUrl, ClientEndpointConfig config) returns HttpClient|error {
     boolean httpClientRequired = false;
     string url = serviceUrl;
-    if (internal:hasSuffix(url, "/")) {
+    if (url.endsWith("/")) {
         int lastIndex = url.length() - 1;
         url = url.substring(0, lastIndex);
     }
     var cbConfig = config.circuitBreaker;
     if (cbConfig is CircuitBreakerConfig) {
-        if (internal:hasSuffix(url, "/")) {
+        if (url.endsWith("/")) {
             int lastIndex = url.length() - 1;
             url = url.substring(0, lastIndex);
         }

--- a/stdlib/http/src/main/ballerina/src/http/http_commons.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_commons.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/internal;
 import ballerina/mime;
 import ballerina/io;
 
@@ -360,12 +359,12 @@ function populateMultipartRequest(Request inRequest) returns Request|error {
 
 function isMultipartRequest(Request request) returns @tainted boolean {
     return request.hasHeader(mime:CONTENT_TYPE) &&
-        internal:hasPrefix(request.getHeader(mime:CONTENT_TYPE), MULTIPART_AS_PRIMARY_TYPE);
+        request.getHeader(mime:CONTENT_TYPE).startsWith(MULTIPART_AS_PRIMARY_TYPE);
 }
 
 function isNestedEntity(mime:Entity entity) returns @tainted boolean {
     return entity.hasHeader(mime:CONTENT_TYPE) &&
-        internal:hasPrefix(entity.getHeader(mime:CONTENT_TYPE), MULTIPART_AS_PRIMARY_TYPE);
+        entity.getHeader(mime:CONTENT_TYPE).startsWith(MULTIPART_AS_PRIMARY_TYPE);
 }
 
 function createFailoverRequest(Request request, mime:Entity requestEntity) returns Request|error {

--- a/stdlib/http/src/main/ballerina/src/http/http_request.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_request.bal
@@ -485,13 +485,13 @@ public type Request object {
                 reqCC.noTransform = true;
             } else if (directive == ONLY_IF_CACHED) {
                 reqCC.onlyIfCached = true;
-            } else if (internal:hasPrefix(directive, MAX_AGE)) {
+            } else if (directive.startsWith(MAX_AGE)) {
                 reqCC.maxAge = getExpirationDirectiveValue(directive);
             } else if (directive == MAX_STALE) {
                 reqCC.maxStale = MAX_STALE_ANY_AGE;
-            } else if (internal:hasPrefix(directive, MAX_STALE)) {
+            } else if (directive.startsWith(MAX_STALE)) {
                 reqCC.maxStale = getExpirationDirectiveValue(directive);
-            } else if (internal:hasPrefix(directive, MIN_FRESH)) {
+            } else if (directive.startsWith(MIN_FRESH)) {
                 reqCC.minFresh = getExpirationDirectiveValue(directive);
             }
             // non-standard directives are ignored

--- a/stdlib/http/src/main/ballerina/src/http/redirect/redirect_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/redirect/redirect_client.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/log;
-import ballerina/internal;
 
 # Provides redirect functionality for HTTP client remote functions.
 #
@@ -393,7 +392,7 @@ function createRedirectRequest(int statusCode, Request request) returns Request 
 }
 
 function isAbsolute(string locationUrl) returns boolean {
-    return (internal:hasPrefix(locationUrl, HTTP_SCHEME) || internal:hasPrefix(locationUrl, HTTPS_SCHEME));
+    return (locationUrl.startsWith(HTTP_SCHEME) || locationUrl.startsWith(HTTPS_SCHEME));
 }
 
 //Reset the current redirect count to 0 and set the resolved requested URI.

--- a/stdlib/http/src/test/resources/test-src/multipart/multipart-request.bal
+++ b/stdlib/http/src/test/resources/test-src/multipart/multipart-request.bal
@@ -157,7 +157,7 @@ service test on mockEP {
 function handleNestedParts(mime:Entity parentPart) returns @tainted string {
     string content = "";
     string contentTypeOfParent = parentPart.getContentType();
-    if (internal:hasPrefix(contentTypeOfParent, "multipart/")) {
+    if (contentTypeOfParent.startsWith("multipart/")) {
         var childParts = parentPart.getBodyParts();
         if (childParts is mime:Entity[]) {
             int i = 0;

--- a/stdlib/http/src/test/resources/test-src/multipart/multipart-request.bal
+++ b/stdlib/http/src/test/resources/test-src/multipart/multipart-request.bal
@@ -1,7 +1,6 @@
 import ballerina/encoding;
 import ballerina/http;
 import ballerina/mime;
-import ballerina/internal;
 
 function setErrorResponse(http:Response response,  error err) {
     response.statusCode = 500;

--- a/stdlib/websub/src/main/ballerina/src/websub/hub_service.bal
+++ b/stdlib/websub/src/main/ballerina/src/websub/hub_service.bal
@@ -253,7 +253,7 @@ function validateSubscriptionChangeRequest(string mode, string topic, string cal
     if (topic != "" && callback != "") {
         PendingSubscriptionChangeRequest pendingRequest = new(mode, topic, callback);
         pendingRequests[generateKey(topic, callback)] = pendingRequest;
-        if (!internal:hasPrefix(callback, "http://") && !internal:hasPrefix(callback, "https://")) {
+        if (!callback.startsWith("http://") && !callback.startsWith("https://")) {
             error err = error(WEBSUB_ERROR_CODE, message = "Malformed URL specified as callback");
             return err;
         }

--- a/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/17_auth_with_custom_providers_handlers.bal
+++ b/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/17_auth_with_custom_providers_handlers.bal
@@ -17,7 +17,6 @@
 import ballerina/auth;
 import ballerina/crypto;
 import ballerina/http;
-import ballerina/internal;
 
 OutboundCustomAuthProvider outboundCustomAuthProvider = new;
 OutboundCustomAuthHandler outboundCustomAuthHandler = new(outboundCustomAuthProvider);
@@ -135,7 +134,7 @@ public type InboundCustomAuthHandler object {
 
     public function canProcess(http:Request req) returns @tainted boolean {
         var customAuthHeader = req.getHeader(http:AUTH_HEADER);
-        return internal:hasPrefix(customAuthHeader, "Custom");
+        return customAuthHeader.startsWith("Custom");
     }
 };
 

--- a/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/oauth2-mock-server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/oauth2-mock-server.bal
@@ -258,7 +258,7 @@ function getResponseForRefreshRequest(http:Request req, string authorizationHead
                     refreshToken = internal:split(param, "=")[1];
                     // If the refresh token contains the `=` symbol, then it is required to concatenate all the parts of the value since
                     // the String split breaks all those into separate parts.
-                    if (internal:hasSuffix(param, "==")) {
+                    if (param.endsWith("==")) {
                         refreshToken += "==";
                     }
                 } else if (internal:contains(param, "scope")) {

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/12_http_retry.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/12_http_retry.bal
@@ -19,7 +19,6 @@ import ballerina/log;
 import ballerina/mime;
 import ballerina/runtime;
 import ballerina/io;
-import ballerina/internal;
 
 listener http:Listener serviceEndpoint1 = new(9105);
 
@@ -96,12 +95,12 @@ service mockHelloService on serviceEndpoint1 {
             log:printInfo("Request received from the client to healthy service.");
             http:Response response = new;
             if (req.hasHeader(mime:CONTENT_TYPE)
-                && internal:hasPrefix(req.getHeader(mime:CONTENT_TYPE), http:MULTIPART_AS_PRIMARY_TYPE)) {
+                && req.getHeader(mime:CONTENT_TYPE).startsWith(http:MULTIPART_AS_PRIMARY_TYPE)) {
                 var bodyParts = req.getBodyParts();
                 if (bodyParts is mime:Entity[]) {
                     foreach var bodyPart in bodyParts {
                         if (bodyPart.hasHeader(mime:CONTENT_TYPE)
-                            && internal:hasPrefix(bodyPart.getHeader(mime:CONTENT_TYPE), http:MULTIPART_AS_PRIMARY_TYPE)) {
+                            && bodyPart.getHeader(mime:CONTENT_TYPE).startsWith(http:MULTIPART_AS_PRIMARY_TYPE)) {
                             var nestedParts = bodyPart.getBodyParts();
                             if (nestedParts is error) {
                                 log:printError(<string> nestedParts.detail().message);

--- a/tests/jballerina-integration-test/src/test/resources/socket/src/services/01_client_callback.bal
+++ b/tests/jballerina-integration-test/src/test/resources/socket/src/services/01_client_callback.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/internal;
 import ballerina/io;
 import ballerina/socket;
 
@@ -33,7 +32,7 @@ service echo on echoEP {
         var payload = req.getTextPayload();
         http:Response resp = new;
         if (payload is string) {
-            byte[] payloadByte = internal:toByteArray(payload, "UTF-8");
+            byte[] payloadByte = payload.toBytes();
             var writeResult = socketClient->write(payloadByte);
             if (writeResult is int) {
                 io:println("Number of bytes written: ", writeResult);


### PR DESCRIPTION
## Purpose
Replace following usages of internal moduel:
`internal:toByteArray()` -> `string.toBytes()`
`internal:hasPrefix()` -> `string.startsWith()`
`internal:hasSuffix()` -> `string.endsWith()`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
