### PR TITLE
Panic when attempting to retrieve a config as an incompatible type

### DIFF
--- a/bvm/ballerina-config/src/main/java/org/ballerinalang/config/ConfigRegistry.java
+++ b/bvm/ballerina-config/src/main/java/org/ballerinalang/config/ConfigRegistry.java
@@ -211,7 +211,7 @@ public class ConfigRegistry {
                 }
                 return (Boolean) value;
             } catch (ClassCastException e) {
-                throw new IllegalArgumentException(key + " does not map to a valid boolean");
+                throw new IllegalArgumentException("The config key '" + key + "' does not map to a valid 'boolean'");
             }
         }
 
@@ -245,7 +245,7 @@ public class ConfigRegistry {
                 }
                 return (Long) value;
             } catch (ClassCastException | NumberFormatException e) {
-                throw new IllegalArgumentException(key + " does not map to a valid int");
+                throw new IllegalArgumentException("The config key '" + key + "' does not map to a valid 'int'");
             }
         }
 
@@ -281,7 +281,7 @@ public class ConfigRegistry {
                 }
                 return (Double) value;
             } catch (ClassCastException | NumberFormatException e) {
-                throw new IllegalArgumentException(key + " does not map to a valid float");
+                throw new IllegalArgumentException("The config key '" + key + "' does not map to a valid 'float'");
             }
         }
 

--- a/bvm/ballerina-config/src/main/java/org/ballerinalang/config/ConfigRegistry.java
+++ b/bvm/ballerina-config/src/main/java/org/ballerinalang/config/ConfigRegistry.java
@@ -211,7 +211,7 @@ public class ConfigRegistry {
                 }
                 return (Boolean) value;
             } catch (ClassCastException e) {
-                throw new IllegalArgumentException("The config key '" + key + "' does not map to a valid 'boolean'");
+                throw new IllegalArgumentException("config key '" + key + "' does not map to a valid 'boolean'");
             }
         }
 
@@ -245,7 +245,7 @@ public class ConfigRegistry {
                 }
                 return (Long) value;
             } catch (ClassCastException | NumberFormatException e) {
-                throw new IllegalArgumentException("The config key '" + key + "' does not map to a valid 'int'");
+                throw new IllegalArgumentException("config key '" + key + "' does not map to a valid 'int'");
             }
         }
 
@@ -281,7 +281,7 @@ public class ConfigRegistry {
                 }
                 return (Double) value;
             } catch (ClassCastException | NumberFormatException e) {
-                throw new IllegalArgumentException("The config key '" + key + "' does not map to a valid 'float'");
+                throw new IllegalArgumentException("config key '" + key + "' does not map to a valid 'float'");
             }
         }
 

--- a/stdlib/config-api/src/main/java/org/ballerinalang/stdlib/config/GetConfig.java
+++ b/stdlib/config-api/src/main/java/org/ballerinalang/stdlib/config/GetConfig.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.stdlib.config;
 
 import org.ballerinalang.config.ConfigRegistry;
+import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.MapValueImpl;
@@ -38,23 +39,27 @@ import java.util.Map;
 public class GetConfig {
 
     private static final ConfigRegistry configRegistry = ConfigRegistry.getInstance();
+    private static final String lookupErrReason = "{ballerina/config}LookupError";
 
     public static Object get(Strand strand, String configKey, Object type) {
 
-        // TODO: Add a try-catch
-        switch (type.toString()) {
-            case "STRING":
-                return configRegistry.getAsString(configKey);
-            case "INT":
-                return configRegistry.getAsInt(configKey);
-            case "FLOAT":
-                return configRegistry.getAsFloat(configKey);
-            case "BOOLEAN":
-                return configRegistry.getAsBoolean(configKey);
-            case "MAP":
-                return buildMapValue(configRegistry.getAsMap(configKey));
-            default:
-                throw new IllegalStateException("invalid value type: " + type.toString());
+        try {
+            switch (type.toString()) {
+                case "STRING":
+                    return configRegistry.getAsString(configKey);
+                case "INT":
+                    return configRegistry.getAsInt(configKey);
+                case "FLOAT":
+                    return configRegistry.getAsFloat(configKey);
+                case "BOOLEAN":
+                    return configRegistry.getAsBoolean(configKey);
+                case "MAP":
+                    return buildMapValue(configRegistry.getAsMap(configKey));
+                default:
+                    throw new IllegalStateException("invalid value type: " + type.toString());
+            }
+        } catch (IllegalArgumentException e) {
+            throw BallerinaErrors.createError(lookupErrReason, e.getMessage());
         }
     }
 

--- a/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigRegistryTest.java
+++ b/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigRegistryTest.java
@@ -83,7 +83,7 @@ public class ConfigRegistryTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*hello.http.port does not map to a valid boolean")
+          expectedExceptionsMessageRegExp = ".*The config key 'hello.http.port' does not map to a valid 'boolean'")
     public void testGetAsBooleanNegative() throws IOException {
         registry.initRegistry(new HashMap<>(), null, null);
         registry.addConfiguration("hello.http.port", 8080);
@@ -107,7 +107,7 @@ public class ConfigRegistryTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*hello.http.port does not map to a valid int")
+          expectedExceptionsMessageRegExp = ".*The config key 'hello.http.port' does not map to a valid 'int'")
     public void testGetAsIntNegative() throws IOException {
         registry.initRegistry(new HashMap<>(), null, null);
         registry.addConfiguration("hello.http.port", "invalid port");
@@ -136,7 +136,8 @@ public class ConfigRegistryTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*hello.cache.evictionFactor does not map to a valid float")
+          expectedExceptionsMessageRegExp = ".*The config key 'hello.cache.evictionFactor' does not map to a valid " +
+                  "'float'")
     public void testGetAsFloatNegative() throws IOException {
         registry.initRegistry(new HashMap<>(), null, null);
         registry.addConfiguration("hello.cache.evictionFactor", "invalid float");

--- a/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigRegistryTest.java
+++ b/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigRegistryTest.java
@@ -83,7 +83,7 @@ public class ConfigRegistryTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*The config key 'hello.http.port' does not map to a valid 'boolean'")
+          expectedExceptionsMessageRegExp = ".*config key 'hello.http.port' does not map to a valid 'boolean'")
     public void testGetAsBooleanNegative() throws IOException {
         registry.initRegistry(new HashMap<>(), null, null);
         registry.addConfiguration("hello.http.port", 8080);
@@ -107,7 +107,7 @@ public class ConfigRegistryTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*The config key 'hello.http.port' does not map to a valid 'int'")
+          expectedExceptionsMessageRegExp = ".*config key 'hello.http.port' does not map to a valid 'int'")
     public void testGetAsIntNegative() throws IOException {
         registry.initRegistry(new HashMap<>(), null, null);
         registry.addConfiguration("hello.http.port", "invalid port");
@@ -136,7 +136,7 @@ public class ConfigRegistryTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*The config key 'hello.cache.evictionFactor' does not map to a valid " +
+          expectedExceptionsMessageRegExp = ".*config key 'hello.cache.evictionFactor' does not map to a valid " +
                   "'float'")
     public void testGetAsFloatNegative() throws IOException {
         registry.initRegistry(new HashMap<>(), null, null);

--- a/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigTest.java
+++ b/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -247,6 +248,21 @@ public class ConfigTest {
         Assert.assertEquals(((BFloat) returnVals[0]).floatValue(), 0.3455);
     }
 
+    @Test(description = "Test for getAsFloat for scientific notation")
+    public void testGetAsFloat2() throws IOException {
+        BString key = new BString("expirationPeriod");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetAsFloat", inputArg);
+
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                           "Invalid Return Values.");
+        Assert.assertTrue(returnVals[0] instanceof BFloat);
+        Assert.assertEquals(((BFloat) returnVals[0]).floatValue(), 1800000.0D);
+    }
+
     @Test(description = "Test for getting an int as a float")
     public void testGetIntAsFloat() throws IOException {
         BString key = new BString("http1.request_limit");
@@ -351,6 +367,42 @@ public class ConfigTest {
                 "Invalid Return Values.");
         Assert.assertTrue(returnVals[0] instanceof BString);
         Assert.assertEquals(returnVals[0].stringValue(), "abcd");
+    }
+
+    @Test(description = "Test retrieving an invalid int config", expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=The config key " +
+                  "'expirationPeriod' does not map to a valid 'int'.*")
+    public void testGetAsIntNegative() throws IOException {
+        BString key = new BString("expirationPeriod");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BRunUtil.invoke(compileResult, "testGetAsInt", inputArg);
+    }
+
+    @Test(description = "Test retrieving an invalid float config", expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=The config key " +
+                  "'\"ballerina.http.host\"' does not map to a valid 'float'.*")
+    public void testGetAsFloatNegative() throws IOException {
+        BString key = new BString("\"ballerina.http.host\"");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BRunUtil.invoke(compileResult, "testGetAsFloat", inputArg);
+    }
+
+    @Test(description = "Test retrieving an invalid boolean config", expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=The config key " +
+                  "'expirationPeriod' does not map to a valid 'boolean'.*")
+    public void testGetAsBooleanNegative() throws IOException {
+        BString key = new BString("expirationPeriod");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BRunUtil.invoke(compileResult, "testGetAsBoolean", inputArg);
     }
 
     private Map<String, String> getRuntimeProperties() {

--- a/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigTest.java
+++ b/stdlib/config-api/src/test/java/org/ballerinalang/stdlib/config/ConfigTest.java
@@ -370,7 +370,7 @@ public class ConfigTest {
     }
 
     @Test(description = "Test retrieving an invalid int config", expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=The config key " +
+          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=config key " +
                   "'expirationPeriod' does not map to a valid 'int'.*")
     public void testGetAsIntNegative() throws IOException {
         BString key = new BString("expirationPeriod");
@@ -382,7 +382,7 @@ public class ConfigTest {
     }
 
     @Test(description = "Test retrieving an invalid float config", expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=The config key " +
+          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=config key " +
                   "'\"ballerina.http.host\"' does not map to a valid 'float'.*")
     public void testGetAsFloatNegative() throws IOException {
         BString key = new BString("\"ballerina.http.host\"");
@@ -394,7 +394,7 @@ public class ConfigTest {
     }
 
     @Test(description = "Test retrieving an invalid boolean config", expectedExceptions = BLangRuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=The config key " +
+          expectedExceptionsMessageRegExp = ".*error: \\{ballerina/config\\}LookupError message=config key " +
                   "'expirationPeriod' does not map to a valid 'boolean'.*")
     public void testGetAsBooleanNegative() throws IOException {
         BString key = new BString("expirationPeriod");

--- a/stdlib/config-api/src/test/resources/datafiles/default/ballerina.conf
+++ b/stdlib/config-api/src/test/resources/datafiles/default/ballerina.conf
@@ -22,6 +22,7 @@
 "ballerina.env.Path"="${env:PATH}"
 "ballerina.log.format"="{{timestamp}}[yyyy-MM-dd HH:mm:ss,SSS] {{level}} [{{package}}:{{unit}}] [{{file}}:{{line}}] [{{worker}}] - \"{{msg}}\" {{err}}"
 "path.test"='C:\Users\John'
+expirationPeriod=1.8e+06
 
 [http1]
 port=8085


### PR DESCRIPTION
## Purpose
> Currently, when you try to retrieve a config value as a type which is incompatible to its actual type, the runtime crashes. Instead, it should panic. This PR fixes that behaviour.

Fixes #19369

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
