### PR TITLE
Fix a compound assignment issue in function calling

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -286,6 +286,7 @@ public class Desugar extends BLangNodeVisitor {
     private int errorCount = 0;
     private int annonVarCount = 0;
     private int initFuncIndex = 0;
+    private int indexExprNumber = 0;
 
     // Safe navigation related variables
     private Stack<BLangMatch> matchStmtStack = new Stack<>();
@@ -2349,7 +2350,6 @@ public class Desugar extends BLangNodeVisitor {
         // var $temp2$ = 3;
         // var $temp1$ = 2;
         // a[$temp3$][$temp2$][$temp1$] = a[$temp3$][$temp2$][$temp1$] + y;
-        int indexExprNumber = 0;
         List<BLangStatement> statements = new ArrayList<>();
         List<BLangSimpleVarRef> varRefs = new ArrayList<>();
         List<BType> types = new ArrayList<>();
@@ -2369,15 +2369,11 @@ public class Desugar extends BLangNodeVisitor {
             varRefs.add(0, tempVarRef);
             types.add(0, varRef.type);
 
-            if (((BLangIndexBasedAccess) varRef).expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR) {
-                varRef = (BLangVariableReference) ((BLangIndexBasedAccess) varRef).expr;
-                continue;
-            }
-            break;
-        } while (true);
+            varRef = (BLangVariableReference) ((BLangIndexBasedAccess) varRef).expr;
+        } while (varRef.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR);
 
         // Create the index access expression. ex: c[$temp3$][$temp2$][$temp1$]
-        BLangVariableReference var = (BLangVariableReference) ((BLangIndexBasedAccess) varRef).expr;
+        BLangVariableReference var = varRef;
         for (int ref = 0; ref < varRefs.size(); ref++) {
             var = ASTBuilderUtil.createIndexAccessExpr(var, varRefs.get(ref));
             var.type = types.get(ref);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2351,9 +2351,9 @@ public class Desugar extends BLangNodeVisitor {
                         indexBasedAccess.indexExpr.type, indexBasedAccess.indexExpr, compoundAssignment.pos);
                 BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(tempIndexVarDef.pos,
                         tempIndexVarDef.var.symbol);
-                statements.add(tempIndexVarDef);
-                varRef.add(tempVarRef);
-                type.add(indexBasedAccess.type);
+                statements.add(0, tempIndexVarDef);
+                varRef.add(0, tempVarRef);
+                type.add(0, indexBasedAccess.type);
 
                 if (indexBasedAccess.expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR) {
                     indexBasedAccess = (BLangIndexBasedAccess) indexBasedAccess.expr;
@@ -2364,7 +2364,7 @@ public class Desugar extends BLangNodeVisitor {
 
             // Create the index access expression. ex: c[$temp3$][$temp2$][$temp1$]
             BLangVariableReference var = (BLangVariableReference) indexBasedAccess.expr;
-            for (int ref = varRef.size() - 1; ref >= 0; ref--) {
+            for (int ref = 0; ref < varRef.size(); ref++) {
                 var = ASTBuilderUtil.createIndexAccessExpr(var, varRef.get(ref));
                 var.type = type.get(ref);
             }
@@ -2374,8 +2374,6 @@ public class Desugar extends BLangNodeVisitor {
             BLangExpression rhsExpression = ASTBuilderUtil.createBinaryExpr(compoundAssignment.pos, var,
                     compoundAssignment.expr, compoundAssignment.type, compoundAssignment.opKind, null);
             rhsExpression.type = compoundAssignment.modifiedExpr.type;
-
-            Collections.reverse(statements);
 
             // Create assignment statement. ex: a[$temp3$][$temp2$][$temp1$] = a[$temp3$][$temp2$][$temp1$] + y;
             BLangAssignment assignStmt = ASTBuilderUtil.createAssignmentStmt(compoundAssignment.pos, var,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2330,9 +2330,9 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangCompoundAssignment compoundAssignment) {
         // If compound Assignment is an index based expression such as a[f(1, foo)][3][2] += y,
         // should return a block statement which is equivalent to
-        // var $temp1$ = 2;
-        // var $temp2$ = 3;
         // var $temp3$ = a[f(1, foo)];
+        // var $temp2$ = 3;
+        // var $temp1$ = 2;
         // a[$temp3$][$temp2$][$temp1$] = a[$temp3$][$temp2$][$temp1$] + y;
         if (compoundAssignment.varRef.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR) {
             int indexExprNumber = 0;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -286,7 +286,7 @@ public class Desugar extends BLangNodeVisitor {
     private int errorCount = 0;
     private int annonVarCount = 0;
     private int initFuncIndex = 0;
-    private int indexExprNumber = 0;
+    private int indexExprCount = 0;
 
     // Safe navigation related variables
     private Stack<BLangMatch> matchStmtStack = new Stack<>();
@@ -2355,12 +2355,11 @@ public class Desugar extends BLangNodeVisitor {
         List<BType> types = new ArrayList<>();
 
         // Extract the index Expressions from compound assignment and create variable definitions. ex:
-        // var $temp1$ = 2;
-        // var $temp2$ = 3;
         // var $temp3$ = a[f(1, foo)];
+        // var $temp2$ = 3;
+        // var $temp1$ = 2;
         do {
-            indexExprNumber += 1;
-            BLangSimpleVariableDef tempIndexVarDef = createVarDef("$temp" + indexExprNumber + "$",
+            BLangSimpleVariableDef tempIndexVarDef = createVarDef("$temp" + ++indexExprCount + "$",
                     ((BLangIndexBasedAccess) varRef).indexExpr.type, ((BLangIndexBasedAccess) varRef).indexExpr,
                     compoundAssignment.pos);
             BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(tempIndexVarDef.pos,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2347,9 +2347,10 @@ public class Desugar extends BLangNodeVisitor {
             // var $temp3$ = a[f(1, foo)];
             do {
                 indexExprNumber += 1;
-                BLangSimpleVariableDef tempIndexVarDef = createVarDef("$temp" + indexExprNumber + "$", indexBasedAccess.indexExpr.type,
-                        indexBasedAccess.indexExpr, compoundAssignment.pos);
-                BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(tempIndexVarDef.pos, tempIndexVarDef.var.symbol);
+                BLangSimpleVariableDef tempIndexVarDef = createVarDef("$temp" + indexExprNumber + "$",
+                        indexBasedAccess.indexExpr.type, indexBasedAccess.indexExpr, compoundAssignment.pos);
+                BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(tempIndexVarDef.pos,
+                        tempIndexVarDef.var.symbol);
                 statements.add(tempIndexVarDef);
                 varRef.add(tempVarRef);
                 type.add(indexBasedAccess.type);
@@ -2370,13 +2371,15 @@ public class Desugar extends BLangNodeVisitor {
             var.type = compoundAssignment.varRef.type;
 
             // Create the right hand side binary expression of the assignment. ex: c[$temp3$][$temp2$][$temp1$] + y
-            BLangExpression rhsExpression = ASTBuilderUtil.createBinaryExpr(compoundAssignment.pos, var, compoundAssignment.expr, compoundAssignment.type, compoundAssignment.opKind, null);
+            BLangExpression rhsExpression = ASTBuilderUtil.createBinaryExpr(compoundAssignment.pos, var,
+                    compoundAssignment.expr, compoundAssignment.type, compoundAssignment.opKind, null);
             rhsExpression.type = compoundAssignment.modifiedExpr.type;
 
             Collections.reverse(statements);
 
             // Create assignment statement. ex: a[$temp3$][$temp2$][$temp1$] = a[$temp3$][$temp2$][$temp1$] + y;
-            BLangAssignment assignStmt = ASTBuilderUtil.createAssignmentStmt(compoundAssignment.pos, var, rhsExpression);
+            BLangAssignment assignStmt = ASTBuilderUtil.createAssignmentStmt(compoundAssignment.pos, var,
+                    rhsExpression);
 
             statements.add(assignStmt);
             // Create block statement. ex: var $temp3$ = a[f(1, foo)];var $temp2$ = 3;var $temp1$ = 2;
@@ -2394,7 +2397,8 @@ public class Desugar extends BLangNodeVisitor {
                 varRef.lhsVar = true;
             }
 
-            result = ASTBuilderUtil.createAssignmentStmt(compoundAssignment.pos, rewriteExpr(varRef), rewriteExpr(compoundAssignment.modifiedExpr));
+            result = ASTBuilderUtil.createAssignmentStmt(compoundAssignment.pos, rewriteExpr(varRef),
+                    rewriteExpr(compoundAssignment.modifiedExpr));
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
@@ -154,6 +154,59 @@ public class CompoundAssignmentTest {
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
     }
 
+    @Test(description = "Test compound assignment with addition on array element where the index is an invocation.")
+    public void testCompoundAssignmentAdditionArrayElementFunctionInvocation() {
+        BValue[] returns = BRunUtil.invoke(result,
+                "testCompoundAssignmentAdditionArrayElementFunctionInvocation");
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertTrue(returns[1] instanceof BInteger);
+        Assert.assertTrue(returns[2] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 11);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 1);
+    }
+
+    @Test(description = "Test compound assignment with subtraction on array element where the index is an invocation.")
+    public void testCompoundAssignmentSubtractionArrayElementFunctionInvocation() {
+        BValue[] returns = BRunUtil.invoke(result,
+                "testCompoundAssignmentSubtractionArrayElementFunctionInvocation");
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertTrue(returns[1] instanceof BInteger);
+        Assert.assertTrue(returns[2] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 1);
+    }
+
+    @Test(description = "Test compound assignment with division on array element where the index is an invocation.")
+    public void testCompoundAssignmentDivisionArrayElementFunctionInvocation() {
+        BValue[] returns = BRunUtil.invoke(result,
+                "testCompoundAssignmentDivisionArrayElementFunctionInvocation");
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertTrue(returns[1] instanceof BInteger);
+        Assert.assertTrue(returns[2] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 1);
+    }
+
+    @Test(description = "Test compound assignment with multiplication on array element where the index is an " +
+            "invocation.")
+    public void testCompoundAssignmentMultiplicationArrayElementFunctionInvocation() {
+        BValue[] returns = BRunUtil.invoke(result,
+                "testCompoundAssignmentMultiplicationArrayElementFunctionInvocation");
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertTrue(returns[1] instanceof BInteger);
+        Assert.assertTrue(returns[2] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 30);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 1);
+    }
+
     @Test(description = "Test compound assignment with addition on struct element.")
     public void testCompoundAssignmentAdditionStructElement() {
         BValue[] returns = BRunUtil.invoke(result, "testCompoundAssignmentAdditionStructElement");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
@@ -208,9 +208,11 @@ public class CompoundAssignmentTest {
             "invocation.")
     public void testCompoundAssignmentArrayElementFunctionInvocationOrder() {
         BValue[] returns = BRunUtil.invoke(result, "testCompoundAssignmentArrayElementFunctionInvocationOrder");
-        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(returns.length, 3);
         Assert.assertTrue(returns[0] instanceof BInteger);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 18);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 30);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 1);
     }
 
     @Test(description = "Test compound assignment with addition on struct element.")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
@@ -156,8 +156,7 @@ public class CompoundAssignmentTest {
 
     @Test(description = "Test compound assignment with addition on array element where the index is an invocation.")
     public void testCompoundAssignmentAdditionArrayElementFunctionInvocation() {
-        BValue[] returns = BRunUtil.invoke(result,
-                "testCompoundAssignmentAdditionArrayElementFunctionInvocation");
+        BValue[] returns = BRunUtil.invoke(result, "testCompoundAssignmentAdditionArrayElementFunctionInvocation");
         Assert.assertEquals(returns.length, 3);
         Assert.assertTrue(returns[0] instanceof BInteger);
         Assert.assertTrue(returns[1] instanceof BInteger);
@@ -169,8 +168,7 @@ public class CompoundAssignmentTest {
 
     @Test(description = "Test compound assignment with subtraction on array element where the index is an invocation.")
     public void testCompoundAssignmentSubtractionArrayElementFunctionInvocation() {
-        BValue[] returns = BRunUtil.invoke(result,
-                "testCompoundAssignmentSubtractionArrayElementFunctionInvocation");
+        BValue[] returns = BRunUtil.invoke(result, "testCompoundAssignmentSubtractionArrayElementFunctionInvocation");
         Assert.assertEquals(returns.length, 3);
         Assert.assertTrue(returns[0] instanceof BInteger);
         Assert.assertTrue(returns[1] instanceof BInteger);
@@ -182,8 +180,7 @@ public class CompoundAssignmentTest {
 
     @Test(description = "Test compound assignment with division on array element where the index is an invocation.")
     public void testCompoundAssignmentDivisionArrayElementFunctionInvocation() {
-        BValue[] returns = BRunUtil.invoke(result,
-                "testCompoundAssignmentDivisionArrayElementFunctionInvocation");
+        BValue[] returns = BRunUtil.invoke(result, "testCompoundAssignmentDivisionArrayElementFunctionInvocation");
         Assert.assertEquals(returns.length, 3);
         Assert.assertTrue(returns[0] instanceof BInteger);
         Assert.assertTrue(returns[1] instanceof BInteger);
@@ -205,6 +202,15 @@ public class CompoundAssignmentTest {
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 30);
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
         Assert.assertEquals(((BInteger) returns[2]).intValue(), 1);
+    }
+
+    @Test(description = "Test execution order of compound assignment on array element where the index is an " +
+            "invocation.")
+    public void testCompoundAssignmentArrayElementFunctionInvocationOrder() {
+        BValue[] returns = BRunUtil.invoke(result, "testCompoundAssignmentArrayElementFunctionInvocationOrder");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 18);
     }
 
     @Test(description = "Test compound assignment with addition on struct element.")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
@@ -290,3 +290,65 @@ function testCompoundAssignmentAdditionWithRecordAccess() returns int {
     x += (ibm["count"] + arr[0]);
     return x;
 }
+
+function testCompoundAssignmentAdditionArrayElementFunctionInvocation() returns [int, int, int] {
+    var x = 5;
+    Girl girl = {};
+    Boy boy = {};
+    int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
+    [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
+
+    b[f(1, girl)][2][g(0, boy)] += x;
+    return [b[2][2][1], girl.age, boy.age];
+}
+
+function testCompoundAssignmentSubtractionArrayElementFunctionInvocation() returns [int, int, int] {
+    var x = 5;
+    Girl girl = {};
+    Boy boy = {};
+    int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
+    [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
+
+    b[f(1, girl)][2][g(0, boy)] -= x;
+    return [b[2][2][1], girl.age, boy.age];
+}
+
+function testCompoundAssignmentDivisionArrayElementFunctionInvocation() returns [int, int, int] {
+    var x = 5;
+    Girl girl = {};
+    Boy boy = {};
+    int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
+    [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
+
+    b[f(1, girl)][2][g(0, boy)] /= x;
+    return [b[2][2][1], girl.age, boy.age];
+}
+
+function testCompoundAssignmentMultiplicationArrayElementFunctionInvocation() returns [int, int, int] {
+    var x = 5;
+    Girl girl = {};
+    Boy boy = {};
+    int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
+    [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
+
+    b[f(1, girl)][2][g(0, boy)] *= x;
+    return [b[2][2][1], girl.age, boy.age];
+}
+
+function f(int i, Girl g) returns (int) {
+    g.age += 1;
+    return i + 1;
+}
+
+function g(int i, Boy b) returns (int) {
+    b.age += 1;
+    return i + 1;
+}
+
+type Girl record  {
+    int age = 0;
+};
+
+type Boy record  {
+    int age = 0;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
@@ -335,6 +335,17 @@ function testCompoundAssignmentMultiplicationArrayElementFunctionInvocation() re
     return [b[2][2][1], girl.age, boy.age];
 }
 
+function testCompoundAssignmentArrayElementFunctionInvocationOrder() returns int {
+    var x = 3;
+    Girl girl = {};
+    Boy boy = {};
+    int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
+    [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
+
+    b[f(1, girl)][2][g(0, boy)] *= x;
+    return b[2][2][1];
+}
+
 function f(int i, Girl g) returns (int) {
     g.age += 1;
     return i + 1;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
@@ -298,7 +298,7 @@ function testCompoundAssignmentAdditionArrayElementFunctionInvocation() returns 
     int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
     [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
 
-    b[f(1, girl)][2][g(0, boy)] += x;
+    b[incrementAgeOfGirl(1, girl)][2][incrementAgeOfBoy(0, boy)] += x;
     return [b[2][2][1], girl.age, boy.age];
 }
 
@@ -309,7 +309,7 @@ function testCompoundAssignmentSubtractionArrayElementFunctionInvocation() retur
     int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
     [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
 
-    b[f(1, girl)][2][g(0, boy)] -= x;
+    b[incrementAgeOfGirl(1, girl)][2][incrementAgeOfBoy(0, boy)] -= x;
     return [b[2][2][1], girl.age, boy.age];
 }
 
@@ -320,7 +320,7 @@ function testCompoundAssignmentDivisionArrayElementFunctionInvocation() returns 
     int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
     [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
 
-    b[f(1, girl)][2][g(0, boy)] /= x;
+    b[incrementAgeOfGirl(1, girl)][2][incrementAgeOfBoy(0, boy)] /= x;
     return [b[2][2][1], girl.age, boy.age];
 }
 
@@ -331,7 +331,7 @@ function testCompoundAssignmentMultiplicationArrayElementFunctionInvocation() re
     int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
     [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
 
-    b[f(1, girl)][2][g(0, boy)] *= x;
+    b[incrementAgeOfGirl(1, girl)][2][incrementAgeOfBoy(0, boy)] *= x;
     return [b[2][2][1], girl.age, boy.age];
 }
 
@@ -342,29 +342,29 @@ function testCompoundAssignmentArrayElementFunctionInvocationOrder() returns [in
     int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
     [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
 
-    b[foo(girl)][2][bar(boy)] *= x;
+    b[incrementIndexOfGirl(girl)][2][incrementIndexOfBoy(boy)] *= x;
     return [b[1][2][2], girl.age, boy.age];
 }
 
-function f(int i, Girl g) returns (int) {
+function incrementAgeOfGirl(int i, Girl g) returns (int) {
     g.age += 1;
     return i + 1;
 }
 
-function g(int i, Boy b) returns (int) {
+function incrementAgeOfBoy(int i, Boy b) returns (int) {
     b.age += 1;
     return i + 1;
 }
 
 int index = 0;
 
-function foo(Girl g) returns (int) {
+function incrementIndexOfGirl(Girl g) returns (int) {
     g.age += 1;
     index = index + 1;
     return index;
 }
 
-function bar(Boy b) returns (int) {
+function incrementIndexOfBoy(Boy b) returns (int) {
     b.age += 1;
     index = index + 1;
     return index;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
@@ -335,15 +335,15 @@ function testCompoundAssignmentMultiplicationArrayElementFunctionInvocation() re
     return [b[2][2][1], girl.age, boy.age];
 }
 
-function testCompoundAssignmentArrayElementFunctionInvocationOrder() returns int {
+function testCompoundAssignmentArrayElementFunctionInvocationOrder() returns [int, int, int] {
     var x = 3;
     Girl girl = {};
     Boy boy = {};
     int[][][] b = [[[1, 2, 3], [3, 2, 1], [3, 2, 1]], [[10, 20, 30], [30, 20, 10], [30, 20, 10]],
     [[5, 6, 7], [7, 6, 5], [7, 6, 5]]];
 
-    b[f(1, girl)][2][g(0, boy)] *= x;
-    return b[2][2][1];
+    b[foo(girl)][2][bar(boy)] *= x;
+    return [b[1][2][2], girl.age, boy.age];
 }
 
 function f(int i, Girl g) returns (int) {
@@ -354,6 +354,20 @@ function f(int i, Girl g) returns (int) {
 function g(int i, Boy b) returns (int) {
     b.age += 1;
     return i + 1;
+}
+
+int index = 0;
+
+function foo(Girl g) returns (int) {
+    g.age += 1;
+    index = index + 1;
+    return index;
+}
+
+function bar(Boy b) returns (int) {
+    b.age += 1;
+    index = index + 1;
+    return index;
 }
 
 type Girl record  {


### PR DESCRIPTION
## Purpose
Fixes #15459

## Approach
If my compound assignment is ```a[f(1, foo)][3][2] += y```, index expressions should be extracted and evaluated them separately. Finally, create a block statement as follows.
```
var $temp3$ = a[f(1, foo)];
var $temp2$ = 3;
var $temp1$ = 2;
a[$temp3$][$temp2$][$temp1$] = a[$temp3$][$temp2$][$temp1$] + y;
```
## Samples

## Remarks

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
