### PR TITLE
Add log message to start and stop kafka listener

### DIFF
--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Connect.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Connect.java
@@ -28,13 +28,16 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 
+import java.io.PrintStream;
 import java.util.Objects;
 import java.util.Properties;
 
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_BOOTSTRAP_SERVERS_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CONFIG_FIELD_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKAGE_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_SERVERS;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
@@ -56,6 +59,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.processKafkaCon
         isPublic = true
 )
 public class Connect {
+    private static final PrintStream console = System.out;
 
     public static Object connect(Strand strand, ObjectValue consumerObject) {
         // Check whether already native consumer is attached to the struct.
@@ -73,6 +77,7 @@ public class Connect {
         } catch (KafkaException e) {
             return createKafkaError("Cannot connect to the kafka server: " + e.getMessage(), CONSUMER_ERROR);
         }
+        console.println(KAFKA_SERVERS + configs.get(CONSUMER_BOOTSTRAP_SERVERS_CONFIG));
         return null;
     }
 }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Subscribe.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Subscribe.java
@@ -28,6 +28,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
@@ -35,8 +36,10 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKA
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SUBSCRIBED_TOPICS;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getStringListFromStringArrayValue;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicNamesString;
 
 /**
  * Native function subscribes consumer to given set of topic array.
@@ -53,6 +56,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getStringListFr
         isPublic = true
 )
 public class Subscribe {
+    private static final PrintStream console = System.out;
 
     public static Object subscribe(Strand strand, ObjectValue consumerObject, ArrayValue topics) {
         KafkaConsumer<byte[], byte[]> kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
@@ -62,6 +66,7 @@ public class Subscribe {
         } catch (IllegalArgumentException | IllegalStateException | KafkaException e) {
             return createKafkaError("Failed to subscribe to the provided topics: " + e.getMessage(), CONSUMER_ERROR);
         }
+        console.println(SUBSCRIBED_TOPICS + getTopicNamesString(topicsList));
         return null;
     }
 }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Register.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Register.java
@@ -37,12 +37,12 @@ import java.util.Properties;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CONFIG_FIELD_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
-import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_SERVER_CONNECTOR_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_STRUCT_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKAGE_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.UNCHECKED;
 
 /**
@@ -75,7 +75,7 @@ public class Register {
             String serviceId = service.getType().getQualifiedName();
             KafkaServerConnector serverConnector = new KafkaServerConnectorImpl(serviceId, configs, kafkaListener,
                     kafkaConsumer);
-            listener.addNativeData(CONSUMER_SERVER_CONNECTOR_NAME, serverConnector);
+            listener.addNativeData(SERVER_CONNECTOR, serverConnector);
         } catch (KafkaConnectorException e) {
             return KafkaUtils.createKafkaError(e.getMessage(), CONSUMER_ERROR);
         }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
@@ -27,12 +27,15 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 
+import java.io.PrintStream;
+
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_SERVER_CONNECTOR_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_STRUCT_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKAGE_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STARTED;
 
 /**
  * Start server connector.
@@ -50,12 +53,14 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
         isPublic = true
 )
 public class Start {
+    private static final PrintStream console = System.out;
 
     public static Object start(Strand strand, ObjectValue listener) {
         KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener
                 .getNativeData(CONSUMER_SERVER_CONNECTOR_NAME);
         try {
             serverConnector.start();
+            console.println(SERVICE_STARTED);
         } catch (KafkaConnectorException e) {
             return KafkaUtils.createKafkaError(e.getMessage(), CONSUMER_ERROR);
         }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
@@ -36,7 +36,6 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTO
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STARTED;
-import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getBrokerNames;
 
 /**
  * Start server connector.
@@ -60,7 +59,7 @@ public class Start {
         KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener.getNativeData(SERVER_CONNECTOR);
         try {
             serverConnector.start();
-            console.println(SERVICE_STARTED + getBrokerNames(listener));
+            console.println(SERVICE_STARTED);
         } catch (KafkaConnectorException e) {
             return KafkaUtils.createKafkaError(e.getMessage(), CONSUMER_ERROR);
         }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
@@ -30,12 +30,13 @@ import org.ballerinalang.natives.annotations.Receiver;
 import java.io.PrintStream;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
-import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_SERVER_CONNECTOR_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_STRUCT_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKAGE_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STARTED;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getBrokerNames;
 
 /**
  * Start server connector.
@@ -56,11 +57,10 @@ public class Start {
     private static final PrintStream console = System.out;
 
     public static Object start(Strand strand, ObjectValue listener) {
-        KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener
-                .getNativeData(CONSUMER_SERVER_CONNECTOR_NAME);
+        KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener.getNativeData(SERVER_CONNECTOR);
         try {
             serverConnector.start();
-            console.println(SERVICE_STARTED);
+            console.println(SERVICE_STARTED + getBrokerNames(listener));
         } catch (KafkaConnectorException e) {
             return KafkaUtils.createKafkaError(e.getMessage(), CONSUMER_ERROR);
         }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Stop.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Stop.java
@@ -30,12 +30,13 @@ import org.ballerinalang.natives.annotations.Receiver;
 import java.io.PrintStream;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
-import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_SERVER_CONNECTOR_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_STRUCT_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKAGE_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STOPPED;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getBrokerNames;
 
 /**
  * Stop the server connector.
@@ -56,7 +57,7 @@ public class Stop {
 
     public static Object stop(Strand strand, ObjectValue listener) {
         KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener
-                .getNativeData(CONSUMER_SERVER_CONNECTOR_NAME);
+                .getNativeData(SERVER_CONNECTOR);
         boolean isStopped;
         try {
             isStopped = serverConnector.stop();
@@ -66,7 +67,7 @@ public class Stop {
         if (!isStopped) {
             return KafkaUtils.createKafkaError("Failed to stop the kafka service.", CONSUMER_ERROR);
         }
-        console.println(SERVICE_STOPPED);
+        console.println(SERVICE_STOPPED + getBrokerNames(listener));
         return null;
     }
 }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Stop.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/service/Stop.java
@@ -27,12 +27,15 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 
+import java.io.PrintStream;
+
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ERROR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_SERVER_CONNECTOR_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_STRUCT_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PACKAGE_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.KAFKA_PROTOCOL_PACKAGE;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STOPPED;
 
 /**
  * Stop the server connector.
@@ -49,6 +52,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.ORG_NAME;
         isPublic = true
 )
 public class Stop {
+    private static final PrintStream console = System.out;
 
     public static Object stop(Strand strand, ObjectValue listener) {
         KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener
@@ -62,6 +66,7 @@ public class Stop {
         if (!isStopped) {
             return KafkaUtils.createKafkaError("Failed to stop the kafka service.", CONSUMER_ERROR);
         }
+        console.println(SERVICE_STOPPED);
         return null;
     }
 }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -39,6 +39,9 @@ public class KafkaConstants {
     public static final String FULL_PACKAGE_NAME = KAFKA_PACKAGE_NAME + BLOCK_SEPARATOR + VERSION;
     public static final String KAFKA_PROTOCOL_PACKAGE = BALLERINA_PACKAGE_PREFIX + KAFKA_PACKAGE_NAME;
 
+    public static final String SERVICE_STARTED = "[ballerina/kafka] started kafka listener ";
+    public static final String SERVICE_STOPPED = "[ballerina/kafka] stopped kafka listener ";
+
     public static final String NATIVE_CONSUMER = "KafkaConsumer";
     public static final String NATIVE_PRODUCER = "KafkaProducer";
     public static final String NATIVE_PRODUCER_CONFIG = "KafkaProducerConfig";

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -59,7 +59,7 @@ public class KafkaConstants {
 
     public static final String CONSUMER_RECORD_STRUCT_NAME = "ConsumerRecord";
     public static final String CONSUMER_STRUCT_NAME = "Consumer";
-    public static final String CONSUMER_SERVER_CONNECTOR_NAME = "serverConnector";
+    public static final String SERVER_CONNECTOR = "serverConnector";
 
     public static final String CONSUMER_CONFIG_FIELD_NAME = "consumerConfig";
 

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -39,8 +39,11 @@ public class KafkaConstants {
     public static final String FULL_PACKAGE_NAME = KAFKA_PACKAGE_NAME + BLOCK_SEPARATOR + VERSION;
     public static final String KAFKA_PROTOCOL_PACKAGE = BALLERINA_PACKAGE_PREFIX + KAFKA_PACKAGE_NAME;
 
-    public static final String SERVICE_STARTED = "[ballerina/kafka] started kafka listener ";
-    public static final String SERVICE_STOPPED = "[ballerina/kafka] stopped kafka listener ";
+    // Kafka log messages
+    public static final String SERVICE_STARTED = "[ballerina/kafka] started kafka listener";
+    public static final String SERVICE_STOPPED = "[ballerina/kafka] stopped kafka listener";
+    public static final String KAFKA_SERVERS = "[ballerina/kafka] kafka servers: ";
+    public static final String SUBSCRIBED_TOPICS = "[ballerina/kafka] subscribed topics: ";
 
     public static final String NATIVE_CONSUMER = "KafkaConsumer";
     public static final String NATIVE_PRODUCER = "KafkaProducer";
@@ -106,6 +109,7 @@ public class KafkaConstants {
     public static final String CONSUMER_CLIENT_ID_CONFIG = "clientId";
     public static final String CONSUMER_INTERCEPTOR_CLASSES_CONFIG = "interceptorClasses";
     public static final String CONSUMER_ISOLATION_LEVEL_CONFIG = "isolationLevel";
+    public static final String CONSUMER_TOPICS_CONFIG = "topics";
 
     public static final String CONSUMER_SESSION_TIMEOUT_MS_CONFIG = "sessionTimeoutInMillis";
     public static final String CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG = "heartBeatIntervalInMillis";

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -684,4 +684,8 @@ public class KafkaUtils {
         MapValue<String, Object> listenerConfigurations = listener.getMapValue(CONSUMER_CONFIG_FIELD_NAME);
         return (String) listenerConfigurations.get(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
     }
+
+    public static String getTopicNamesString(ArrayList<String> topicsList) {
+        return String.join(", ", topicsList);
+    }
 }

--- a/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/stdlib/messaging/kafka/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -58,6 +58,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_AU
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_BOOTSTRAP_SERVERS_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CHECK_CRCS_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CLIENT_ID_CONFIG;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CONFIG_FIELD_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CONNECTIONS_MAX_IDLE_MS_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_DEFAULT_API_TIMEOUT_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_ENABLE_AUTO_COMMIT_CONFIG;
@@ -677,5 +678,10 @@ public class KafkaUtils {
         KafkaProducer<byte[], byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
         producerObject.addNativeData(NATIVE_PRODUCER, kafkaProducer);
         producerObject.addNativeData(NATIVE_PRODUCER_CONFIG, producerProperties);
+    }
+
+    public static String getBrokerNames(ObjectValue listener) {
+        MapValue<String, Object> listenerConfigurations = listener.getMapValue(CONSUMER_CONFIG_FIELD_NAME);
+        return (String) listenerConfigurations.get(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
     }
 }


### PR DESCRIPTION
## Purpose
> The Kafka listener currently does not log when the listener is started or stopped. It will be added with this PR.

Fixes #<Issue Number>

## Approach
> * When a Kafka consumer listener is connected to a Kafka server, it logs `[ballerina/kafka] kafka servers: <server_names_comma_separated>`.
> * When the Kafka consumer subscribed to a topic, it logs `[ballerina/kafka] subscribed topics: <topic_subscribed_comma_separated>`.
> * When the listener is started, it logs `[ballerina/kafka] started kafka listener`.

## Samples
> Following is a an example log from a ballerina Kafka listener:
```
[ballerina/kafka] kafka servers: localhost:9092, localhost:9093
[ballerina/kafka] subscribed topics: simple-topic, advanced-topic
[ballerina/kafka] started kafka listener
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
