### PR TITLE
Validate the LHS expression in compound assignment

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -2475,7 +2475,6 @@ public class BLangPackageBuilder {
         assignmentNode.setExpression(exprNodeStack.pop());
 
         assignmentNode.setVariable((BLangVariableReference) exprNodeStack.pop());
-        validateLvexpr(assignmentNode.varRef, DiagnosticCode.INVALID_INVOCATION_LVALUE_ASSIGNMENT);
         assignmentNode.pos = pos;
         assignmentNode.addWS(ws);
         assignmentNode.addWS(this.operatorWs.pop());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -2475,6 +2475,7 @@ public class BLangPackageBuilder {
         assignmentNode.setExpression(exprNodeStack.pop());
 
         assignmentNode.setVariable((BLangVariableReference) exprNodeStack.pop());
+        validateLvexpr(assignmentNode.varRef, DiagnosticCode.INVALID_INVOCATION_LVALUE_ASSIGNMENT);
         assignmentNode.pos = pos;
         assignmentNode.addWS(ws);
         assignmentNode.addWS(this.operatorWs.pop());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1529,7 +1529,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
     private Boolean validateLhsVar(BLangExpression vRef) {
         if (vRef.getKind() == NodeKind.INVOCATION) {
-            dlog.error(((BLangInvocation) vRef).pos, DiagnosticCode.INVALID_VARIABLE_ASSIGNMENT, vRef);
+            dlog.error(((BLangInvocation) vRef).pos, DiagnosticCode.INVALID_INVOCATION_LVALUE_ASSIGNMENT, vRef);
             return false;
         }
         if (vRef.getKind() == NodeKind.FIELD_BASED_ACCESS_EXPR

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
@@ -364,12 +364,15 @@ public class CompoundAssignmentTest {
         Assert.assertEquals(compileResult.getErrorCount(), 22);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'any' and 'int'", 5, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '-' not defined for 'any' and 'int'", 13, 5);
-        BAssertUtil.validateError(compileResult, i++, "invalid assignment in variable 'getInt()'", 20, 5);
-        BAssertUtil.validateError(compileResult, i++, "invalid assignment in variable 'getInt()'", 25, 5);
+        BAssertUtil.validateError(compileResult, i++, "invocations are not supported on the left hand side of an " +
+                "assignment", 20, 5);
+        BAssertUtil.validateError(compileResult, i++, "invocations are not supported on the left hand side of an " +
+                "assignment", 25, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'string' and 'int'", 35, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '-' not defined for 'string' and 'int'", 41, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int' and '(int|error)'", 47, 5);
-        BAssertUtil.validateError(compileResult, i++, "invalid assignment in variable 'getInt()'", 53, 5);
+        BAssertUtil.validateError(compileResult, i++, "invocations are not supported on the left hand side of an " +
+                "assignment", 53, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'json' and 'string'", 59, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int' and 'string'", 65, 5);
         BAssertUtil.validateError(compileResult, i++, "incompatible types: expected 'int', found 'float'", 72, 10);
@@ -383,6 +386,7 @@ public class CompoundAssignmentTest {
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int?'", 132, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int?'", 140, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int'", 150, 11);
-        BAssertUtil.validateError(compileResult, i, "invalid assignment in variable 'foo(bar)'", 156, 5);
+        BAssertUtil.validateError(compileResult, i, "invocations are not supported on the left hand side of an " +
+                "assignment", 156, 5);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
@@ -361,7 +361,7 @@ public class CompoundAssignmentTest {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/statements/compoundassignment/compound_assignment_negative.bal");
         int i = 0;
-        Assert.assertEquals(compileResult.getErrorCount(), 21);
+        Assert.assertEquals(compileResult.getErrorCount(), 22);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'any' and 'int'", 5, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '-' not defined for 'any' and 'int'", 13, 5);
         BAssertUtil.validateError(compileResult, i++, "invalid assignment in variable 'getInt()'", 20, 5);
@@ -382,6 +382,7 @@ public class CompoundAssignmentTest {
         BAssertUtil.validateError(compileResult, i++, "operator '>>>' not defined for 'int' and 'string'", 120, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int?'", 132, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int?'", 140, 5);
-        BAssertUtil.validateError(compileResult, i, "operator '+' not defined for 'int?' and 'int'", 150, 11);
+        BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int'", 150, 11);
+        BAssertUtil.validateError(compileResult, i, "invalid assignment in variable 'foo(bar)'", 156, 5);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment_negative.bal
@@ -150,3 +150,17 @@ function testCompoundAssignmentAdditionWithStructAccess() returns int {
     x += (ibm["count"] + arr[0]);
     return x;
 }
+
+function testFunctionInvocation() returns (int) {
+    Bar bar = {};
+    foo(bar).bar += 10;
+}
+
+function foo(Bar b) returns Bar {
+    b.bar += 1;
+    return b;
+}
+
+type Bar record {
+    int bar = 0;
+};


### PR DESCRIPTION
## Purpose
In the compound assignment, LHS expression cannot be a function invocation. This issue is fixed here.

Fixes #19116

## Approach
Validate the LHS expression. It throws an error once it found a function invocation in LHS.

## Remarks
#17998

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
