### PR TITLE
Fix dataflow analysis of match statement

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -439,16 +439,29 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     public void visit(BLangMatch match) {
         analyzeNode(match.expr, env);
         Map<BSymbol, InitStatus> uninitVars = new HashMap<>();
+        BranchResult lastPatternResult = null;
         for (BLangMatch.BLangMatchBindingPatternClause patternClause : match.patternClauses) {
-            BranchResult result = analyzeBranch(patternClause, env);
-            // If the flow was terminated within the block, then that branch should not be considered for
-            // analyzing the data-flow for the downstream code.
-            if (result.flowTerminated) {
-                continue;
+            if (patternClause.isLastPattern) {
+                lastPatternResult = analyzeBranch(patternClause, env);
+            } else {
+                BranchResult result = analyzeBranch(patternClause, env);
+                // If the flow was terminated within the block, then that branch should not be considered for
+                // analyzing the data-flow for the downstream code.
+                if (result.flowTerminated) {
+                    continue;
+                }
+                uninitVars = mergeUninitializedVars(uninitVars, result.uninitializedVars);
             }
-            uninitVars = mergeUninitializedVars(uninitVars, result.uninitializedVars);
         }
 
+        if (lastPatternResult != null) {
+            // only if last pattern is present, uninitializedVars should be updated
+            uninitVars = mergeUninitializedVars(uninitVars, lastPatternResult.uninitializedVars);
+            this.uninitializedVars = uninitVars;
+            return;
+        }
+        uninitVars = new HashMap<>();
+        uninitVars = mergeUninitializedVars(uninitVars, this.uninitializedVars);
         this.uninitializedVars = uninitVars;
     }
 
@@ -1172,10 +1185,12 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangMatchStaticBindingPatternClause bLangMatchStaticBindingPatternClause) {
+        analyzeNode(bLangMatchStaticBindingPatternClause.body, env);
     }
 
     @Override
     public void visit(BLangMatchStructuredBindingPatternClause bLangMatchStructuredBindingPatternClause) {
+        analyzeNode(bLangMatchStructuredBindingPatternClause.body, env);
     }
 
     private void addUninitializedVar(BLangVariable variable) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -460,8 +460,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             this.uninitializedVars = uninitVars;
             return;
         }
-        uninitVars = new HashMap<>();
-        uninitVars = mergeUninitializedVars(uninitVars, this.uninitializedVars);
+        uninitVars = mergeUninitializedVars(new HashMap<>(), this.uninitializedVars);
         this.uninitializedVars = uninitVars;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
@@ -77,6 +77,7 @@ public class DataflowAnalysisTest {
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 618, 12);
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 628, 12);
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 650, 12);
+        BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 673, 12);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
@@ -33,7 +33,6 @@ public class DataflowAnalysisTest {
     @Test(description = "Test uninitialized variables")
     public void testUninitializedVariables() {
         CompileResult result = BCompileUtil.compile("test-src/dataflow/analysis/dataflow-analysis-negative.bal");
-
         int i = 0;
         BAssertUtil.validateError(result, i++, "variable 'msg' may not have been initialized", 53, 12);
         BAssertUtil.validateError(result, i++, "variable 'msg' may not have been initialized", 70, 12);
@@ -60,7 +59,6 @@ public class DataflowAnalysisTest {
         BAssertUtil.validateError(result, i++, "uninitialized field 'd'", 304, 5);
         BAssertUtil.validateError(result, i++, "undefined field 'f' in object 'Foo'", 312, 9);
         BAssertUtil.validateError(result, i++, "variable 'd' is not initialized", 329, 16);
-        BAssertUtil.validateError(result, i++, "variable 'val' may not have been initialized", 360, 12);
         BAssertUtil.validateError(result, i++, "variable 'a' is not initialized", 385, 5);
         BAssertUtil.validateError(result, i++, "variable 'a' is not initialized", 404, 13);
         BAssertUtil.validateError(result, i++, "variable 'b' may not have been initialized", 404, 16);
@@ -75,6 +73,10 @@ public class DataflowAnalysisTest {
         BAssertUtil.validateError(result, i++, "uninitialized field 'b'", 577, 5);
         BAssertUtil.validateError(result, i++, "uninitialized field 'c'", 578, 5);
         BAssertUtil.validateError(result, i++, "uninitialized field 's'", 586, 14);
+        BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 596, 12);
+        BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 618, 12);
+        BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 628, 12);
+        BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 650, 12);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
@@ -585,3 +585,67 @@ type F object {
 public function testDataFlow_13(){
     object { public string s; } o = new;
 }
+
+function testMatch2() returns int {
+    any v = 1;
+    int k;
+    match v {
+        1 => {k = 1;}
+        2 => {k = 2;}
+    }
+    return k; // variable 'k' may not have been initialized
+}
+
+function testMatch3() returns int {
+    any v = 1;
+    int k;
+    match v {
+        1 => {k = 1;}
+        2 => {k = 2;}
+        _ => {k = 0;}
+    }
+    return k;
+}
+
+function testMatch4() returns int {
+    any v = 1;
+    int k;
+    match v {
+        1 => {k = 1;}
+        2 => {}
+        _ => {k = 0;}
+    }
+    return k; // variable 'k' may not have been initialized
+}
+
+function testMatch5() returns int {
+    any v = 1;
+    int k;
+    match v {
+        var [a, b] => {k = 1;}
+        var {a, b} => {k = 2;}
+    }
+    return k; // variable 'k' may not have been initialized
+}
+
+function testMatch6() returns int {
+    any v = 1;
+    int k;
+    match v {
+        var [a, b] => {k = 1;}
+        var {a, b} => {k = 2;}
+        var x => {k = 0;}
+    }
+    return k;
+}
+
+function testMatch7() returns int {
+    any v = 1;
+    int k;
+    match v {
+        var [a, b] => {k = 1;}
+        var {a, b} => {}
+        var x => {k = 0;}
+    }
+    return k; // variable 'k' may not have been initialized
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
@@ -649,3 +649,26 @@ function testMatch7() returns int {
     }
     return k; // variable 'k' may not have been initialized
 }
+
+function testMatch8() returns int {
+    any | error v = 1;
+    int k;
+    match v {
+        1 => {
+            k = 1;
+        }
+        2 => {
+            k = 2;
+        }
+        3 => {
+            k = 3;
+        }
+        4 => {
+            k = 4;
+        }
+        _ => {
+            k = 0;
+        }
+    }
+    return k; // variable 'k' may not have been initialized
+}


### PR DESCRIPTION
## Purpose
If a variable is initialized in all match pattern clauses including a default match pattern, the variable should be marked as initialized.

Fixes #18251

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
