### PR TITLE
Bump versions of javascript modules for tooling

### DIFF
--- a/composer/lerna.json
+++ b/composer/lerna.json
@@ -3,5 +3,5 @@
     "packages/*",
     "tools/*"
   ],
-  "version": "1.0.1-SNAPSHOT"
+  "version": "1.0.2-SNAPSHOT"
 }

--- a/composer/packages/api-designer/package.json
+++ b/composer/packages/api-designer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/api-designer",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "author": "ballerina.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
     "copyfiles": "^2.1.0"
   },
   "dependencies": {

--- a/composer/packages/ast-model/package.json
+++ b/composer/packages/ast-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/ast-model",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "ast-model",
   "license": "Apache-2.0",
   "files": [
@@ -23,7 +23,7 @@
     "gen-default-nodes": "npm run build && node lib/tools/gen-default-nodes"
   },
   "dependencies": {
-    "@ballerina/lang-service": "^1.0.1-SNAPSHOT",
+    "@ballerina/lang-service": "^1.0.2-SNAPSHOT",
     "glob": "^7.1.3",
     "lodash": "^4.17.11",
     "prettier": "^1.5.2",
@@ -31,7 +31,7 @@
     "vscode-uri": "^1.0.6"
   },
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
     "@types/lodash": "^4.14.117",
     "copyfiles": "^2.1.0"
   },

--- a/composer/packages/bbe/package.json
+++ b/composer/packages/bbe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/ballerina-by-examples",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "Provides components for displaying Ballerina By Examples",
   "main": "lib/src/index.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "lodash": "^4.17.11"
   },
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
     "@types/lodash": "^4.14.118"
   },
   "author": "ballerina.io",

--- a/composer/packages/diagram/package.json
+++ b/composer/packages/diagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/diagram",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "Provides a set of react components to draw Ballerina Diagrams.",
   "keywords": [
     "ballerina",
@@ -31,16 +31,16 @@
     "react-dom": "^16.2.0"
   },
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
-    "@ballerina/font": "^1.0.1-SNAPSHOT",
-    "@ballerina/theme": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
+    "@ballerina/font": "^1.0.2-SNAPSHOT",
+    "@ballerina/theme": "^1.0.2-SNAPSHOT",
     "@types/lodash": "^4.14.118",
     "@types/lodash.debounce": "^4.0.4",
     "copyfiles": "^2.1.0"
   },
   "dependencies": {
-    "@ballerina/ast-model": "^1.0.1-SNAPSHOT",
-    "@ballerina/lang-service": "^1.0.1-SNAPSHOT",
+    "@ballerina/ast-model": "^1.0.2-SNAPSHOT",
+    "@ballerina/lang-service": "^1.0.2-SNAPSHOT",
     "lodash": "^4.17.11",
     "lodash.debounce": "^4.0.8",
     "log4javascript": "^1.4.15",

--- a/composer/packages/distribution/package.json
+++ b/composer/packages/distribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/distribution",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "",
   "main": "build/composer.js",
   "scripts": {
@@ -15,15 +15,15 @@
   "author": "ballerina.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ballerina/api-designer": "^1.0.1-SNAPSHOT",
-    "@ballerina/ballerina-by-examples": "^1.0.1-SNAPSHOT",
-    "@ballerina/diagram": "^1.0.1-SNAPSHOT",
-    "@ballerina/documentation": "^1.0.1-SNAPSHOT",
-    "@ballerina/font": "^1.0.1-SNAPSHOT",
-    "@ballerina/theme": "^1.0.1-SNAPSHOT",
-    "@ballerina/tracing": "^1.0.1-SNAPSHOT"
+    "@ballerina/api-designer": "^1.0.2-SNAPSHOT",
+    "@ballerina/ballerina-by-examples": "^1.0.2-SNAPSHOT",
+    "@ballerina/diagram": "^1.0.2-SNAPSHOT",
+    "@ballerina/documentation": "^1.0.2-SNAPSHOT",
+    "@ballerina/font": "^1.0.2-SNAPSHOT",
+    "@ballerina/theme": "^1.0.2-SNAPSHOT",
+    "@ballerina/tracing": "^1.0.2-SNAPSHOT"
   },
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT"
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT"
   }
 }

--- a/composer/packages/documentation/package.json
+++ b/composer/packages/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/documentation",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   "author": "ballerina.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ballerina/ast-model": "^1.0.1-SNAPSHOT",
+    "@ballerina/ast-model": "^1.0.2-SNAPSHOT",
     "diff": "^3.5.0",
     "escape-html": "^1.0.3",
     "react-markdown": "^4.0.0"

--- a/composer/packages/font/package.json
+++ b/composer/packages/font/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/font",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "Ballerina Diagram Font",
   "main": "build/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "ballerina.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
     "watch": "^1.0.2",
     "webfont": "^8.1.4"
   }

--- a/composer/packages/lang-service/package.json
+++ b/composer/packages/lang-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/lang-service",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "lang-service",
   "license": "Apache-2.0",
   "files": [
@@ -31,7 +31,7 @@
     "ws": "^6.1.0"
   },
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "^7.1.1",
     "@types/jest": "^22.0.1",

--- a/composer/packages/syntax-highlighter/package.json
+++ b/composer/packages/syntax-highlighter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/syntax-highlighter",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "A frontend syntax highlighter for Ballerina based on monaco.",
   "main": "lib/highlighter.js",
   "scripts": {

--- a/composer/packages/theme/package.json
+++ b/composer/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/theme",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "Theme for web components of Ballerina Tooling.",
   "keywords": [
     "ballerina",
@@ -21,6 +21,6 @@
     "watch": "^1.0.2"
   },
   "dependencies": {
-    "@ballerina/font": "^1.0.1-SNAPSHOT"
+    "@ballerina/font": "^1.0.2-SNAPSHOT"
   }
 }

--- a/composer/packages/tracing/package.json
+++ b/composer/packages/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerina/tracing",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "",
   "main": "lib/src/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "author": "ballerina.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@ballerina/composer-cli": "^1.0.1-SNAPSHOT",
+    "@ballerina/composer-cli": "^1.0.2-SNAPSHOT",
     "@types/lodash": "^4.14.116"
   },
   "dependencies": {

--- a/composer/tools/composer-cli/package.json
+++ b/composer/tools/composer-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ballerina/composer-cli",
-  "version": "1.0.1-SNAPSHOT",
+  "version": "1.0.2-SNAPSHOT",
   "description": "Includes a CLI util to help with composer packages development",
   "bin": {
     "composer": "./bin/composer"


### PR DESCRIPTION
A fix for automatically bumping the version has been merged with https://github.com/ballerina-platform/ballerina-lang/pull/19225. Hence we won't need this manual bumping here after.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
