### PR TITLE
Improve error when trying to retrieve the payload when there is no payload

### DIFF
--- a/stdlib/http/src/main/ballerina/src/http/http_commons.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_commons.bal
@@ -386,5 +386,10 @@ function getInvalidTypeError() returns ClientError {
     return invalidTypeError;
 }
 
+function createErrorForNoPayload(mime:Error err) returns GenericClientError {
+    string message = "No payload";
+    return getGenericClientError(message, err);
+}
+
 //Resolve a given path against a given URI.
 function resolve(string baseUrl, string path) returns string|ClientError = external;

--- a/stdlib/http/src/main/ballerina/src/http/http_request.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_request.bal
@@ -209,8 +209,12 @@ public type Request object {
         } else {
             var payload = result.getJson();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the json payload from the request";
-                return getGenericClientError(message, payload);
+                if (payload.detail()?.cause is mime:NoContentError) {
+                    return createErrorForNoPayload(payload);
+                } else {
+                    string message = "Error occurred while retrieving the json payload from the request";
+                    return getGenericClientError(message, payload);
+               }
             } else {
                 return payload;
             }
@@ -227,8 +231,12 @@ public type Request object {
         } else {
             var payload = result.getXml();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the xml payload from the request";
-                return getGenericClientError(message, payload);
+                if (payload.detail()?.cause is mime:NoContentError) {
+                    return createErrorForNoPayload(payload);
+                } else {
+                    string message = "Error occurred while retrieving the xml payload from the request";
+                    return getGenericClientError(message, payload);
+                }
             } else {
                 return payload;
             }
@@ -245,8 +253,12 @@ public type Request object {
         } else {
             var payload = result.getText();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the text payload from the request";
-                return getGenericClientError(message, payload);
+                if (payload.detail()?.cause is mime:NoContentError) {
+                    return createErrorForNoPayload(payload);
+                } else {
+                    string message = "Error occurred while retrieving the text payload from the request";
+                    return getGenericClientError(message, payload);
+                }
             } else {
                 return payload;
             }

--- a/stdlib/http/src/main/ballerina/src/http/http_response.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_response.bal
@@ -165,8 +165,12 @@ public type Response object {
         } else {
             var payload = result.getJson();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the json payload from the response";
-                return getGenericClientError(message, payload);
+                if (payload.detail()?.cause is mime:NoContentError) {
+                    return createErrorForNoPayload(payload);
+                } else {
+                    string message = "Error occurred while retrieving the json payload from the response";
+                    return getGenericClientError(message, payload);
+               }
             } else {
                 return payload;
             }
@@ -183,8 +187,12 @@ public type Response object {
         } else {
             var payload = result.getXml();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the xml payload from the response";
-                return getGenericClientError(message, payload);
+                if (payload.detail()?.cause is mime:NoContentError) {
+                    return createErrorForNoPayload(payload);
+                } else {
+                    string message = "Error occurred while retrieving the xml payload from the response";
+                    return getGenericClientError(message, payload);
+               }
             } else {
                 return payload;
             }
@@ -201,8 +209,12 @@ public type Response object {
         } else {
             var payload = result.getText();
             if (payload is mime:Error) {
-                string message = "Error occurred while retrieving the text payload from the response";
-                return getGenericClientError(message, payload);
+                if (payload.detail()?.cause is mime:NoContentError) {
+                    return createErrorForNoPayload(payload);
+                } else {
+                    string message = "Error occurred while retrieving the text payload from the response";
+                    return getGenericClientError(message, payload);
+               }
             } else {
                 return payload;
             }

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/ServiceTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/ServiceTest.java
@@ -222,7 +222,7 @@ public class ServiceTest {
         HttpCarbonMessage responseMsg = Services.invoke(TEST_ENDPOINT_1_PORT, requestMsg);
 
         assertResponseMessage(responseMsg,
-                              "Error occurred while extracting text data from entity : error Empty content ");
+                              "Error occurred while extracting text data from entity");
     }
 
     @Test(description = "Test GetFormParams with unsupported media type")

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/request/RequestNativeFunctionNegativeTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/request/RequestNativeFunctionNegativeTest.java
@@ -83,9 +83,9 @@ public class RequestNativeFunctionNegativeTest {
         inRequest.set(REQUEST_ENTITY_FIELD, entity);
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetJsonPayload", new Object[]{ inRequest });
         Assert.assertNotNull(returnVals[0]);
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the json payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting json data from entity: error Empty content \"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"No payload\", "
+                + "cause:{ballerina/mime}ParsingEntityBodyFailed {cause:{ballerina/mime}NoContentError "
+                + "{message:\"Empty content\"}, message:\"Error occurred while extracting json data from entity\"}}");
     }
 
     @Test(description = "Test method with string payload")
@@ -100,10 +100,10 @@ public class RequestNativeFunctionNegativeTest {
 
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetJsonPayload", new Object[]{ inRequest });
         Assert.assertNotNull(returnVals[0]);
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the json payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting json data from entity: unrecognized token 'ballerina' at " +
-                "line: 1 column: 11\"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while "
+                + "retrieving the json payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed "
+                + "{message:\"Error occurred while extracting json data from entity: unrecognized token 'ballerina' "
+                + "at line: 1 column: 11\"}}");
     }
 
     @Test(description = "Test getEntity method on a outRequest without a entity")
@@ -122,9 +122,9 @@ public class RequestNativeFunctionNegativeTest {
         inRequest.set(REQUEST_ENTITY_FIELD, entity);
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetTextPayload", new Object[]{ inRequest });
         Assert.assertTrue(returnVals[0].stringValue()
-                        .contains("{message:\"Error occurred while retrieving the text payload from the request\", " +
-                                          "cause:{ballerina/mime}ParsingEntityBodyFailed {message:\"Error occurred " +
-                                          "while extracting text data from entity : error Empty content \"}}"));
+                        .contains("{message:\"No payload\", cause:{ballerina/mime}ParsingEntityBodyFailed "
+                                + "{cause:{ballerina/mime}NoContentError {message:\"Empty content\"}, "
+                                + "message:\"Error occurred while extracting text data from entity\"}}"));
     }
 
     @Test
@@ -134,9 +134,9 @@ public class RequestNativeFunctionNegativeTest {
         TestEntityUtils.enrichTestEntityHeaders(entity, APPLICATION_XML);
         inRequest.set(REQUEST_ENTITY_FIELD, entity);
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetXmlPayload", new Object[]{ inRequest });
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the xml payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting xml data from entity : error Empty content \"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"No payload\", "
+                + "cause:{ballerina/mime}ParsingEntityBodyFailed {cause:{ballerina/mime}NoContentError "
+                + "{message:\"Empty content\"}, message:\"Error occurred while extracting xml data from entity\"}}");
     }
 
     @Test
@@ -150,11 +150,11 @@ public class RequestNativeFunctionNegativeTest {
 
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetXmlPayload", new Object[]{inRequest});
         Assert.assertNotNull(returnVals[0]);
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the xml payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting xml data from entity : error Unexpected character 'b' " +
-                "(code 98) in prolog; expected '<'" + System.lineSeparator() +
-                " at [row,col {unknown-source}]: [1,1] \"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while "
+                + "retrieving the xml payload from the request\", cause:{ballerina/mime}ParsingEntityBodyFailed "
+                + "{cause:Unexpected character 'b' (code 98) in prolog; expected '<'\n"
+                + " at [row,col {unknown-source}]: [1,1] {}, message:\"Error occurred while extracting xml "
+                + "data from entity\"}}");
     }
 
     @Test

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
@@ -84,9 +84,9 @@ public class ResponseNativeFunctionNegativeTest {
         inResponse.set(RESPONSE_ENTITY_FIELD, entity);
         BValue[] returnVals = BRunUtil.invoke(result, "testGetJsonPayload", new Object[]{ inResponse });
         Assert.assertNotNull(returnVals[0]);
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the json payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting json data from entity: error Empty content \"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"No payload\", "
+                + "cause:{ballerina/mime}ParsingEntityBodyFailed {cause:{ballerina/mime}NoContentError "
+                + "{message:\"Empty content\"}, message:\"Error occurred while extracting json data from entity\"}}");
     }
 
     @Test(description = "Test method with string payload")
@@ -99,10 +99,10 @@ public class ResponseNativeFunctionNegativeTest {
         inResponse.addNativeData(IS_BODY_BYTE_CHANNEL_ALREADY_SET, true);
         BValue[] returnVals = BRunUtil.invoke(result, "testGetJsonPayload", new Object[]{ inResponse });
         Assert.assertNotNull(returnVals[0]);
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the json payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting json data from entity: unrecognized token 'ballerina' at " +
-                "line: 1 column: 11\"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while "
+                + "retrieving the json payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed "
+                + "{message:\"Error occurred while extracting json data from entity: unrecognized token 'ballerina' "
+                + "at line: 1 column: 11\"}}");
     }
 
     @Test(description = "Test getTextPayload method without a payload")
@@ -114,9 +114,9 @@ public class ResponseNativeFunctionNegativeTest {
         BValue[] returnVals = BRunUtil.invoke(result, "testGetTextPayload", new Object[]{ inResponse });
         Assert.assertFalse(returnVals.length == 0 || returnVals[0] == null, "Invalid Return Values.");
         Assert.assertTrue(returnVals[0].stringValue()
-                .contains("{message:\"Error occurred while retrieving the text payload from the response\", " +
-                                  "cause:{ballerina/mime}ParsingEntityBodyFailed {message:\"Error occurred while " +
-                                  "extracting text data from entity : error Empty content \"}}"));
+                .contains("{message:\"No payload\", cause:{ballerina/mime}ParsingEntityBodyFailed "
+                        + "{cause:{ballerina/mime}NoContentError {message:\"Empty content\"}, message:\"Error occurred "
+                        + "while extracting text data from entity\"}}"));
     }
 
     @Test
@@ -126,9 +126,9 @@ public class ResponseNativeFunctionNegativeTest {
         TestEntityUtils.enrichTestEntityHeaders(entity, APPLICATION_XML);
         inResponse.set(RESPONSE_ENTITY_FIELD, entity);
         BValue[] returnVals = BRunUtil.invoke(result, "testGetXmlPayload", new Object[]{ inResponse });
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the xml payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting xml data from entity : error Empty content \"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"No payload\", "
+                + "cause:{ballerina/mime}ParsingEntityBodyFailed {cause:{ballerina/mime}NoContentError "
+                + "{message:\"Empty content\"}, message:\"Error occurred while extracting xml data from entity\"}}");
     }
 
     @Test
@@ -142,11 +142,11 @@ public class ResponseNativeFunctionNegativeTest {
         inResponse.addNativeData(IS_BODY_BYTE_CHANNEL_ALREADY_SET, true);
         BValue[] returnVals = BRunUtil.invoke(result, "testGetXmlPayload", new Object[]{ inResponse });
         Assert.assertNotNull(returnVals[0]);
-        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while " +
-                "retrieving the xml payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed " +
-                "{message:\"Error occurred while extracting xml data from entity : error Unexpected character 'b' " +
-                "(code 98) in prolog; expected '<'" + System.lineSeparator() +
-                " at [row,col {unknown-source}]: [1,1] \"}}");
+        Assert.assertEquals(((BError) returnVals[0]).getDetails().stringValue(), "{message:\"Error occurred while "
+                + "retrieving the xml payload from the response\", cause:{ballerina/mime}ParsingEntityBodyFailed "
+                + "{cause:Unexpected character 'b' (code 98) in prolog; expected '<'\n"
+                + " at [row,col {unknown-source}]: [1,1] {}, message:\"Error occurred while extracting xml "
+                + "data from entity\"}}");
     }
 
     @Test(description = "Test getEntity method on a response without a entity")

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/Utils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/Utils.java
@@ -51,20 +51,32 @@ public class Utils {
     private static final String MIME_ERROR_MESSAGE = "message";
     private static final String ERROR_RECORD_TYPE = "Detail";
     private static final String STRUCT_TYPE = "ReadableByteChannel";
+    private static final String ERROR_CAUSE_FIELD = "cause";
     private static final String ENCODING_ERROR = "{ballerina/mime}EncodingFailed";
     private static final String DECODING_ERROR = "{ballerina/mime}DecodingFailed";
 
 
     private static ErrorValue createBase64Error(String reason, String msg, boolean isMimeSpecific) {
         if (isMimeSpecific) {
-            return BallerinaErrors.createError(reason, populateMimeErrorRecord(msg));
+            return BallerinaErrors.createError(reason, populateMimeErrorRecord(null, msg));
         }
         return BallerinaErrors.createError(IOConstants.ErrorCode.GenericError.errorCode(), msg);
     }
 
-    public static MapValue populateMimeErrorRecord(String msg) {
+//    public static MapValue populateMimeErrorRecord(String msg) {
+//        Map<String, Object> valueMap = new HashMap<>();
+//        valueMap.put(MIME_ERROR_MESSAGE, msg);
+//        return BallerinaValues.createRecordValue(PACKAGE_ID_MIME, ERROR_RECORD_TYPE, valueMap);
+//    }
+
+    public static MapValue populateMimeErrorRecord(ErrorValue errorValue, String msg) {
         Map<String, Object> valueMap = new HashMap<>();
-        valueMap.put(MIME_ERROR_MESSAGE, msg);
+        if (errorValue != null) {
+            valueMap.put(ERROR_CAUSE_FIELD, errorValue);
+        }
+        if (msg != null) {
+            valueMap.put(MIME_ERROR_MESSAGE, msg);
+        }
         return BallerinaValues.createRecordValue(PACKAGE_ID_MIME, ERROR_RECORD_TYPE, valueMap);
     }
 

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/Utils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/Utils.java
@@ -63,12 +63,6 @@ public class Utils {
         return BallerinaErrors.createError(IOConstants.ErrorCode.GenericError.errorCode(), msg);
     }
 
-//    public static MapValue populateMimeErrorRecord(String msg) {
-//        Map<String, Object> valueMap = new HashMap<>();
-//        valueMap.put(MIME_ERROR_MESSAGE, msg);
-//        return BallerinaValues.createRecordValue(PACKAGE_ID_MIME, ERROR_RECORD_TYPE, valueMap);
-//    }
-
     public static MapValue populateMimeErrorRecord(ErrorValue errorValue, String msg) {
         Map<String, Object> valueMap = new HashMap<>();
         if (errorValue != null) {

--- a/stdlib/mime/src/main/ballerina/src/mime/mime_errors.bal
+++ b/stdlib/mime/src/main/ballerina/src/mime/mime_errors.bal
@@ -80,9 +80,16 @@ public const IDLE_TIMEOUT_TRIGGERED = "{ballerina/mime}IdleTimeoutTriggeredError
 # Represents a `IdleTimeoutTriggeredError` with a detailed message.
 public type IdleTimeoutTriggeredError error<IDLE_TIMEOUT_TRIGGERED, Detail>;
 
+// Identifies no content errors in payload.
+public const NO_CONTENT_ERROR_CODE = "{ballerina/mime}NoContentError";
+
+# Represents a `NoContentError` with a detailed message.
+public type NoContentError error<NO_CONTENT_ERROR_CODE, Detail>;
+
 # Represents MIME related errors.
 public type Error ParserError|EncodeError|DecodeError|GenericMimeError|SetHeaderError|InvalidContentTypeError
-                |ReadingHeaderFailed|InvalidContentTypeError|HeaderUnavailableError|IdleTimeoutTriggeredError;
+                |ReadingHeaderFailed|InvalidContentTypeError|HeaderUnavailableError|IdleTimeoutTriggeredError
+                |NoContentError;
 
 # Constructs an `EncodeError` with the given details.
 # + detail - error details

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/AbstractGetPayloadHandler.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/AbstractGetPayloadHandler.java
@@ -105,11 +105,6 @@ public abstract class AbstractGetPayloadHandler {
         callback.notifySuccess();
     }
 
-//    static Object createParsingEntityBodyFailedErrorAndNotify(NonBlockingCallback callback, String errMsg) {
-//        ErrorValue error = MimeUtil.createError(PARSING_ENTITY_BODY_FAILED, errMsg);
-//        return returnErrorValue(callback, error);
-//    }
-
     static Object createParsingEntityBodyFailedErrorAndNotify(NonBlockingCallback callback, String errMsg,
             ErrorValue errorValue) {
         ErrorValue error = MimeUtil.createError(PARSING_ENTITY_BODY_FAILED, errMsg, errorValue);
@@ -162,7 +157,6 @@ public abstract class AbstractGetPayloadHandler {
             return message;
         } else {
             throw BallerinaErrors.createError(NO_CONTENT_ERROR_CODE, "Empty content");
-//            throw BallerinaErrors.createError("Empty content");
         }
     }
 

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/AbstractGetPayloadHandler.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/AbstractGetPayloadHandler.java
@@ -39,6 +39,7 @@ import static org.ballerinalang.mime.util.EntityBodyHandler.constructJsonDataSou
 import static org.ballerinalang.mime.util.EntityBodyHandler.constructStringDataSource;
 import static org.ballerinalang.mime.util.EntityBodyHandler.constructXmlDataSource;
 import static org.ballerinalang.mime.util.MimeConstants.ENTITY_BYTE_CHANNEL;
+import static org.ballerinalang.mime.util.MimeConstants.NO_CONTENT_ERROR_CODE;
 import static org.ballerinalang.mime.util.MimeConstants.PARSING_ENTITY_BODY_FAILED;
 import static org.ballerinalang.mime.util.MimeConstants.TRANSPORT_MESSAGE;
 
@@ -79,8 +80,9 @@ public abstract class AbstractGetPayloadHandler {
                     }
                     updateDataSourceAndNotify(callback, entity, dataSource);
                 } catch (Exception e) {
-                    createParsingEntityBodyFailedErrorAndNotify(callback, "Error occurred while extracting " +
-                            sourceType.toString().toLowerCase(Locale.ENGLISH) + " data from entity: " + getErrorMsg(e));
+                    createParsingEntityBodyFailedErrorAndNotify(callback,
+                            "Error occurred while extracting " + sourceType.toString().toLowerCase(Locale.ENGLISH)
+                                    + " data from entity: " + getErrorMsg(e), null);
                 } finally {
                     try {
                         inputStream.close();
@@ -93,7 +95,7 @@ public abstract class AbstractGetPayloadHandler {
             @Override
             public void onError(Exception ex) {
                 createParsingEntityBodyFailedErrorAndNotify(callback,
-                                     "Error occurred while extracting content from message : " + ex.getMessage());
+                        "Error occurred while extracting content from message : " + ex.getMessage(), null);
             }
         });
     }
@@ -103,8 +105,14 @@ public abstract class AbstractGetPayloadHandler {
         callback.notifySuccess();
     }
 
-    static Object createParsingEntityBodyFailedErrorAndNotify(NonBlockingCallback callback, String errMsg) {
-        ErrorValue error = MimeUtil.createError(PARSING_ENTITY_BODY_FAILED, errMsg);
+//    static Object createParsingEntityBodyFailedErrorAndNotify(NonBlockingCallback callback, String errMsg) {
+//        ErrorValue error = MimeUtil.createError(PARSING_ENTITY_BODY_FAILED, errMsg);
+//        return returnErrorValue(callback, error);
+//    }
+
+    static Object createParsingEntityBodyFailedErrorAndNotify(NonBlockingCallback callback, String errMsg,
+            ErrorValue errorValue) {
+        ErrorValue error = MimeUtil.createError(PARSING_ENTITY_BODY_FAILED, errMsg, errorValue);
         return returnErrorValue(callback, error);
     }
 
@@ -153,7 +161,8 @@ public abstract class AbstractGetPayloadHandler {
         if (message != null) {
             return message;
         } else {
-            throw BallerinaErrors.createError("Empty content");
+            throw BallerinaErrors.createError(NO_CONTENT_ERROR_CODE, "Empty content");
+//            throw BallerinaErrors.createError("Empty content");
         }
     }
 

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetByteArray.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetByteArray.java
@@ -21,6 +21,7 @@ package org.ballerinalang.mime.nativeimpl;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.jvm.values.utils.StringUtils;
@@ -88,8 +89,12 @@ public class GetByteArray extends AbstractGetPayloadHandler {
                 constructNonBlockingDataSource(callback, entityObj, SourceType.BLOB);
             }
         } catch (Exception ex) {
+            if (ex instanceof ErrorValue) {
+                return createParsingEntityBodyFailedErrorAndNotify(callback,
+                        "Error occurred while extracting blob data from entity", (ErrorValue) ex);
+            }
             createParsingEntityBodyFailedErrorAndNotify(callback,
-                                 "Error occurred while extracting blob data from entity : " + getErrorMsg(ex));
+                    "Error occurred while extracting blob data from entity : " + getErrorMsg(ex), null);
         }
         return result;
     }

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetJson.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetJson.java
@@ -22,6 +22,7 @@ import org.ballerinalang.jvm.JSONParser;
 import org.ballerinalang.jvm.TypeChecker;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.RefValue;
 import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
@@ -74,8 +75,12 @@ public class GetJson extends AbstractGetPayloadHandler {
                 constructNonBlockingDataSource(callback, entityObj, SourceType.JSON);
             }
         } catch (Exception ex) {
+            if (ex instanceof ErrorValue) {
+                return createParsingEntityBodyFailedErrorAndNotify(callback,
+                        "Error occurred while extracting json data from entity", (ErrorValue) ex);
+            }
             return createParsingEntityBodyFailedErrorAndNotify(callback,
-                                 "Error occurred while extracting json data from entity: " + getErrorMsg(ex));
+                    "Error occurred while extracting json data from entity: " + getErrorMsg(ex), null);
         }
         return result;
     }

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetText.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetText.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.mime.nativeimpl;
 
 import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.mime.util.EntityBodyHandler;
@@ -61,9 +62,13 @@ public class GetText extends AbstractGetPayloadHandler {
                 constructNonBlockingDataSource(callback, entityObj, SourceType.TEXT);
             }
         } catch (Exception ex) {
+            if (ex instanceof ErrorValue) {
+                return createParsingEntityBodyFailedErrorAndNotify(callback,
+                        "Error occurred while extracting text data from entity", (ErrorValue) ex);
+            }
             return createParsingEntityBodyFailedErrorAndNotify(callback,
                                                                "Error occurred while extracting text data from entity" +
-                                                                       " : " + getErrorMsg(ex));
+                                                                       " : " + getErrorMsg(ex), null);
         }
         return result;
     }

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetXml.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/nativeimpl/GetXml.java
@@ -20,6 +20,7 @@ package org.ballerinalang.mime.nativeimpl;
 
 import org.ballerinalang.jvm.XMLFactory;
 import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.XMLValue;
 import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
@@ -70,8 +71,12 @@ public class GetXml extends AbstractGetPayloadHandler {
                 constructNonBlockingDataSource(callback, entityObj, SourceType.XML);
             }
         } catch (Exception ex) {
+            if (ex instanceof ErrorValue) {
+                return createParsingEntityBodyFailedErrorAndNotify(callback,
+                        "Error occurred while extracting xml data from entity", (ErrorValue) ex);
+            }
             return createParsingEntityBodyFailedErrorAndNotify(callback,
-                                 "Error occurred while extracting xml data from entity : " + getErrorMsg(ex));
+                                 "Error occurred while extracting xml data from entity : " + getErrorMsg(ex), null);
         }
         return result;
     }

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/util/MimeConstants.java
@@ -46,6 +46,7 @@ public class MimeConstants {
     public static final String INVALID_CONTENT_LENGTH = "{ballerina/mime}InvalidContentLength";
     public static final String HEADER_NOT_FOUND = "{ballerina/mime}HeaderNotFound";
     public static final String SERIALIZATION_ERROR_CODE = "{ballerina/mime}SerializationError";
+    public static final String NO_CONTENT_ERROR_CODE = "{ballerina/mime}NoContentError";
 
     /**
      * Content type HTTP header.

--- a/stdlib/mime/src/main/java/org/ballerinalang/mime/util/MimeUtil.java
+++ b/stdlib/mime/src/main/java/org/ballerinalang/mime/util/MimeUtil.java
@@ -453,7 +453,11 @@ public class MimeUtil {
      * @return Ballerina error value
      */
     public static ErrorValue createError(String reason, String errMsg) {
-        return BallerinaErrors.createError(reason, populateMimeErrorRecord(errMsg));
+        return BallerinaErrors.createError(reason, populateMimeErrorRecord(null, errMsg));
+    }
+
+    public static ErrorValue createError(String reason, String errMsg, ErrorValue errorValue) {
+        return BallerinaErrors.createError(reason, populateMimeErrorRecord(errorValue, errMsg));
     }
 
     public static boolean isJSONCompatible(org.ballerinalang.jvm.types.BType type) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPClientActionsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPClientActionsTestCase.java
@@ -54,7 +54,7 @@ public class HTTPClientActionsTestCase extends HttpBaseTest {
     @Test
     public void testPostAction() throws IOException {
         sendAndAssert("clientPostWithoutBody",
-                      "Error occurred while retrieving the text payload from the response");
+                      "No payload");
     }
 
     @Test

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/TestReusabilityOfRequest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/TestReusabilityOfRequest.java
@@ -93,7 +93,6 @@ public class TestReusabilityOfRequest extends HttpBaseTest {
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
         Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString()),
                 TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
-        Assert.assertEquals(response.getData(), "Hello from POST!Error occurred while retrieving the text" +
-                " payload from the request", "Message content mismatched");
+        Assert.assertEquals(response.getData(), "Hello from POST!No payload", "Message content mismatched");
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/HTTP2ClientActionsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/HTTP2ClientActionsTestCase.java
@@ -50,8 +50,7 @@ public class HTTP2ClientActionsTestCase extends Http2BaseTest {
         HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
                 "test2/clientPostWithoutBody"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getData(), "Error occurred while retrieving the text payload from the response",
-                "Message content mismatched");
+        Assert.assertEquals(response.getData(), "No payload");
     }
 
     @Test


### PR DESCRIPTION
## Purpose
$subject.
Fixes #19126

## Approach
The previous error message says "Empty content". It doesn't specifically say that there is no payload. Changed the error message to represent it.
