### PR TITLE
Remove unnecessary error creation in Failover client

### DIFF
--- a/stdlib/http/src/main/ballerina/src/http/resiliency/failover_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/failover_client_endpoint.bal
@@ -397,19 +397,16 @@ function performFailoverAction (string path, Request request, HttpOperation requ
     return inResponse;
 }
 
-// Populates generic error specific to Failover connector by including all the errors returned from endpoints.
+// Populates an error specific to the Failover connector by including all the errors returned from endpoints.
 function populateGenericFailoverActionError (ClientError?[] failoverActionErr, ClientError httpActionErr, int index)
-                                                                                        returns ClientError {
+                                                                            returns FailoverAllEndpointsFailedError {
 
     failoverActionErr[index] = httpActionErr;
     error err = httpActionErr;
-    string? lastErrorMsg = err.detail()?.message;
-    string failoverMessage = "All the failover endpoints failed. Last error was: ";
-    if (lastErrorMsg is string) {
-        failoverMessage = failoverMessage + lastErrorMsg;
-    }
-    FailoverActionFailedError actionError =
-                error(FAILOVER_ENDPOINT_ACTION_FAILED, message = failoverMessage, failoverErrors = failoverActionErr);
+    string lastErrorMsg = <string> err.detail()?.message;
+    string failoverMessage = "All the failover endpoints failed. Last error was: " + lastErrorMsg;
+    FailoverAllEndpointsFailedError actionError =
+                error(FAILOVER_ALL_ENDPOINTS_FAILED, message = failoverMessage, failoverErrors = failoverActionErr);
     return actionError;
 }
 
@@ -512,7 +509,7 @@ function getLastSuceededClientEP(FailoverClient failoverClient) returns Client {
     var lastSuccessClient = failoverClient.failoverInferredConfig
                                             .failoverClientsArray[failoverClient.succeededEndpointIndex];
     if (lastSuccessClient is Client) {
-        // We dont have to check this again as we already check for the response when we get the future.
+        // We don't have to check this again as we already check for the response when we get the future.
         return lastSuccessClient;
     } else {
         // This should not happen as we only fill Client objects to the Clients array
@@ -568,10 +565,7 @@ function handleResponseWithErrorCode(Response response, int initialIndex, int no
 function handleError(ClientError err, int initialIndex, int noOfEndpoints, int index, error?[] failoverActionErrData)
                                                                                         returns [int, ClientError?] {
     ClientError? httpConnectorErr = ();
-    // err is the error received instead of a Response. We wrap it to a `ClientError` here.
-    string invalidResponseMessage = "An error received while retrieving the response";
-    FailoverActionFailedError actionError = error(FAILOVER_ENDPOINT_ACTION_FAILED,
-                                                    message = invalidResponseMessage, cause = err);
+
     int currentIndex = index;
     // If the initialIndex == DEFAULT_FAILOVER_EP_STARTING_INDEX check successful, that means the first
     // endpoint configured in the failover endpoints gave the erroneous response.
@@ -584,7 +578,7 @@ function handleError(ClientError err, int initialIndex, int noOfEndpoints, int i
             // If the execution lands here, that means all the endpoints has been tried out and final
             // endpoint gave an erroneous response. Therefore appropriate error message needs to be
             //  generated and should return it to the client.
-            httpConnectorErr = populateGenericFailoverActionError(failoverActionErrData, actionError, currentIndex - 1);
+            httpConnectorErr = populateGenericFailoverActionError(failoverActionErrData, err, currentIndex - 1);
         }
     } else {
         // If execution reaches here, that means failover has not started with the default starting index.
@@ -593,7 +587,7 @@ function handleError(ClientError err, int initialIndex, int noOfEndpoints, int i
             // If the execution lands here, that means all the endpoints has been tried out and final
             // endpoint gave an erroneous response. Therefore appropriate error message needs to be
             //  generated and should return it to the client.
-            httpConnectorErr = populateGenericFailoverActionError(failoverActionErrData, actionError, currentIndex - 1);
+            httpConnectorErr = populateGenericFailoverActionError(failoverActionErrData, err, currentIndex - 1);
         } else if (noOfEndpoints == currentIndex) {
             // If the execution lands here, that means the last endpoint has been tried out and endpoint gave
             // a erroneous response. Since failover resumed from the last succeeded endpoint we need try out

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/resiliency/HttpResiliencyTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/resiliency/HttpResiliencyTest.java
@@ -178,8 +178,8 @@ public class HttpResiliencyTest extends BaseTest {
 
     @Test(description = "Test the functionality for all endpoints failure scenario")
     public void testAllEndpointFailure() throws IOException {
-        String expectedMessage = "All the failover endpoints failed. Last error was: An error received while " +
-                "retrieving the response";
+        String expectedMessage = "All the failover endpoints failed. Last error was: " +
+                "Idle timeout triggered before initiating inbound response";
         Map<String, String> headers = new HashMap<>();
         headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         HttpResponse response = HttpClientRequest.doPost(serverInstance.getServiceURLHttp(9303, FAILURES_SERVICE_PATH)


### PR DESCRIPTION
## Purpose
> Failover client was creating unnecessary errors, where it wraps a `ClientError`. This is unnecessary because, there is already a client error, and we should store that particular error in Failover Errors array.

When All the endpoints failed, or a response with Error Code received, Failover client should create Failover client-specific error. 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
