### PR TITLE
Override JAVA_HOME in langserver shell scripts when running from installers

### DIFF
--- a/distribution/zip/jballerina-tools/resources/debug-adapter-launcher.bat
+++ b/distribution/zip/jballerina-tools/resources/debug-adapter-launcher.bat
@@ -42,11 +42,11 @@ rem -------------------------- set BALLERINA_HOME -----------------------------
 rem TODO: Validate BALLERINA_HOME
 rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
 set BALLERINA_HOME=%~sdp0..\..\..\..
-if exist "%BALLERINA_HOME%\bre\lib\jre1.8.0_172" goto setJava
+if exist "%BALLERINA_HOME%\dependencies\jdk8u202-b08-jre" goto setJava
 goto checkJava
 
 :setJava
-set JAVA_HOME="%BALLERINA_HOME%\bre\lib\jre1.8.0_172"
+set JAVA_HOME="%BALLERINA_HOME%\dependencies\jdk8u202-b08-jre"
 goto checkJava
 
 :checkJava

--- a/distribution/zip/jballerina-tools/resources/debug-adapter-launcher.sh
+++ b/distribution/zip/jballerina-tools/resources/debug-adapter-launcher.sh
@@ -27,6 +27,13 @@
 # NOTE: Borrowed generously from Apache Tomcat startup scripts.
 # ----------------------------------------------------------------------------
 
+# ---------------------- Override JAVA_HOME for Installers -------------------
+DIR="$(cd "$(dirname "$0")" && pwd)"
+JAVA_PATH="$DIR/../../../../../../dependencies/jdk8u202-b08-jre"
+if test -d "$JAVA_PATH"; then
+  JAVA_HOME=$JAVA_PATH
+fi
+
 # ---------------------- Developer Configurations ---------------------------
 BALLERINA_DEBUG_LOG=false;
 DEBUG_MODE=false;
@@ -104,11 +111,6 @@ if $os400; then
   # Enable multi threading
   QIBM_MULTI_THREADED=Y
   export QIBM_MULTI_THREADED
-fi
-
-# If the jre is found inside BALLERINA_HOME, override JAVA_HOME
-if [ -x "$BALLERINA_HOME/bre/lib/jre1.8.0_172" ] ; then
-  JAVA_HOME="$BALLERINA_HOME/bre/lib/jre1.8.0_172"
 fi
 
 if [ -z "$JAVACMD" ] ; then

--- a/distribution/zip/jballerina-tools/resources/language-server-launcher.bat
+++ b/distribution/zip/jballerina-tools/resources/language-server-launcher.bat
@@ -42,11 +42,11 @@ rem -------------------------- set BALLERINA_HOME -----------------------------
 rem TODO: Validate BALLERINA_HOME
 rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
 set BALLERINA_HOME=%~sdp0..\..\..\..
-if exist "%BALLERINA_HOME%\bre\lib\jre1.8.0_172" goto setJava
+if exist "%BALLERINA_HOME%\dependencies\jdk8u202-b08-jre" goto setJava
 goto checkJava
 
 :setJava
-set JAVA_HOME="%BALLERINA_HOME%\bre\lib\jre1.8.0_172"
+set JAVA_HOME="%BALLERINA_HOME%\dependencies\jdk8u202-b08-jre"
 goto checkJava
 
 :checkJava

--- a/distribution/zip/jballerina-tools/resources/language-server-launcher.sh
+++ b/distribution/zip/jballerina-tools/resources/language-server-launcher.sh
@@ -27,13 +27,19 @@
 # NOTE: Borrowed generously from Apache Tomcat startup scripts.
 # ----------------------------------------------------------------------------
 
+# ---------------------- Override JAVA_HOME for Installers -------------------
+DIR="$(cd "$(dirname "$0")" && pwd)"
+JAVA_PATH="$DIR/../../../../../../dependencies/jdk8u202-b08-jre"
+if test -d "$JAVA_PATH"; then
+  JAVA_HOME=$JAVA_PATH
+fi
+
 # ---------------------- Developer Configurations ---------------------------
 BALLERINA_DEBUG_LOG=false;
 DEBUG_MODE=false;
 ALLOW_EXPERIMETAL=false;
 DEBUG_PORT=5005;
 CUSTOM_CLASSPATH="";
-# ----------------------------------------------------------------------------
 
 # ---------------------- Command Line Args ---------------------------
 while [ "$1" != "" ]; do
@@ -104,11 +110,6 @@ if $os400; then
   # Enable multi threading
   QIBM_MULTI_THREADED=Y
   export QIBM_MULTI_THREADED
-fi
-
-# If the jre is found inside BALLERINA_HOME, override JAVA_HOME
-if [ -x "$BALLERINA_HOME/bre/lib/jre1.8.0_172" ] ; then
-  JAVA_HOME="$BALLERINA_HOME/bre/lib/jre1.8.0_172"
 fi
 
 if [ -z "$JAVACMD" ] ; then


### PR DESCRIPTION
## Purpose
> Override JAVA_HOME in langserver shell scripts when running from installers

## Related PR
https://github.com/ballerina-platform/ballerina-distribution/pull/173

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
