### PR TITLE
Fix type init invocation with defaultable parameters and union of object types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1676,7 +1676,9 @@ public class TypeChecker extends BLangNodeVisitor {
     }
 
     private List<BType> findMembersWithMatchingInitFunc(BLangTypeInit cIExpr, BUnionType lhsUnionType) {
-        cIExpr.initInvocation.argExprs.forEach(expr -> checkExpr(expr, env, symTable.noType));
+        boolean containsSingleObject = lhsUnionType.getMemberTypes().stream()
+                .filter(x -> x.tag == TypeTags.OBJECT)
+                .count() == 1;
 
         List<BType> matchingLhsMemberTypes = new ArrayList<>();
         for (BType memberType : lhsUnionType.getMemberTypes()) {
@@ -1686,6 +1688,10 @@ public class TypeChecker extends BLangNodeVisitor {
             }
             if ((memberType.tsymbol.flags & Flags.ABSTRACT) == Flags.ABSTRACT) {
                 dlog.error(cIExpr.pos, DiagnosticCode.CANNOT_INITIALIZE_ABSTRACT_OBJECT, lhsUnionType.tsymbol);
+            }
+
+            if (containsSingleObject) {
+                return Collections.singletonList(memberType);
             }
 
             BAttachedFunction initializerFunc = ((BObjectTypeSymbol) memberType.tsymbol).initializerFunc;
@@ -1714,6 +1720,8 @@ public class TypeChecker extends BLangNodeVisitor {
     }
 
     private boolean isArgsMatchesFunction(List<BLangExpression> invocationArguments, BAttachedFunction function) {
+        invocationArguments.forEach(expr -> checkExpr(expr, env, symTable.noType));
+
         if (function == null) {
             return invocationArguments.isEmpty();
         }
@@ -1723,90 +1731,78 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         List<BLangNamedArgsExpression> namedArgs = new ArrayList<>();
-        List<BLangExpression> unnamedArgs = new ArrayList<>();
+        List<BLangExpression> positionalArgs = new ArrayList<>();
         for (BLangExpression argument : invocationArguments) {
             if (argument.getKind() == NodeKind.NAMED_ARGS_EXPR) {
                 namedArgs.add((BLangNamedArgsExpression) argument);
             } else {
-                unnamedArgs.add(argument);
+                positionalArgs.add(argument);
             }
         }
 
-        // All named arguments must be present in function as defaultable parameters.
-        if (!matchDefaultableParameters(function, namedArgs)) {
-            return false;
-        }
-
-        // Given arguments are less than required parameters.
         List<BVarSymbol> requiredParams = function.symbol.params.stream()
-                .filter(param -> !param.defaultableParam).collect(Collectors.toList());
-        if (requiredParams.size() > unnamedArgs.size()) {
+                .filter(param -> !param.defaultableParam)
+                .collect(Collectors.toList());
+        // Given named and positional arguments are less than required parameters.
+        if (requiredParams.size() > invocationArguments.size()) {
             return false;
         }
 
-        // No rest params, all (unnamed) args must match params.
-        if (function.symbol.restParam == null && requiredParams.size() != unnamedArgs.size()) {
-            return false;
-        }
-
-        // Match rest param type.
-        if (function.symbol.restParam != null) {
-            BType restParamType = ((BArrayType) function.symbol.restParam.type).eType;
-            if (!restArgTypesMatch(unnamedArgs, requiredParams.size(), restParamType)) {
-                return false;
-            }
-        }
-
-        // Each arguments must be assignable to required parameter at respective position.
-        for (int i = 0, paramsSize = requiredParams.size(); i < paramsSize; i++) {
-            BVarSymbol param = requiredParams.get(i);
-            BLangExpression argument = unnamedArgs.get(i);
-            if (!types.isAssignable(argument.type, param.type)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean restArgTypesMatch(List<BLangExpression> unnamedArgs, int requiredParamCount, BType restParamType) {
-        if (unnamedArgs.size() == requiredParamCount) {
-            return true;
-        }
-        List<BLangExpression> restArgs = unnamedArgs.subList(requiredParamCount, unnamedArgs.size());
-        for (BLangExpression restArg : restArgs) {
-            if (!types.isAssignable(restArg.type, restParamType)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean matchDefaultableParameters(BAttachedFunction function, List<BLangNamedArgsExpression> namedArgs) {
         List<BVarSymbol> defaultableParams = function.symbol.params.stream()
                 .filter(param -> param.defaultableParam)
                 .collect(Collectors.toList());
-        // More named args given than function can accept.
-        if (defaultableParams.size() < namedArgs.size()) {
+
+        int givenRequiredParamCount = 0;
+        for (int i = 0; i < positionalArgs.size(); i++) {
+            if (function.symbol.params.size() > i) {
+                givenRequiredParamCount++;
+                BVarSymbol functionParam = function.symbol.params.get(i);
+                // check the type compatibility of positional args against function params.
+                if (!types.isAssignable(positionalArgs.get(i).type, functionParam.type)) {
+                    return false;
+                }
+                requiredParams.remove(functionParam);
+                defaultableParams.remove(functionParam);
+                continue;
+            }
+
+            if (function.symbol.restParam != null) {
+                BType restParamType = ((BArrayType) function.symbol.restParam.type).eType;
+                if (!types.isAssignable(positionalArgs.get(i).type, restParamType)) {
+                    return false;
+                }
+                continue;
+            }
+
+            // additional positional args given for function with no rest param
             return false;
         }
 
-        int matchedParamterCount = 0;
-        for (BVarSymbol defaultableParam : defaultableParams) {
-            for (BLangNamedArgsExpression namedArg : namedArgs) {
-                if (!namedArg.name.value.equals(defaultableParam.name.value)) {
+        for (BLangNamedArgsExpression namedArg : namedArgs) {
+            boolean foundNamedArg = false;
+            // check the type compatibility of named args against function params.
+            List<BVarSymbol> params = function.symbol.params;
+            for (int i = givenRequiredParamCount; i < params.size(); i++) {
+                BVarSymbol functionParam = params.get(i);
+                if (!namedArg.name.value.equals(functionParam.name.value)) {
                     continue;
                 }
+                foundNamedArg = true;
                 BType namedArgExprType = checkExpr(namedArg.expr, env);
-                if (types.isAssignable(defaultableParam.type, namedArgExprType)) {
-                    matchedParamterCount++;
-                } else {
+                if (!types.isAssignable(functionParam.type, namedArgExprType)) {
                     // Name matched, type mismatched.
                     return false;
                 }
+                requiredParams.remove(functionParam);
+                defaultableParams.remove(functionParam);
+            }
+            if (!foundNamedArg) {
+                return false;
             }
         }
-        // All named arguments have their respective defaultable parameters.
-        return namedArgs.size() == matchedParamterCount;
+
+        // all required params are not given by positional or named args.
+        return requiredParams.size() <= 0;
     }
 
     public void visit(BLangWaitForAllExpr waitForAllExpr) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -396,19 +396,22 @@ public class ObjectInBaloTest {
         BAssertUtil.validateError(result, 2, "variable 'p' is not initialized", 7, 35);
     }
 
-    @Test (description = "Negative test to test returning different type without type name")
+    @Test(description = "Negative test to test returning different type without type name")
     public void testObjectNegativeTestForReturnDifferentType() {
         CompileResult result = BCompileUtil.compile("test-src/balo/test_balo/object" +
                 "/object_new_in_return_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 5);
-        BAssertUtil.validateError(result, 0, "cannot infer type of the object from 'testorg/foo:1.0.0:Apartment?'", 8,
+        int i = 0;
+        BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'testorg/foo:1.0.0:Apartment?'", 8,
                 12);
-        BAssertUtil.validateError(result, 1, "cannot infer type of the object from 'testorg/foo:1.0.0:Apartment?'", 12,
+        BAssertUtil.validateError(result, i++, "missing required parameter 'addVal' in call to 'new'()", 8, 12);
+        BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'testorg/foo:1.0.0:Apartment?'", 12,
                 33);
-        BAssertUtil.validateError(result, 2, "cannot infer type of the object from 'other'", 13, 19);
-        BAssertUtil.validateError(result, 3, "invalid variable definition; can not infer the assignment type.",
+        BAssertUtil.validateError(result, i++, "missing required parameter 'addVal' in call to 'new'()", 12, 33);
+        BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'other'", 13, 19);
+        BAssertUtil.validateError(result, i++, "invalid variable definition; can not infer the assignment type.",
                 13, 19);
-        BAssertUtil.validateError(result, 4, "cannot infer type of the object from 'error'", 14, 21);
+        BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'error'", 14, 21);
+        Assert.assertEquals(result.getErrorCount(), i);
     }
 
 //    @Test (description = "Negative test to test returning different type without type name")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -401,11 +401,9 @@ public class ObjectInBaloTest {
         CompileResult result = BCompileUtil.compile("test-src/balo/test_balo/object" +
                 "/object_new_in_return_negative.bal");
         int i = 0;
-        BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'testorg/foo:1.0.0:Apartment?'", 8,
-                12);
+        BAssertUtil.validateError(result, i++, "not enough arguments in call to 'new()'", 8, 12);
         BAssertUtil.validateError(result, i++, "missing required parameter 'addVal' in call to 'new'()", 8, 12);
-        BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'testorg/foo:1.0.0:Apartment?'", 12,
-                33);
+        BAssertUtil.validateError(result, i++, "not enough arguments in call to 'new()'", 12, 33);
         BAssertUtil.validateError(result, i++, "missing required parameter 'addVal' in call to 'new'()", 12, 33);
         BAssertUtil.validateError(result, i++, "cannot infer type of the object from 'other'", 13, 19);
         BAssertUtil.validateError(result, i++, "invalid variable definition; can not infer the assignment type.",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
@@ -691,15 +691,54 @@ public class ObjectTest {
         Assert.assertEquals(((BMap) foo.get("bar")).get("p").stringValue(), "{name:\"John Doe\"}");
     }
 
+    @Test(description = "Test invoking object inits with union params in another object's function")
+    public void testObjectInitFunctionWithDefaultableParams() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/object/ObjectProject", "pkg2");
+        BValue[] result = BRunUtil.invoke(compileResult, "testObjectInitFunctionWithDefaultableParams");
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 900000);
+        Assert.assertEquals(((BInteger) result[1]).intValue(), 10000);
+        Assert.assertEquals(((BInteger) result[2]).intValue(), 20000);
+        Assert.assertEquals(((BInteger) result[3]).intValue(), 30000);
+        Assert.assertEquals(((BInteger) result[4]).intValue(), 40000);
+    }
+
+    @Test(description = "Test invoking object inits with union params in another object's function")
+    public void testObjectInitFunctionWithDefaultableParams2() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/object/ObjectProject", "pkg2");
+        BValue[] result = BRunUtil.invoke(compileResult, "testObjectInitFunctionWithDefaultableParams2");
+        Assert.assertEquals(((BFloat) result[0]).floatValue(), 1.1);
+        Assert.assertEquals(((BInteger) result[1]).intValue(), 1);
+    }
+
     @Test(description = "Negative test for object union type inference")
     public void testNegativeUnionTypeInit() {
         CompileResult resultNegative = BCompileUtil.compile("test-src/object/object_type_union_negative.bal");
-        Assert.assertEquals(resultNegative.getErrorCount(), 4);
-        BAssertUtil.validateError(resultNegative, 0, "ambiguous type '(Obj|Obj2|Obj3|Obj4)'", 48, 25);
-        BAssertUtil.validateError(resultNegative, 1, "ambiguous type '(Obj|Obj2|Obj3|Obj4)'", 49, 25);
-        BAssertUtil.validateError(resultNegative, 2, "cannot infer type of the object from '(Obj|Obj2|Obj3|Obj4)'",
+        int i = 0;
+        BAssertUtil.validateError(resultNegative, i++, "ambiguous type '(Obj|Obj2|Obj3|Obj4)'", 48, 25);
+        BAssertUtil.validateError(resultNegative, i++, "ambiguous type '(Obj|Obj2|Obj3|Obj4)'", 49, 25);
+        BAssertUtil.validateError(resultNegative, i++, "cannot infer type of the object from '(Obj|Obj2|Obj3|Obj4)'",
                                   50, 46);
-        BAssertUtil.validateError(resultNegative, 3, "cannot infer type of the object from 'Bar?'", 71, 20);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected '(PersonRec|EmployeeRec)', found 'string'", 71, 24);
+        BAssertUtil.validateError(resultNegative, i++,
+                "positional argument not allowed after named arguments", 114, 53);
+        BAssertUtil.validateError(resultNegative, i++,
+                "missing required parameter 'i' in call to 'new'()", 114, 38);
+        BAssertUtil.validateError(resultNegative, i++,
+                "cannot infer type of the object from '(InitObjOne|InitObjTwo|int)'", 119, 36);
+        BAssertUtil.validateError(resultNegative, i++,
+                "ambiguous type '(InitObjOne|InitObjTwo|float)'", 120, 38);
+        BAssertUtil.validateError(resultNegative, i++,
+                "cannot infer type of the object from '(InitObjOne|InitObjTwo|float)'", 121, 38);
+        BAssertUtil.validateError(resultNegative, i++,
+                "incompatible types: expected 'int', found 'string'", 126, 51);
+        BAssertUtil.validateError(resultNegative, i++,
+                "cannot infer type of the object from '(InitObjOne|InitObjThree|boolean|string)'", 127, 50);
+        BAssertUtil.validateError(resultNegative, i++,
+                "positional argument not allowed after named arguments", 128, 59);
+        BAssertUtil.validateError(resultNegative, i++,
+                "cannot infer type of the object from '(InitObjThree|InitObjOne|boolean|string)'", 129, 50);
+        Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 
     @DataProvider

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg1/pkg1.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg1/pkg1.bal
@@ -40,3 +40,15 @@ public type SameFieldAndMethodObject object {
         return [f1, f2];
     }
 };
+
+public type TempCache object {
+    public int capacity;
+    public int expiryTimeInMillis;
+    public float evictionFactor;
+
+    public function __init(public int expiryTimeInMillis = 900000, public int capacity = 100, public float evictionFactor = 0.25) {
+        self.capacity = capacity;
+        self.expiryTimeInMillis = expiryTimeInMillis;
+        self.evictionFactor = evictionFactor;
+    }
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg2/pkg2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/pkg2/pkg2.bal
@@ -28,3 +28,42 @@ function testBaloWithFieldWithSameNameAsMethod() returns [int, int, int, float, 
 
     return [a, b, c, d, e, f, g];
 }
+
+function testObjectInitFunctionWithDefaultableParams() returns [int, int, int, int, int] {
+    pkg1:TempCache? cache1 = new();
+    pkg1:TempCache? cache2 = new(10000, capacity = 10);
+    pkg1:TempCache? cache3 = new(20000, evictionFactor = 0.1);
+    pkg1:TempCache? cache4 = new(30000, capacity = 10, evictionFactor = 0.2);
+    pkg1:TempCache? cache5 = new(expiryTimeInMillis = 40000, capacity = 20, evictionFactor = 0.3);
+
+    if (cache1 is pkg1:TempCache && cache2 is pkg1:TempCache && cache3 is pkg1:TempCache && cache4 is pkg1:TempCache && cache5 is pkg1:TempCache) {
+        return [cache1.expiryTimeInMillis, cache2.expiryTimeInMillis, cache3.expiryTimeInMillis, cache4.expiryTimeInMillis, cache5.expiryTimeInMillis];
+    }
+    return [0, 0, 0, 0, 0];
+}
+
+type InitObjOne object {
+    float f;
+
+    public function __init(float i) {
+        self.f = i;
+    }
+};
+
+type InitObjTwo object {
+    int f;
+    public function __init(int i) {
+        self.f = i;
+    }
+};
+
+function testObjectInitFunctionWithDefaultableParams2() returns [float, int] {
+    InitObjOne|InitObjTwo|int f1 = new(1.1);
+    InitObjOne|InitObjTwo|float f2 = new(1);
+
+    if (f1 is InitObjOne && f2 is InitObjTwo) {
+        return [f1.f, f2.f];
+    }
+
+    return [0.0, 0];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_type_union_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_type_union_negative.bal
@@ -45,9 +45,9 @@ type Obj4 object {
 Obj4 aOb = new(55, 66, 77);
 
 Obj|Obj2|Obj3|Obj4 a = new(5, 6, 7);
-Obj|Obj2|Obj3|Obj4 ab = new(5);
-Obj|Obj2|Obj3|Obj4 ac = new();
-Obj|Obj2|Obj3|Obj4 wrongDefaultableArgType = new(5, j="zero");
+Obj|Obj2|Obj3|Obj4 ab = new(5); // ambiguous type '(Obj|Obj2|Obj3|Obj4)'
+Obj|Obj2|Obj3|Obj4 ac = new(); // ambiguous type '(Obj|Obj2|Obj3|Obj4)'
+Obj|Obj2|Obj3|Obj4 wrongDefaultableArgType = new(5, j="zero"); // cannot infer type of the object from '(Obj|Obj2|Obj3|Obj4)'
 
 function getA() returns Obj|Obj2|Obj3|Obj4 {
     return a;
@@ -68,7 +68,7 @@ type Foo object {
 
     function test() {
         string p = "John Doe";
-        self.bar = new(p);
+        self.bar = new(p); // incompatible types: expected '(PersonRec|EmployeeRec)', found 'string'
     }
 };
 
@@ -87,3 +87,44 @@ type PersonRec record {|
 type EmployeeRec record {
     string name;
 };
+
+
+type InitObjOne object {
+
+    public function __init(int i, string f = "str") {
+
+    }
+};
+
+type InitObjTwo object {
+
+    public function __init(int i, boolean f = true) {
+
+    }
+};
+
+type InitObjThree object {
+
+    public function __init(int i, string s, int j = 10, string... k) {
+
+    }
+};
+
+function testAmbiguousObjectTypes() {
+    InitObjOne|InitObjTwo|float f1 = new(f = false, 2); // positional argument not allowed after named arguments
+    InitObjOne|InitObjTwo|float f2 = new(1, false); // valid
+    InitObjOne|InitObjTwo|float f3 = new(1, "str2"); // valid
+    InitObjOne|InitObjTwo|float f4 = new(1, f = false); // valid
+    InitObjOne|InitObjTwo|float f5 = new(1, f = "str2"); // valid
+    InitObjOne|InitObjTwo|int f6 = new(); // cannot infer type of the object from '(InitObjOne|InitObjTwo|int)'
+    InitObjOne|InitObjTwo|float f7 = new(1); // ambiguous type '(InitObjOne|InitObjTwo|float)'
+    InitObjOne|InitObjTwo|float f8 = new(1, 1.1); // cannot infer type of the object from '(InitObjOne|InitObjTwo|float)'
+
+    InitObjThree|boolean|string f9 = new(1, "s"); // valid
+    InitObjThree|boolean|string f10 = new(1, "s", 12, "a", "b", "c"); // valid
+    InitObjThree|boolean|string f11 = new(1, "s", j = 12); // valid
+    InitObjThree|boolean|string f12 = new(1, "s", "a", "b", "c"); // incompatible types: expected 'int', found 'string'
+    InitObjOne|InitObjThree|boolean|string f13 = new(1, "s", "a", "b", "c"); // cannot infer type of the object from '(InitObjOne|InitObjThree|boolean|string)'
+    InitObjThree|boolean|string f14 = new(1, "s", j = 20, "a"); // positional argument not allowed after named arguments
+    InitObjThree|InitObjOne|boolean|string f15 = new(1, "s", j = 20, "a", "b", "c"); // cannot infer type of the object from '(InitObjThree|InitObjOne|boolean|string)'
+}


### PR DESCRIPTION
## Purpose
Fix issue with inferring the object type when the expected type is an object type.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/18008

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
