### PR TITLE
Fix receiver error scenario when a sync send is done after an async send

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/scheduling/WorkerDataChannel.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/scheduling/WorkerDataChannel.java
@@ -121,12 +121,11 @@ public class WorkerDataChannel {
             }
 
             reschedule = false;
-            if (this.panic != null && this.channel.peek() != null && this.channel.peek().isSync) {
+            if (this.panic != null && this.channel.peek() != null) {
                 Throwable e = this.panic;
                 this.panic = null;
                 throw e;
-            } else if (this.error != null && this.channel.peek() != null && this.channel.peek().isSync) {
-                // should make sure this error happened before sending the sync message
+            } else if (this.error != null && this.channel.peek() != null) {
                 ErrorValue ret = this.error;
                 this.error = null;
                 return ret;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
@@ -171,4 +171,12 @@ public class WorkerSyncSendTest {
         Assert.assertEquals(returns[0].getType().getName(), "Rec");
         Assert.assertEquals(((BMap) returns[0]).get("k"), new BInteger(10));
     }
+
+    @Test
+    public void testSyncSendAfterSend() {
+        BValue[] returns = BRunUtil.invoke(result, "testSyncSendAfterSend");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(returns[0].getType().getName(), "error");
+        Assert.assertEquals(returns[0].stringValue(), "w2 error {}");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/sync-send.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/sync-send.bal
@@ -457,3 +457,25 @@ public function testComplexType() returns Rec {
 
     return wait w2;
 }
+
+
+public function testSyncSendAfterSend() returns error? {
+    worker w1 returns error? {
+        5 -> w2;
+
+        error? x = "foo" ->> w2;
+        return x;
+    }
+
+    worker w2 returns error? {
+        if (true) {
+            error e = error("w2 error");
+            return e;
+        }
+
+        int x = <- w1;
+        string s = <- w1;
+    }
+
+    return wait w1;
+}


### PR DESCRIPTION
## Purpose
> Fix receiver error scenario when a sync send is done after an async send.

Fixes #19122

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
