### PR TITLE
Make observability logs adhere to ballerina log levels

### DIFF
--- a/stdlib/log-api/src/main/java/org/ballerinalang/stdlib/log/AbstractLogFunction.java
+++ b/stdlib/log-api/src/main/java/org/ballerinalang/stdlib/log/AbstractLogFunction.java
@@ -80,8 +80,8 @@ public abstract class AbstractLogFunction {
         boolean logEnabled = LOG_MANAGER.getPackageLogLevel(pckg).value() <= logLevel.value();
         if (logEnabled) {
             consumer.accept(pckg, logMessage.get());
+            ObserveUtils.logMessageToActiveSpan(strand, logLevel.name(), logMessage, logLevel == BLogLevel.ERROR);
         }
-        ObserveUtils.logMessageToActiveSpan(strand, logLevel.name(), logMessage, logLevel == BLogLevel.ERROR);
     }
 
     static String getPackagePath() {


### PR DESCRIPTION
## Purpose
Purpose of this PR is to $title. So that, it will let user control observability logging levels similar to [1].

Fixes #19375

[1] https://v1-0.ballerina.io/learn/by-example/log-api.html

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
