### PR TITLE
Issue#19073: Inconsistent parameter names in stringutils API

### DIFF
--- a/stdlib/stringutils/src/main/ballerina/src/stringutils/natives.bal
+++ b/stdlib/stringutils/src/main/ballerina/src/stringutils/natives.bal
@@ -108,7 +108,7 @@ public function replaceAll(string originalString, string regex, string replaceme
 # + return - the resultant string
 public function replaceFirst(string originalString, string regex, string replacement) returns string {
     handle value = replaceFirstExternal(java:fromString(originalString),
-                                java:fromString(stringToReplace),
+                                java:fromString(regex),
                                 java:fromString(replacement));
     string? updatedString = java:toString(value);
     if (updatedString is string) {

--- a/stdlib/stringutils/src/main/ballerina/src/stringutils/natives.bal
+++ b/stdlib/stringutils/src/main/ballerina/src/stringutils/natives.bal
@@ -64,18 +64,18 @@ public function matches(string stringToMatch, string regex) returns boolean {
 # Replaces each substring of the provided string, that matches the provided substring, with the specified replacement
 # string.
 #
-# + originalText - original string
-# + textToReplace - string to replace
+# + originalString - original string
+# + stringToReplace - string to replace
 # + replacement - replacement string
 # + return - the resultant string
-public function replace(string originalText, string textToReplace, string replacement) returns string {
-    handle value = replaceExternal(java:fromString(originalText), java:fromString(textToReplace), java:fromString(replacement));
+public function replace(string originalString, string stringToReplace, string replacement) returns string {
+    handle value = replaceExternal(java:fromString(originalString), java:fromString(stringToReplace), java:fromString(replacement));
     string? updatedString = java:toString(value);
     if (updatedString is string) {
         return updatedString;
     } else {
         // should never reach here
-        error e = error(io:sprintf("error occurred while replacing '%s' in '%s' ", textToReplace, originalText));
+        error e = error(io:sprintf("error occurred while replacing '%s' in '%s' ", stringToReplace, originalString));
         panic e;
     }
 }
@@ -88,7 +88,7 @@ public function replace(string originalText, string textToReplace, string replac
 # + replacement - the replacement string
 # + return - the resultant string
 public function replaceAll(string originalString, string regex, string replacement) returns string {
-    handle value = replaceAllExternal(java:fromString(originalString), java:fromString(regex), 
+    handle value = replaceAllExternal(java:fromString(originalString), java:fromString(regex),
                                       java:fromString(replacement));
     string? updatedString = java:toString(value);
     if (updatedString is string) {
@@ -100,14 +100,13 @@ public function replaceAll(string originalString, string regex, string replaceme
     }
 }
 
-# Replaces the first substring that matches the given sequence from the provided string, with the specified literal
-# replacement sequence.
+# Replaces the first substring that matches the given regular expression, with the specified replacement string.
 #
 # + originalString - the original string
-# + stringToReplace - string to replace
+# + regex - Regex to find substring to replace
 # + replacement - the replacement string
 # + return - the resultant string
-public function replaceFirst(string originalString, string stringToReplace, string replacement) returns string {
+public function replaceFirst(string originalString, string regex, string replacement) returns string {
     handle value = replaceFirstExternal(java:fromString(originalString),
                                 java:fromString(stringToReplace),
                                 java:fromString(replacement));
@@ -116,7 +115,7 @@ public function replaceFirst(string originalString, string stringToReplace, stri
         return updatedString;
     } else {
         // should never reach here
-        error e = error(io:sprintf("error occurred while replacing '%s' in '%s' ", stringToReplace, originalString));
+        error e = error(io:sprintf("error occurred while replacing '%s' in '%s' ", regex, originalString));
         panic e;
     }
 }
@@ -164,7 +163,7 @@ function matchesExternal(handle stringToMatch, handle regex) returns boolean = @
     paramTypes: ["java.lang.String"]
 } external;
 
-function replaceExternal(handle originalText, handle textToReplace, handle replacement) returns handle = @java:Method {
+function replaceExternal(handle originalString, handle stringToReplace, handle replacement) returns handle = @java:Method {
     name: "replace",
     class: "java.lang.String",
     paramTypes: ["java.lang.String", "java.lang.String"]
@@ -176,7 +175,7 @@ function replaceAllExternal(handle originalString, handle regex, handle replacem
     paramTypes: ["java.lang.String", "java.lang.String"]
 } external;
 
-function replaceFirstExternal(handle originalString, handle stringToReplace, handle replacement) returns
+function replaceFirstExternal(handle originalString, handle regex, handle replacement) returns
                             handle = @java:Method {
     name: "replaceFirst",
     class: "java.lang.String",

--- a/stdlib/stringutils/src/test/resources/test-src/string-utils-test.bal
+++ b/stdlib/stringutils/src/test/resources/test-src/string-utils-test.bal
@@ -46,8 +46,8 @@ function testReplaceAll(string original, string regex, string replacement) retur
     return stringutils:replaceAll(original, regex, replacement);
 }
 
-function testReplaceFirst(string original, string stringToReplace, string replacement) returns string {
-    return stringutils:replaceFirst(original, stringToReplace, replacement);
+function testReplaceFirst(string original, string regex, string replacement) returns string {
+    return stringutils:replaceFirst(original, regex, replacement);
 }
 
 function testSplit() returns string[] {


### PR DESCRIPTION

## Purpose
The first parameters in the three methods should be named the same.
the second parameter in replaceAll and replaceFirst signifies a regex, while replace is a charSequence in the corresponding Java replace method.
Fixes #19073

## Approach
> Updated parameter names and description.