### PR TITLE
Add observability metrics, logging and tracing for WebSockets

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
@@ -47,12 +47,14 @@ import static org.ballerinalang.jvm.observability.tracer.TraceConstants.TAG_SPAN
 public class ObserveUtils {
     private static final List<BallerinaObserver> observers = new CopyOnWriteArrayList<>();
     private static final boolean enabled;
+    private static final boolean metricsEnabled;
     private static final boolean tracingEnabled;
 
     static {
         ConfigRegistry configRegistry = ConfigRegistry.getInstance();
         tracingEnabled = configRegistry.getAsBoolean(CONFIG_TRACING_ENABLED);
-        enabled = configRegistry.getAsBoolean(CONFIG_METRICS_ENABLED) || tracingEnabled;
+        metricsEnabled = configRegistry.getAsBoolean(CONFIG_METRICS_ENABLED);
+        enabled = metricsEnabled || tracingEnabled;
     }
 
     /**
@@ -220,6 +222,24 @@ public class ObserveUtils {
      */
     public static boolean isObservabilityEnabled() {
         return enabled;
+    }
+
+    /**
+     * Check if metrics is enabled or not.
+     *
+     * @return true if metrics is enabled else false
+     */
+    public static boolean isMetricsEnabled() {
+        return metricsEnabled;
+    }
+
+    /**
+     * Check if tracing is enabled or not.
+     *
+     * @return true if tracing is enabled else false
+     */
+    public static boolean isTracingEnabled() {
+        return tracingEnabled;
     }
 
     /**

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Ping.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Ping.java
@@ -26,6 +26,8 @@ import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.websocket.WebSocketConstants;
 import org.ballerinalang.net.http.websocket.WebSocketUtil;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityConstants;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityUtil;
 import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,13 +52,22 @@ public class Ping {
 
     public static Object ping(Strand strand, ObjectValue wsConnection, ArrayValue binaryData) {
         NonBlockingCallback callback = new NonBlockingCallback(strand);
+        WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
+                .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
+        WebSocketObservabilityUtil.observeResourceInvocation(strand, connectionInfo,
+                                                             WebSocketConstants.RESOURCE_NAME_PING);
         try {
-            WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
-                    .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
             ChannelFuture future = connectionInfo.getWebSocketConnection().ping(ByteBuffer.wrap(binaryData.getBytes()));
             WebSocketUtil.handleWebSocketCallback(callback, future, log);
+            WebSocketObservabilityUtil.observeSend(WebSocketObservabilityConstants.MESSAGE_TYPE_PING,
+                                                   connectionInfo);
         } catch (Exception e) {
             log.error("Error occurred when pinging", e);
+            WebSocketObservabilityUtil.observeError(WebSocketObservabilityUtil.getConnectionInfo(wsConnection),
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_SENT,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_PING,
+                                                    e.getMessage());
+
             callback.notifyFailure(WebSocketUtil.createErrorByType(e));
         }
         return null;

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/WebSocketConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/WebSocketConstants.java
@@ -57,6 +57,13 @@ public class WebSocketConstants {
     public static final String RESOURCE_NAME_ON_CLOSE = "onClose";
     public static final String RESOURCE_NAME_ON_IDLE_TIMEOUT = "onIdleTimeout";
     public static final String RESOURCE_NAME_ON_ERROR = "onError";
+    public static final String RESOURCE_NAME_CLOSE = "close";
+    public static final String RESOURCE_NAME_PING = "ping";
+    public static final String RESOURCE_NAME_PONG = "pong";
+    public static final String RESOURCE_NAME_PUSH_BINARY = "pushBinary";
+    public static final String RESOURCE_NAME_PUSH_TEXT = "pushText";
+    public static final String RESOURCE_NAME_READY = "ready";
+    public static final String RESOURCE_NAME_UPGRADE = "upgrade";
 
     public static final String WEBSOCKET_HANDSHAKER = "WEBSOCKET_MESSAGE";
 

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/WebSocketResourceCallback.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/WebSocketResourceCallback.java
@@ -1,25 +1,28 @@
 /*
-*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.ballerinalang.net.http.websocket;
 
 import org.ballerinalang.jvm.services.ErrorHandlerUtils;
 import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.connector.CallableUnitCallback;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityConstants;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityUtil;
+import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 
 /**
@@ -28,9 +31,14 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 public class WebSocketResourceCallback implements CallableUnitCallback {
 
     private final WebSocketConnection webSocketConnection;
+    private final WebSocketConnectionInfo connectionInfo;
+    private final String resource;
 
-    WebSocketResourceCallback(WebSocketConnection webSocketConnection) {
-        this.webSocketConnection = webSocketConnection;
+    WebSocketResourceCallback(WebSocketConnectionInfo webSocketConnectionInfo, String resource)
+            throws IllegalAccessException {
+        this.connectionInfo = webSocketConnectionInfo;
+        this.webSocketConnection = connectionInfo.getWebSocketConnection();
+        this.resource = resource;
     }
 
     @Override
@@ -42,6 +50,12 @@ public class WebSocketResourceCallback implements CallableUnitCallback {
     public void notifyFailure(ErrorValue error) {
         ErrorHandlerUtils.printError(error.getPrintableStackTrace());
         WebSocketUtil.closeDuringUnexpectedCondition(webSocketConnection);
+        //Observe error
+        WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                WebSocketObservabilityConstants.ERROR_TYPE_RESOURCE_INVOCATION,
+                                                resource,
+                                                error.getMessage());
+
     }
 
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/WebSocketResourceDispatcher.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/WebSocketResourceDispatcher.java
@@ -24,6 +24,8 @@ import org.ballerinalang.jvm.JSONParser;
 import org.ballerinalang.jvm.JSONUtils;
 import org.ballerinalang.jvm.XMLFactory;
 import org.ballerinalang.jvm.XMLNodeType;
+import org.ballerinalang.jvm.observability.ObservabilityConstants;
+import org.ballerinalang.jvm.observability.ObserveUtils;
 import org.ballerinalang.jvm.services.ErrorHandlerUtils;
 import org.ballerinalang.jvm.types.AttachedFunction;
 import org.ballerinalang.jvm.types.BArrayType;
@@ -40,6 +42,9 @@ import org.ballerinalang.jvm.values.connector.Executor;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpDispatcher;
 import org.ballerinalang.net.http.HttpResource;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityConstants;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityUtil;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObserverContext;
 import org.ballerinalang.net.http.websocket.server.OnUpgradeResourceCallback;
 import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
 import org.ballerinalang.net.http.websocket.server.WebSocketConnectionManager;
@@ -56,6 +61,7 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketTextMessage;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * {@code WebSocketDispatcher} This is the web socket request dispatcher implementation which finds best matching
@@ -94,20 +100,20 @@ public class WebSocketResourceDispatcher {
                                        WebSocketServerService wsService) {
         AttachedFunction onOpenResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_OPEN);
         if (onOpenResource != null) {
-            executeOnOpenResource(wsService, onOpenResource, webSocketCaller,
-                                  webSocketConnection);
+            executeOnOpenResource(wsService, onOpenResource, webSocketCaller, webSocketConnection);
         } else {
             webSocketConnection.readNextFrame();
         }
     }
 
-    public static void executeOnOpenResource(WebSocketService wsService, AttachedFunction onOpenResource,
-                                             ObjectValue webSocketEndpoint, WebSocketConnection webSocketConnection) {
+    private static void executeOnOpenResource(WebSocketService wsService, AttachedFunction onOpenResource,
+                                              ObjectValue webSocketEndpoint, WebSocketConnection webSocketConnection) {
         BType[] parameterTypes = onOpenResource.getParameterType();
         Object[] bValues = new Object[parameterTypes.length * 2];
         bValues[0] = webSocketEndpoint;
         bValues[1] = true;
-
+        WebSocketConnectionInfo connectionInfo = new WebSocketConnectionInfo(
+                wsService, webSocketConnection, webSocketEndpoint);
         CallableUnitCallback onOpenCallableUnitCallback = new CallableUnitCallback() {
             @Override
             public void notifySuccess() {
@@ -118,62 +124,73 @@ public class WebSocketResourceDispatcher {
             public void notifyFailure(ErrorValue error) {
                 ErrorHandlerUtils.printError("error: " + error.getPrintableStackTrace());
                 WebSocketUtil.closeDuringUnexpectedCondition(webSocketConnection);
+                WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                        WebSocketObservabilityConstants.ERROR_TYPE_RESOURCE_INVOCATION,
+                                                        WebSocketConstants.RESOURCE_NAME_ON_OPEN,
+                                                        error.getMessage());
             }
         };
-
-        Executor.submit(wsService.getScheduler(), wsService.getBalService(), onOpenResource.getName(),
-                        onOpenCallableUnitCallback,
-                        null, bValues);
+        executeResource(wsService, onOpenCallableUnitCallback, bValues, connectionInfo,
+                        WebSocketConstants.RESOURCE_NAME_ON_OPEN);
     }
-    public static void dispatchOnText(WebSocketConnectionInfo connectionInfo, WebSocketTextMessage textMessage)
-            throws IllegalAccessException {
-        WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
-        WebSocketService wsService = connectionInfo.getService();
-        AttachedFunction onTextMessageResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_TEXT);
-        if (onTextMessageResource == null) {
-            webSocketConnection.readNextFrame();
-            return;
-        }
-        BType[] parameterTypes = onTextMessageResource.getParameterType();
-        Object[] bValues = new Object[parameterTypes.length * 2];
-
-        bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = true;
-
-        boolean finalFragment = textMessage.isFinalFragment();
-        BType dataType = parameterTypes[1];
-        int dataTypeTag = dataType.getTag();
-        if (dataTypeTag == TypeTags.STRING_TAG) {
-            bValues[2] = textMessage.getText();
-            bValues[3] = true;
-            if (parameterTypes.length == 3) {
-                bValues[4] = finalFragment;
-                bValues[5] = true;
-            }
-            Executor.submit(wsService.getScheduler(), wsService.getBalService(),
-                            WebSocketConstants.RESOURCE_NAME_ON_TEXT,
-                            new WebSocketResourceCallback(webSocketConnection), null, bValues);
-        } else if (isDataBindingSupported(dataTypeTag)) {
-            // During data binding the string is aggregated before it is dispatched to the resource
-            WebSocketConnectionInfo.StringAggregator stringAggregator =
-                    connectionInfo.createIfNullAndGetStringAggregator();
-            if (finalFragment) {
-                stringAggregator.appendAggregateString(textMessage.getText());
-                Object aggregate = getAggregatedObject(webSocketConnection, dataType,
-                                                       stringAggregator.getAggregateString());
-                if (aggregate != null) {
-                    bValues[2] = aggregate;
-                    bValues[3] = true;
-                    Executor.submit(wsService.getScheduler(), wsService.getBalService(),
-                                    WebSocketConstants.RESOURCE_NAME_ON_TEXT,
-                                    new WebSocketResourceCallback(webSocketConnection), null, bValues);
-                }
-                stringAggregator.resetAggregateString();
-            } else {
-                stringAggregator.appendAggregateString(textMessage.getText());
+    public static void dispatchOnText(WebSocketConnectionInfo connectionInfo, WebSocketTextMessage textMessage) {
+        WebSocketObservabilityUtil.observeOnMessage(WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
+                                                    connectionInfo);
+        try {
+            WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
+            WebSocketService wsService = connectionInfo.getService();
+            AttachedFunction onTextMessageResource = wsService.getResourceByName(
+                    WebSocketConstants.RESOURCE_NAME_ON_TEXT);
+            if (onTextMessageResource == null) {
                 webSocketConnection.readNextFrame();
+                return;
             }
+            BType[] parameterTypes = onTextMessageResource.getParameterType();
+            Object[] bValues = new Object[parameterTypes.length * 2];
 
+            bValues[0] = connectionInfo.getWebSocketEndpoint();
+            bValues[1] = true;
+
+            boolean finalFragment = textMessage.isFinalFragment();
+            BType dataType = parameterTypes[1];
+            int dataTypeTag = dataType.getTag();
+            if (dataTypeTag == TypeTags.STRING_TAG) {
+                bValues[2] = textMessage.getText();
+                bValues[3] = true;
+                if (parameterTypes.length == 3) {
+                    bValues[4] = finalFragment;
+                    bValues[5] = true;
+                }
+                executeResource(wsService, new WebSocketResourceCallback(connectionInfo,
+                                                                         WebSocketConstants.RESOURCE_NAME_ON_TEXT),
+                                bValues, connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_TEXT);
+            } else if (isDataBindingSupported(dataTypeTag)) {
+                // During data binding the string is aggregated before it is dispatched to the resource
+                WebSocketConnectionInfo.StringAggregator stringAggregator =
+                        connectionInfo.createIfNullAndGetStringAggregator();
+                if (finalFragment) {
+                    stringAggregator.appendAggregateString(textMessage.getText());
+                    Object aggregate = getAggregatedObject(webSocketConnection, dataType,
+                                                           stringAggregator.getAggregateString(), connectionInfo);
+                    if (aggregate != null) {
+                        bValues[2] = aggregate;
+                        bValues[3] = true;
+                        executeResource(wsService, new WebSocketResourceCallback(
+                                connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_TEXT), bValues, connectionInfo,
+                                        WebSocketConstants.RESOURCE_NAME_ON_TEXT);
+                    }
+                    stringAggregator.resetAggregateString();
+                } else {
+                    stringAggregator.appendAggregateString(textMessage.getText());
+                    webSocketConnection.readNextFrame();
+                }
+
+            }
+        } catch (Exception e) {
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
+                                                    e.getMessage());
         }
     }
 
@@ -183,7 +200,7 @@ public class WebSocketResourceDispatcher {
     }
 
     private static Object getAggregatedObject(WebSocketConnection webSocketConnection, BType dataType,
-                                              String aggregateString) {
+                                              String aggregateString, WebSocketConnectionInfo connectionInfo) {
         try {
             switch (dataType.getTag()) {
                 case TypeTags.JSON_TAG:
@@ -210,41 +227,56 @@ public class WebSocketResourceDispatcher {
             }
         } catch (WebSocketException ex) {
             webSocketConnection.terminateConnection(1003, ex.detailMessage());
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
+                                                    ex.getMessage());
         } catch (Exception ex) {
             webSocketConnection.terminateConnection(1003, WebSocketUtil.getErrorMessage(ex));
             log.error("Data binding failed. Hence connection terminated. ", ex);
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
+                                                    ex.getMessage());
         }
         return null;
     }
 
-    public static void dispatchOnBinary(WebSocketConnectionInfo connectionInfo,
-                                        WebSocketBinaryMessage binaryMessage) throws IllegalAccessException {
-        WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
-        WebSocketService wsService = connectionInfo.getService();
-        AttachedFunction onBinaryMessageResource = wsService.getResourceByName(
-                WebSocketConstants.RESOURCE_NAME_ON_BINARY);
-        if (onBinaryMessageResource == null) {
-            webSocketConnection.readNextFrame();
-            return;
+    public static void dispatchOnBinary(WebSocketConnectionInfo connectionInfo, WebSocketBinaryMessage binaryMessage) {
+        WebSocketObservabilityUtil.observeOnMessage(WebSocketObservabilityConstants.MESSAGE_TYPE_BINARY,
+                                                    connectionInfo);
+        try {
+            WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
+            WebSocketService wsService = connectionInfo.getService();
+            AttachedFunction onBinaryMessageResource = wsService.getResourceByName(
+                    WebSocketConstants.RESOURCE_NAME_ON_BINARY);
+            if (onBinaryMessageResource == null) {
+                webSocketConnection.readNextFrame();
+                return;
+            }
+            BType[] paramDetails = onBinaryMessageResource.getParameterType();
+            Object[] bValues = new Object[paramDetails.length * 2];
+            bValues[0] = connectionInfo.getWebSocketEndpoint();
+            bValues[1] = true;
+            bValues[2] = new ArrayValue(binaryMessage.getByteArray());
+            bValues[3] = true;
+            if (paramDetails.length == 3) {
+                bValues[4] = binaryMessage.isFinalFragment();
+                bValues[5] = true;
+            }
+            executeResource(wsService, new WebSocketResourceCallback(
+                    connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_BINARY), bValues, connectionInfo,
+                            WebSocketConstants.RESOURCE_NAME_ON_BINARY);
+        } catch (Exception e) {
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_BINARY,
+                                                    e.getMessage());
         }
-        BType[] paramDetails = onBinaryMessageResource.getParameterType();
-        Object[] bValues = new Object[paramDetails.length * 2];
-        bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = true;
-        bValues[2] = new ArrayValue(binaryMessage.getByteArray());
-        bValues[3] = true;
-        if (paramDetails.length == 3) {
-            bValues[4] = binaryMessage.isFinalFragment();
-            bValues[5] = true;
-        }
-        Executor.submit(wsService.getScheduler(), wsService.getBalService(), WebSocketConstants.RESOURCE_NAME_ON_BINARY,
-                        new WebSocketResourceCallback(webSocketConnection), null, bValues);
-
     }
 
     public static void dispatchOnPingOnPong(WebSocketConnectionInfo connectionInfo,
-                                            WebSocketControlMessage controlMessage)
-            throws IllegalAccessException {
+                                            WebSocketControlMessage controlMessage) {
         if (controlMessage.getControlSignal() == WebSocketControlSignal.PING) {
             WebSocketResourceDispatcher.dispatchOnPing(connectionInfo, controlMessage);
         } else if (controlMessage.getControlSignal() == WebSocketControlSignal.PONG) {
@@ -252,81 +284,113 @@ public class WebSocketResourceDispatcher {
         }
     }
 
-    private static void dispatchOnPing(WebSocketConnectionInfo connectionInfo,
-                                       WebSocketControlMessage controlMessage) throws IllegalAccessException {
-        WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
-        WebSocketService wsService = connectionInfo.getService();
-        AttachedFunction onPingMessageResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_PING);
-        if (onPingMessageResource == null) {
-            pongAutomatically(controlMessage);
-            return;
+    private static void dispatchOnPing(WebSocketConnectionInfo connectionInfo, WebSocketControlMessage controlMessage) {
+        WebSocketObservabilityUtil.observeOnMessage(WebSocketObservabilityConstants.MESSAGE_TYPE_PING,
+                                                    connectionInfo);
+        try {
+            WebSocketService wsService = connectionInfo.getService();
+            AttachedFunction onPingMessageResource = wsService.getResourceByName(
+                    WebSocketConstants.RESOURCE_NAME_ON_PING);
+            if (onPingMessageResource == null) {
+                pongAutomatically(controlMessage);
+                return;
+            }
+            BType[] paramTypes = onPingMessageResource.getParameterType();
+            Object[] bValues = new Object[paramTypes.length * 2];
+            bValues[0] = connectionInfo.getWebSocketEndpoint();
+            bValues[1] = true;
+            bValues[2] = new ArrayValue(controlMessage.getByteArray());
+            bValues[3] = true;
+            executeResource(wsService, new WebSocketResourceCallback(
+                    connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_PING),
+                            bValues, connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_PING);
+        } catch (Exception e) {
+            //Observe error
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_PING,
+                                                    e.getMessage());
         }
-        BType[] paramTypes = onPingMessageResource.getParameterType();
-        Object[] bValues = new Object[paramTypes.length * 2];
-        bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = true;
-        bValues[2] = new ArrayValue(controlMessage.getByteArray());
-        bValues[3] = true;
-        Executor.submit(wsService.getScheduler(), wsService.getBalService(), WebSocketConstants.RESOURCE_NAME_ON_PING,
-                        new WebSocketResourceCallback(webSocketConnection), null, bValues);
     }
 
-    private static void dispatchOnPong(WebSocketConnectionInfo connectionInfo,
-                                       WebSocketControlMessage controlMessage) throws IllegalAccessException {
-        WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
-        WebSocketService wsService = connectionInfo.getService();
-        AttachedFunction onPongMessageResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_PONG);
-        if (onPongMessageResource == null) {
-            webSocketConnection.readNextFrame();
-            return;
+    private static void dispatchOnPong(WebSocketConnectionInfo connectionInfo, WebSocketControlMessage controlMessage) {
+        WebSocketObservabilityUtil.observeOnMessage(WebSocketObservabilityConstants.MESSAGE_TYPE_PONG,
+                                                    connectionInfo);
+        try {
+            WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
+            WebSocketService wsService = connectionInfo.getService();
+            AttachedFunction onPongMessageResource = wsService.getResourceByName(
+                    WebSocketConstants.RESOURCE_NAME_ON_PONG);
+            if (onPongMessageResource == null) {
+                webSocketConnection.readNextFrame();
+                return;
+            }
+            BType[] paramDetails = onPongMessageResource.getParameterType();
+            Object[] bValues = new Object[paramDetails.length * 2];
+            bValues[0] = connectionInfo.getWebSocketEndpoint();
+            bValues[1] = true;
+            bValues[2] = new ArrayValue(controlMessage.getByteArray());
+            bValues[3] = true;
+            executeResource(wsService, new WebSocketResourceCallback(
+                    connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_PONG),
+                            bValues, connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_PONG);
+        } catch (Exception e) {
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_PONG,
+                                                    e.getMessage());
         }
-        BType[] paramDetails = onPongMessageResource.getParameterType();
-        Object[] bValues = new Object[paramDetails.length * 2];
-        bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = true;
-        bValues[2] = new ArrayValue(controlMessage.getByteArray());
-        bValues[3] = true;
-        Executor.submit(wsService.getScheduler(), wsService.getBalService(), WebSocketConstants.RESOURCE_NAME_ON_PONG,
-                        new WebSocketResourceCallback(webSocketConnection), null, bValues);
     }
 
-    public static void dispatchOnClose(WebSocketConnectionInfo connectionInfo, WebSocketCloseMessage closeMessage)
-            throws IllegalAccessException {
-        WebSocketUtil.setListenerOpenField(connectionInfo);
-        WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
-        WebSocketService wsService = connectionInfo.getService();
-        AttachedFunction onCloseResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_CLOSE);
-        int closeCode = closeMessage.getCloseCode();
-        String closeReason = closeMessage.getCloseReason();
+    public static void dispatchOnClose(WebSocketConnectionInfo connectionInfo, WebSocketCloseMessage closeMessage) {
+        WebSocketObservabilityUtil.observeOnMessage(WebSocketObservabilityConstants.MESSAGE_TYPE_CLOSE,
+                                                    connectionInfo);
+        try {
+            WebSocketUtil.setListenerOpenField(connectionInfo);
+            WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
+            WebSocketService wsService = connectionInfo.getService();
+            AttachedFunction onCloseResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_CLOSE);
+            int closeCode = closeMessage.getCloseCode();
+            String closeReason = closeMessage.getCloseReason();
 
-        if (onCloseResource == null) {
-            finishConnectionClosureIfOpen(webSocketConnection, closeCode, connectionInfo);
-            return;
+            if (onCloseResource == null) {
+                finishConnectionClosureIfOpen(webSocketConnection, closeCode, connectionInfo);
+                return;
+            }
+
+            BType[] paramDetails = onCloseResource.getParameterType();
+            Object[] bValues = new Object[paramDetails.length * 2];
+            bValues[0] = connectionInfo.getWebSocketEndpoint();
+            bValues[1] = true;
+            bValues[2] = closeCode;
+            bValues[3] = true;
+            bValues[4] = closeReason == null ? "" : closeReason;
+            bValues[5] = true;
+            CallableUnitCallback onCloseCallback = new CallableUnitCallback() {
+                @Override
+                public void notifySuccess() {
+                    finishConnectionClosureIfOpen(webSocketConnection, closeCode, connectionInfo);
+                }
+
+                @Override
+                public void notifyFailure(ErrorValue error) {
+                    ErrorHandlerUtils.printError(error.getPrintableStackTrace());
+                    finishConnectionClosureIfOpen(webSocketConnection, closeCode, connectionInfo);
+                    //Observe error
+                    WebSocketObservabilityUtil.observeError(
+                            connectionInfo, WebSocketObservabilityConstants.ERROR_TYPE_RESOURCE_INVOCATION,
+                            WebSocketConstants.RESOURCE_NAME_ON_CLOSE,
+                            error.getMessage());
+                }
+            };
+            executeResource(wsService, onCloseCallback,
+                            bValues, connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_CLOSE);
+        } catch (Exception e) {
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_CLOSE,
+                                                    e.getMessage());
         }
-
-        BType[] paramDetails = onCloseResource.getParameterType();
-        Object[] bValues = new Object[paramDetails.length * 2];
-        bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = true;
-        bValues[2] = closeCode;
-        bValues[3] = true;
-        bValues[4] = closeReason == null ? "" : closeReason;
-        bValues[5] = true;
-        CallableUnitCallback onCloseCallback = new CallableUnitCallback() {
-            @Override
-            public void notifySuccess() {
-                finishConnectionClosureIfOpen(webSocketConnection, closeCode, connectionInfo);
-            }
-
-            @Override
-            public void notifyFailure(ErrorValue error) {
-                ErrorHandlerUtils.printError(error.getPrintableStackTrace());
-                finishConnectionClosureIfOpen(webSocketConnection, closeCode, connectionInfo);
-            }
-        };
-
-        Executor.submit(wsService.getScheduler(), wsService.getBalService(), WebSocketConstants.RESOURCE_NAME_ON_CLOSE,
-                        onCloseCallback, null, bValues);
     }
 
     private static void finishConnectionClosureIfOpen(WebSocketConnection webSocketConnection, int closeCode,
@@ -353,6 +417,10 @@ public class WebSocketResourceDispatcher {
                 WebSocketConstants.RESOURCE_NAME_ON_ERROR);
         if (isUnexpectedError(throwable)) {
             log.error("Unexpected error", throwable);
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
+                                                    "Unexpected error");
         }
         if (onErrorResource == null) {
             return;
@@ -371,45 +439,55 @@ public class WebSocketResourceDispatcher {
             @Override
             public void notifyFailure(ErrorValue error) {
                 ErrorHandlerUtils.printError(error.getPrintableStackTrace());
+                WebSocketObservabilityUtil.observeError(
+                        connectionInfo, WebSocketObservabilityConstants.ERROR_TYPE_RESOURCE_INVOCATION,
+                        WebSocketConstants.RESOURCE_NAME_ON_ERROR,
+                        error.getMessage());
             }
         };
-
-        Executor.submit(webSocketService.getScheduler(), webSocketService.getBalService(),
-                        WebSocketConstants.RESOURCE_NAME_ON_ERROR, onErrorCallback, null, bValues);
+        executeResource(webSocketService, onErrorCallback,
+                        bValues, connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_ERROR);
     }
 
     private static boolean isUnexpectedError(Throwable throwable) {
         return !(throwable instanceof CorruptedFrameException);
     }
 
-    public static void dispatchOnIdleTimeout(WebSocketConnectionInfo connectionInfo) throws IllegalAccessException {
-        WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
-        WebSocketService wsService = connectionInfo.getService();
-        AttachedFunction onIdleTimeoutResource = wsService.getResourceByName(
-                WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT);
-        if (onIdleTimeoutResource == null) {
-            return;
+    public static void dispatchOnIdleTimeout(WebSocketConnectionInfo connectionInfo) {
+        try {
+            WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
+            WebSocketService wsService = connectionInfo.getService();
+            AttachedFunction onIdleTimeoutResource = wsService.getResourceByName(
+                    WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT);
+            if (onIdleTimeoutResource == null) {
+                return;
+            }
+            BType[] paramDetails = onIdleTimeoutResource.getParameterType();
+            Object[] bValues = new Object[paramDetails.length * 2];
+            bValues[0] = connectionInfo.getWebSocketEndpoint();
+            bValues[1] = true;
+
+            CallableUnitCallback onIdleTimeoutCallback = new CallableUnitCallback() {
+                @Override
+                public void notifySuccess() {
+                    // Do nothing.
+                }
+
+                @Override
+                public void notifyFailure(ErrorValue error) {
+                    ErrorHandlerUtils.printError(error.getPrintableStackTrace());
+                    WebSocketUtil.closeDuringUnexpectedCondition(webSocketConnection);
+                }
+            };
+            executeResource(wsService, onIdleTimeoutCallback,
+                            bValues, connectionInfo, WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT);
+        } catch (Exception e) {
+            log.error("Error on idle timeout", e);
+            WebSocketObservabilityUtil.observeError(connectionInfo,
+                                                    WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_RECEIVED,
+                                                    WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
+                                                    e.getMessage());
         }
-        BType[] paramDetails = onIdleTimeoutResource.getParameterType();
-        Object[] bValues = new Object[paramDetails.length * 2];
-        bValues[0] = connectionInfo.getWebSocketEndpoint();
-        bValues[1] = true;
-
-        CallableUnitCallback onIdleTimeoutCallback = new CallableUnitCallback() {
-            @Override
-            public void notifySuccess() {
-                // Do nothing.
-            }
-
-            @Override
-            public void notifyFailure(ErrorValue error) {
-                ErrorHandlerUtils.printError(error.getPrintableStackTrace());
-                WebSocketUtil.closeDuringUnexpectedCondition(webSocketConnection);
-            }
-        };
-
-        Executor.submit(wsService.getScheduler(), wsService.getBalService(),
-                        WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT, onIdleTimeoutCallback, null, bValues);
     }
 
     private static void pongAutomatically(WebSocketControlMessage controlMessage) {
@@ -421,5 +499,20 @@ public class WebSocketResourceDispatcher {
             }
             webSocketConnection.readNextFrame();
         });
+    }
+
+    private static void executeResource(WebSocketService wsService, CallableUnitCallback callback, Object[] bValues,
+                                        WebSocketConnectionInfo connectionInfo, String resource) {
+        if (ObserveUtils.isTracingEnabled()) {
+            Map<String, Object> properties = new HashMap<>();
+            WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+            properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
+            Executor.submit(wsService.getScheduler(), wsService.getBalService(), resource, callback,
+                            properties, bValues);
+        } else {
+            Executor.submit(wsService.getScheduler(), wsService.getBalService(), resource,
+                            callback, null, bValues);
+        }
+        WebSocketObservabilityUtil.observeResourceInvocation(connectionInfo, resource);
     }
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/client/InitEndpoint.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/client/InitEndpoint.java
@@ -110,7 +110,6 @@ public class InitEndpoint {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new WebSocketException("Error occurred: " + e.getMessage());
-
         }
     }
 

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/client/WebSocketClientConnectorListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/client/WebSocketClientConnectorListener.java
@@ -20,6 +20,7 @@ package org.ballerinalang.net.http.websocket.client;
 
 import org.ballerinalang.net.http.websocket.WebSocketResourceDispatcher;
 import org.ballerinalang.net.http.websocket.WebSocketUtil;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityUtil;
 import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketCloseMessage;
@@ -37,7 +38,6 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketTextMessage;
 public class WebSocketClientConnectorListener implements WebSocketConnectorListener {
     private WebSocketConnectionInfo connectionInfo;
 
-
     public void setConnectionInfo(WebSocketConnectionInfo connectionInfo) {
         this.connectionInfo = connectionInfo;
     }
@@ -49,38 +49,22 @@ public class WebSocketClientConnectorListener implements WebSocketConnectorListe
 
     @Override
     public void onMessage(WebSocketTextMessage webSocketTextMessage) {
-        try {
-            WebSocketResourceDispatcher.dispatchOnText(connectionInfo, webSocketTextMessage);
-        } catch (IllegalAccessException e) {
-            // Ignore as it is not possible have an Illegal access
-        }
+        WebSocketResourceDispatcher.dispatchOnText(connectionInfo, webSocketTextMessage);
     }
 
     @Override
     public void onMessage(WebSocketBinaryMessage webSocketBinaryMessage) {
-        try {
-            WebSocketResourceDispatcher.dispatchOnBinary(connectionInfo, webSocketBinaryMessage);
-        } catch (IllegalAccessException e) {
-            // Ignore as it is not possible have an Illegal access
-        }
+        WebSocketResourceDispatcher.dispatchOnBinary(connectionInfo, webSocketBinaryMessage);
     }
 
     @Override
     public void onMessage(WebSocketControlMessage webSocketControlMessage) {
-        try {
-            WebSocketResourceDispatcher.dispatchOnPingOnPong(connectionInfo, webSocketControlMessage);
-        } catch (IllegalAccessException e) {
-            // Ignore as it is not possible have an Illegal access
-        }
+        WebSocketResourceDispatcher.dispatchOnPingOnPong(connectionInfo, webSocketControlMessage);
     }
 
     @Override
     public void onMessage(WebSocketCloseMessage webSocketCloseMessage) {
-        try {
-            WebSocketResourceDispatcher.dispatchOnClose(connectionInfo, webSocketCloseMessage);
-        } catch (IllegalAccessException e) {
-            // Ignore as it is not possible have an Illegal access
-        }
+        WebSocketResourceDispatcher.dispatchOnClose(connectionInfo, webSocketCloseMessage);
     }
 
     @Override
@@ -90,15 +74,12 @@ public class WebSocketClientConnectorListener implements WebSocketConnectorListe
 
     @Override
     public void onIdleTimeout(WebSocketControlMessage controlMessage) {
-        try {
-            WebSocketResourceDispatcher.dispatchOnIdleTimeout(connectionInfo);
-        } catch (IllegalAccessException e) {
-            // Ignore as it is not possible have an Illegal access
-        }
+        WebSocketResourceDispatcher.dispatchOnIdleTimeout(connectionInfo);
     }
 
     @Override
     public void onClose(WebSocketConnection webSocketConnection) {
+        WebSocketObservabilityUtil.observeClose(connectionInfo);
         try {
             WebSocketUtil.setListenerOpenField(connectionInfo);
         } catch (IllegalAccessException e) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/client/WebSocketClientHandshakeListener.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/client/WebSocketClientHandshakeListener.java
@@ -25,6 +25,7 @@ import org.ballerinalang.net.http.websocket.WebSocketConstants;
 import org.ballerinalang.net.http.websocket.WebSocketResourceDispatcher;
 import org.ballerinalang.net.http.websocket.WebSocketService;
 import org.ballerinalang.net.http.websocket.WebSocketUtil;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityUtil;
 import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
 import org.wso2.transport.http.netty.contract.websocket.ClientHandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
@@ -73,6 +74,7 @@ public class WebSocketClientHandshakeListener implements ClientHandshakeListener
             WebSocketUtil.readFirstFrame(webSocketConnection, webSocketClient);
         }
         countDownLatch.countDown();
+        WebSocketObservabilityUtil.observeConnection(connectionInfo);
     }
 
     @Override

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketMetricsUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketMetricsUtil.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.websocket.observability;
+
+import org.ballerinalang.jvm.observability.ObservabilityConstants;
+import org.ballerinalang.jvm.observability.ObserveUtils;
+import org.ballerinalang.jvm.observability.metrics.DefaultMetricRegistry;
+import org.ballerinalang.jvm.observability.metrics.MetricId;
+import org.ballerinalang.jvm.observability.metrics.MetricRegistry;
+import org.ballerinalang.jvm.observability.metrics.Tag;
+
+import java.util.Set;
+
+/**
+ * Providing metrics functionality to WebSockets.
+ *
+ * @since 1.1.0
+ */
+
+class WebSocketMetricsUtil {
+
+    private static final MetricRegistry metricRegistry = DefaultMetricRegistry.getInstance();
+
+    static void reportRequestMetrics(WebSocketObserverContext observerContext) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_REQUESTS[0],
+                               WebSocketObservabilityConstants.METRIC_REQUESTS[1]);
+    }
+
+    static void reportConnectionMetrics(WebSocketObserverContext observerContext) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        incrementGaugeMetric(observerContext, WebSocketObservabilityConstants.METRIC_CONNECTIONS[0],
+                               WebSocketObservabilityConstants.METRIC_CONNECTIONS[1]);
+    }
+
+    static void reportSendMetrics(WebSocketObserverContext observerContext, String type) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        //Define type of message (text, binary, control, close)
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_MESSAGE_TYPE, type);
+        //Increment message sent metric
+        incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_MESSAGES_SENT[0],
+                               WebSocketObservabilityConstants.METRIC_MESSAGES_SENT[1]);
+    }
+
+    static void reportReceivedMetrics(WebSocketObserverContext observerContext, String type) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        //Define type of message (text, binary, control, close)
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_MESSAGE_TYPE, type);
+        //Increment messages received metric
+        incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_MESSAGES_RECEIVED[0],
+                               WebSocketObservabilityConstants.METRIC_MESSAGES_RECEIVED[1]);
+    }
+
+    static void reportCloseMetrics(WebSocketObserverContext observerContext) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        decrementGaugeMetric(observerContext, WebSocketObservabilityConstants.METRIC_CONNECTIONS[0],
+                             WebSocketObservabilityConstants.METRIC_CONNECTIONS[1]);
+    }
+
+    static void reportResourceInvocationMetrics(WebSocketObserverContext observerContext, String resource) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_RESOURCE, resource);
+        incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_RESOURCES_INVOKED[0],
+                               WebSocketObservabilityConstants.METRIC_RESOURCES_INVOKED[1]);
+    }
+
+    static void reportErrorMetrics(WebSocketObserverContext observerContext, String errorType, String messageType) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_ERROR_TYPE, errorType);
+        //If the error is related to sending/receiving a message, set the type of message
+        if (messageType != null) {
+            observerContext.addTag(WebSocketObservabilityConstants.TAG_MESSAGE_TYPE, messageType);
+        }
+        //Increment errors metric
+        incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_ERRORS[0],
+                               WebSocketObservabilityConstants.METRIC_ERRORS[1]);
+    }
+
+    static void reportErrorMetrics(String errorType, String url, String clientOrServer) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        WebSocketObserverContext observerContext = new WebSocketObserverContext();
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_ERROR_TYPE, errorType);
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_SERVICE, url);
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_CONTEXT, clientOrServer);
+        //Increment errors metric
+        incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_ERRORS[0],
+                               WebSocketObservabilityConstants.METRIC_ERRORS[1]);
+    }
+
+    private static void incrementCounterMetric(WebSocketObserverContext observerContext, String name, String desc) {
+        Set<Tag> tags = observerContext.getAllTags();
+        metricRegistry.counter(new MetricId(ObservabilityConstants.SERVER_CONNECTOR_WEBSOCKET + "_" +
+                                                    name, desc, tags)).increment();
+    }
+
+    private static void incrementGaugeMetric(WebSocketObserverContext observerContext, String name, String desc) {
+        Set<Tag> tags = observerContext.getAllTags();
+        metricRegistry.gauge(new MetricId(ObservabilityConstants.SERVER_CONNECTOR_WEBSOCKET + "_" +
+                                                  name, desc, tags)).increment();
+    }
+
+    private static void decrementGaugeMetric(WebSocketObserverContext observerContext, String name, String desc) {
+        Set<Tag> tags = observerContext.getAllTags();
+        metricRegistry.gauge(new MetricId(ObservabilityConstants.SERVER_CONNECTOR_WEBSOCKET + "_" +
+                                                  name, desc, tags)).decrement();
+    }
+
+    private WebSocketMetricsUtil() {
+    }
+
+}

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObservabilityConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObservabilityConstants.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.websocket.observability;
+
+/**
+ * Providing observability functionality to WebSockets.
+ *
+ * @since 1.1.0
+ */
+public class WebSocketObservabilityConstants {
+
+    public static final String TAG_CONNECTION_ID = "connectionID";
+    public static final String TAG_CONTEXT = "client_or_server";
+    public static final String TAG_SERVICE = "service";
+    public static final String TAG_MESSAGE_TYPE = "type";
+    public static final String TAG_ERROR_TYPE = "error_type";
+    public static final String TAG_RESOURCE = "resource";
+
+    static final String[] METRIC_REQUESTS = { "requests", "Number of WebSocket connection requests"};
+    static final String[] METRIC_CONNECTIONS = {"connections", "Number of currenctly active connections"};
+    static final String[] METRIC_MESSAGES_RECEIVED = {"messages_received", "Number of messages received"};
+    static final String[] METRIC_MESSAGES_SENT = {"messages_sent", "Number of messages sent"};
+    static final String[] METRIC_ERRORS = {"errors", "Number of errors"};
+    static final String[] METRIC_RESOURCES_INVOKED = {"resources_invoked", "Number of resources invoked"};
+
+    static final String CONTEXT_CLIENT = "client";
+    public static final String CONTEXT_SERVER = "server";
+
+    public static final String MESSAGE_TYPE_TEXT = "text";
+    public static final String MESSAGE_TYPE_BINARY = "binary";
+    public static final String MESSAGE_TYPE_PING = "ping";
+    public static final String MESSAGE_TYPE_PONG = "pong";
+    public static final String MESSAGE_TYPE_CLOSE = "close";
+
+    public static final String ERROR_TYPE_CONNECTION = "connection";
+    public static final String ERROR_TYPE_CLOSE = "close";
+    public static final String ERROR_TYPE_MESSAGE_SENT = "message_sent";
+    public static final String ERROR_TYPE_MESSAGE_RECEIVED = "message_received";
+    public static final String ERROR_TYPE_READY = "ready";
+    public static final String ERROR_TYPE_RESOURCE_INVOCATION = "resource_invocation";
+
+    static final String UNKNOWN = "unknown";
+
+    private WebSocketObservabilityConstants(){
+    }
+}

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObservabilityUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObservabilityUtil.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.websocket.observability;
+
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.ObjectValue;
+import org.ballerinalang.net.http.websocket.WebSocketConstants;
+import org.ballerinalang.net.http.websocket.WebSocketService;
+import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
+import org.ballerinalang.net.http.websocket.server.WebSocketServerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Providing observability functionality to WebSockets (Logging and Metrics).
+ *
+ * @since 1.1.0
+ */
+public class WebSocketObservabilityUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketObservabilityUtil.class);
+
+    /**
+     * Observes successful WebSocket connections.
+     *
+     * @param connectionInfo information regarding connection.
+     */
+    public static void observeConnection(WebSocketConnectionInfo connectionInfo) {
+        WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+        WebSocketMetricsUtil.reportConnectionMetrics(observerContext);
+
+        LOGGER.debug("WebSocket new connection established. connectionID: {}, service/url: {}",
+                     observerContext.getConnectionId(),
+                     observerContext.getServicePathOrClientUrl());
+    }
+
+    /**
+     * Observes messages pushed (sent).
+     *
+     * @param type           type of message pushed (text, binary, control, close).
+     * @param connectionInfo information regarding connection.
+     */
+    public static void observeSend(String type, WebSocketConnectionInfo connectionInfo) {
+        WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+        WebSocketMetricsUtil.reportSendMetrics(observerContext, type);
+
+        LOGGER.debug("WebSocket message sent. connectionID: {}, service/url: {}, type: {}",
+                     observerContext.getConnectionId(),
+                     observerContext.getServicePathOrClientUrl(),
+                     type);
+    }
+
+    /**
+     * Observes messages received.
+     *
+     * @param type           type of message pushed (text, binary, control, close).
+     * @param connectionInfo information regarding connection.
+     */
+    public static void observeOnMessage(String type, WebSocketConnectionInfo connectionInfo) {
+        WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+        WebSocketMetricsUtil.reportReceivedMetrics(observerContext, type);
+
+        LOGGER.debug("WebSocket message received. connectionID: {}, service/url: {}, type:{}",
+                     observerContext.getConnectionId(),
+                     observerContext.getServicePathOrClientUrl(),
+                     type);
+    }
+
+    /**
+     * Observes WebSocket connection closures.
+     *
+     * @param connectionInfo information regarding connection.
+     */
+    public static void observeClose(WebSocketConnectionInfo connectionInfo) {
+        WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+        WebSocketMetricsUtil.reportCloseMetrics(observerContext);
+
+        LOGGER.debug("WebSocket connection closed. connectionID: {}, service/url: {}",
+                     observerContext.getConnectionId(),
+                     observerContext.getServicePathOrClientUrl());
+    }
+
+    /**
+     * Observes WebSocket errors where the errorType is not related to a message being sent or received, or the type of
+     * the message is unknown.
+     *
+     * @param connectionInfo information regarding connection.
+     * @param errorType      type of error (connection, closure, message sent/received).
+     * @param errorMessage   error message.
+     */
+    public static void observeError(WebSocketConnectionInfo connectionInfo, String errorType,
+                                    String errorMessage) {
+        observeError(connectionInfo, errorType, null, errorMessage);
+    }
+
+    /**
+     * Observes WebSocket errors where the errorType is related to a message being sent or received. and the type of the
+     * message is known.
+     *
+     * @param connectionInfo information regarding connection.
+     * @param errorType      type of error (connection, closure, message sent/received).
+     * @param messageType    type of message (text, binary, control, close).
+     * @param errorMessage   error message.
+     */
+    public static void observeError(WebSocketConnectionInfo connectionInfo, String errorType,
+                                    String messageType, String errorMessage) {
+        WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+        WebSocketMetricsUtil.reportErrorMetrics(observerContext, errorType, messageType);
+
+        if (errorMessage == null) {
+            errorMessage = WebSocketObservabilityConstants.UNKNOWN;
+        }
+
+        if (messageType == null) {
+            LOGGER.debug("WebSocket type:{}, message: {}, connectionId: {}, service/url: {}",
+                         errorType, errorMessage, observerContext.getConnectionId(),
+                         observerContext.getServicePathOrClientUrl());
+        } else {
+            LOGGER.debug("WebSocket type:{}/{}, message: {}, connectionId: {}, service/url: {}",
+                         errorType, messageType, errorMessage, observerContext.getConnectionId(),
+                         observerContext.getServicePathOrClientUrl());
+        }
+    }
+
+    /**
+     * Observes WebSocket errors before the connection is initialized (handshake errors etc).
+     *
+     * @param errorType      type of error (connection, closure, message sent/received).
+     * @param errorMessage   error message.
+     * @param url            service base path or remote url.
+     * @param clientOrServer current context of connection.
+     */
+    public static void observeError(String errorType, String errorMessage, String url, String clientOrServer) {
+        WebSocketMetricsUtil.reportErrorMetrics(errorType, url, clientOrServer);
+
+        LOGGER.debug("WebSocket type:{}, message: {}, service/url: {}", errorType, errorMessage, url);
+    }
+
+    /**
+     * Observes when a new resource is invoked. In addition to metrics and logging, relevant tags are added to the
+     * span in the trace as well.
+     *
+     * @param strand            current strand
+     * @param connectionInfo    information regarding the connection.
+     * @param resource          name of the resource invoked.
+     */
+    public static void observeResourceInvocation(Strand strand, WebSocketConnectionInfo connectionInfo,
+                                                 String resource) {
+        WebSocketTracingUtil.traceResourceInvocation(strand, connectionInfo);
+        observeResourceInvocation(connectionInfo, resource);
+    }
+
+    /**
+     * Observes when a new resource is invoked.
+     *
+     * @param connectionInfo    information regarding the connection.
+     * @param resource          name of the resource invoked.
+     */
+    public static void observeResourceInvocation(WebSocketConnectionInfo connectionInfo, String resource) {
+        WebSocketObserverContext observerContext = new WebSocketObserverContext(connectionInfo);
+        WebSocketMetricsUtil.reportResourceInvocationMetrics(observerContext, resource);
+
+        LOGGER.debug("WebSocket resource invoked. connectionID: {}, service/url: {}, resource: {}",
+                     observerContext.getConnectionId(),
+                     observerContext.getServicePathOrClientUrl(),
+                     resource);
+    }
+
+    /**
+     * Determines whether the current context is server or client.
+     *
+     * @param connectionInfo information regarding connection.
+     * @return whether the current context is client or server.
+     */
+    static String getClientOrServerContext(WebSocketConnectionInfo connectionInfo) {
+        WebSocketService service = connectionInfo.getService();
+        if (service instanceof WebSocketServerService) {
+            return WebSocketObservabilityConstants.CONTEXT_SERVER;
+        } else {
+            return WebSocketObservabilityConstants.CONTEXT_CLIENT;
+        }
+    }
+
+    /**
+     * Determines whether the current context is server or client and returns the relevant base bath (if server) or
+     * remote URL (if client).
+     *
+     * @param connectionInfo information of the current connection.
+     * @return if server context, service base path else (in client context), the remote URL
+     */
+    static String getServicePathOrClientUrl(WebSocketConnectionInfo connectionInfo) {
+        WebSocketService service = connectionInfo.getService();
+        if (service instanceof WebSocketServerService) {
+            return ((WebSocketServerService) service).getBasePath();
+        } else {
+            return connectionInfo.getWebSocketEndpoint().getStringValue("url");
+        }
+    }
+
+    public static WebSocketConnectionInfo getConnectionInfo(ObjectValue wsConnection) {
+        return (WebSocketConnectionInfo) wsConnection.getNativeData(
+                WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
+    }
+
+    static String getConnectionId(WebSocketConnectionInfo connectionInfo) {
+        try {
+            return connectionInfo.getWebSocketConnection().getChannelId();
+        } catch (Exception e) {
+            return WebSocketObservabilityConstants.UNKNOWN;
+        }
+    }
+
+    private WebSocketObservabilityUtil() {
+    }
+}

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObserverContext.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObserverContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.websocket.observability;
+
+import org.ballerinalang.jvm.observability.ObservabilityConstants;
+import org.ballerinalang.jvm.observability.ObserverContext;
+import org.ballerinalang.jvm.observability.metrics.Tag;
+import org.ballerinalang.jvm.observability.metrics.Tags;
+import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Extension of ObserverContext for WebSockets.
+ *
+ * @since 1.1.0
+ */
+
+public class WebSocketObserverContext extends ObserverContext {
+
+    private String connectionId = WebSocketObservabilityConstants.UNKNOWN;
+    private String servicePathOrClientUrl = WebSocketObservabilityConstants.UNKNOWN;
+
+    WebSocketObserverContext() {
+        setConnectorName(ObservabilityConstants.SERVER_CONNECTOR_WEBSOCKET);
+    }
+
+    public WebSocketObserverContext(WebSocketConnectionInfo connectionInfo) {
+        this();
+        this.connectionId = WebSocketObservabilityUtil.getConnectionId(connectionInfo);
+        this.servicePathOrClientUrl = WebSocketObservabilityUtil.getServicePathOrClientUrl(connectionInfo);
+        setTags(connectionInfo);
+    }
+
+    /**
+     * Sets the basic tags for the current WebSocket Observer context.
+     * (Connection ID, whether in client or server context, and the service path/client URL).
+     *
+     * @param connectionInfo  information regarding connection.
+     */
+    public void setTags(WebSocketConnectionInfo connectionInfo) {
+        addTag(WebSocketObservabilityConstants.TAG_CONTEXT,
+                    WebSocketObservabilityUtil.getClientOrServerContext(connectionInfo));
+        addTag(WebSocketObservabilityConstants.TAG_SERVICE, servicePathOrClientUrl);
+    }
+
+    String getConnectionId() {
+        return connectionId;
+    }
+
+    String getServicePathOrClientUrl() {
+        return servicePathOrClientUrl;
+    }
+
+    Set<Tag> getAllTags() {
+        Map<String, String> tags = getTags();
+        Set<Tag> allTags = new HashSet<>(tags.size());
+        Tags.tags(allTags, tags);
+        return allTags;
+    }
+}

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketTracingUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketTracingUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.websocket.observability;
+
+import org.ballerinalang.jvm.observability.ObserveUtils;
+import org.ballerinalang.jvm.observability.ObserverContext;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.net.http.websocket.server.WebSocketConnectionInfo;
+
+import java.util.Optional;
+
+/**
+ * Providing tracing functionality to WebSockets.
+ *
+ * @since 1.1.0
+ */
+
+public class WebSocketTracingUtil {
+
+    /**
+     * Obtains the current observer context of new resource that was invoked and sets the necessary tags to it.
+     *
+     * @param strand         Strand of the new resource invoked
+     * @param connectionInfo information regarding connection.
+     */
+    static void traceResourceInvocation(Strand strand, WebSocketConnectionInfo connectionInfo) {
+        if (!ObserveUtils.isTracingEnabled()) {
+            return;
+        }
+        ObserverContext observerContext;
+        Optional<ObserverContext> observerContextOptional = ObserveUtils.getObserverContextOfCurrentFrame(strand);
+        if (observerContextOptional.isPresent()) {
+            observerContext = observerContextOptional.get();
+        } else {
+            observerContext = new ObserverContext();
+            ObserveUtils.setObserverContextToCurrentFrame(strand, observerContext);
+        }
+        setTags(observerContext, connectionInfo);
+    }
+
+    private static void setTags(ObserverContext observerContext, WebSocketConnectionInfo connectionInfo) {
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_CONTEXT,
+               WebSocketObservabilityUtil.getClientOrServerContext(connectionInfo));
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_SERVICE,
+                               WebSocketObservabilityUtil.getServicePathOrClientUrl(connectionInfo));
+    }
+
+
+    private WebSocketTracingUtil() {
+
+    }
+}

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/WebSocketMetricsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/WebSocketMetricsTestCase.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.observability.metrics;
+
+import org.ballerinalang.jvm.observability.ObservabilityConstants;
+import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityConstants;
+import org.ballerinalang.test.BaseTest;
+import org.ballerinalang.test.context.BServerInstance;
+import org.ballerinalang.test.util.websocket.client.WebSocketTestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Integration test for observability of metrics.
+ */
+@Test(groups = "websocket-metrics-test")
+public class WebSocketMetricsTestCase extends BaseTest {
+    private static BServerInstance serverInstance;
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketMetricsTestCase.class);
+    private static final String MESSAGE = "test message";
+    private static final String CLOSE_MESSAGE = "closeMe";
+
+
+    private static final String RESOURCE_LOCATION = "src" + File.separator + "test" + File.separator +
+            "resources" + File.separator + "observability" + File.separator + "metrics" + File.separator;
+    private Map<String, String> expectedMetrics = new HashMap<>();
+    private static final ByteBuffer SENDING_BYTE_BUFFER = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+
+
+    @BeforeGroups(value = "websocket-metrics-test", alwaysRun = true)
+    private void setup() throws Exception {
+        serverInstance = new BServerInstance(balServer);
+        String balFile = new File(RESOURCE_LOCATION + "websocket-metrics-test.bal").getAbsolutePath();
+        List<String> args = new ArrayList<>();
+        args.add("--" + ObservabilityConstants.CONFIG_METRICS_ENABLED + "=true");
+        args.add("--b7a.log.console.loglevel=INFO");
+        serverInstance.startServer(balFile, null, args.toArray(new String[args.size()]), new int[] { 9090 });
+        addMetrics();
+    }
+    /**
+     * Creates a new WebSocket client and connects to the server. Sends 5 text messages, 1 ping, 1 ping, 1 binary, 1
+     * close message and then closes the connection.
+     *
+     * Checks whether the published metrics are the same as the expected metrics.
+     *
+     * @throws Exception Error when executing the commands.
+     */
+    @Test
+    public void testMetrics() throws Exception {
+        WebSocketTestClient client = new WebSocketTestClient("ws://localhost:9090/basic/ws");
+        client.handshake();
+        client.sendText(MESSAGE);
+        client.sendText(MESSAGE);
+        client.sendText(MESSAGE);
+        client.sendText(MESSAGE);
+        client.sendText(MESSAGE);
+        client.sendPing(SENDING_BYTE_BUFFER);
+        client.sendPong(SENDING_BYTE_BUFFER);
+        client.sendBinary(SENDING_BYTE_BUFFER);
+        client.sendText(CLOSE_MESSAGE);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownLatch.await(10, TimeUnit.SECONDS);
+        client.shutDown();
+
+        URL metricsEndPoint = new URL("http://localhost:9797/metrics");
+        BufferedReader reader = new BufferedReader(new InputStreamReader(metricsEndPoint.openConnection()
+                .getInputStream()));
+        List<String> metricsList = reader.lines().filter(s -> !s.startsWith("#")).collect(Collectors.toList());
+        Assert.assertTrue(metricsList.size() != 0);
+        int count = 0;
+        for (String line : metricsList) {
+            int index = line.lastIndexOf(" ");
+            String key = line.substring(0, index);
+            String value = line.substring(index + 1);
+            String metric = getMetricName(key);
+            String connectionID = getTag(key, WebSocketObservabilityConstants.TAG_CONNECTION_ID);
+            String clientOrServer = getTag(key, WebSocketObservabilityConstants.TAG_CONTEXT);
+            String service = getTag(key, WebSocketObservabilityConstants.TAG_SERVICE);
+            String type = getTag(key, WebSocketObservabilityConstants.TAG_MESSAGE_TYPE);
+            String[] tags = {connectionID, clientOrServer, service, type};
+            key = generateNewKey(metric, tags);
+            String actualValue = expectedMetrics.get(key);
+            if (actualValue != null) {
+                count++;
+                logger.info(key + " -- " + value);
+                Assert.assertEquals(value, actualValue, "Unexpected value found for metric " + key + ".");
+            }
+        }
+        Assert.assertEquals(count, expectedMetrics.size(), "metrics count is not equal to the expected metrics count.");
+        reader.close();
+    }
+
+    @AfterGroups(value = "websocket-metrics-test", alwaysRun = true)
+    private void cleanup() throws Exception {
+        serverInstance.shutdownServer();
+    }
+
+    private void addMetrics() {
+        expectedMetrics.put("ws_messages_received_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"binary\",}", "1.0");
+        expectedMetrics.put("ws_messages_sent_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"text\",}", "5.0");
+        expectedMetrics.put("ws_connections_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",}", "0.0");
+        expectedMetrics.put("ws_messages_received_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"text\",}", "6.0");
+        expectedMetrics.put("ws_messages_sent_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"binary\",}", "1.0");
+        expectedMetrics.put("ws_messages_sent_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"close\",}", "1.0");
+        expectedMetrics.put("ws_messages_received_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"pong\",}", "1.0");
+        expectedMetrics.put("ws_errors_value{client_or_server=\"server\"," +
+                                    "service=\"/basic/ws\",type=\"close\",}", "2.0");
+    }
+
+    private String getMetricName(String key) {
+        int index = key.lastIndexOf("{");
+        return key.substring(0, index);
+    }
+
+    private String getTag(String key, String tag) {
+        Pattern connectionIDPattern = Pattern.compile(tag + "=\"[^\"]*\",");
+        Matcher connectionIDMatcher = connectionIDPattern.matcher(key);
+        if (connectionIDMatcher.find()) {
+            return connectionIDMatcher.group(0);
+        }
+        return "";
+    }
+
+    private String generateNewKey(String metric, String[] tags) {
+        String key = metric + "{";
+        for (String tag: tags) {
+            key = key + tag;
+        }
+        key = key + "}";
+        return key;
+    }
+}

--- a/tests/jballerina-integration-test/src/test/resources/observability/metrics/websocket-metrics-test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/metrics/websocket-metrics-test.bal
@@ -1,0 +1,76 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerina/http;string ping = "ping";
+byte[] pingData = ping.toBytes();
+
+@http:WebSocketServiceConfig {
+    path: "/basic/ws",
+    subProtocols: ["xml", "json"],
+    idleTimeoutInSeconds: 120
+}
+service basic on new http:Listener(9090) {
+    resource function onOpen(http:WebSocketCaller caller) {
+    }
+    resource function onText(http:WebSocketCaller caller, string text,
+                                boolean finalFrame) {
+        if (text == "ping") {
+            var err = caller->ping(pingData);
+            if (err is http:WebSocketError) {
+                log:printError("Error sending ping", err);
+            }
+        } else if (text == "closeMe") {
+            error? result = caller->close(statusCode = 1001,
+                            reason = "You asked me to close the connection",
+                            timeoutInSeconds = 0);
+            if (result is http:WebSocketError) {
+                log:printError("Error occurred when closing connection", result);
+            }
+        } else {
+            var err = caller->pushText("You said: " + text);
+            if (err is http:WebSocketError) {
+                log:printError("Error occurred when sending text", err);
+            }
+        }
+    }
+    resource function onBinary(http:WebSocketCaller caller, byte[] b) {
+        var err = caller->pushBinary(b);
+        if (err is http:WebSocketError) {
+            log:printError("Error occurred when sending binary", err);
+        }
+    }
+    resource function onPing(http:WebSocketCaller caller, byte[] data) {
+        var err = caller->pong(data);
+        if (err is http:WebSocketError) {
+            log:printError("Error occurred when closing the connection", err);
+        }
+    }
+    resource function onPong(http:WebSocketCaller caller, byte[] data) {
+    }
+    resource function onIdleTimeout(http:WebSocketCaller caller) {
+        var err = caller->close(statusCode = 1001, reason =
+                                    "Connection timeout");
+        if (err is http:WebSocketError) {
+            log:printError("Error occurred when closing the connection", err);
+        }
+    }
+    resource function onError(http:WebSocketCaller caller, error err) {
+    }
+    resource function onClose(http:WebSocketCaller caller, int statusCode,
+                                string reason) {
+    }
+}

--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -279,6 +279,7 @@
         <classes>
             <class name="org.ballerinalang.test.observability.tracing.TracingTestCase"/>
             <class name="org.ballerinalang.test.observability.metrics.MetricsTestCase"/>
+            <class name="org.ballerinalang.test.observability.metrics.WebSocketMetricsTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Added the following observability metrics to WebSockets (both client and server)
- Current active # of connections
- Number of errors (with service level, error type breakdown)
- Number of messages received (with service level, message type breakdown)
- Number of messages sent (with service level, message type breakdown)

INFO and ERROR level logging added as well with context data including connection ID, service.

Added tags to tracing spans (connection ID, service, client/server context)

## Approach
> Describe how you are implementing the solutions along with the design details.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
