### PR TITLE
Remove redundant outbound write closure

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ResponseWriter.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ResponseWriter.java
@@ -177,9 +177,8 @@ public class ResponseWriter {
             ErrorValue httpConnectorError = HttpUtil.createHttpError(throwable.getMessage(),
                     HttpErrorType.GENERIC_LISTENER_ERROR);
             if (outboundMsgDataStreamer != null) {
-                if (throwable instanceof IOException) {
-                    this.dataContext.getOutboundRequest().setIoException((IOException) throwable);
-                } else {
+                // Relevant transport state should set the IO Exception. Following code snippet is for other exceptions
+                if (!(throwable instanceof IOException)) {
                     this.dataContext.getOutboundRequest()
                             .setIoException(new IOException(throwable.getMessage(), throwable));
                 }


### PR DESCRIPTION
## Purpose
> The same HttpMessage is notified twice to stop outbound-payload write by setting IO exception from both transport and Ballerina levels. Since this task is quite belong to that particular state in transport, this PR will be removing the redundant code from the ballerina level. 
> Ideally developer should handle particular outbound write operation closure at transport level by setting the IO exception specifically.

Fixes #18983

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
