### PR TITLE
Fix tuple rest param and tuple variable whitespace issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/TupleVariableNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/TupleVariableNode.java
@@ -17,6 +17,8 @@
 */
 package org.ballerinalang.model.tree;
 
+import org.wso2.ballerinalang.compiler.tree.BLangVariable;
+
 import java.util.List;
 
 /**
@@ -33,5 +35,7 @@ public interface TupleVariableNode extends VariableNode, AnnotatableNode, Docume
     List<? extends VariableNode> getVariables();
     
     void addVariable(VariableNode node);
+
+    BLangVariable getRestVariable();
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/TupleVariableReferenceNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/TupleVariableReferenceNode.java
@@ -39,4 +39,6 @@ public interface TupleVariableReferenceNode extends VariableReferenceNode {
 
     List<? extends ExpressionNode> getExpressions();
 
+    ExpressionNode getRestParam();
+
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TupleDestructureNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TupleDestructureNode.java
@@ -36,4 +36,5 @@ public interface TupleDestructureNode extends StatementNode {
 
     void setExpression(ExpressionNode expression);
 
+    ExpressionNode getRestParam();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/types/TupleTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/types/TupleTypeNode.java
@@ -17,6 +17,8 @@
  */
 package org.ballerinalang.model.tree.types;
 
+import org.wso2.ballerinalang.compiler.tree.types.BLangType;
+
 import java.util.List;
 
 /**
@@ -29,4 +31,5 @@ import java.util.List;
 public interface TupleTypeNode {
 
     List<? extends TypeNode> getMemberTypeNodes();
+    BLangType getRestParamType();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTupleVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTupleVariable.java
@@ -62,6 +62,11 @@ public class BLangTupleVariable extends BLangVariable implements TupleVariableNo
     }
 
     @Override
+    public BLangVariable getRestVariable() {
+        return this.restVariable;
+    }
+
+    @Override
     public NodeKind getKind() {
         return NodeKind.TUPLE_VARIABLE;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangTupleVarRef.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangTupleVarRef.java
@@ -55,6 +55,10 @@ public class BLangTupleVarRef extends BLangVariableReference implements TupleVar
         return expressions;
     }
 
+    @Override
+    public ExpressionNode getRestParam() {
+        return this.restParam;
+    }
 
     @Override
     public String toString() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTupleDestructure.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTupleDestructure.java
@@ -57,6 +57,11 @@ public class BLangTupleDestructure extends BLangStatement implements TupleDestru
     }
 
     @Override
+    public ExpressionNode getRestParam() {
+        return varRef.restParam;
+    }
+
+    @Override
     public void accept(BLangNodeVisitor visitor) {
         visitor.visit(this);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangTupleTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangTupleTypeNode.java
@@ -43,6 +43,11 @@ public class BLangTupleTypeNode extends BLangType implements TupleTypeNode {
     }
 
     @Override
+    public BLangType getRestParamType() {
+        return this.restParamType;
+    }
+
+    @Override
     public void accept(BLangNodeVisitor visitor) {
         visitor.visit(this);
     }

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
@@ -5507,9 +5507,10 @@ public class FormattingNodeTree {
                     }
                 }
 
+                JsonArray variables = null;
                 // Update whitespaces of parameters.
                 if (node.has("variables")) {
-                    JsonArray variables = node.getAsJsonArray("variables");
+                    variables = node.getAsJsonArray("variables");
                     iterateAndFormatMembers(indentation, variables);
                 }
 
@@ -5522,6 +5523,23 @@ public class FormattingNodeTree {
                         annotationAttachment.getAsJsonObject().add(FormattingConstants.FORMATTING_CONFIG,
                                 annotationAttachmentFormattingConfig);
                     }
+                }
+
+                if (node.has("restVariable")) {
+                    JsonObject restVariable = node.getAsJsonObject("restVariable");
+                    JsonObject restParamFormatConfig;
+                    if (variables != null && variables.size() > 0) {
+                        restParamFormatConfig = this.getFormattingConfig(0, 1,
+                                this.getWhiteSpaceCount(indentation), false,
+                                this.getWhiteSpaceCount(useParentIndentation
+                                        ? indentWithParentIndentation : indentation), true);
+                    } else {
+                        restParamFormatConfig = this.getFormattingConfig(0, 0,
+                                this.getWhiteSpaceCount(indentation), false,
+                                this.getWhiteSpaceCount(useParentIndentation
+                                        ? indentWithParentIndentation : indentation), true);
+                    }
+                    restVariable.add(FormattingConstants.FORMATTING_CONFIG, restParamFormatConfig);
                 }
             } else if (node.has(FormattingConstants.TYPE_NODE)) {
                 node.getAsJsonObject(FormattingConstants.TYPE_NODE)
@@ -6201,14 +6219,21 @@ public class FormattingNodeTree {
                                         FormattingConstants.NEW_LINE + indentation);
                             }
                         } else if (text.equals(Tokens.ELLIPSIS)) {
-                            currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                            if (!node.has(FormattingConstants.TYPE_NODE) && firstKeyword.equals(Tokens.ELLIPSIS)) {
+                                currentWS.addProperty(FormattingConstants.WS, this.getWhiteSpaces(formatConfig
+                                        .get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                            } else {
+                                currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                            }
                         } else if (text.equals(Tokens.EQUAL)) {
                             currentWS.addProperty(FormattingConstants.WS, FormattingConstants.SINGLE_SPACE);
                         } else if (text.equals(Tokens.COLON)) {
                             currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
                             isColonAvailable = true;
                         } else {
-                            if (node.has(FormattingConstants.IS_ANON_TYPE)
+                            if (!node.has(FormattingConstants.TYPE_NODE) && firstKeyword.equals(Tokens.ELLIPSIS)) {
+                                currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
+                            } else if (node.has(FormattingConstants.IS_ANON_TYPE)
                                     && node.get(FormattingConstants.IS_ANON_TYPE).getAsBoolean()) {
                                 currentWS.addProperty(FormattingConstants.WS,
                                         FormattingConstants.SINGLE_SPACE);
@@ -6233,7 +6258,6 @@ public class FormattingNodeTree {
                                                 ? this.getWhiteSpaces(formatConfig.get(FormattingConstants.SPACE_COUNT)
                                                 .getAsInt())
                                                 : FormattingConstants.SINGLE_SPACE);
-
                             }
                         }
                     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -166,6 +166,7 @@ public class FormattingTest {
                 {"expectedXMLAttributeAccessExpr.bal", "xmlAttributeAccessExpr.bal"},
                 {"expectedXMLQName.bal", "xmlQName.bal"},
                 {"expectedUnicodeCharTest.bal", "unicodeCharTest.bal"},
+                {"expectedTupleTypeRest.bal", "tupleTypeRest.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/formatting/FormattingTest.java
@@ -167,6 +167,7 @@ public class FormattingTest {
                 {"expectedXMLQName.bal", "xmlQName.bal"},
                 {"expectedUnicodeCharTest.bal", "unicodeCharTest.bal"},
                 {"expectedTupleTypeRest.bal", "tupleTypeRest.bal"},
+                {"expectedTupleDestructure.bal", "tupleDestructure.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleDestructure.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleDestructure.bal
@@ -1,0 +1,84 @@
+type Person record {
+    string name;
+};
+
+type Employee record {
+    string name;
+    boolean intern;
+};
+
+Person person1 = {name: "Person 1"};
+Employee employee1 = {name: "Employee 1", intern: true};
+Employee employee2 = {name: "Employee 2", intern: false};
+
+function tupleDestructureTest1() returns [int, string] {
+    [int, string] x = [1, "a"];
+    int a;
+    string b;
+    [a, b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest2() returns [int, int[]] {
+    [int, int, int, int] x = [1, 2, 3, 4];
+    int a;
+    int[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest3() returns [int, int[]] {
+    [int, int, int...] x = [1, 2, 3, 4];
+    int a;
+    int[] b;
+    [
+    a
+    ,
+    ...
+    b
+    ]
+    =
+    x
+    ;
+    return [a, b];
+}
+
+function tupleDestructureTest4() returns int[] {
+    [int...] x = [1, 2, 3, 4];
+    int[] a;
+    [...a] = x;
+    return a;
+}
+
+function tupleDestructureTest5() returns [int, int[]] {
+    [int...] x = [1, 2, 3, 4];
+    int a;
+    int[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest6() returns [int, string[]] {
+    [int, string, string] x = [1, "a", "b"];
+    int a;
+    string[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest7() returns [int, string[]] {
+    [int, string...] x = [1, "a", "b"];
+    int a;
+    string[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest8() returns [int, string, string[]] {
+    [int, string...] x = [1, "a", "b"];
+    int a;
+    string b;
+    string[] c;
+    [a, b, ...c] = x;
+    return [a, b, c];
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleType.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleType.bal
@@ -32,3 +32,17 @@ function name2() returns [int, [string, int, float]] {
 function searchPeople() returns ([string, int, float]) {
     return (["", 1, 1.0]);
 }
+
+function testArrayToTupleAssignment3() returns [string, string[]] {
+    string[3] x = ["a", "b", "c"];
+    [string, string...][i, ...j] = x;
+    return [i, j];
+}
+
+function testArrayToTupleAssignment4() returns [string, string[]] {
+    string[3] x = ["a", "b", "c"];
+    [string, string...][i,
+    ...
+    j] = x;
+    return [i, j];
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleTypeRest.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleTypeRest.bal
@@ -1,0 +1,114 @@
+type Person record {
+    string name;
+};
+
+type Employee record {
+    string name;
+    boolean intern;
+};
+
+Person person1 = {name: "John"};
+Employee employee1 = {name: "John", intern: true};
+
+function basicTupleAssignment() returns string {
+    [int, string, boolean...] t = [1, "s", true, true];
+    [int, string,
+    boolean...] t1 = [2, "s", true];
+    [int, string, boolean...] t2 = [3, "s"];
+    return t.toString() + " " + t1.toString() + " " + t2.toString();
+}
+
+function tupleAssignmentWithNilRestDescriptor() returns string {
+    [int, string, ()...] t = [1, "s"];
+    [int, string, ()...] t1 = [1, "s", ()];
+    [int, string, ()...] t2 = [1, "s", (), ()];
+    [(
+    ()
+    |
+    ())...] t3 = [(), ()];
+    return t.toString() + " " + t1.toString() + " " + t2.toString() + " " + t3.toString();
+}
+
+function tupleAssignmentWithOnlyRestDescriptor() returns string {
+    [int...] t = [1, 2];
+    [
+    string
+    ...] t1 = ["s", "s"];
+    [()...] t2 = [(), ()];
+    return t.toString() + " " + t1.toString() + " " + t2.toString();
+}
+
+function tupleCovarianceWithRestDescriptor() returns string {
+    [string, Employee...] e = ["s", employee1, employee1, employee1];
+    [string, Person...] t = e;
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function tupleCovarianceWithOnlyRestDescriptor() returns string {
+    [Employee...] e = [employee1, employee1, employee1];
+    [Person...] t = e;
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testFunctionInvocation() returns string {
+    [string, float, boolean...] t = ["y", 5.0, true, false];
+    string x = testTuples(t);
+    return x;
+}
+
+function testTuples([string, float, boolean...] t) returns string {
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testFunctionReturnValue() returns string {
+    [string, float, boolean...] t = testReturnTuples("x");
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testReturnTuples(string a) returns [string, float, boolean...] {
+    [string, float, boolean...] t = [a, 5.0, true, false];
+    return t;
+}
+
+function testIndexBasedAccess() returns string {
+    [boolean, string...] t = [true, "a", "b", "c"];
+    boolean tempBool = t[0];
+    string tempStringA = t[1];
+    string tempStringB = t[2];
+    string tempStringC = t[3];
+    t[0] = false;
+    t[1] = "a1";
+    t[2] = "b1";
+    t[3] = "c1";
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testIndexBasedAccessNegative() returns string {
+    [boolean, string...] t = [true, "a", "b", "c"];
+    string tempStringC = t[4];
+    string s = "";
+    foreach var i in t {
+        s += i.toString();
+    }
+    return s;
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/tupleDestructure.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/tupleDestructure.bal
@@ -1,0 +1,83 @@
+type Person record {
+    string name;
+};
+
+type Employee record {
+    string name;
+    boolean intern;
+};
+
+Person person1 = { name: "Person 1" };
+Employee employee1 = { name: "Employee 1", intern: true };
+Employee employee2 = { name: "Employee 2", intern: false };
+
+function tupleDestructureTest1() returns [int, string] {
+	   [int, string] x = [1, "a"];
+    int a;
+    string b;
+    [a, b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest2() returns [int, int[]] {
+    [int, int, int, int] x = [1, 2, 3, 4];
+    int a;
+    int[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest3() returns [int, int[]] {
+    [int, int, int...] x = [1, 2, 3, 4];
+    int a;
+    int[] b;
+    [
+        a
+                 ,
+                 ...
+     b
+         ]
+              =
+                   x
+                   ;
+    return [a, b];
+}
+
+function tupleDestructureTest4() returns int[] {
+        [   int   ...  ]  x = [1, 2, 3, 4];
+    int[] a;[   ...  a  ] = x;
+    return a;
+}
+
+function tupleDestructureTest5() returns [int, int[]] {
+    [int...] x = [1, 2, 3, 4];
+    int a;
+    int[] b;
+       [  a ,    ...b   ]=x ;
+    return [a, b];
+}
+
+function tupleDestructureTest6() returns [int, string[]] {
+    [int, string, string] x = [1, "a", "b"];
+    int a;
+    string[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest7() returns [int, string[]] {
+    [int, string...] x = [1, "a", "b"];
+    int a;
+    string[] b;
+    [a, ...b] = x;
+    return [a, b];
+}
+
+function tupleDestructureTest8() returns [int, string, string[]] {
+    [int, string ... ] x = [1, "a", "b"];
+    int a;
+    string b;
+    string[] c;
+    [ a ,b ,       ...   c  ]   =  x ;
+    return [a, b, c];
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/tupleType.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/tupleType.bal
@@ -24,3 +24,17 @@ function name2() returns [int, [string, int, float]] {
 function searchPeople() returns (   [   string , int , float  ]  ) {
     return (  [ "" , 1 , 1.0 ] );
 }
+
+function testArrayToTupleAssignment3() returns [string, string[]] {
+    string[3] x = ["a", "b", "c"];
+     [string,  string ...]   [i,   ... j ] = x;
+    return [i, j];
+}
+
+function testArrayToTupleAssignment4() returns [string, string[]] {
+    string[3] x = ["a", "b", "c"];
+    [ string ,  string ...][i ,
+            ...
+j] = x;
+    return [i, j];
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/tupleTypeRest.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/tupleTypeRest.bal
@@ -1,0 +1,113 @@
+type Person record {
+    string name;
+};
+
+type Employee record {
+    string name;
+    boolean intern;
+};
+
+Person person1 = {name: "John"};
+Employee employee1 = {name: "John", intern: true};
+
+function basicTupleAssignment() returns string {
+    [   int,    string,    boolean   ...   ] t = [1, "s", true, true];
+    [    int,    string,
+    boolean   ...] t1  =  [2, "s", true];
+ [  int,   string,  boolean   ...] t2 = [3, "s"];
+    return t.toString() + " " + t1.toString() + " " + t2.toString();
+}
+
+function tupleAssignmentWithNilRestDescriptor() returns string {
+    [int, string, (  )...] t = [1, "s"];
+    [int, string, (  )...] t1 = [1, "s", (    )];
+    [int, string, (  )...] t2 = [1, "s", (  ), (   )];
+    [(
+   (  )
+       |
+        (  ))   ...] t3 = [(   ), (  )];
+    return t.toString() + " " + t1.toString() + " " + t2.toString() + " " + t3.toString();
+}
+
+function tupleAssignmentWithOnlyRestDescriptor() returns string {
+    [  int  ...] t = [1, 2];
+    [
+            string
+ ...]   t1 = ["s", "s"];
+    [   ()  ...  ] t2 = [(), ()];
+    return t.toString() + " " + t1.toString() + " " + t2.toString();
+}
+
+function tupleCovarianceWithRestDescriptor() returns string {
+    [string, Employee  ...] e = ["s", employee1, employee1, employee1];
+    [string,   Person ...] t = e;
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function tupleCovarianceWithOnlyRestDescriptor() returns string {
+  [ Employee ... ] e = [employee1, employee1, employee1];
+       [ Person ... ] t = e;
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testFunctionInvocation() returns string {
+   [ string , float , boolean  ...  ] t = ["y", 5.0, true, false];
+    string x = testTuples(t);
+    return x;
+}
+
+function testTuples([string, float, boolean...] t) returns string {
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testFunctionReturnValue() returns string {[ string,float ,boolean   ...] t = testReturnTuples("x");
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testReturnTuples(string a) returns [string, float, boolean...] {
+  [   string  ,   float,boolean    ...] t = [a, 5.0, true, false];
+    return t;
+}
+
+function testIndexBasedAccess() returns string {
+        [boolean,   string   ...  ] t = [true, "a", "b", "c"];
+    boolean tempBool = t[0];
+    string tempStringA = t[1];
+    string tempStringB = t[2];
+    string tempStringC = t[3];
+    t[0] = false;
+    t[1] = "a1";
+    t[2] = "b1";
+    t[3] = "c1";
+    string s = "";
+    foreach var i in t {
+        s += i.toString() + " ";
+    }
+    return s;
+}
+
+function testIndexBasedAccessNegative() returns string {
+    [boolean,     string   ...   ] t = [true, "a", "b", "c"];
+    string tempStringC = t[4];
+    string s = "";
+    foreach var i in t {
+        s += i.toString();
+    }
+    return s;
+}


### PR DESCRIPTION
## Purpose
This will fix the whitespace capturing issue for the tuple type rest param. This also will fix the tuple variable rest param whitespace capturing issue. Also Fix tuple destructure rest param formatting.

Fixes #18723
Fixes #18732
Fixes #18739

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
