### PR TITLE
Refactor lang-lib imports

### DIFF
--- a/cli/ballerina-cli-module-pull/src/main/ballerina/src/module_pull/module_pull.bal
+++ b/cli/ballerina-cli-module-pull/src/main/ballerina/src/module_pull/module_pull.bal
@@ -14,12 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/file;
 import ballerina/filepath;
 import ballerina/http;
-import ballerina/io;
-import ballerina/file;
-import ballerina/'lang\.int as lint;
 import ballerina/internal;
+import ballerina/io;
+import ballerina/lang.'int as lint;
 
 const int MAX_INT_VALUE = 2147483647;
 const string VERSION_REGEX = "(\\d+\\.)(\\d+\\.)(\\d+)";

--- a/cli/ballerina-cli-module-push/src/main/ballerina/src/module_push/module_push.bal
+++ b/cli/ballerina-cli-module-push/src/main/ballerina/src/module_push/module_push.bal
@@ -14,10 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
-import ballerina/mime;
 import ballerina/http;
-import ballerina/'lang\.int as lint;
+import ballerina/io;
+import ballerina/lang.'int as lint;
+import ballerina/mime;
 
 # This functions pulls a module from ballerina central.
 #

--- a/cli/ballerina-cli-module-search/src/main/ballerina/src/module_search/module_search.bal
+++ b/cli/ballerina-cli-module-search/src/main/ballerina/src/module_search/module_search.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/http;
-import ballerina/time;
+import ballerina/io;
+import ballerina/lang.'int as lint;
 import ballerina/math;
-import ballerina/'lang\.int as lint;
+import ballerina/time;
 
 # This function searches modules from ballerina central.
 #

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorBindingPatternsTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorBindingPatternsTests.java
@@ -71,20 +71,17 @@ public class ForeachErrorBindingPatternsTests {
         Assert.assertEquals(negative.getErrorCount(), 8);
         int i = 0;
         BAssertUtil.validateError(negative, i++,
-                "invalid error variable; expecting an error type but found '$anonType$3?' in type definition", 30, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'map<string>', found 'string?'", 59, 25);
+                "invalid error variable; expecting an error type but found '$anonType$3?' in type definition", 31, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'map<string>', found 'string?'", 60, 25);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected '(string|boolean)', found 'string?'",
-                63, 28);
+                64, 28);
         BAssertUtil.validateError(negative, i++,
-                "invalid error variable; expecting an error type but found '$anonType$16?' in type definition", 75, 17);
+                "invalid error variable; expecting an error type but found '$anonType$16?' in type definition", 76, 17);
         BAssertUtil.validateError(negative, i++,
-                "incompatible types: expected 'map<string>', found 'string?'", 106, 25);
+                "incompatible types: expected 'map<string>', found 'string?'", 107, 25);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected '(string|boolean)', found 'string?'",
-                110, 28);
-        BAssertUtil.validateError(negative, i++,
-                                  "invalid error binding pattern with type '$anonType$28'",
-                                  126, 17);
-        BAssertUtil.validateError(negative, i++,
-                                  "undefined symbol 'otherVar'", 129, 17);
+                111, 28);
+        BAssertUtil.validateError(negative, i++, "invalid error binding pattern with type '$anonType$28'", 127, 17);
+        BAssertUtil.validateError(negative, i++, "undefined symbol 'otherVar'", 130, 17);
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -14,8 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.decimal as decimals;
-
+import ballerina/lang.'decimal as decimals;
 
 function testSum(decimal p1, decimal p2) returns decimal {
     return decimals:sum(p1, p2);

--- a/langlib/langlib-test/src/test/resources/test-src/errorlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/errorlib_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.error as errorLib;
+import ballerina/lang.'error as errorLib;
 
 type Detail record {|
     string message?;

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.float as floats;
+import ballerina/lang.'float as floats;
 
 function testIsFinite() returns [boolean, boolean] {
     float f = 12.34;

--- a/langlib/langlib-test/src/test/resources/test-src/intlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/intlib_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.int as ints;
+import ballerina/lang.'int as ints;
 
 function testMax(int n, int... ns) returns int {
     return ints:max(n, ...ns);

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_errors.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_errors.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.error as lang;
+
+import ballerina/lang.'error as lang;
 
 type Detail record {
     *lang:Detail;

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_errors_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_errors_negative.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.error as lang;
+
+import ballerina/lang.'error as lang;
 
 type Detail record {
     *lang:Detail;

--- a/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.string as strings;
+import ballerina/lang.'string as strings;
 
 string str = "Hello Ballerina!";
 

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.xml as xmllib;
+import ballerina/lang.'xml as xmllib;
 
 xml catalog = xml `<CATALOG>
                        <CD>

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/annotationInSameModule4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/annotationInSameModule4.json
@@ -1,6 +1,6 @@
 {
   "position": {
-    "line": 21,
+    "line": 22,
     "character": 1
   },
   "source": "annotation/source/annotationInSameModule4.bal",

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/annotationInSameModule5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/annotationInSameModule5.json
@@ -1,6 +1,6 @@
 {
   "position": {
-    "line": 22,
+    "line": 23,
     "character": 5
   },
   "source": "annotation/source/annotationInSameModule5.bal",

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression1.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string foo;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression2.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string foo;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression3.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string foo;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationAccessExpression4.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string foo;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationInSameModule4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationInSameModule4.bal
@@ -1,4 +1,5 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
+
 type Annot record {
     string foo;
     int bar?;

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationInSameModule5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation/source/annotationInSameModule5.bal
@@ -1,4 +1,5 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
+
 type Annot record {
     string foo;
     int bar?;

--- a/language-server/modules/langserver-core/src/test/resources/completion/service/source/serviceBodyCompletion7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service/source/serviceBodyCompletion7.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 public listener Listener lis = new();
 

--- a/language-server/modules/langserver-core/src/test/resources/definition/sources/defFl19.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/sources/defFl19.bal
@@ -1,6 +1,6 @@
 import ballerina/http;
+import ballerina/lang.'object as lang;
 import ballerina/reflect;
-import ballerina/'lang\.object as lang;
 
 type Annot record {
     string foo;  

--- a/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/ballerina/src/prometheus/reporter.bal
+++ b/misc/metrics-extensions/modules/ballerina-prometheus-extension/src/main/ballerina/src/prometheus/reporter.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
-import ballerina/observe;
 import ballerina/config;
-import ballerina/'lang\.string as str;
+import ballerina/http;
 import ballerina/internal;
+import ballerina/lang.'string as str;
+import ballerina/observe;
 
 const string METRIC_TYPE_GAUGE = "gauge";
 const string METRIC_TYPE_SUMMARY = "summary";

--- a/stdlib/config-api/src/main/ballerina/src/config/config.bal
+++ b/stdlib/config-api/src/main/ballerina/src/config/config.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.int as langint;
-import ballerina/'lang\.float as langfloat;
 import ballerina/internal;
+import ballerina/lang.'float as langfloat;
+import ballerina/lang.'int as langint;
 import ballerina/system;
 
 type ValueType STRING|INT|FLOAT|BOOLEAN|MAP|ARRAY;

--- a/stdlib/grpc/src/main/ballerina/src/grpc/service_endpoint.bal
+++ b/stdlib/grpc/src/main/ballerina/src/grpc/service_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/crypto;
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 # Represents server listener where one or more services can be registered. so that ballerina program can offer
 # service through this listener.

--- a/stdlib/http/src/main/ballerina/src/http/non_listening_service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/non_listening_service_endpoint.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.object as lang;
+
+import ballerina/lang.'object as lang;
 
 # Mock server endpoint which does not open a listening port.
 public type MockListener object {

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/cache;
 import ballerina/crypto;
+import ballerina/lang.'object as lang;
 import ballerina/runtime;
 import ballerina/system;
-import ballerina/'lang\.object as lang;
-import ballerina/cache;
 
 /////////////////////////////
 /// HTTP Listener Endpoint ///

--- a/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
+++ b/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
@@ -1,7 +1,7 @@
 import ballerina/http;
-import ballerina/'lang\.int as langint;
-import ballerina/'lang\.float as langfloat;
 import ballerina/internal;
+import ballerina/lang.'float as langfloat;
+import ballerina/lang.'int as langint;
 
 listener http:MockListener testEP = new(9090);
 

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -19,8 +19,8 @@ import ballerina/crypto;
 import ballerina/encoding;
 import ballerina/internal;
 import ballerina/io;
+import ballerina/lang.'int as langint;
 import ballerina/time;
-import ballerina/'lang\.int as langint;
 
 # Represents JWT validator configurations.
 # + issuer - Expected issuer

--- a/stdlib/messaging/kafka/src/main/ballerina/src/kafka/consumer.bal
+++ b/stdlib/messaging/kafka/src/main/ballerina/src/kafka/consumer.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 # Configuration related to consumer endpoint.
 #

--- a/stdlib/messaging/nats/src/main/ballerina/src/nats/basic/subscriber.bal
+++ b/stdlib/messaging/nats/src/main/ballerina/src/nats/basic/subscriber.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.object as lang;
+
+import ballerina/lang.'object as lang;
 
 # Represents a connection which will be used for subscription.
 public type Listener object {

--- a/stdlib/messaging/nats/src/main/ballerina/src/nats/streaming/listener.bal
+++ b/stdlib/messaging/nats/src/main/ballerina/src/nats/streaming/listener.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.object as lang;
+
+import ballerina/lang.'object as lang;
 
 # Represents the NATS Streaming Server connection, to which a subscription service should be bound to in order to receive messages
 # of the corresponding subscription.

--- a/stdlib/messaging/rabbitmq/src/main/ballerina/src/rabbitmq/listener.bal
+++ b/stdlib/messaging/rabbitmq/src/main/ballerina/src/rabbitmq/listener.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 # Public Ballerina API - Ballerina RabbitMQ Message Listener.
 # To provide a listener to consume messages from RabbitMQ.

--- a/stdlib/mime/src/main/ballerina/src/mime/natives.bal
+++ b/stdlib/mime/src/main/ballerina/src/mime/natives.bal
@@ -13,8 +13,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 import ballerina/io;
-import ballerina/'lang\.int as langint;
+import ballerina/lang.'int as langint;
 
 # Key name for `boundary` parameter in MediaType. This is needed for composite type media types.
 public const string BOUNDARY = "boundary";

--- a/stdlib/socket/src/main/ballerina/src/socket/listener_endpoint.bal
+++ b/stdlib/socket/src/main/ballerina/src/socket/listener_endpoint.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 # Represents service endpoint where socket server service registered and start.
 #

--- a/stdlib/streams/src/main/ballerina/src/streams/processor/order-by-processor.bal
+++ b/stdlib/streams/src/main/ballerina/src/streams/processor/order-by-processor.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/internal;
-import ballerina/'lang\.int as langint;
+import ballerina/lang.'int as langint;
 
 # The `OrderBy` object represents the desugared code of `order by` clause of a streaming query. This object takes 3
 # parameters to initialize itself. `nextProcessPointer` is the `process` method of the next processor. `fieldFuncs`

--- a/stdlib/streams/src/main/ballerina/src/streams/util/snapshot.bal
+++ b/stdlib/streams/src/main/ballerina/src/streams/util/snapshot.bal
@@ -15,13 +15,13 @@
 // under the License.
 
 import ballerina/config;
+import ballerina/file;
 import ballerina/filepath;
 import ballerina/io;
+import ballerina/lang.'int as langint;
 import ballerina/log;
 import ballerina/task;
 import ballerina/time;
-import ballerina/file;
-import ballerina/'lang\.int as langint;
 
 # Abstract Snapshotable to be referenced by all snapshotable objects.
 public type Snapshotable abstract object {

--- a/stdlib/streams/src/main/ballerina/src/streams/util/stream-event.bal
+++ b/stdlib/streams/src/main/ballerina/src/streams/util/stream-event.bal
@@ -13,9 +13,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/system;
+
 import ballerina/internal;
-import ballerina/'lang\.int as langint;
+import ballerina/lang.'int as langint;
+import ballerina/system;
 
 # The `StreamEvent` object is a wrapper around the actual data being received to the input stream. If a record is
 # receive to a input stream, that record is converted to a map of anydata values and set that map to a field called

--- a/stdlib/streams/src/test/resources/test-src/streamingv2-aggregate-with-groupby-and-window-with-langlib-func-test.bal
+++ b/stdlib/streams/src/test/resources/test-src/streamingv2-aggregate-with-groupby-and-window-with-langlib-func-test.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/lang.'int as ints;
+import ballerina/lang.'value as val;
 import ballerina/runtime;
-import ballerina/'lang\.int as ints;
-import ballerina/'lang\.value as val;
 
 type Teacher record {
     string name;

--- a/stdlib/task/src/main/ballerina/src/task/listener.bal
+++ b/stdlib/task/src/main/ballerina/src/task/listener.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.object as lang;
+
+import ballerina/lang.'object as lang;
 
 # Represents a ballerina task listener.
 public type Listener object {

--- a/stdlib/websub/src/main/ballerina/src/websub/hub_service.bal
+++ b/stdlib/websub/src/main/ballerina/src/websub/hub_service.bal
@@ -18,11 +18,11 @@ import ballerina/config;
 import ballerina/crypto;
 import ballerina/encoding;
 import ballerina/http;
+import ballerina/internal;
+import ballerina/lang.'int as langint;
 import ballerina/log;
 import ballerina/system;
 import ballerina/time;
-import ballerina/'lang\.int as langint;
-import ballerina/internal;
 
 map<PendingSubscriptionChangeRequest> pendingRequests = {};
 

--- a/stdlib/websub/src/main/ballerina/src/websub/subscriber_service_endpoint.bal
+++ b/stdlib/websub/src/main/ballerina/src/websub/subscriber_service_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 import ballerina/log;
 
 //////////////////////////////////////////

--- a/stdlib/websub/src/test/resources/test-src/specific_subscriber/test_specific_subscriber.bal
+++ b/stdlib/websub/src/test/resources/test-src/specific_subscriber/test_specific_subscriber.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/lang.'object as lang;
 import ballerina/websub;
-import ballerina/'lang\.object as lang;
 
 public type MockActionEvent record {|
     string action;

--- a/tests/jballerina-integration-test/src/test/resources/websub/subscriber/custom-subs-proj/src/custom_subs_mod/test_custom_subscribers.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websub/subscriber/custom-subs-proj/src/custom_subs_mod/test_custom_subscribers.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/io;
+import ballerina/lang.'object as lang;
 import ballerina/websub;
-import ballerina/'lang\.object as lang;
 
 const string MOCK_HEADER = "MockHeader";
 

--- a/tests/jballerina-integration-test/src/test/resources/websub/subscriber/test_custom_subscribers.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websub/subscriber/test_custom_subscribers.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/io;
+import ballerina/lang.'object as lang;
 import ballerina/websub;
-import ballerina/'lang\.object as lang;
 
 const string MOCK_HEADER = "MockHeader";
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
@@ -44,7 +44,7 @@ public class ErrorTest {
 
     @Test(description = "Test panic an error", expectedExceptions = RuntimeException.class, 
           expectedExceptionsMessageRegExp = "error: reason foo 2 message=int value\n\tat errors:foo\\(errors"
-                  + ".bal:47\\)\n\t   errors:testPanic\\(errors.bal:19\\)")
+                  + ".bal:48\\)\n\t   errors:testPanic\\(errors.bal:20\\)")
     public void testPanic() {
             BRunUtil.invoke(compileResult, "testPanic", new BValue[] { new BInteger(0) });
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -35,15 +35,14 @@ public class IOTest {
         Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
-    @Test()
+    @Test
     public void testCharacterIONegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/character-io-negative.bal");
         Assert.assertEquals(result.getDiagnostics().length, 4);
-        BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'path'", 9, 69);
-        BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'path'", 12, 69);
-        BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'numberOfChars'", 16, 35);
-        BAssertUtil.validateError(result, 3, "tainted value passed to untainted parameter 'untaintedValue'", 18,
-                26);
+        BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'path'", 10, 69);
+        BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'path'", 13, 69);
+        BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'numberOfChars'", 17, 35);
+        BAssertUtil.validateError(result, 3, "tainted value passed to untainted parameter 'untaintedValue'", 19, 26);
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string foo;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access_via_reflect.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_access_via_reflect.bal
@@ -13,9 +13,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 import ballerina/http;
+import ballerina/lang.'object as lang;
 import ballerina/reflect;
-import ballerina/'lang\.object as lang;
 
 type Annot record {
     string foo;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string val;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments_negative.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/'lang\.object as lang;
+import ballerina/lang.'object as lang;
 
 type Annot record {
     string val;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.int as ints;
+
+import ballerina/lang.'int as ints;
 
 type Person record {|
     string name = "";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
@@ -1,5 +1,5 @@
-import ballerina/'lang\.int as ints;
-import ballerina/'lang\.float as floats;
+import ballerina/lang.'float as floats;
+import ballerina/lang.'int as ints;
 
 int add = 0;
 int index = 0;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -1,5 +1,5 @@
-import ballerina/'lang\.int as ints;
-import ballerina/'lang\.float as floats;
+import ballerina/lang.'float as floats;
+import ballerina/lang.'int as ints;
 
 function floattoint(float value) returns (int) {
     int result;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/value-type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/value-type-casting.bal
@@ -1,5 +1,5 @@
-import ballerina/'lang\.int as ints;
-import ballerina/'lang\.float as floats;
+import ballerina/lang.'float as floats;
+import ballerina/lang.'int as ints;
 
 function intToFloat (int value) returns (float) {
     float result;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
@@ -1,5 +1,5 @@
 import ballerina/io;
-import ballerina/'lang\.int as ints;
+import ballerina/lang.'int as ints;
 
 function testPrint1() {
     io:println("Hello");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/errors.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/'lang\.error as lang;
+
+import ballerina/lang.'error as lang;
 
 function testPanic(int y) returns int|error {
     int|error x = foo(y);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/locks-in-functions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/locks-in-functions.bal
@@ -1,5 +1,5 @@
+import ballerina/lang.'int as ints;
 import ballerina/runtime;
-import ballerina/'lang\.int as ints;
 
 int lockWithinLockInt1 = 0;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment_negative.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.int as ints;
+import ballerina/lang.'int as ints;
 
 function testMapElementIncrement()  returns int|error {
     map<any> namesMap = { fname: 1 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.float as floats;
+import ballerina/lang.'float as floats;
 
 function testWhileStmt(int x, int y) returns (int) {
     int z = 0;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/connectors/character-io-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/connectors/character-io-negative.bal
@@ -1,10 +1,11 @@
 import ballerina/io;
-import ballerina/'lang\.int as landlib;
+import ballerina/lang.'int as ints;
+
 public function main (string... args) returns error? {
     string filePath = args[0];
     string chars = args[0];
 
-    var intArg = landlib:fromString(args[0]);
+    var intArg = ints:fromString(args[0]);
     if (intArg is int) {
         io:ReadableByteChannel rbh = checkpanic io:openReadableFile(filePath);
         io:ReadableCharacterChannel rch = new io:ReadableCharacterChannel(rbh, "UTF-8");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/compound-assignment-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/compound-assignment-negative.bal
@@ -1,4 +1,4 @@
-import ballerina/'lang\.int as ints;
+import ballerina/lang.'int as ints;
 
 xmlns "http://sample.com/wso2/a1" as ns0;
 public function main (string... args) returns error? {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/compound-assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/compound-assignment.bal
@@ -1,4 +1,5 @@
-import ballerina/'lang\.int as landlib;
+import ballerina/lang.'int as landlib;
+
 public function main (string... args) returns error? {
     string x = "static";
     x += "static";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/constant-assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/constant-assignment.bal
@@ -1,5 +1,5 @@
+import ballerina/lang.'string as strings;
 import ballerina/system;
-import ballerina/'lang\.string as strings;
 
 final string envVar = system:getEnv("env_var");
 final string varFunc = dummyStringFunction();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/simple-literal-constant.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/simple-literal-constant.bal
@@ -1,4 +1,5 @@
-import ballerina/'lang\.string as strings;
+import ballerina/lang.'string as strings;
+
 const nameWithoutType = "Ballerina";
 const string nameWithType = "Ballerina";
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_conversion.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_conversion.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 // Decimal to other types (int, float, string, boolean, any, json) conversion.
-import ballerina/'lang\.decimal as decimals;
+import ballerina/lang.'decimal as decimals;
 
 function testDecimalToOtherTypesConversion() returns [int, float, string, any, json] {
     decimal d = 23.456;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/io;
-import ballerina/'lang\.int as ints;
+import ballerina/lang.'int as ints;
 
 function tupleAccessTest() returns string {
     [int, string, boolean, ()] tuple = [100, "string_value", true, ()];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
@@ -1,5 +1,5 @@
-import ballerina/'lang\.int as intlib;
 import ballerina/io;
+import ballerina/lang.'int as intlib;
 
 // Sample XML taken from: https://www.w3schools.com/xml/books.xml
 xml bookstore = xml `<bookstore>


### PR DESCRIPTION
## Purpose
There are 2 types of imports as follows:
```ballerina
import ballerina/'lang\.string as str;
import ballerina/lang.'string as str;
```
- 1st one, `'lang\.string` is one identifier. 
- 2nd one, `lang` and `string` are 2 identifiers.

This PR updates all the 1st occurrences into the 2nd one and updates the ascending order of the imports.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
