### PR TITLE
Add formatting support for indirect error match pattern

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
@@ -7555,7 +7555,7 @@ public class FormattingNodeTree {
                     && reason.has(FormattingConstants.NAME)) {
                 JsonObject name = reason.getAsJsonObject(FormattingConstants.NAME);
                 String value = name.get(FormattingConstants.VALUE).getAsString();
-                if (value.equals("$reason$")) {
+                if (value.equals("$reason$") || value.equals("_")) {
                     reasonAvailable = false;
                 }
             }

--- a/language-server/modules/langserver-core/src/test/resources/formatting/errorVariableDefinition.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/errorVariableDefinition.bal
@@ -145,3 +145,41 @@ function testIndirectErrorVariableDef2() {
  e
               ;
 }
+
+type ErrorData record {
+    string message?;
+    error cause?;
+};
+
+type ER error<string, ErrorData>;
+
+function testIndirectErrorMatchPattern1() returns string {
+    ER err1 = error("Error Code", message = "Msg");
+    match err1 {
+                     ER (    message   =   m  ,    ...    var    rest  )     =>  {
+    return <string>m;
+             }
+    }
+    return "Default";
+}
+
+function testIndirectErrorMatchPattern2() returns string {
+    ER err1 = error("Error Code", message = "Msg");
+    match err1 {
+                 ER
+   (
+               message
+     =
+               m
+   ,
+                 ...
+  var
+                  rest
+  )
+                  =>
+            {
+   return <string>m;
+            }
+    }
+    return "Default";
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedErrorVariableDefinition.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedErrorVariableDefinition.bal
@@ -171,3 +171,41 @@ function testIndirectErrorVariableDef2() {
     e
     ;
 }
+
+type ErrorData record {
+    string message?;
+    error cause?;
+};
+
+type ER error<string, ErrorData>;
+
+function testIndirectErrorMatchPattern1() returns string {
+    ER err1 = error("Error Code", message = "Msg");
+    match err1 {
+        ER (message = m, ...var rest) => {
+            return <string>m;
+        }
+    }
+    return "Default";
+}
+
+function testIndirectErrorMatchPattern2() returns string {
+    ER err1 = error("Error Code", message = "Msg");
+    match err1 {
+        ER
+        (
+        message
+        =
+        m
+        ,
+        ...
+        var
+        rest
+        )
+        =>
+        {
+            return <string>m;
+        }
+    }
+    return "Default";
+}


### PR DESCRIPTION
## Purpose
This commit will add formatting support for indirect error match pattern construct.

Related Issue #17213

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
