### PR TITLE
Fix class not found issue when run grpc service as uber java.

### DIFF
--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -13,6 +13,13 @@ target = "java8"
     modules = ["grpc"]
 
     [[platform.libraries]]
+    artifactId = "http"
+    version = "@project.version@"
+    path = "./lib/ballerina-http-@project.version@.jar"
+    groupId = "ballerina"
+    modules = ["grpc"]
+
+    [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
     version = "6.0.294"
     path = "./lib/org.wso2.transport.http.netty-6.2.13.jar"


### PR DESCRIPTION
## Purpose
There is an issue when running gRPC service as uber java. This is because, grpc internally uses http module and http module jar doesn't pack in uber jar. This PR is to add http module jar to grpc uber jar.