### PR TITLE
Add jsonutils module.

### DIFF
--- a/distribution/zip/jballerina/build.gradle
+++ b/distribution/zip/jballerina/build.gradle
@@ -140,6 +140,7 @@ dependencies {
     distBal project(path: ':ballerina-jwt', configuration: 'baloImplementation')
     distBal project(path: ':ballerina-ldap', configuration: 'baloImplementation')
     distBal project(path: ':ballerina-oauth2', configuration: 'baloImplementation')
+    distBal project(path: ':ballerina-jsonutils', configuration: 'baloImplementation')
 
     // Lang libs
     distBal project(path: ':ballerina-lang:internal', configuration: 'baloImplementation')
@@ -194,6 +195,7 @@ dependencies {
     balSource project(path: ':ballerina-jwt', configuration: 'balSource')
     balSource project(path: ':ballerina-ldap', configuration: 'balSource')
     balSource project(path: ':ballerina-oauth2', configuration: 'balSource')
+    balSource project(path: ':ballerina-jsonutils', configuration: 'balSource')
 
     // Lang Libs
     balSource project(path: ':ballerina-lang:internal', configuration: 'balSource')
@@ -256,6 +258,7 @@ dependencies {
     dist project(':ballerina-jwt')
     dist project(':ballerina-ldap')
     dist project(':ballerina-oauth2')
+    dist project(':ballerina-jsonutils')
 
     // Lang libs
     dist project(':ballerina-lang:internal')

--- a/settings.gradle
+++ b/settings.gradle
@@ -106,6 +106,7 @@ include(':observability-test-utils')
 include(':jballerina-integration-test')
 // include(':composer-integration-test')
 // include(':ballerina-tools-integration-test')
+include(':ballerina-jsonutils')
 
 // include(':examples-test')
 // TODO: enable at 'dependsOn' of tools-intergration-tests
@@ -234,6 +235,7 @@ project(':ballerina-nats').projectDir = file('stdlib/messaging/nats')
 project(':ballerina-jwt').projectDir = file('stdlib/jwt')
 project(':ballerina-ldap').projectDir = file('stdlib/ldap')
 project(':ballerina-oauth2').projectDir = file('stdlib/oauth2')
+project(':ballerina-jsonutils').projectDir = file('stdlib/jsonutils')
 project(':ballerina-bootstrapper').projectDir = file('distribution/bootstrapper')
 
 project(':debug-adapter').projectDir = file('misc/debug-adapter')

--- a/stdlib/jsonutils/build.gradle
+++ b/stdlib/jsonutils/build.gradle
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+apply from: "$rootDir/gradle/balNativeLibProject.gradle"
+apply from: "$rootDir/gradle/baseNativeStdLibProject.gradle"
+
+configurations.testCompileClasspath {
+    resolutionStrategy {
+        preferProjectModules()
+    }
+}
+
+dependencies {
+    implementation 'org.apache.ws.commons.axiom:axiom-impl'
+    implementation 'org.apache.ws.commons.axiom:axiom-dom'
+    implementation 'org.apache.ws.commons.axiom:axiom-c14n'
+    
+    baloImplementation project(path: ':ballerina-lang:annotations', configuration: 'baloImplementation')
+    baloImplementation project(path: ':ballerina-runtime-api', configuration: 'baloImplementation')
+
+    baloCreat project(':lib-creator')
+    implementation project(':ballerina-lang')
+    implementation project(':ballerina-runtime')
+    implementation project(':ballerina-logging')
+    implementation project(':ballerina-runtime-api')
+
+    testCompile project(path: ':ballerina-test-common', configuration: 'tests')
+    testCompile 'org.testng:testng'
+    testCompile 'org.slf4j:slf4j-jdk14'
+
+    testCompile project(path: ':ballerina-test-utils', configuration: 'shadow')
+    testCompile project(':ballerina-test-utils')
+    testCompile project(':ballerina-reflect')
+    testCompile project(':ballerina-core')
+
+    baloTestImplementation project(path: ':ballerina-time', configuration: 'baloImplementation')
+}
+
+createBalo {
+    jvmTarget = 'true'
+}
+
+description = 'Ballerina - Jsonutils'
+
+configurations {
+    testCompile.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    testCompile.exclude group: 'org.slf4j', module: 'slf4j-simple'
+    testCompile.exclude group: 'org.ops4j.pax.logging', module: 'pax-logging-api'
+}
+
+configurations.all {
+    resolutionStrategy.preferProjectModules()
+}

--- a/stdlib/jsonutils/src/main/ballerina/Ballerina.toml
+++ b/stdlib/jsonutils/src/main/ballerina/Ballerina.toml
@@ -1,0 +1,3 @@
+[project]
+org-name = "ballerina"
+version = "0.0.0"

--- a/stdlib/jsonutils/src/main/ballerina/src/jsonutils/json-to-xml.bal
+++ b/stdlib/jsonutils/src/main/ballerina/src/jsonutils/json-to-xml.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Type for XML options.
+#
+# + attributePrefix - attribute prefix of JSON
+# + arrayEntryTag - array entry tag of JSON
+public type XmlOptions record {
+    string attributePrefix = "@";
+    string arrayEntryTag = "root";
+};
+
+# Converts a JSON object to a XML representation.
+#
+# + x - The json source
+# + options - jsonOptions struct for JSON to XML conversion properties
+# + return - XML representation of the given JSON
+public function toXML(json x, XmlOptions options = {}) returns xml|error = external;

--- a/stdlib/jsonutils/src/main/java/org/ballerinalang/stdlib/jsonutils/JSONToXMLConverter.java
+++ b/stdlib/jsonutils/src/main/java/org/ballerinalang/stdlib/jsonutils/JSONToXMLConverter.java
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.stdlib.jsonutils;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.axiom.om.OMText;
+import org.ballerinalang.jvm.BallerinaErrors;
+import org.ballerinalang.jvm.TypeChecker;
+import org.ballerinalang.jvm.XMLFactory;
+import org.ballerinalang.jvm.XMLValidator;
+import org.ballerinalang.jvm.types.BArrayType;
+import org.ballerinalang.jvm.types.BMapType;
+import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.types.BTypes;
+import org.ballerinalang.jvm.types.TypeTags;
+import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.MapValueImpl;
+import org.ballerinalang.jvm.values.RefValue;
+import org.ballerinalang.jvm.values.XMLItem;
+import org.ballerinalang.jvm.values.XMLSequence;
+import org.ballerinalang.jvm.values.XMLValue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map.Entry;
+
+/**
+ * Common utility methods used for JSON manipulation.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("unchecked")
+public class JSONToXMLConverter {
+
+    private static final OMFactory OM_FACTORY = OMAbstractFactory.getOMFactory();
+    private static final String XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final String XSI_PREFIX = "xsi";
+    private static final String NIL = "nil";
+
+    /**
+     * Converts given JSON object to the corresponding XML.
+     *
+     * @param json            JSON object to get the corresponding XML
+     * @param attributePrefix String prefix used for attributes
+     * @param arrayEntryTag   String used as the tag in the arrays
+     * @return XMLValue XML representation of the given JSON object
+     */
+    @SuppressWarnings("rawtypes")
+    public static XMLValue convertToXML(Object json, String attributePrefix, String arrayEntryTag) {
+        if (json == null) {
+            return new XMLSequence();
+        }
+
+        List<XMLValue> omElementArrayList = traverseTree(json, attributePrefix, arrayEntryTag);
+        if (omElementArrayList.size() == 1) {
+            return omElementArrayList.get(0);
+        } else {
+            // There is a multi rooted node and create xml sequence from it
+            ArrayValue elementsSeq = new ArrayValue(new BArrayType(BTypes.typeXML));
+            int count = omElementArrayList.size();
+            for (int i = 0; i < count; i++) {
+                elementsSeq.add(i, omElementArrayList.get(i));
+            }
+            return new XMLSequence(elementsSeq);
+        }
+    }
+
+    // Private methods
+
+    /**
+     * Traverse a JSON root node and produces the corresponding XML items.
+     *
+     * @param json            to be traversed
+     * @param attributePrefix String prefix used for attributes
+     * @param arrayEntryTag   String used as the tag in the arrays
+     * @return List of XML items generated during the traversal.
+     */
+    @SuppressWarnings("rawtypes")
+    private static List<XMLValue> traverseTree(Object json, String attributePrefix, String arrayEntryTag) {
+        List<XMLValue> xmlArray = new ArrayList<>();
+        if (!(json instanceof RefValue)) {
+            XMLValue xml = XMLFactory.parse(json.toString());
+            xmlArray.add(xml);
+        } else {
+            traverseJsonNode(json, null, null, xmlArray, attributePrefix, arrayEntryTag);
+        }
+        return xmlArray;
+    }
+
+    /**
+     * Traverse a JSON node ad produces the corresponding xml items.
+     *
+     * @param json               to be traversed
+     * @param nodeName           name of the current traversing node
+     * @param parentElement      parent element of the current node
+     * @param omElementArrayList List of XML items generated
+     * @param attributePrefix    String prefix used for attributes
+     * @param arrayEntryTag      String used as the tag in the arrays
+     * @return List of XML items generated during the traversal.
+     */
+    @SuppressWarnings("rawtypes")
+    private static OMElement traverseJsonNode(Object json, String nodeName, OMElement parentElement,
+            List<XMLValue> omElementArrayList, String attributePrefix, String arrayEntryTag) {
+        OMElement currentRoot = null;
+        if (nodeName != null) {
+            // Extract attributes and set to the immediate parent.
+            if (nodeName.startsWith(attributePrefix)) {
+                if (json instanceof RefValue) {
+                    throw BallerinaErrors.createError("attribute cannot be an object or array");
+                }
+                if (parentElement != null) {
+                    String attributeKey = nodeName.substring(1);
+                    // Validate whether the attribute name is an XML supported qualified name, according to the XML
+                    // recommendation.
+                    XMLValidator.validateXMLName(attributeKey);
+
+                    parentElement.addAttribute(attributeKey, json.toString(), null);
+                }
+                return parentElement;
+            }
+
+            // Validate whether the tag name is an XML supported qualified name, according to the XML recommendation.
+            XMLValidator.validateXMLName(nodeName);
+
+            currentRoot = OM_FACTORY.createOMElement(nodeName, null);
+        }
+
+        if (json == null) {
+            OMNamespace xsiNameSpace = OM_FACTORY.createOMNamespace(XSI_NAMESPACE, XSI_PREFIX);
+            currentRoot.addAttribute(NIL, "true", xsiNameSpace);
+        } else {
+            LinkedHashMap<String, Object> map;
+
+            BType type = TypeChecker.getType(json);
+            switch (type.getTag()) {
+
+            case TypeTags.MAP_TAG:
+                if (((BMapType) type).getConstrainedType().getTag() != TypeTags.JSON_TAG) {
+                    throw BallerinaErrors.createError("error in converting map<non-json> to xml");
+                }
+                map = (MapValueImpl) json;
+                for (Entry<String, Object> entry : map.entrySet()) {
+                    currentRoot = traverseJsonNode(entry.getValue(), entry.getKey(), currentRoot, omElementArrayList,
+                            attributePrefix, arrayEntryTag);
+                    if (nodeName == null) { // Outermost object
+                        omElementArrayList.add(new XMLItem(currentRoot));
+                        currentRoot = null;
+                    }
+                }
+                break;
+            case TypeTags.JSON_TAG:
+                map = (MapValueImpl) json;
+                for (Entry<String, Object> entry : map.entrySet()) {
+                    currentRoot = traverseJsonNode(entry.getValue(), entry.getKey(), currentRoot, omElementArrayList,
+                            attributePrefix, arrayEntryTag);
+                    if (nodeName == null) { // Outermost object
+                        omElementArrayList.add(new XMLItem(currentRoot));
+                        currentRoot = null;
+                    }
+                }
+                break;
+            case TypeTags.ARRAY_TAG:
+                ArrayValue array = (ArrayValue) json;
+                for (int i = 0; i < array.size(); i++) {
+                    currentRoot = traverseJsonNode(array.getRefValue(i), arrayEntryTag, currentRoot, omElementArrayList,
+                            attributePrefix, arrayEntryTag);
+                    if (nodeName == null) { // Outermost array
+                        omElementArrayList.add(new XMLItem(currentRoot));
+                        currentRoot = null;
+                    }
+                }
+                break;
+            case TypeTags.INT_TAG:
+            case TypeTags.FLOAT_TAG:
+            case TypeTags.DECIMAL_TAG:
+            case TypeTags.STRING_TAG:
+            case TypeTags.BOOLEAN_TAG:
+                if (currentRoot == null) {
+                    throw BallerinaErrors.createError("error in converting json to xml");
+                }
+
+                OMText txt1 = OM_FACTORY.createOMText(currentRoot, json.toString());
+                currentRoot.addChild(txt1);
+                break;
+            default:
+                throw BallerinaErrors.createError("error in converting json to xml");
+            }
+        }
+
+        // Set the current constructed root the parent element
+        if (parentElement != null) {
+            parentElement.addChild(currentRoot);
+            currentRoot = parentElement;
+        }
+        return currentRoot;
+    }
+}

--- a/stdlib/jsonutils/src/main/java/org/ballerinalang/stdlib/jsonutils/ToXML.java
+++ b/stdlib/jsonutils/src/main/java/org/ballerinalang/stdlib/jsonutils/ToXML.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.jsonutils;
+
+import org.ballerinalang.jvm.BallerinaErrors;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+
+/**
+ * Converts a JSON to the corresponding XML representation.
+ *
+ * @since 1.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "jsonutils", functionName = "toXML", isPublic = true
+)
+public class ToXML {
+
+    private static final String OPTIONS_ATTRIBUTE_PREFIX = "attributePrefix";
+    private static final String OPTIONS_ARRAY_ENTRY_TAG = "arrayEntryTag";
+
+    public static Object toXML(Strand strand, Object json, MapValue<?, ?> options) {
+        try {
+            String attributePrefix = (String) options.get(OPTIONS_ATTRIBUTE_PREFIX);
+            String arrayEntryTag = (String) options.get(OPTIONS_ARRAY_ENTRY_TAG);
+            return JSONToXMLConverter.convertToXML(json, attributePrefix, arrayEntryTag);
+        } catch (Throwable e) {
+            return BallerinaErrors.createError("{ballerina/jsonutils}Error", e.getMessage());
+        }
+    }
+}

--- a/stdlib/jsonutils/src/test/java/org/ballerinalang/stdlib/jsonutils/JsonUtilsTest.java
+++ b/stdlib/jsonutils/src/test/java/org/ballerinalang/stdlib/jsonutils/JsonUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.jsonutils;
+
+import org.ballerinalang.jvm.types.TypeTags;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.model.values.BXML;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Class to test functionality of jsonutils.
+ *
+ * @since 1.0
+ */
+public class JsonUtilsTest {
+
+    @Test
+    public void testToXmlFunction() {
+        CompileResult result = BCompileUtil.compile("test-src/json-to-xml-test.bal");
+        BValue[] returns = BRunUtil.invoke(result, "testToXml");
+        Assert.assertTrue(returns[0] instanceof BXML);
+        Assert.assertEquals(returns[0].getType().getTag(), TypeTags.XML_TAG);
+        Assert.assertEquals(returns[0].stringValue(), "<name>John</name><age>30</age>");
+    }
+}

--- a/stdlib/jsonutils/src/test/resources/test-src/json-to-xml-test.bal
+++ b/stdlib/jsonutils/src/test/resources/test-src/json-to-xml-test.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jsonutils;
+
+function testToXml() returns xml|error {
+    json data = {
+        name: "John",
+        age: 30
+    };
+    xml|error x = jsonutils:toXML(data);
+    return x;
+}

--- a/stdlib/jsonutils/src/test/resources/testng.xml
+++ b/stdlib/jsonutils/src/test/resources/testng.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="ballerina-test-suite">
+    <listeners>
+        <listener class-name="org.ballerinalang.test.listener.JBallerinaTestInitializer"/>
+    </listeners>
+    <test name="ballerina-lang-stdlib-utils-xml-test-suite" parallel="false">
+        <parameter name="enableJBallerinaTests" value="true"/>
+        <groups>
+            <run>
+                <exclude name="brokenOnBootstrappedJVMCodegen"/>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.ballerinalang.stdlib.jsonutils.*"/>
+        </packages>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose
This module restores removed json.toXML functionality.

```ballerina
import ballerina/jsonutils;

function testToXml() returns xml {
    json data = {
        name: "John",
        age: 30
    };
    xml x = jsonutils:toXML(data);
    return x;
}
```
x will be `<name>John</name><age>30</age>`

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
