### PR TITLE
Updating to remove redirection git path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,14 @@ Building Ballerina requires a Java SE Development Kit (JDK) version 8 to be inst
 Clone this repository using the following command.
 
 ```
-git clone --recursive https://github.com/ballerinalang/ballerina
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang.git
 ```
+
+If you have forked the repository to your github account then use the following command replacing <YOUR-GITHUB-USERNAME> with your git username.
+
+````
+git clone --recursive https://github.com/<YOUR-GITHUB-USERNAME>/ballerina-lang.git
+````
 
 If you download the sources, you need to update the git submodules using the following command.
 


### PR DESCRIPTION
Updated the Contributing section to add the github repository path for the ballerina download instead of the redirection path.
Also added a couple of lines on how to clone it the recommended way i.e. via forking.

## Check List 
- [ x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
