### PR TITLE
Add console logger

### DIFF
--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
@@ -23,6 +23,7 @@ import org.ballerinalang.logging.formatters.HttpAccessLogFormatter;
 import org.ballerinalang.logging.formatters.HttpTraceLogFormatter;
 import org.ballerinalang.logging.formatters.JsonLogFormatter;
 import org.ballerinalang.logging.util.BLogLevel;
+import org.ballerinalang.logging.util.BLogLevelMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -126,12 +127,19 @@ public class BLogManager extends LogManager {
             consoleLogger = Logger.getLogger(CONSOLE_LOGGER);
         }
 
+        BLogLevel level = loggerLevels.get(CONSOLE_LOGGER);
+        if (level == null) {
+            level = loggerLevels.get(BALLERINA_USER_LOG_LEVEL);
+        }
+
+        Level logLevel = BLogLevelMapper.getLoggerLevel(level);
+
         ConsoleHandler consoleHandler = new ConsoleHandler();
-        consoleHandler.setLevel(Level.FINEST);
+        consoleHandler.setLevel(logLevel);
         consoleHandler.setFormatter(new DefaultLogFormatter());
         consoleLogger.addHandler(consoleHandler);
         consoleLogger.setUseParentHandlers(false);
-        consoleLogger.setLevel(Level.FINEST);
+        consoleLogger.setLevel(logLevel);
     }
 
     /**

--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.logging;
 
 import org.ballerinalang.config.ConfigRegistry;
+import org.ballerinalang.logging.formatters.DefaultLogFormatter;
 import org.ballerinalang.logging.formatters.HttpAccessLogFormatter;
 import org.ballerinalang.logging.formatters.HttpTraceLogFormatter;
 import org.ballerinalang.logging.formatters.JsonLogFormatter;
@@ -44,6 +45,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.ballerinalang.logging.util.Constants.BALLERINA_USER_LOG_LEVEL;
+import static org.ballerinalang.logging.util.Constants.CONSOLE_LOGGER;
 import static org.ballerinalang.logging.util.Constants.DEFAULT_LOG_FILE_HANDLER_PATTERN;
 import static org.ballerinalang.logging.util.Constants.HTTP_ACCESS_LOG;
 import static org.ballerinalang.logging.util.Constants.HTTP_ACCESS_LOG_CONSOLE;
@@ -73,6 +75,7 @@ public class BLogManager extends LogManager {
     private BLogLevel ballerinaUserLogLevel = BLogLevel.INFO; // default to INFO
     private Logger httpTraceLogger;
     private Logger httpAccessLogger;
+    private Logger consoleLogger;
 
     @Override
     public void readConfiguration(InputStream ins) throws IOException, SecurityException {
@@ -110,10 +113,25 @@ public class BLogManager extends LogManager {
 
         setHttpTraceLogHandler();
         setHttpAccessLogHandler();
+        setConsoleLogHandler();
     }
 
     public BLogLevel getPackageLogLevel(String pkg) {
         return loggerLevels.containsKey(pkg) ? loggerLevels.get(pkg) : ballerinaUserLogLevel;
+    }
+
+    public void setConsoleLogHandler() {
+        if (consoleLogger == null) {
+            // keep a reference to prevent this logger from being garbage collected
+            consoleLogger = Logger.getLogger(CONSOLE_LOGGER);
+        }
+
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+        consoleHandler.setLevel(Level.FINEST);
+        consoleHandler.setFormatter(new DefaultLogFormatter());
+        consoleLogger.addHandler(consoleHandler);
+        consoleLogger.setUseParentHandlers(false);
+        consoleLogger.setLevel(Level.FINEST);
     }
 
     /**

--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/BLogLevelMapper.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/BLogLevelMapper.java
@@ -47,4 +47,24 @@ public class BLogLevelMapper {
                 return "<UNDEFINED>";
         }
     }
+
+    public static Level getLoggerLevel(BLogLevel level) {
+        switch (level) {
+            case OFF:
+                return Level.OFF;
+            case ERROR:
+                return Level.SEVERE;
+            case WARN:
+                return Level.WARNING;
+            case INFO:
+                return Level.INFO;
+            case DEBUG:
+                return Level.FINER;
+            case TRACE:
+                return Level.FINEST;
+            case ALL:
+                return Level.ALL;
+        }
+        return Level.INFO;
+    }
 }

--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/Constants.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/Constants.java
@@ -30,10 +30,11 @@ public class Constants {
     public static final String BALLERINA_USER_LOG_LEVEL = "b7a.log.level";
     public static final String LOG_LEVEL = ".loglevel";
 
+    public static final String CONSOLE_LOGGER = "b7a.log.console";
+
     public static final String HTTP_TRACE_LOG = "http.tracelog";
     public static final String HTTP_TRACE_LOG_ENABLED = "http.tracelog.enabled";
     public static final String HTTP_TRACE_LOG_CONSOLE = "b7a.http.tracelog.console";
-    public static final String CONSOLE_LOGGER = "b7a.log.console";
     public static final String HTTP_TRACE_LOG_FILE = "b7a.http.tracelog.path";
     public static final String HTTP_TRACE_LOG_HOST = "b7a.http.tracelog.host";
     public static final String HTTP_TRACE_LOG_PORT = "b7a.http.tracelog.port";

--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/Constants.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/Constants.java
@@ -33,6 +33,7 @@ public class Constants {
     public static final String HTTP_TRACE_LOG = "http.tracelog";
     public static final String HTTP_TRACE_LOG_ENABLED = "http.tracelog.enabled";
     public static final String HTTP_TRACE_LOG_CONSOLE = "b7a.http.tracelog.console";
+    public static final String CONSOLE_LOGGER = "b7a.log.console";
     public static final String HTTP_TRACE_LOG_FILE = "b7a.http.tracelog.path";
     public static final String HTTP_TRACE_LOG_HOST = "b7a.http.tracelog.host";
     public static final String HTTP_TRACE_LOG_PORT = "b7a.http.tracelog.port";


### PR DESCRIPTION
## Purpose
> Add a logger that prints messages only to the console (System.err). This is to be used by standard libraries when they need to log some messages to the console. Logger uses the `DefaultLogFormatter()` log format.

Fixes #17884

## Approach
> To use this feature, get the logger with the name "b7a.log.console"
```
import static org.ballerinalang.logging.util.Constants.CONSOLE_LOGGER;

private static final Logger log = LoggerFactory.getLogger(CONSOLE_LOGGER);
```

The log level can be configured using the config `b7a.log.console.loglevel`. Ballerina user log level `b7a.log.level` is used by default as the log level.
## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
