### PR TITLE
Fix errorneous error messages in http response functions

### DIFF
--- a/stdlib/http/src/main/ballerina/src/http/http_response.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_response.bal
@@ -165,7 +165,7 @@ public type Response object {
         } else {
             var payload = result.getJson();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the json payload from the request";
+                string message = "Error occurred while retrieving the json payload from the response";
                 return getGenericClientError(message, payload);
             } else {
                 return payload;
@@ -183,7 +183,7 @@ public type Response object {
         } else {
             var payload = result.getXml();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the xml payload from the request";
+                string message = "Error occurred while retrieving the xml payload from the response";
                 return getGenericClientError(message, payload);
             } else {
                 return payload;
@@ -201,7 +201,7 @@ public type Response object {
         } else {
             var payload = result.getText();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the text payload from the request";
+                string message = "Error occurred while retrieving the text payload from the response";
                 return getGenericClientError(message, payload);
             } else {
                 return payload;
@@ -220,7 +220,7 @@ public type Response object {
         } else {
             var payload = result.getByteChannel();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the byte channel from the request";
+                string message = "Error occurred while retrieving the byte channel from the response";
                 return getGenericClientError(message, payload);
             } else {
                 return payload;
@@ -238,7 +238,7 @@ public type Response object {
         } else {
             var payload = result.getByteArray();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the binary payload from the request";
+                string message = "Error occurred while retrieving the binary payload from the response";
                 return getGenericClientError(message, payload);
             } else {
                 return payload;
@@ -258,7 +258,7 @@ public type Response object {
         } else {
             var bodyParts = result.getBodyParts();
             if (bodyParts is mime:Error) {
-                string message = "Error occurred while retrieving body parts from the request";
+                string message = "Error occurred while retrieving body parts from the response";
                 return getGenericClientError(message, bodyParts);
             } else {
                 return bodyParts;

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
@@ -84,7 +84,7 @@ public class ResponseNativeFunctionNegativeTest {
         BValue[] returnVals = BRunUtil.invoke(result, "testGetJsonPayload", new Object[]{ inResponse });
         Assert.assertNotNull(returnVals[0]);
         Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the json payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
+                "retrieving the json payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
                 "{message:\"Error occurred while extracting json data from entity: Empty content\"}}");
     }
 
@@ -99,7 +99,7 @@ public class ResponseNativeFunctionNegativeTest {
         BValue[] returnVals = BRunUtil.invoke(result, "testGetJsonPayload", new Object[]{ inResponse });
         Assert.assertNotNull(returnVals[0]);
         Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the json payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
+                "retrieving the json payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
                 "{message:\"Error occurred while extracting json data from entity: unrecognized token 'ballerina' at " +
                 "line: 1 column: 11\"}}");
     }
@@ -124,7 +124,7 @@ public class ResponseNativeFunctionNegativeTest {
         inResponse.set(RESPONSE_ENTITY_FIELD, entity);
         BValue[] returnVals = BRunUtil.invoke(result, "testGetXmlPayload", new Object[]{ inResponse });
         Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the xml payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
+                "retrieving the xml payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
                 "{message:\"Error occurred while extracting xml data from entity : Empty content\"}}");
     }
 
@@ -140,7 +140,7 @@ public class ResponseNativeFunctionNegativeTest {
         BValue[] returnVals = BRunUtil.invoke(result, "testGetXmlPayload", new Object[]{ inResponse });
         Assert.assertNotNull(returnVals[0]);
         Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the xml payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
+                "retrieving the xml payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
                 "{message:\"Error occurred while extracting xml data from entity : Unexpected character 'b' (code 98)" +
                 " in prolog; expected '<'" + System.lineSeparator() +
                 " at [row,col {unknown-source}]: [1,1]\"}}");

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPClientActionsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPClientActionsTestCase.java
@@ -54,7 +54,7 @@ public class HTTPClientActionsTestCase extends HttpBaseTest {
     @Test
     public void testPostAction() throws IOException {
         sendAndAssert("clientPostWithoutBody",
-                      "Error occurred while retrieving the text payload from the request");
+                      "Error occurred while retrieving the text payload from the response");
     }
 
     @Test

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/HTTP2ClientActionsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/HTTP2ClientActionsTestCase.java
@@ -50,7 +50,7 @@ public class HTTP2ClientActionsTestCase extends Http2BaseTest {
         HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
                 "test2/clientPostWithoutBody"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getData(), "Error occurred while retrieving the text payload from the request",
+        Assert.assertEquals(response.getData(), "Error occurred while retrieving the text payload from the response",
                 "Message content mismatched");
     }
 


### PR DESCRIPTION
## Purpose
> Error messages in HTTP response object functions have invalid messages (referring request, instead of response). This will fix it.

Fixes #18288 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
