### PR TITLE
Fix incorrect allow header construction

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/DispatcherUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/DispatcherUtil.java
@@ -60,9 +60,6 @@ public class DispatcherUtil {
         if (cachedMethods.isEmpty()) {
             return cachedMethods;
         }
-        if (cachedMethods.contains(HttpConstants.HTTP_METHOD_GET)) {
-            cachedMethods.add(HttpConstants.HTTP_METHOD_HEAD);
-        }
         cachedMethods.add(HttpConstants.HTTP_METHOD_OPTIONS);
         cachedMethods = cachedMethods.stream().distinct().collect(Collectors.toList());
         return cachedMethods;

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/UriTemplateDispatcherTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/UriTemplateDispatcherTest.java
@@ -243,7 +243,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals((int) response.getHttpStatusCode(), 200, "Response code mismatch");
 
         String allowHeader = cMsg.getHeader(HttpHeaderNames.ALLOW.toString());
-        Assert.assertEquals(allowHeader, "GET, HEAD, OPTIONS");
+        Assert.assertEquals(allowHeader, "GET, OPTIONS");
     }
 
     @Test(description = "Test dispatching with OPTIONS request with POST method")
@@ -303,7 +303,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals((int) response.getHttpStatusCode(), 200, "Response code mismatch");
 
         String allowHeader = response.getHeader(HttpHeaderNames.ALLOW.toString());
-        Assert.assertEquals(allowHeader, "POST, UPDATE, GET, PUT, HEAD, OPTIONS");
+        Assert.assertEquals(allowHeader, "POST, UPDATE, GET, PUT, OPTIONS");
     }
 
     @Test(description = "Test dispatching with OPTIONS request to Root")
@@ -317,7 +317,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals((int) response.getHttpStatusCode(), 200, "Response code mismatch");
 
         String allowHeader = response.getHeader(HttpHeaderNames.ALLOW.toString());
-        Assert.assertEquals(allowHeader, "POST, UPDATE, OPTIONS, GET, PUT, DELETE, HEAD");
+        Assert.assertEquals(allowHeader, "POST, UPDATE, OPTIONS, GET, PUT, DELETE");
     }
 
     @Test(description = "Test dispatching with OPTIONS request wrong Root")


### PR DESCRIPTION
## Purpose
> The OPTIONS request should return the `allow` header mentioning all possible HTTP methods particular resource could be invoked with. Back then the HEAD method was appended to that method list, if the request has GET method support. Since we do not allow HEAD requests to be dispatched to the GET resources, this HEAD method addition is incorrect. Hence PR addressed it.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19222

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
