### PR TITLE
Handle the run time exception occurred when populating the sender configurations

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -97,8 +97,11 @@ public class CreateSimpleHttpClient {
             String keepAliveConfig = http1Settings.getStringValue(HttpConstants.CLIENT_EP_IS_KEEP_ALIVE);
             senderConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAliveConfig));
         }
-
-        populateSenderConfigurations(senderConfiguration, clientEndpointConfig, scheme);
+        try {
+            populateSenderConfigurations(senderConfiguration, clientEndpointConfig, scheme);
+        } catch (RuntimeException e) {
+            throw HttpUtil.createHttpError(e.getMessage(), HttpErrorType.GENERIC_CLIENT_ERROR);
+        }
         ConnectionManager poolManager;
         MapValue<String, Long> userDefinedPoolConfig = (MapValue<String, Long>) clientEndpointConfig.get(
                 HttpConstants.USER_DEFINED_POOL_CONFIG);


### PR DESCRIPTION
## Purpose
Fix the issue of printing the whole stack trace when the system properties are not defined. 
Fix the issue: https://github.com/ballerina-platform/ballerina-lang/issues/19110