### PR TITLE
Add 75th, 95th, 0.999th percentiles to default Gauge percentiles

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/metrics/StatisticConfig.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/metrics/StatisticConfig.java
@@ -29,8 +29,8 @@ import java.util.Objects;
 public class StatisticConfig {
 
     public static final StatisticConfig DEFAULT = StatisticConfig.builder()
-            // Compute 33rd, 50th, 66th, 99th, and 99.9th percentiles.
-            .percentiles(0.33, 0.5, 0.66, 0.99, 0.999).build();
+            // Compute 33rd, 50th, 66th, 75th, 95th, 99th, and 99.9th percentiles.
+            .percentiles(0.33, 0.5, 0.66, 0.75, 0.95, 0.99, 0.999).build();
 
     private StatisticConfig() {
     }

--- a/observelib/observe/src/main/ballerina/src/observe/natives.bal
+++ b/observelib/observe/src/main/ballerina/src/observe/natives.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 final StatisticConfig[] DEFAULT_GAUGE_STATS_CONFIG = [{ timeWindow: 600000, buckets: 5,
-    percentiles: [0.33, 0.5, 0.66, 0.99] }];
+    percentiles: [0.33, 0.5, 0.66, 0.75, 0.95, 0.99, 0.999] }];
 
 final map<string> DEFAULT_TAGS = {};
 


### PR DESCRIPTION
## Purpose
Purpose of this PR is to add 75th, 95th, 0.999th percentiles to default Gauge percentiles.

Further, a user can define their own `observe:StatisticConfig` with custom percentile values and use it with `observe:Gauge` API, as in the given example;
 
```ballerina

        // create gauge with custom statistics config.
        observe:StatisticConfig config = { timeWindow: 30000,
                    percentiles: [0.33, 0.5, 0.9, 0.99], buckets: 3 };
        statsConfigs[0] = config;
        observe:Gauge gaugeWithCustomStats = new("gauge_with_custom_stats",
                desc = "Some description", statisticConfig = statsConfigs);

```

Fixes #19371

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
