### PR TITLE
Fix completion item default order and grouping based on kind

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetBlock.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetBlock.java
@@ -116,7 +116,6 @@ public class SnippetBlock {
                 return CompletionItemKind.Keyword;
             case SNIPPET:
             case STATEMENT:
-                return CompletionItemKind.Snippet;
             default:
                 return CompletionItemKind.Snippet;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BTypeCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BTypeCompletionItemBuilder.java
@@ -19,12 +19,17 @@ package org.ballerinalang.langserver.completions.builder;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.ArrayList;
 import java.util.Locale;
 
 /**
@@ -61,15 +66,39 @@ public class BTypeCompletionItemBuilder {
         if (bSymbol instanceof BPackageSymbol) {
             // package
             item.setKind(CompletionItemKind.Module);
+        } else if (bSymbol.type instanceof BFiniteType) {
+            // Finite types
+            item.setKind(CompletionItemKind.TypeParameter);
+        } else if (bSymbol.type instanceof BUnionType) {
+            // Union types
+            ArrayList<BType> memberTypes = new ArrayList(((BUnionType) bSymbol.type).getMemberTypes());
+            boolean allMatch = memberTypes.stream().allMatch(bType -> bType.tag == memberTypes.get(0).tag);
+            if (allMatch) {
+                switch (memberTypes.get(0).tag) {
+                    case TypeTags.ERROR:
+                        item.setKind(CompletionItemKind.Event);
+                        break;
+                    case TypeTags.RECORD:
+                        item.setKind(CompletionItemKind.Struct);
+                        break;
+                    case TypeTags.OBJECT:
+                        item.setKind(CompletionItemKind.Interface);
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                item.setKind(CompletionItemKind.Enum);
+            }
+        } else if (bSymbol instanceof BRecordTypeSymbol) {
+            item.setKind(CompletionItemKind.Struct);
+        } else if (bSymbol instanceof BObjectTypeSymbol) {
+            item.setKind(CompletionItemKind.Interface);
+        }  else if (bSymbol instanceof BErrorTypeSymbol) {
+            item.setKind(CompletionItemKind.Event);
         } else if (bSymbol.kind != null) {
             // class / objects
             item.setKind(CompletionItemKind.Class);
-        } else if (bSymbol.type instanceof BFiniteType || bSymbol.type instanceof BUnionType) {
-            // enums
-            item.setKind(CompletionItemKind.Enum);
-        } else if (bSymbol.pkgID.orgName.equals(Names.BUILTIN_ORG)) {
-            // keyword
-            item.setKind(CompletionItemKind.Keyword);
         } else {
             // default
             item.setKind(CompletionItemKind.Unit);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BVariableCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/BVariableCompletionItemBuilder.java
@@ -18,11 +18,9 @@
 package org.ballerinalang.langserver.completions.builder;
 
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
-import org.ballerinalang.model.types.TypeKind;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
-import org.wso2.ballerinalang.util.Flags;
 
 /**
  * This class is being used to build variable type completion item.
@@ -52,22 +50,9 @@ public final class BVariableCompletionItemBuilder {
     }
 
     private static void setMeta(CompletionItem item, BVarSymbol bSymbol) {
+        item.setKind(CompletionItemKind.Variable);
         if (bSymbol == null) {
-            item.setKind(CompletionItemKind.Variable);
             return;
-        }
-        //Or, else
-        if ((bSymbol.flags & Flags.FINAL) == Flags.FINAL) {
-            if (bSymbol.type.tsymbol != null && TypeKind.STRING.typeName().equals(bSymbol.type.tsymbol.name.value)) {
-                // string final
-                item.setKind(CompletionItemKind.Text);
-            } else {
-                // non-string final
-                item.setKind(CompletionItemKind.Unit);
-            }
-        } else {
-            // variables
-            item.setKind(CompletionItemKind.Variable);
         }
         if (bSymbol.markdownDocumentation != null) {
             item.setDocumentation(bSymbol.markdownDocumentation.description);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Priority.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Priority.java
@@ -32,7 +32,9 @@ public enum  Priority {
     PRIORITY190(190),
     PRIORITY200(200),
     PRIORITY210(210),
-    PRIORITY220(220);
+    PRIORITY220(220),
+    PRIORITY230(230),
+    PRIORITY240(240);
 
     private int priority;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
@@ -18,7 +18,6 @@
 package org.ballerinalang.langserver.completions.util.sorters;
 
 import org.ballerinalang.langserver.compiler.LSContext;
-import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -57,35 +56,54 @@ public abstract class CompletionItemSorter {
     }
 
     void setPriority(CompletionItem completionItem) {
-        String detail = completionItem.getDetail();
-        switch (detail) {
-            case ItemResolverConstants.NONE:
+        if (completionItem.getKind() == null) {
+            completionItem.setSortText(Priority.PRIORITY110.toString());
+            return;
+        }
+        switch (completionItem.getKind()) {
+            case Snippet:
+                completionItem.setSortText(Priority.PRIORITY240.toString());
+                break;
+            case Unit:
+                completionItem.setSortText(Priority.PRIORITY230.toString());
+                break;
+            case Keyword:
                 completionItem.setSortText(Priority.PRIORITY220.toString());
                 break;
-            case ItemResolverConstants.KEYWORD_TYPE:
+            case Field:
                 completionItem.setSortText(Priority.PRIORITY210.toString());
                 break;
-            case ItemResolverConstants.STATEMENT_TYPE:
+            case Event:
                 completionItem.setSortText(Priority.PRIORITY200.toString());
                 break;
-            case ItemResolverConstants.FIELD_TYPE:
+            case Interface:
+                completionItem.setSortText(Priority.PRIORITY190.toString());
+                break;
+            case Struct:
                 completionItem.setSortText(Priority.PRIORITY180.toString());
                 break;
-            case ItemResolverConstants.B_TYPE:
+            case TypeParameter:
                 completionItem.setSortText(Priority.PRIORITY170.toString());
                 break;
-            case ItemResolverConstants.PACKAGE_TYPE:
+            case Enum:
+                completionItem.setSortText(Priority.PRIORITY160.toString());
+                break;
+            case Class:
+                completionItem.setSortText(Priority.PRIORITY150.toString());
+                break;
+            case Module:
                 completionItem.setSortText(Priority.PRIORITY140.toString());
                 break;
-            case ItemResolverConstants.FUNCTION_TYPE:
+            case Variable:
                 completionItem.setSortText(Priority.PRIORITY130.toString());
                 break;
-            case ItemResolverConstants.SNIPPET_TYPE:
-                completionItem.setSortText(Priority.PRIORITY110.toString());
-                break;
-            default:
+            case Function:
                 completionItem.setSortText(Priority.PRIORITY120.toString());
                 break;
+            default:
+                completionItem.setSortText(Priority.PRIORITY110.toString());
+                break;
+                
         }
     }
 }


### PR DESCRIPTION
## Purpose
> Completion Item Default order and sorting modified to be based on completion item kind, instead of detail

Fixes #18271 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
