### PR TITLE
Fix Bad Sad on Stackoverflow errors

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BallerinaErrors.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BallerinaErrors.java
@@ -82,6 +82,16 @@ public class BallerinaErrors {
         return createError(error.getMessage());
     }
 
+    public static ErrorValue trapError(Throwable throwable) {
+        // Used to trap and create error value for non error value exceptions. At the moment, we can trap
+        // stack overflow exceptions in addition to error value.
+        // In the future, if we need to trap more exception types, we need to check instance of each exception and
+        // handle accordingly.
+        ErrorValue error = createError(BallerinaErrorReasons.STACK_OVERFLOW_ERROR);
+        error.setStackTrace(throwable.getStackTrace());
+        return error;
+    }
+
     public static ErrorValue createConversionError(Object inputValue, BType targetType) {
         return createError(BALLERINA_PREFIXED_CONVERSION_ERROR,
                            BLangExceptionHelper.getErrorMessage(INCOMPATIBLE_CONVERT_OPERATION,

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
@@ -319,10 +319,12 @@ const string PRINT_STACK_TRACE_METHOD = "printStackTrace";
 const string SET_DETAIL_TYPE_METHOD = "setDetailType";
 const string ERROR_REASON_METHOD_TOO_LARGE = "MethodTooLarge";
 const string ERROR_REASON_CLASS_TOO_LARGE = "ClassTooLarge";
+const string TRAP_ERROR_METHOD = "trapError"
 
 // exception classes
 const string BLANG_RUNTIME_EXCEPTION = "org/ballerinalang/jvm/util/exceptions/BLangRuntimeException";
 const string THROWABLE = "java/lang/Throwable";
+const string STACK_OVERFLOW_ERROR = "java/lang/StackOverflowError";
 const string HANDLE_THROWABLE_METHOD = "handleRuntimeErrors";
 const string HANDLE_STOP_PANIC_METHOD = "silentlyLogBadSad";
 const string HANDLE_RETURNED_ERROR_METHOD = "handleRuntimeReturnValues";

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
@@ -319,7 +319,7 @@ const string PRINT_STACK_TRACE_METHOD = "printStackTrace";
 const string SET_DETAIL_TYPE_METHOD = "setDetailType";
 const string ERROR_REASON_METHOD_TOO_LARGE = "MethodTooLarge";
 const string ERROR_REASON_CLASS_TOO_LARGE = "ClassTooLarge";
-const string TRAP_ERROR_METHOD = "trapError"
+const string TRAP_ERROR_METHOD = "trapError";
 
 // exception classes
 const string BLANG_RUNTIME_EXCEPTION = "org/ballerinalang/jvm/util/exceptions/BLangRuntimeException";

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
@@ -36,14 +36,8 @@ type ErrorHandlerGenerator object {
         self.mv.visitInsn(ATHROW);
     }
 
-    function generateTryIns(jvm:Label endLabel, jvm:Label handlerLabel) {
-        jvm:Label startLabel = new;
-        self.mv.visitTryCatchBlock(startLabel, endLabel, handlerLabel, ERROR_VALUE);
-        self.mv.visitLabel(startLabel);
-    }
-
     function generateTryInsForTrap(bir:ErrorEntry currentEE, string[] errorVarNames, jvm:Label endLabel, 
-                                   jvm:Label handlerLabel, jvm:Label jumpLabel) {
+                                   jvm:Label errorValueLabel, jvm:Label otherErrorLabel, jvm:Label jumpLabel) {
         var varDcl = <bir:VariableDcl>currentEE.errorOp.variableDcl;
         int lhsIndex = self.getJVMIndexOfVarRef(varDcl);
         if (!stringArrayContains(errorVarNames, currentEE.errorOp.variableDcl.name.value)) {
@@ -53,7 +47,8 @@ type ErrorHandlerGenerator object {
         }
 
         jvm:Label startLabel = new;
-        self.mv.visitTryCatchBlock(startLabel, endLabel, handlerLabel, ERROR_VALUE);
+        self.mv.visitTryCatchBlock(startLabel, endLabel, errorValueLabel, ERROR_VALUE);
+        self.mv.visitTryCatchBlock(startLabel, endLabel, otherErrorLabel, STACK_OVERFLOW_ERROR);
         jvm:Label temp = new;
         self.mv.visitLabel(temp);
 
@@ -62,15 +57,20 @@ type ErrorHandlerGenerator object {
         self.mv.visitLabel(startLabel);
     }
 
-    function generateCatchInsForTrap(bir:ErrorEntry currentEE, jvm:Label endLabel, jvm:Label handlerLabel,
-                                     jvm:Label jumpLabel) {
+    function generateCatchInsForTrap(bir:ErrorEntry currentEE, jvm:Label endLabel,
+                                    jvm:Label errorValueLabel, jvm:Label otherErrorLabel, jvm:Label jumpLabel) {
         self.mv.visitLabel(endLabel);
         self.mv.visitJumpInsn(GOTO, jumpLabel);
-        self.mv.visitLabel(handlerLabel);
+        self.mv.visitLabel(errorValueLabel);
 
         var varDcl = <bir:VariableDcl>currentEE.errorOp.variableDcl;
         int lhsIndex = self.getJVMIndexOfVarRef(varDcl);
         generateVarStore(self.mv, varDcl, self.currentPackageName, lhsIndex);
+        self.mv.visitJumpInsn(GOTO, jumpLabel);
+        self.mv.visitLabel(otherErrorLabel);
+        self.mv.visitMethodInsn(INVOKESTATIC, BAL_ERRORS, TRAP_ERROR_METHOD,
+                                        io:sprintf("(L%s;)L%s", THROWABLE, ERROR_VALUE), false);
+        self.mv.visitVarInsn(ASTORE, lhsIndex);
         self.mv.visitLabel(jumpLabel);
     }
 

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
@@ -69,7 +69,7 @@ type ErrorHandlerGenerator object {
         self.mv.visitJumpInsn(GOTO, jumpLabel);
         self.mv.visitLabel(otherErrorLabel);
         self.mv.visitMethodInsn(INVOKESTATIC, BAL_ERRORS, TRAP_ERROR_METHOD,
-                                        io:sprintf("(L%s;)L%s", THROWABLE, ERROR_VALUE), false);
+                                        io:sprintf("(L%s;)L%s;", THROWABLE, ERROR_VALUE), false);
         self.mv.visitVarInsn(ASTORE, lhsIndex);
         self.mv.visitLabel(jumpLabel);
     }

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -567,7 +567,8 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
     bir:ErrorEntry? currentEE = ();
     string[] errorVarNames = []; 
     jvm:Label endLabel = new;
-    jvm:Label handlerLabel = new;
+    jvm:Label errorValueLabel = new;
+    jvm:Label otherErrorLabel = new;
     jvm:Label jumpLabel = new;
     int errorEntryCnt = 0;
     if (errorEntries.length() > errorEntryCnt) {
@@ -601,11 +602,12 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
         // trapped we need to generate two try catches as for instructions and terminator.
         if (isTrapped && insCount > 0) {
             endLabel = new;
-            handlerLabel = new;
+            errorValueLabel = new;
+            otherErrorLabel = new;
             jumpLabel = new;
             // start try for instructions.
             errorGen.generateTryInsForTrap(<bir:ErrorEntry>currentEE, errorVarNames, endLabel, 
-                                                handlerLabel, jumpLabel);
+                                                errorValueLabel, otherErrorLabel, jumpLabel);
         }
         while (m < insCount) {
             jvm:Label insLabel = labelGen.getLabel(funcName + bb.id.value + "ins" + m.toString());
@@ -709,7 +711,8 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
 
         // close the started try block with a catch statement for instructions.
         if (isTrapped && insCount > 0) {
-            errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, handlerLabel, jumpLabel);
+            errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel,
+                                                errorValueLabel, otherErrorLabel, jumpLabel);
         }
         jvm:Label bbEndLable = labelGen.getLabel(funcName + bb.id.value + "beforeTerm");
         mv.visitLabel(bbEndLable);
@@ -727,11 +730,12 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
             if (isTrapped && !(terminator is bir:GOTO)) {
                 isTerminatorTrapped = true;
                 endLabel = new;
-                handlerLabel = new;
+                errorValueLabel = new;
+                otherErrorLabel = new;
                 jumpLabel = new;
                 // start try for terminator if current block is trapped.
                 errorGen.generateTryInsForTrap(<bir:ErrorEntry>currentEE, errorVarNames, endLabel, 
-                                                handlerLabel, jumpLabel);
+                                                errorValueLabel, otherErrorLabel, jumpLabel);
             }
             generateDiagnosticPos(terminator.pos, mv);
             if (isModuleInitFunction(module, func) && terminator is bir:Return) {
@@ -740,7 +744,8 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
             termGen.genTerminator(terminator, func, funcName, localVarOffset, returnVarRefIndex, attachedType, isObserved);
             if (isTerminatorTrapped) {
                 // close the started try block with a catch statement for terminator.
-                errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, handlerLabel, jumpLabel);
+                errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, errorValueLabel,
+                                                    otherErrorLabel, jumpLabel);
             }
         }
 

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
@@ -319,10 +319,12 @@ const string PRINT_STACK_TRACE_METHOD = "printStackTrace";
 const string SET_DETAIL_TYPE_METHOD = "setDetailType";
 const string ERROR_REASON_METHOD_TOO_LARGE = "MethodTooLarge";
 const string ERROR_REASON_CLASS_TOO_LARGE = "ClassTooLarge";
+const string TRAP_ERROR_METHOD = "trapError"
 
 // exception classes
 const string BLANG_RUNTIME_EXCEPTION = "org/ballerinalang/jvm/util/exceptions/BLangRuntimeException";
 const string THROWABLE = "java/lang/Throwable";
+const string STACK_OVERFLOW_ERROR = "java/lang/StackOverflowError";
 const string HANDLE_THROWABLE_METHOD = "handleRuntimeErrors";
 const string HANDLE_STOP_PANIC_METHOD = "silentlyLogBadSad";
 const string HANDLE_RETURNED_ERROR_METHOD = "handleRuntimeReturnValues";

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
@@ -319,7 +319,7 @@ const string PRINT_STACK_TRACE_METHOD = "printStackTrace";
 const string SET_DETAIL_TYPE_METHOD = "setDetailType";
 const string ERROR_REASON_METHOD_TOO_LARGE = "MethodTooLarge";
 const string ERROR_REASON_CLASS_TOO_LARGE = "ClassTooLarge";
-const string TRAP_ERROR_METHOD = "trapError"
+const string TRAP_ERROR_METHOD = "trapError";
 
 // exception classes
 const string BLANG_RUNTIME_EXCEPTION = "org/ballerinalang/jvm/util/exceptions/BLangRuntimeException";

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
@@ -70,7 +70,7 @@ type ErrorHandlerGenerator object {
         self.mv.visitJumpInsn(GOTO, jumpLabel);
         self.mv.visitLabel(otherErrorLabel);
         self.mv.visitMethodInsn(INVOKESTATIC, BAL_ERRORS, TRAP_ERROR_METHOD,
-                                        io:sprintf("(L%s;)L%s", THROWABLE, ERROR_VALUE), false);
+                                                io:sprintf("(L%s;)L%s;", THROWABLE, ERROR_VALUE), false);
         self.mv.visitVarInsn(ASTORE, lhsIndex);
         self.mv.visitLabel(jumpLabel);
     }

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_error_gen.bal
@@ -37,14 +37,8 @@ type ErrorHandlerGenerator object {
         self.mv.visitInsn(ATHROW);
     }
 
-    function generateTryIns(jvm:Label endLabel, jvm:Label handlerLabel) {
-        jvm:Label startLabel = new;
-        self.mv.visitTryCatchBlock(startLabel, endLabel, handlerLabel, ERROR_VALUE);
-        self.mv.visitLabel(startLabel);
-    }
-
     function generateTryInsForTrap(bir:ErrorEntry currentEE, string[] errorVarNames, jvm:Label endLabel, 
-                                   jvm:Label handlerLabel, jvm:Label jumpLabel) {
+                                   jvm:Label errorValueLabel, jvm:Label otherErrorLabel, jvm:Label jumpLabel) {
         var varDcl = <bir:VariableDcl>currentEE.errorOp.variableDcl;
         int lhsIndex = self.getJVMIndexOfVarRef(varDcl);
         if (!stringArrayContains(errorVarNames, currentEE.errorOp.variableDcl.name.value)) {
@@ -54,7 +48,8 @@ type ErrorHandlerGenerator object {
         }
 
         jvm:Label startLabel = new;
-        self.mv.visitTryCatchBlock(startLabel, endLabel, handlerLabel, ERROR_VALUE);
+        self.mv.visitTryCatchBlock(startLabel, endLabel, errorValueLabel, ERROR_VALUE);
+        self.mv.visitTryCatchBlock(startLabel, endLabel, otherErrorLabel, STACK_OVERFLOW_ERROR);
         jvm:Label temp = new;
         self.mv.visitLabel(temp);
 
@@ -63,15 +58,20 @@ type ErrorHandlerGenerator object {
         self.mv.visitLabel(startLabel);
     }
 
-    function generateCatchInsForTrap(bir:ErrorEntry currentEE, jvm:Label endLabel, jvm:Label handlerLabel,
-                                     jvm:Label jumpLabel) {
+    function generateCatchInsForTrap(bir:ErrorEntry currentEE, jvm:Label endLabel,
+                                    jvm:Label errorValueLabel, jvm:Label otherErrorLabel, jvm:Label jumpLabel) {
         self.mv.visitLabel(endLabel);
         self.mv.visitJumpInsn(GOTO, jumpLabel);
-        self.mv.visitLabel(handlerLabel);
+        self.mv.visitLabel(errorValueLabel);
 
         var varDcl = <bir:VariableDcl>currentEE.errorOp.variableDcl;
         int lhsIndex = self.getJVMIndexOfVarRef(varDcl);
         generateVarStore(self.mv, varDcl, self.currentPackageName, lhsIndex);
+        self.mv.visitJumpInsn(GOTO, jumpLabel);
+        self.mv.visitLabel(otherErrorLabel);
+        self.mv.visitMethodInsn(INVOKESTATIC, BAL_ERRORS, TRAP_ERROR_METHOD,
+                                        io:sprintf("(L%s;)L%s", THROWABLE, ERROR_VALUE), false);
+        self.mv.visitVarInsn(ASTORE, lhsIndex);
         self.mv.visitLabel(jumpLabel);
     }
 

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -573,7 +573,8 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
     bir:ErrorEntry? currentEE = ();
     string[] errorVarNames = [];
     jvm:Label endLabel = new;
-    jvm:Label handlerLabel = new;
+    jvm:Label errorValueLabel = new;
+    jvm:Label otherErrorLabel = new;
     jvm:Label jumpLabel = new;
     int errorEntryCnt = 0;
     if (errorEntries.length() > errorEntryCnt) {
@@ -607,11 +608,12 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
         // trapped we need to generate two try catches as for instructions and terminator.
         if (isTrapped && insCount > 0) {
             endLabel = new;
-            handlerLabel = new;
+            errorValueLabel = new;
+            otherErrorLabel = new;
             jumpLabel = new;
             // start try for instructions.
             errorGen.generateTryInsForTrap(<bir:ErrorEntry>currentEE, errorVarNames, endLabel,
-                                                handlerLabel, jumpLabel);
+                                                errorValueLabel, otherErrorLabel, jumpLabel);
         }
         while (m < insCount) {
             jvm:Label insLabel = labelGen.getLabel(funcName + bb.id.value + "ins" + m.toString());
@@ -715,7 +717,8 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
 
         // close the started try block with a catch statement for instructions.
         if (isTrapped && insCount > 0) {
-            errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, handlerLabel, jumpLabel);
+            errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, errorValueLabel, otherErrorLabel,
+                                                jumpLabel);
         }
         jvm:Label bbEndLable = labelGen.getLabel(funcName + bb.id.value + "beforeTerm");
         mv.visitLabel(bbEndLable);
@@ -733,11 +736,12 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
             if (isTrapped && !(terminator is bir:GOTO)) {
                 isTerminatorTrapped = true;
                 endLabel = new;
-                handlerLabel = new;
+                errorValueLabel = new;
+                otherErrorLabel = new;
                 jumpLabel = new;
                 // start try for terminator if current block is trapped.
                 errorGen.generateTryInsForTrap(<bir:ErrorEntry>currentEE, errorVarNames, endLabel,
-                                                handlerLabel, jumpLabel);
+                                                errorValueLabel, otherErrorLabel, jumpLabel);
             }
             generateDiagnosticPos(terminator.pos, mv);
             if (isModuleInitFunction(module, func) && terminator is bir:Return) {
@@ -746,7 +750,8 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
             termGen.genTerminator(terminator, func, funcName, localVarOffset, returnVarRefIndex, attachedType, isObserved);
             if (isTerminatorTrapped) {
                 // close the started try block with a catch statement for terminator.
-                errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, handlerLabel, jumpLabel);
+                errorGen.generateCatchInsForTrap(<bir:ErrorEntry>currentEE, endLabel, errorValueLabel,
+                                                    otherErrorLabel, jumpLabel);
             }
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -368,7 +368,7 @@ public class ErrorTest {
     public void testStackOverFlow() {
         BValue[] result = BRunUtil.invoke(errorTestResult, "testStackOverFlow");
         Assert.assertEquals(((BValueArray) result[0]).getRefValue(0).toString(),
-                "{callableName:\"bar2\", moduleName:\"error_test\", fileName:\"error_test.bal\", lineNumber:333}");
+                "{callableName:\"bar\", moduleName:\"error_test\", fileName:\"error_test.bal\", lineNumber:329}");
         Assert.assertEquals(result[1].stringValue(), "{ballerina}StackOverflow");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -365,6 +365,14 @@ public class ErrorTest {
     }
 
     @Test
+    public void testStackOverFlow() {
+        BValue[] result = BRunUtil.invoke(errorTestResult, "testStackOverFlow");
+        Assert.assertEquals(((BValueArray) result[0]).getRefValue(0).toString(),
+                "{callableName:\"bar2\", moduleName:\"error_test\", fileName:\"error_test.bal\", lineNumber:333}");
+        Assert.assertEquals(result[1].stringValue(), "{ballerina}StackOverflow");
+    }
+
+    @Test
     public void testNonModuleQualifiedReasons() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/error/non_module_qualified_error_reasons_negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/MainFunctionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/MainFunctionsTest.java
@@ -113,6 +113,17 @@ public class MainFunctionsTest {
                 "'error?' containing '()'", 17, 32);
     }
 
+    @Test
+    public void testMainWithStackOverflow() {
+        CompileResult compileResult = BCompileUtil
+                .compile("test-src/main.function/test_main_with_stackoverflow.bal");
+        BCompileUtil.ExitDetails details = BCompileUtil.run(compileResult, new String[]{});
+        assertTrue(details.errorOutput.contains("error: {ballerina}StackOverflow \n\tat $value$Foo:__init" +
+                "(test_main_with_stackoverflow.bal:19)\n\t   $value$Foo:__init(test_main_with_stackoverflow.bal:19)" +
+                "\n\t   $value$Foo:__init(test_main_with_stackoverflow.bal:19)"));
+    }
+
+
     private String runMain(CompileResult compileResult, String[] args) {
         try {
             return BCompileUtil.runMain(compileResult, args);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -324,3 +324,18 @@ public function testErrorUnionPassedToErrorParam() returns string {
 function takeError(error e) returns string {
     return e.reason();
 }
+
+function bar(){
+    bar2();
+}
+
+function bar2(){
+    bar();
+}
+
+function testStackOverFlow() returns [runtime:CallStackElement[], string]? {
+    error? e = trap bar();
+    if (e is error){
+        return [e.stackTrace().callStack, e.reason()];
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/main.function/test_main_with_stackoverflow.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/main.function/test_main_with_stackoverflow.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo object {
+    public function __init() {
+        self.__init();
+    }
+};
+
+public function main() {
+    Foo foo = new;
+}


### PR DESCRIPTION
## Purpose
Fixes #18966

Stacktrace will be printed in console if doesn't trap.

```
error: {ballerina}StackOverflow 
	at main:bar(main.bal:2)
	   main:bar2(main.bal:6)
	   main:bar(main.bal:2)
	   main:bar2(main.bal:6)
	   main:bar(main.bal:2)
	   main:bar2(main.bal:6)
	   main:bar(main.bal:2)
	   main:bar2(main.bal:6)
	   main:bar(main.bal:2)
	   main:bar2(main.bal:6)
```

## Approach
Try catch block code gen has been improved to handle stackoverflow errors as well.
ex. sample codegen
```
      ErrorValue e1;
        try{
            
        } catch (ErrorValue e) {
            e1 =e;
        } catch (StackOverflowError e) {
 // Future we can add any exception types here
 // if we need to trap them as well. ex StackOverflowError | Ex1 | Ex2
            e1 = BallerinaErrors.trapError(e);
        }

```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
