### PR TITLE
Show worker sends and receives in the interaction mode

### DIFF
--- a/composer/packages/diagram/src/views/components/worker-send.tsx
+++ b/composer/packages/diagram/src/views/components/worker-send.tsx
@@ -16,6 +16,19 @@ export const WorkerSend: React.StatelessComponent<{
     }) => {
         const viewState: WorkerSendViewState = model.viewState;
 
+        const statementProps = {
+            className: "statement",
+            x: viewState.bBox.x + config.statement.padding.left,
+            y: viewState.bBox.y + (viewState.bBox.h / 2)
+        };
+
+        if (!viewState.isSynced) {
+            // Don't draw the arrow if not syced
+            return <g className="action-invocation">
+                {!viewState.isAction && <text {...statementProps}>{viewState.bBox.label}</text>}
+            </g>;
+        }
+
         const mLine = { x1: 1, y1: 0, x2: 0, y2: 0 };
         mLine.x1 = viewState.bBox.x;
         mLine.y1 = mLine.y2 = viewState.bBox.y + config.statement.height;
@@ -26,19 +39,6 @@ export const WorkerSend: React.StatelessComponent<{
         }
 
         const arrowDirection = (mLine.x2 > mLine.x1) ? "right" : "left";
-
-        const statementProps = {
-            className: "statement",
-            x: mLine.x1 + config.statement.padding.left,
-            y: viewState.bBox.y + (viewState.bBox.h / 2)
-        };
-
-        if (!viewState.isSynced) {
-            // Don't draw the arrow if not syced
-            return <g className="action-invocation">
-                {!viewState.isAction && <text {...statementProps}>{viewState.bBox.label}</text>}
-            </g>;
-        }
 
         return (
             <g className="action-invocation">

--- a/composer/packages/diagram/src/visitors/mode-visitors/interaction-mode-visitor.ts
+++ b/composer/packages/diagram/src/visitors/mode-visitors/interaction-mode-visitor.ts
@@ -1,7 +1,7 @@
 import { Assignment, ASTNode, ASTUtil, Block, ExpressionStatement, Function as BalFunction,
-    Invocation, Return, Service, VariableDef, Visitor } from "@ballerina/ast-model";
+    Invocation, Return, Service, VariableDef, Visitor, WorkerSend } from "@ballerina/ast-model";
 import * as _ from "lodash";
-import { FunctionViewState, StmntViewState } from "../../view-model/index";
+import { FunctionViewState, StmntViewState, ViewState } from "../../view-model/index";
 
 const currentState: {
     topLevelNode?: ASTNode | undefined,
@@ -94,6 +94,30 @@ export const visitor: Visitor = {
         if (currentState.statement) {
             currentState.statement.viewState.hidden = false;
         }
+    },
+
+    beginVisitWorkerSend(node: WorkerSend) {
+        if (currentState.statement) {
+            currentState.statement.viewState.hidden = false;
+        }
+        const statement = currentState.statement ? currentState.statement : node;
+        (statement.viewState as ViewState).hidden = false;
+    },
+
+    beginVisitWorkerSyncSend(node: WorkerSend) {
+        if (currentState.statement) {
+            currentState.statement.viewState.hidden = false;
+        }
+        const statement = currentState.statement ? currentState.statement : node;
+        (statement.viewState as ViewState).hidden = false;
+    },
+
+    beginVisitWorkerReceive(node: WorkerSend) {
+        if (currentState.statement) {
+            currentState.statement.viewState.hidden = false;
+        }
+        const statement = currentState.statement ? currentState.statement : node;
+        (statement.viewState as ViewState).hidden = false;
     },
 
     beginVisitInvocation(node: Invocation) {


### PR DESCRIPTION
## Purpose
Only worker starts and waits were shown in the interactions mode.
With this PR sends and receives are also shown in the interactions mode.

## Approach
<img width="768" alt="image" src="https://user-images.githubusercontent.com/3872221/63752815-85cb7600-c8cf-11e9-88e9-899690e87639.png">
<img width="848" alt="image" src="https://user-images.githubusercontent.com/3872221/63752846-92e86500-c8cf-11e9-811c-b4a200e6ccd3.png">

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
