### PR TITLE
Add validation for non remote functions registration in service

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/util/Flags.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/util/Flags.java
@@ -31,6 +31,7 @@ public class Flags {
     public static final int PRIVATE = 1024;
     public static final int ABSTRACT = 4096;
     public static final int OPTIONAL = 8192;
+    public static final int RESOURCE = 262144;
     public static final int SERVICE = 524288;
 
     public static boolean isFlagOn(int bitmask, int flag) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpService.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpService.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.net.http;
 
 import org.ballerinalang.jvm.types.AttachedFunction;
+import org.ballerinalang.jvm.util.Flags;
 import org.ballerinalang.jvm.util.exceptions.BallerinaConnectorException;
 import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.ObjectValue;
@@ -233,6 +234,9 @@ public class HttpService implements Cloneable {
         List<HttpResource> httpResources = new ArrayList<>();
         List<HttpResource> upgradeToWebSocketResources = new ArrayList<>();
         for (AttachedFunction resource : httpService.getBalService().getType().getAttachedFunctions()) {
+            if (!Flags.isFlagOn(resource.flags, Flags.RESOURCE)) {
+                continue;
+            }
             MapValue resourceConfigAnnotation =
                     HttpUtil.getResourceConfigAnnotation(resource, HttpConstants.HTTP_PACKAGE_PATH);
             if (checkConfigAnnotationAvailability(resourceConfigAnnotation)

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/ServiceTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/ServiceTest.java
@@ -312,6 +312,18 @@ public class ServiceTest {
         Assert.assertEquals(responseMsgPayload, "Uninitialized configs");
     }
 
+    @Test(description = "Test non remote function invocation")
+    public void testNonRemoteFunctionInvocation() {
+        String path = "/hello/testFunctionCall";
+        HTTPTestRequest requestMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage responseMsg = Services.invoke(TEST_ENDPOINT_1_PORT, requestMsg);
+
+        Assert.assertNotNull(responseMsg, "responseMsg message not found");
+        String responseMsgPayload = StringUtils
+                .getStringFromInputStream(new HttpMessageDataStreamer(responseMsg).getInputStream());
+        Assert.assertEquals(responseMsgPayload, "Non remote function invoked");
+    }
+
     @Test(description = "Test error returning from resource")
     public void testErrorReturn() {
         String path = "/echo/parseJSON";

--- a/stdlib/http/src/test/resources/test-src/services/echo-service.bal
+++ b/stdlib/http/src/test/resources/test-src/services/echo-service.bal
@@ -163,4 +163,12 @@ service hello on echoEP {
     resource function echo(http:Caller caller, http:Request req) {
         checkpanic caller->respond("Uninitialized configs");
     }
+
+    resource function testFunctionCall(http:Caller caller, http:Request req) {
+        checkpanic caller->respond(<@untained> self.nonRemoteFunctionCall());
+    }
+
+    function nonRemoteFunctionCall() returns string {
+        return "Non remote function invoked";
+    }
 }


### PR DESCRIPTION
## Purpose
> $Subject as they are getting validate as a resource function
Fixes #19145

## Approach
> Check specific resource attached function flag during the resource registration

## Samples
```ballerina
@http:ServiceConfig {}
service hello on echoEP {
    resource function testFunctionCall(http:Caller caller, http:Request req) {
        checkpanic caller->respond(<@untained> self.nonRemoteFunctionCall());
    }

    function nonRemoteFunctionCall() returns string {
        return "Non remote function invoked";
    }
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
