### PR TITLE
Fix compiler OutStream printing unnecessary line in OpenAPI tool

### DIFF
--- a/misc/openapi-ballerina/modules/ballerina-to-openapi-generator/src/main/java/org/ballerinalang/ballerina/openapi/convertor/service/OpenApiConverterUtils.java
+++ b/misc/openapi-ballerina/modules/ballerina-to-openapi-generator/src/main/java/org/ballerinalang/ballerina/openapi/convertor/service/OpenApiConverterUtils.java
@@ -80,8 +80,10 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -556,6 +558,13 @@ public class OpenApiConverterUtils {
     private static BLangPackage compileModule(Path sourceRoot, String moduleName) {
         CompilerContext context = getCompilerContext(sourceRoot);
         Compiler compiler = Compiler.getInstance(context);
+
+        try {
+            compiler.setOutStream(new EmptyPrintStream());
+        } catch (UnsupportedEncodingException e) {
+            // Ignore the exception as not setting OutStream won't break the functionality.
+        }
+
         return compiler.compile(moduleName);
     }
 
@@ -580,4 +589,13 @@ public class OpenApiConverterUtils {
         return context;
     }
 
+    static class EmptyPrintStream extends PrintStream {
+        EmptyPrintStream() throws UnsupportedEncodingException {
+            super(new OutputStream() {
+                @Override
+                public void write(int b) {
+                }
+            }, true, "UTF-8");
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
Fix compiler OutStream Printing unnecessary line into OpenAPI `gen-contract` CLI output.

Fixes #19189

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
