### PR TITLE
Allow union of error to be a subtype of error

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1165,8 +1165,17 @@ public class Types {
                     return symbol;
             }
             symbol = createCastOperatorSymbol(symTable.anyType, expType, true, code);
+        } else if (expType.tag == TypeTags.ERROR
+                && (actualType.tag == TypeTags.UNION
+                && isAllErrorMembers((BUnionType) actualType))) {
+            symbol = createCastOperatorSymbol(symTable.anyType, symTable.errorType, true, InstructionCodes.ANY2E);
+
         }
         return symbol;
+    }
+
+    private boolean isAllErrorMembers(BUnionType actualType) {
+        return actualType.getMemberTypes().stream().allMatch(t -> isAssignable(t, symTable.errorType));
     }
 
     public void setImplicitCastExpr(BLangExpression expr, BType actualType, BType expType) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -357,4 +357,10 @@ public class ErrorTest {
         BValue[] args = new BValue[] { new BInteger(2) };
         BRunUtil.invoke(errorTestResult, "testPanicOnErrorUnion", args);
     }
+
+    @Test
+    public void testErrorUnionPassedToErrorParam() {
+        BValue[] result = BRunUtil.invoke(errorTestResult, "testErrorUnionPassedToErrorParam");
+        Assert.assertEquals(result[0].stringValue(), "a1");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -306,3 +306,21 @@ function testFunc(int i) returns string|E1|E2 { // fails even if one of the erro
 public function testIndirectErrorReturn() returns E1|E2|string {
     return E1(message = "error msg");
 }
+
+const A1 = "a1";
+const B1 = "b1";
+
+type A error<A1>;
+type B error<B1>;
+
+type MyError A|B;
+
+public function testErrorUnionPassedToErrorParam() returns string {
+    A aErr = error(A1, one = 1);
+    MyError eErr = aErr;
+    return takeError(eErr);
+}
+
+function takeError(error e) returns string {
+    return e.reason();
+}


### PR DESCRIPTION
## Purpose

```ballerina
const A1 = "a1";
const B1 = "b1";

type A error<A1>;
type B error<B1>;

type MyError A|B;
```
Since MyError is a subtype of `error`, value of type `MyError` should be able to be used in place of a error.

```ballerina
public function testErrorUnionPassedToErrorParam() returns string {
    A aErr = error(A1, one = 1);
    MyError eErr = aErr;
    return takeError(eErr);
}

function takeError(error e) returns string {
    return e.reason();
}
``` 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/16915

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
