### PR TITLE
Create BIR,JAR caches for each ballerina version in home repository

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/buildcontext/BuildContext.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/buildcontext/BuildContext.java
@@ -270,11 +270,13 @@ public class BuildContext extends HashMap<BuildContextField, Object> {
     }
     
     public Path getBirCacheFromHome() {
-        return RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
+        return RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME + "-" +
+                                                             RepoUtils.getBallerinaVersion());
     }
     
     public Path getJarCacheFromHome() {
-        return RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.JAR_CACHE_DIR_NAME);
+        return RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.JAR_CACHE_DIR_NAME + "-" +
+                                                             RepoUtils.getBallerinaVersion());
     }
 
     public Path getBaloCacheFromHome() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateBirTask.java
@@ -74,7 +74,9 @@ public class CreateBirTask implements Task {
                 // If not fetch from home bir cache.
                 importBir = buildContext.getBirPathFromHomeCache(id);
                 // Write only if bir does not exists. No need to overwrite.
-                birWriter.writeBIRToPath(bPackageSymbol.birPackageFile, id, importBir, true);
+                if (Files.notExists(importBir)) {
+                    birWriter.writeBIRToPath(bPackageSymbol.birPackageFile, id, importBir);
+                }
             }
     
             // write child import bir(s)

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateTargetDirTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateTargetDirTask.java
@@ -20,7 +20,6 @@ package org.ballerinalang.packerina.task;
 
 import org.ballerinalang.packerina.buildcontext.BuildContext;
 import org.ballerinalang.packerina.buildcontext.BuildContextField;
-import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
@@ -43,13 +42,10 @@ public class CreateTargetDirTask implements Task {
             }
             // We create a home repo if home repo path not exists
             Path homeRepo = RepoUtils.createAndGetHomeReposPath();
-            Path baloCache = homeRepo.resolve(ProjectDirConstants.BALO_CACHE_DIR_NAME);
-            Path birCache = homeRepo.resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
-            Path jarCache = homeRepo.resolve(ProjectDirConstants.JAR_CACHE_DIR_NAME);
             Files.createDirectories(homeRepo);
-            Files.createDirectories(baloCache);
-            Files.createDirectories(birCache);
-            Files.createDirectories(jarCache);
+            Files.createDirectories(buildContext.getBaloCacheFromHome());
+            Files.createDirectories(buildContext.getBirCacheFromHome());
+            Files.createDirectories(buildContext.getJarCacheFromHome());
         } catch (IOException e) {
             throw createLauncherException("unable to create target directory: " + targetDir);
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/writer/BirFileWriter.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/writer/BirFileWriter.java
@@ -26,14 +26,10 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.programfile.CompiledBinaryFile;
 import org.wso2.ballerinalang.programfile.PackageFileWriter;
-import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BIR_BALLERINA_VERSION_CACHE_FILE_NAME;
 
 /**
  * Write a bir to cache.
@@ -99,27 +95,15 @@ public class BirFileWriter {
     }
 
     public void writeBIRToPath(CompiledBinaryFile.BIRPackageFile birPackageFile, PackageID id, Path birFilePath) {
-        writeBIRToPath(birPackageFile, id, birFilePath, false);
-    }
-    
-    public void writeBIRToPath(CompiledBinaryFile.BIRPackageFile birPackageFile, PackageID id, Path birFilePath,
-                               boolean createBalVersionCache) {
+
         try {
             byte[] pkgBirBinaryContent = PackageFileWriter.writePackage(birPackageFile);
             Files.write(birFilePath, pkgBirBinaryContent);
-    
-            Path versionDir = birFilePath.getParent();
-            if (createBalVersionCache && versionDir != null) {
-                Path moduleDir = versionDir.getParent();
-                if (moduleDir != null) {
-                    Files.write(moduleDir.resolve(BIR_BALLERINA_VERSION_CACHE_FILE_NAME),
-                            RepoUtils.getBallerinaVersion().getBytes(Charset.defaultCharset()));
-                }
-            }
         } catch (IOException e) {
             String msg = "error writing the compiled module(bir) of '" +
-                         id + "' to '" + birFilePath + "': " + e.getMessage();
+                    id + "' to '" + birFilePath + "': " + e.getMessage();
             throw new BLangCompilerException(msg, e);
         }
     }
+
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
@@ -37,7 +37,8 @@ public class HomeBirRepo implements Repo<Path> {
     private PathConverter pathConverter;
     
     public HomeBirRepo() {
-        Path repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
+        Path repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME + "-" +
+                                                                          RepoUtils.getBallerinaVersion());
         this.pathConverter = new PathConverter(repoLocation);
     }
     

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/repo/HomeBirRepo.java
@@ -25,64 +25,35 @@ import org.wso2.ballerinalang.compiler.packaging.converters.PathConverter;
 import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 import org.wso2.ballerinalang.util.RepoUtils;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.wso2.ballerinalang.compiler.packaging.Patten.LATEST_VERSION_DIR;
 import static org.wso2.ballerinalang.compiler.packaging.Patten.path;
-import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BIR_BALLERINA_VERSION_CACHE_FILE_NAME;
 
 /**
  * Repo for bir_cache in home repository.
  */
 public class HomeBirRepo implements Repo<Path> {
-    private Path birCache;
     private PathConverter pathConverter;
     
     public HomeBirRepo() {
-        this.birCache = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
-        this.pathConverter = new PathConverter(this.birCache);
+        Path repoLocation = RepoUtils.createAndGetHomeReposPath().resolve(ProjectDirConstants.BIR_CACHE_DIR_NAME);
+        this.pathConverter = new PathConverter(repoLocation);
     }
     
     @Override
     public Patten calculate(PackageID moduleID) {
-        try {
-            String orgName = moduleID.getOrgName().getValue();
-            String pkgName = moduleID.getName().getValue();
-            Patten.Part version;
-            String versionStr = moduleID.getPackageVersion().getValue();
-            if (versionStr.isEmpty()) {
-                version = LATEST_VERSION_DIR;
-            } else {
-                version = path(versionStr);
-            }
-        
-            Path ballerinaVersionCachePath = this.birCache.resolve(orgName).resolve(pkgName)
-                    .resolve(BIR_BALLERINA_VERSION_CACHE_FILE_NAME);
-            
-            // if ballerina version cache file does not exists,
-            // then consider it that the current ballerina version it not
-            // compatible with the bir(if such exists)
-            if (Files.notExists(ballerinaVersionCachePath)) {
-                return Patten.NULL;
-            }
-        
-            if (Files.exists(ballerinaVersionCachePath)) {
-                String ballerinaVersion = new String(Files.readAllBytes(ballerinaVersionCachePath),
-                        StandardCharsets.UTF_8);
-                // if ballerina version cache file exists but its a different version, then consider it that the
-                // current ballerina version it not compatible with the bir(if such exists)
-                if (!RepoUtils.getBallerinaVersion().equals(ballerinaVersion)) {
-                    return Patten.NULL;
-                }
-            }
-        
-            return new Patten(path(orgName, pkgName), version, path(pkgName + ".bir"));
-        } catch (IOException e) {
-            return Patten.NULL;
+        String orgName = moduleID.getOrgName().getValue();
+        String pkgName = moduleID.getName().getValue();
+        Patten.Part version;
+        String versionStr = moduleID.getPackageVersion().getValue();
+        if (versionStr.isEmpty()) {
+            version = LATEST_VERSION_DIR;
+        } else {
+            version = path(versionStr);
         }
+        
+        return new Patten(path(orgName, pkgName), version, path(pkgName + ".bir"));
     }
     
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -81,8 +81,6 @@ public class ProjectDirConstants {
     public static final String JAVA_MAIN = "main";
 
     public static final String FILE_NAME_DELIMITER = "-";
-    
-    public static final String BIR_BALLERINA_VERSION_CACHE_FILE_NAME = "ballerina-version";
 
     // Balo specific constants
     public static final String BALO_METADATA_DIR_NAME = "metadata";


### PR DESCRIPTION
## Purpose
> Recreate BIRs,JARs in home repository if ballerina version is different.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19510

## Approach
> Create caches for each ballerina version.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
