### PR TITLE
Enable logging on run command

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/PrintRunningExecutableTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/PrintRunningExecutableTask.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.packerina.task;
+
+import org.ballerinalang.packerina.buildcontext.BuildContext;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+
+import java.util.Optional;
+
+/**
+ * Print log to indicate that the executable is about to run.
+ */
+public class PrintRunningExecutableTask implements Task {
+    
+    private final boolean addNewLine;
+    
+    public PrintRunningExecutableTask(boolean addNewLine) {
+        this.addNewLine = addNewLine;
+    }
+    
+    @Override
+    public void execute(BuildContext buildContext) {
+        Optional<BLangPackage> moduleWithEntryPoint = buildContext.getModules().stream()
+                .filter(m -> m.symbol.entryPointExists)
+                .findFirst();
+    
+        if (moduleWithEntryPoint.isPresent()) {
+            if (this.addNewLine) {
+                buildContext.out().println();
+            }
+            
+            buildContext.out().println("Running executables");
+        }
+    }
+}
+

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BalRunFunctionPositiveTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BalRunFunctionPositiveTestCase.java
@@ -41,7 +41,9 @@ public class BalRunFunctionPositiveTestCase extends BaseTest {
                                                                              + "resources" + File.separator + "run" +
                                                                              File.separator + "file"))
                                                                    .getAbsolutePath());
-        Assert.assertEquals(output, "1");
+        Assert.assertEquals(output, "Generating executables\n" +
+                                    "Running executables\n" +
+                                    "1");
     }
 
     @Test
@@ -55,6 +57,8 @@ public class BalRunFunctionPositiveTestCase extends BaseTest {
                                            "run" + File.separator + "file")).getAbsolutePath();
         String output = bMainInstance.runMainAndReadStdOut("run", args, balFile);
         Assert.assertEquals(output,
+                            "Generating executables\n" +
+                            "Running executables\n" +
                             "integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, boolean: true, " +
                                     "JSON Name Field: Maryam, XML Element Name: book, Employee Name Field: Em, " +
                                     "string rest args: just the rest ");

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BalRunFunctionPositiveTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BalRunFunctionPositiveTestCase.java
@@ -41,9 +41,7 @@ public class BalRunFunctionPositiveTestCase extends BaseTest {
                                                                              + "resources" + File.separator + "run" +
                                                                              File.separator + "file"))
                                                                    .getAbsolutePath());
-        Assert.assertEquals(output, "Generating executables\n" +
-                                    "Running executables\n" +
-                                    "1");
+        Assert.assertTrue(output.endsWith("1"));
     }
 
     @Test
@@ -56,11 +54,8 @@ public class BalRunFunctionPositiveTestCase extends BaseTest {
         String balFile = (new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                                            "run" + File.separator + "file")).getAbsolutePath();
         String output = bMainInstance.runMainAndReadStdOut("run", args, balFile);
-        Assert.assertEquals(output,
-                            "Generating executables\n" +
-                            "Running executables\n" +
-                            "integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, boolean: true, " +
-                                    "JSON Name Field: Maryam, XML Element Name: book, Employee Name Field: Em, " +
-                                    "string rest args: just the rest ");
+        Assert.assertTrue(output.endsWith("integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, boolean: " +
+                                          "true, JSON Name Field: Maryam, XML Element Name: book, Employee Name " +
+                                          "Field: Em, string rest args: just the rest "));
     }
 }


### PR DESCRIPTION
## Purpose
> When running a single bal file:
```
hemikak@hemikak:aa$ ~/ballerina/dev/ballerina/distribution/zip/jballerina-tools/build/extracted-distributions/jballerina-tools-1.0.1-SNAPSHOT/bin/ballerina run t.bal
Compiling source
	t.bal

Generating executables
Running executables
WOOOT!
```

> When running a single module:
```
hemikak@hemikak:healthcare-service$ ~/ballerina/dev/ballerina/distribution/zip/jballerina-tools/build/extracted-distributions/jballerina-tools-1.0.1-SNAPSHOT/bin/ballerina run healthcare
Compiling source
	wso2/healthcare:0.1.0

Creating balos
	target/balo/healthcare-2019r3-any-0.1.0.balo

Generating executables
	target/bin/healthcare.jar

Running executables
[ballerina/http] started HTTP/WS listener 0.0.0.0:9095
```

Fixes #<Issue Number>

## Approach
> Set output stream for run command. Introduce new task to print "Running executables"

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
