### PR TITLE
Fix Stack trace is not logged during a casting error in b7a service

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -392,7 +392,7 @@ public class HttpUtil {
     static void handleFailure(HttpCarbonMessage requestMessage, ErrorValue error) {
         String errorMsg = getErrorMessage(error);
         int statusCode = getStatusCode(requestMessage, errorMsg);
-        ErrorHandlerUtils.printError("error: " + error.toString());
+        ErrorHandlerUtils.printError("error: " + error.getPrintableStackTrace());
         sendPipelinedResponse(requestMessage, createErrorMessage(errorMsg, statusCode));
     }
 


### PR DESCRIPTION
## Purpose

Fixes #19064

**sample service** 
```
import ballerina/http;

service hello on new http:Listener(8080) {
    resource function sayHello(http:Caller caller, http:Request request) {
        any a = "e";
        int s = <int>a;
    }
}

```

**Error log in console with change**

```
error: {ballerina}TypeCastError message=incompatible types: 'string' cannot be cast to 'int'
	at $value$hello__service_0:sayHello(main.bal:7)

```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
