### PR TITLE
Invalidate home repo bir upon ballerina version

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
@@ -75,9 +75,7 @@ public class CreateBirTask implements Task {
                 // If not fetch from home bir cache.
                 importBir = buildContext.getBirPathFromHomeCache(id);
                 // Write only if bir does not exists. No need to overwrite.
-                if (Files.notExists(importBir)) {
-                    birWriter.writeBIRToPath(bPackageSymbol.birPackageFile, id, importBir);
-                }
+                birWriter.writeBIRToPath(bPackageSymbol.birPackageFile, id, importBir, true);
             }
     
             // write child import bir(s)

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
@@ -27,7 +27,6 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/writer/BirFileWriter.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/writer/BirFileWriter.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.programfile.PackageFileWriter;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -106,10 +107,14 @@ public class BirFileWriter {
         try {
             byte[] pkgBirBinaryContent = PackageFileWriter.writePackage(birPackageFile);
             Files.write(birFilePath, pkgBirBinaryContent);
-            
-            if (createBalVersionCache) {
-                Files.write(birFilePath.getParent().getParent().resolve(BIR_BALLERINA_VERSION_CACHE_FILE_NAME),
-                        RepoUtils.getBallerinaVersion().getBytes());
+    
+            Path versionDir = birFilePath.getParent();
+            if (createBalVersionCache && versionDir != null) {
+                Path moduleDir = versionDir.getParent();
+                if (moduleDir != null) {
+                    Files.write(moduleDir.resolve(BIR_BALLERINA_VERSION_CACHE_FILE_NAME),
+                            RepoUtils.getBallerinaVersion().getBytes(Charset.defaultCharset()));
+                }
             }
         } catch (IOException e) {
             String msg = "error writing the compiled module(bir) of '" +

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/writer/BirFileWriter.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/writer/BirFileWriter.java
@@ -26,10 +26,13 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.programfile.CompiledBinaryFile;
 import org.wso2.ballerinalang.programfile.PackageFileWriter;
+import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BIR_BALLERINA_VERSION_CACHE_FILE_NAME;
 
 /**
  * Write a bir to cache.
@@ -95,15 +98,23 @@ public class BirFileWriter {
     }
 
     public void writeBIRToPath(CompiledBinaryFile.BIRPackageFile birPackageFile, PackageID id, Path birFilePath) {
-
+        writeBIRToPath(birPackageFile, id, birFilePath, false);
+    }
+    
+    public void writeBIRToPath(CompiledBinaryFile.BIRPackageFile birPackageFile, PackageID id, Path birFilePath,
+                               boolean createBalVersionCache) {
         try {
             byte[] pkgBirBinaryContent = PackageFileWriter.writePackage(birPackageFile);
             Files.write(birFilePath, pkgBirBinaryContent);
+            
+            if (createBalVersionCache) {
+                Files.write(birFilePath.getParent().getParent().resolve(BIR_BALLERINA_VERSION_CACHE_FILE_NAME),
+                        RepoUtils.getBallerinaVersion().getBytes());
+            }
         } catch (IOException e) {
             String msg = "error writing the compiled module(bir) of '" +
-                    id + "' to '" + birFilePath + "': " + e.getMessage();
+                         id + "' to '" + birFilePath + "': " + e.getMessage();
             throw new BLangCompilerException(msg, e);
         }
     }
-
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -69,7 +70,8 @@ public class HomeBirRepo implements Repo<Path> {
             }
         
             if (Files.exists(ballerinaVersionCachePath)) {
-                String ballerinaVersion = new String(Files.readAllBytes(ballerinaVersionCachePath));
+                String ballerinaVersion = new String(Files.readAllBytes(ballerinaVersionCachePath),
+                        StandardCharsets.UTF_8);
                 // if ballerina version cache file exists but its a different version, then consider it that the
                 // current ballerina version it not compatible with the bir(if such exists)
                 if (!RepoUtils.getBallerinaVersion().equals(ballerinaVersion)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
@@ -25,35 +25,62 @@ import org.wso2.ballerinalang.compiler.packaging.converters.PathConverter;
 import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 import org.wso2.ballerinalang.util.RepoUtils;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.wso2.ballerinalang.compiler.packaging.Patten.LATEST_VERSION_DIR;
 import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
+import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BIR_BALLERINA_VERSION_CACHE_FILE_NAME;
 
 /**
  * Repo for bir_cache in home repository.
  */
 public class HomeBirRepo implements Repo<Path> {
+    private Path birCache;
     private PathConverter pathConverter;
     
     public HomeBirRepo() {
-        Path repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
-        this.pathConverter = new PathConverter(repoLocation);
+        this.birCache = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
+        this.pathConverter = new PathConverter(this.birCache);
     }
     
     @Override
     public Patten calculate(PackageID moduleID) {
-        String orgName = moduleID.getOrgName().getValue();
-        String pkgName = moduleID.getName().getValue();
-        Patten.Part version;
-        String versionStr = moduleID.getPackageVersion().getValue();
-        if (versionStr.isEmpty()) {
-            version = LATEST_VERSION_DIR;
-        } else {
-            version = path(versionStr);
-        }
+        try {
+            String orgName = moduleID.getOrgName().getValue();
+            String pkgName = moduleID.getName().getValue();
+            Patten.Part version;
+            String versionStr = moduleID.getPackageVersion().getValue();
+            if (versionStr.isEmpty()) {
+                version = LATEST_VERSION_DIR;
+            } else {
+                version = path(versionStr);
+            }
         
-        return new Patten(path(orgName, pkgName), version, path(pkgName + ".bir"));
+            Path ballerinaVersionCachePath = this.birCache.resolve(orgName).resolve(pkgName)
+                    .resolve(BIR_BALLERINA_VERSION_CACHE_FILE_NAME);
+            
+            // if ballerina version cache file does not exists,
+            // then consider it that the current ballerina version it not
+            // compatible with the bir(if such exists)
+            if (Files.notExists(ballerinaVersionCachePath)) {
+                return Patten.NULL;
+            }
+        
+            if (Files.exists(ballerinaVersionCachePath)) {
+                String ballerinaVersion = new String(Files.readAllBytes(ballerinaVersionCachePath));
+                // if ballerina version cache file exists but its a different version, then consider it that the
+                // current ballerina version it not compatible with the bir(if such exists)
+                if (!RepoUtils.getBallerinaVersion().equals(ballerinaVersion)) {
+                    return Patten.NULL;
+                }
+            }
+        
+            return new Patten(path(orgName, pkgName), version, path(pkgName + ".bir"));
+        } catch (IOException e) {
+            return Patten.NULL;
+        }
     }
     
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -81,6 +81,8 @@ public class ProjectDirConstants {
     public static final String JAVA_MAIN = "main";
 
     public static final String FILE_NAME_DELIMITER = "-";
+    
+    public static final String BIR_BALLERINA_VERSION_CACHE_FILE_NAME = "ballerina-version";
 
     // Balo specific constants
     public static final String BALO_METADATA_DIR_NAME = "metadata";


### PR DESCRIPTION
## Purpose
> Recreate BIRs in home repository if ballerina version is different.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19510

## Approach
> Keep track to which version of ballerina when a BIR is created in the home repository.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
