### PR TITLE
Add the diagram icon to the editor title menu

### DIFF
--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -199,8 +199,8 @@
         ],
         "commands": [
             {
-                "command": "ballerina.showProjectOverview",
-                "title": "Project Overview",
+                "command": "ballerina.showFileOverview",
+                "title": "Show File Overview",
                 "icon": {
                     "dark": "./resources/images/icons/design-view-inverse.svg",
                     "light": "./resources/images/icons/design-view.svg"
@@ -257,6 +257,11 @@
             "editor/title": [
                 {
                     "when": "resourceLangId == ballerina",
+                    "command": "ballerina.showFileOverview",
+                    "group": "navigation"
+                },
+                {
+                    "when": "resourceLangId == ballerina",
                     "command": "ballerina.showDocs",
                     "group": "navigation"
                 }
@@ -264,7 +269,7 @@
             "editor/context": [
                 {
                     "when": "resourceLangId == ballerina",
-                    "command": "ballerina.showProjectOverview",
+                    "command": "ballerina.showFileOverview",
                     "group": "navigation"
                 },
                 {

--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -42,6 +42,8 @@ import { createTelemetryReporter, TM_EVENT_ERROR_INVALID_BAL_HOME_CONFIGURED, TM
 export const EXTENSION_ID = 'ballerina.ballerina';
 
 export interface ConstructIdentifier {
+    sourceRoot?: string;
+    filePath?: string;
     moduleName: string;
     constructName: string;
     subConstructName?: string;

--- a/tool-plugins/vscode/src/overview/activator.ts
+++ b/tool-plugins/vscode/src/overview/activator.ts
@@ -16,27 +16,32 @@
  * under the License.
  *
  */
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import * as _ from 'lodash';
 
 import { BallerinaExtension, ExtendedLangClient, ConstructIdentifier, ballerinaExtInstance } from '../core';
 import { ExtensionContext, commands, window, Uri, ViewColumn, TextDocumentChangeEvent, 
 	workspace, WebviewPanel } from 'vscode';
 
-import {render} from './renderer';
+import { render } from './renderer';
 import { WebViewRPCHandler, getCommonWebViewOptions } from '../utils';
-import { TM_EVENT_OPEN_PROJECT_OVERVIEW_VIA_CMD, CMP_PROJECT_OVERVIEW } from '../telemetry';
+import { TM_EVENT_OPEN_FILE_OVERVIEW, CMP_FILE_OVERVIEW } from '../telemetry';
 
 const DEBOUNCE_WAIT = 500;
 
-let overviewPanel: WebviewPanel | undefined;
-let rpcHandler: WebViewRPCHandler;
+let projectOverviewPanel: WebviewPanel | undefined;
+let fileOverviewPanel: WebviewPanel | undefined;
+let projectOverviewRpcHandler: WebViewRPCHandler;
+let fileOverviewRpcHandler: WebViewRPCHandler;
 
-function updateWebView(docUri: Uri): void {
-	if (rpcHandler) {
-		rpcHandler.invokeRemoteMethod("updateAST", [docUri.toString()], () => {});
+function updateProjectOverview(docUri: Uri): void {
+	if (projectOverviewRpcHandler) {
+		projectOverviewRpcHandler.invokeRemoteMethod("updateAST", [docUri.toString()], () => {});
+	}
+}
+
+function updateFileOverview(docUri: Uri): void {
+	if (fileOverviewRpcHandler) {
+		fileOverviewRpcHandler.invokeRemoteMethod("updateAST", [docUri.toString()], () => {});
 	}
 }
 
@@ -47,15 +52,15 @@ export function activate(ballerinaExtInstance: BallerinaExtension) {
 
 	function updateSelectedConstruct(construct: ConstructIdentifier) {
 		// If Project Overview is already showing update it to show the selected construct
-		if (overviewPanel) {
-			if (rpcHandler) {
-				const { moduleName, constructName, subConstructName } = construct;
-				rpcHandler.invokeRemoteMethod("selectConstruct", [moduleName, constructName, subConstructName], () => {});
+		if (projectOverviewPanel) {
+			if (projectOverviewRpcHandler) {
+				const { sourceRoot, filePath, moduleName, constructName, subConstructName } = construct;
+				projectOverviewRpcHandler.invokeRemoteMethod("selectConstruct", [
+					sourceRoot, filePath, moduleName, constructName, subConstructName], () => {});
 			}
-			overviewPanel.reveal();
 		} else {
 			// If Project Overview is not yet opened open it and show the selected construct
-			openWebView(context, langClient, construct);
+			openProjectOverview(langClient, construct);
 		}
 	}
 
@@ -63,129 +68,85 @@ export function activate(ballerinaExtInstance: BallerinaExtension) {
 		updateSelectedConstruct(construct);
 	});
 
-	const projectOverviewDisposable = commands.registerCommand('ballerina.showProjectOverview', () => {
-		reporter.sendTelemetryEvent(TM_EVENT_OPEN_PROJECT_OVERVIEW_VIA_CMD, { component: CMP_PROJECT_OVERVIEW });
+	const fileOverviewDisposable = commands.registerCommand('ballerina.showFileOverview', () => {
+		reporter.sendTelemetryEvent(TM_EVENT_OPEN_FILE_OVERVIEW, { component: CMP_FILE_OVERVIEW });
 		return ballerinaExtInstance.onReady()
 		.then(() => {
-			openWebView(context, langClient);
+			openFileOverview(langClient);
 		}).catch((e) => {
-			reporter.sendTelemetryException(e, { component: CMP_PROJECT_OVERVIEW });
+			reporter.sendTelemetryException(e, { component: CMP_FILE_OVERVIEW });
 		});
 	});
-    context.subscriptions.push(projectOverviewDisposable);
+
+    context.subscriptions.push(fileOverviewDisposable);
 }
 
-function openWebView(context: ExtensionContext, langClient: ExtendedLangClient, construct?: ConstructIdentifier) {
-	let sourceRoot: string|undefined;
-	let currentFilePath: string|undefined;
-
-	const openFolders = workspace.workspaceFolders;
-	if (openFolders) {
-		if (fs.existsSync(path.join(openFolders[0].uri.path, "Ballerina.toml"))) {
-			sourceRoot = openFolders[0].uri.path;
-		}
-	}
-
-	if (!sourceRoot) {
-		if (window.activeTextEditor) {
-			currentFilePath = window.activeTextEditor.document.fileName;
-			sourceRoot = getSourceRoot(currentFilePath, path.parse(currentFilePath).root);
-		}
-	}
-
-	if (!currentFilePath && !sourceRoot) {
-		return;
-	}
-
-	const options : {
-		currentUri?: string,
-		sourceRootUri?: string,
-		construct?: ConstructIdentifier
-	} = {
-		construct,
-	};
-
-	if (sourceRoot) {
-		options.sourceRootUri = Uri.file(sourceRoot).toString();
-	}
-
-	if (currentFilePath) {
-		options.currentUri = Uri.file(currentFilePath).toString();
-	}
-
-	const didChangeDisposable = workspace.onDidChangeTextDocument(
-		_.debounce((e: TextDocumentChangeEvent) => {
-		updateWebView( e.document.uri);
-	}, DEBOUNCE_WAIT));
-
-	const didChangeActiveEditorDisposable = window.onDidChangeActiveTextEditor((activeEditor) => {
-		if (!(activeEditor && activeEditor.document && activeEditor.document.languageId === "ballerina")) {
-			return;
-		}
-
-		const newCurrentFilePath = activeEditor.document.fileName;
-		const newSourceRoot = getSourceRoot(newCurrentFilePath, path.parse(newCurrentFilePath).root);
-	
-		const newOptions : {
-			currentUri: string,
-			sourceRootUri?: string,
-			construct?: ConstructIdentifier
-		} = {
-			currentUri: Uri.file(newCurrentFilePath).toString(),
-		};
-
-		let shouldRerender = false;
-		if (newSourceRoot) {
-			shouldRerender = sourceRoot !== newSourceRoot;
-			newOptions.sourceRootUri = Uri.file(newSourceRoot).toString();
-		} else {
-			shouldRerender = currentFilePath !== newCurrentFilePath;
-		}
-
-		if (shouldRerender) {
-			currentFilePath = newCurrentFilePath;
-			sourceRoot = newSourceRoot;
-			const html = render(context, langClient, newOptions);
-			if (overviewPanel && html) {
-				overviewPanel.webview.html = html;
-			}
-		}
-	});
-
-	if (!overviewPanel) {
-		overviewPanel = window.createWebviewPanel(
+function openProjectOverview(langClient: ExtendedLangClient, construct: ConstructIdentifier) {
+	if (!projectOverviewPanel) {
+		projectOverviewPanel = window.createWebviewPanel(
 			'projectOverview',
 			'Project Overview',
 			{ viewColumn: ViewColumn.One, preserveFocus: true },
 			getCommonWebViewOptions()
 		);
 
-		ballerinaExtInstance.addWebviewPanel("overview", overviewPanel);
+		ballerinaExtInstance.addWebviewPanel("overview", projectOverviewPanel);
 	}
 
-	rpcHandler = WebViewRPCHandler.create(overviewPanel, langClient);
-	const html = render(context, langClient, options);
-	if (overviewPanel && html) {
-		overviewPanel.webview.html = html;
+	projectOverviewRpcHandler = WebViewRPCHandler.create(projectOverviewPanel, langClient);
+	const html = render(construct);
+	if (projectOverviewPanel && html) {
+		projectOverviewPanel.webview.html = html;
 	}
 
-	overviewPanel.onDidDispose(() => {
-		overviewPanel = undefined;
+	const didChangeDisposable = workspace.onDidChangeTextDocument(
+		_.debounce((e: TextDocumentChangeEvent) => {
+		updateProjectOverview(e.document.uri);
+	}, DEBOUNCE_WAIT));
+
+	projectOverviewPanel.onDidDispose(() => {
+		projectOverviewPanel = undefined;
 		didChangeDisposable.dispose();
-		didChangeActiveEditorDisposable.dispose();
 	});
 }
 
-function getSourceRoot(currentPath: string, root: string): string|undefined {
-	if (fs.existsSync(path.join(currentPath, 'Ballerina.toml'))) {
-		if (currentPath !== os.homedir()) {
-			return currentPath;
-		}
-	}
-
-	if (currentPath === root) {
+function openFileOverview(langClient: ExtendedLangClient) {
+	if (!window.activeTextEditor) {
 		return;
 	}
 
-	return getSourceRoot(path.dirname(currentPath), root);
+	const didChangeDisposable = workspace.onDidChangeTextDocument(
+		_.debounce((e: TextDocumentChangeEvent) => {
+		updateFileOverview(e.document.uri);
+	}, DEBOUNCE_WAIT));
+
+	const didChangeActiveEditorDisposable = window.onDidChangeActiveTextEditor((activeEditor) => {
+		if (!(activeEditor && activeEditor.document && activeEditor.document.languageId === "ballerina")) {
+			return;
+		}
+		openFileOverview(langClient);
+	});
+
+	if (!fileOverviewPanel) {
+		fileOverviewPanel = window.createWebviewPanel(
+			'fileOverview',
+			'File Overview',
+			{ viewColumn: ViewColumn.Two, preserveFocus: true },
+			getCommonWebViewOptions()
+		);
+
+		ballerinaExtInstance.addWebviewPanel("file", fileOverviewPanel);
+	}
+
+	fileOverviewRpcHandler = WebViewRPCHandler.create(fileOverviewPanel, langClient);
+	const html = render({filePath: window.activeTextEditor.document.uri.toString(), constructName: "", moduleName: ""});
+	if (fileOverviewPanel && html) {
+		fileOverviewPanel.webview.html = html;
+	}
+
+	fileOverviewPanel.onDidDispose(() => {
+		fileOverviewPanel = undefined;
+		didChangeDisposable.dispose();
+		didChangeActiveEditorDisposable.dispose();
+	});
 }

--- a/tool-plugins/vscode/src/project-tree-view/activator.ts
+++ b/tool-plugins/vscode/src/project-tree-view/activator.ts
@@ -12,9 +12,14 @@ export function activate(ballerinaExtInstance: BallerinaExtension) {
         treeDataProvider: projectTreeProvider
     });
 
-    vscode.commands.registerCommand('ballerina.executeTreeElement',(moduleName, constructName, subConstructName) => {
+    vscode.commands.registerCommand('ballerina.executeTreeElement',(sourceRoot, filePath, 
+        moduleName, constructName, subConstructName) => {
         reporter.sendTelemetryEvent(TM_EVENT_OPEN_PROJECT_OVERVIEW_VIA_TREE_VIEW, { component: CMP_PROJECT_OVERVIEW });
+
+        console.log(sourceRoot, filePath);
         ballerinaExtInstance.projectTreeElementClicked({
+            sourceRoot,
+            filePath,
             moduleName,
             constructName,
             subConstructName,

--- a/tool-plugins/vscode/src/project-tree-view/project-overview.ts
+++ b/tool-plugins/vscode/src/project-tree-view/project-overview.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 
 import { BallerinaExtension, ExtendedLangClient } from '../core/index';
 import { ProjectTreeElement } from './project-tree';
+import { Uri } from 'vscode';
 
 const errorNode = new ProjectTreeElement(
     "Couldn't create the project overview. Please make sure your code compiles successfully and refresh.",
@@ -68,6 +69,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectTreeE
             }
 
             this.sourceRoot = undefined;
+            this.currentFilePath = document ? document.fileName: undefined;
             const openFolders = vscode.workspace.workspaceFolders;
             if (openFolders) {
                 if (fs.existsSync(path.join(openFolders[0].uri.path, "Ballerina.toml"))) {
@@ -76,7 +78,6 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectTreeE
             }
     
             if (!this.sourceRoot) {
-                this.currentFilePath = document ? document.fileName: undefined;
                 this.sourceRoot = this.currentFilePath? this.getSourceRoot(this.currentFilePath, path.parse(this.currentFilePath).root) : undefined;
             }
 
@@ -221,7 +222,10 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectTreeE
                     elementTree.push(new ProjectTreeElement(child, collapseMode, {
                         command: "ballerina.executeTreeElement",
                         title: "Execute Tree Command",
-                        arguments: [key, child]
+                        arguments: [
+                            this.sourceRoot? Uri.file(this.sourceRoot).toString(): undefined,
+                            this.currentFilePath? Uri.file(this.currentFilePath).toString(): undefined,
+                            key, child]
                     }));
                 });
             } else {
@@ -230,7 +234,10 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectTreeE
                     Object.keys(treeObj).map(child => {
                         let args = [key, child];
                         if (parentEl.command && parentEl.command.arguments) {
-                            args = [...parentEl.command.arguments, child];
+                            args = [
+                                this.sourceRoot? Uri.file(this.sourceRoot).toString(): undefined,
+                                this.currentFilePath? Uri.file(this.currentFilePath).toString(): undefined,
+                                ...parentEl.command.arguments, child];
                         }
                         elementTree.push(new ProjectTreeElement(child, vscode.TreeItemCollapsibleState.None, {
                             command: "ballerina.executeTreeElement",

--- a/tool-plugins/vscode/src/telemetry/components.ts
+++ b/tool-plugins/vscode/src/telemetry/components.ts
@@ -3,6 +3,7 @@ export const CMP_EXAMPLES_VIEW = "component.examples.view";
 export const CMP_DIAGRAM_VIEW = "component.diagram.view";
 export const CMP_DOCS_PREVIEW = "component.docs.preview";
 export const CMP_PROJECT_OVERVIEW = "component.project.overview";
+export const CMP_FILE_OVERVIEW = "component.file.overview";
 export const CMP_PROJECT_SUPPORT = "component.project.support";
 export const CMP_PROJECT_TEST_RUNNER = "component.project.test.runner";
 export const CMP_PROJECT_BUILD = "component.project.test.runner";

--- a/tool-plugins/vscode/src/telemetry/events.ts
+++ b/tool-plugins/vscode/src/telemetry/events.ts
@@ -5,6 +5,7 @@ export const TM_EVENT_OPEN_EXAMPLES = "open.examples";
 export const TM_EVENT_OPEN_DIAGRAM = "open.diagram";
 export const TM_EVENT_OPEN_PROJECT_OVERVIEW_VIA_CMD = "open.project.overview.via.cmd";
 export const TM_EVENT_OPEN_PROJECT_OVERVIEW_VIA_TREE_VIEW = "open.project.overview.via.tree.view";
+export const TM_EVENT_OPEN_FILE_OVERVIEW = "open.file.overview";
 export const TM_EVENT_OPEN_NETWORK_LOGS = "open.network.logs";
 export const TM_EVENT_OPEN_DOC_PREVIEW = "open.doc.preview";
 export const TM_EVENT_OPEN_API_DESIGNER = "open.api.designer";


### PR DESCRIPTION
## Purpose
$title

* By clicking on this icon user can see sequence diagrams for each construct in a file. (File Overview)
* The Project Overview diagrams can now be opened only through the project overview tree view.
* File Overview can be opened through the context menu and through the command pallete.

## Approach
<img width="474" alt="image" src="https://user-images.githubusercontent.com/3872221/64093070-87d08180-cd74-11e9-8102-82301e2c928d.png">

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
