### PR TITLE
Make the root logger off by default

### DIFF
--- a/bvm/ballerina-logging/src/main/resources/logging.properties
+++ b/bvm/ballerina-logging/src/main/resources/logging.properties
@@ -43,7 +43,7 @@ org.ballerinalang.logging.formatters.HttpAccessLogFormatter.format=%1$s %n
 ####################### LOGGERS #######################
 # Root logger
 handlers=java.util.logging.ConsoleHandler
-.level=WARNING
+.level=OFF
 
 # Ballerina user level root logger
 ballerina.handlers=org.ballerinalang.logging.handlers.BallerinaLogApiHandler


### PR DESCRIPTION
## Purpose
The default root logger which prints ballerina-lang related errors to
the console is made to be off by default. To enable use the CLI
parameter `-e b7a.log.console.loglevel=[LOG_LEVEL]`

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/18502
Resolve https://github.com/ballerina-platform/ballerina-lang/issues/18631

## Approach
> Change config

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
