### PR TITLE
Remove the unnecessary logs printed during the build

### DIFF
--- a/bvm/ballerina-core/build.gradle
+++ b/bvm/ballerina-core/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'io.opentracing:opentracing-util'
     implementation 'org.awaitility:awaitility'
     implementation 'com.zaxxer:HikariCP'
+    implementation 'org.slf4j:slf4j-jdk14'
 }
 
 description = 'Ballerina - Core'
@@ -51,6 +52,9 @@ description = 'Ballerina - Core'
 configurations {
     implementation {
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.commons-beanutils'
+        exclude group: 'org.ops4j.pax.logging', module: 'pax-logging-api'
+        exclude group: 'org.ops4j.pax.logging', module: 'pax-logging-log4j2'
+        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
 }
 

--- a/tests/ballerina-test-utils/build.gradle
+++ b/tests/ballerina-test-utils/build.gradle
@@ -61,6 +61,7 @@ shadowJar {
         exclude(dependency('org.wso2.eclipse.osgi:org.eclipse.osgi.services'))
         exclude(dependency('org.slf4j:slf4j-log4j12'))
         exclude(dependency('org.slf4j:slf4j-simple'))
+        exclude(dependency('org.slf4j:slf4j-jdk14'))
         exclude(dependency('org.codehaus.woodstox:woodstox-core-asl'))
         exclude(dependency('org.codehaus.woodstox:stax2-api'))
         exclude(dependency('io.netty:netty-common'))


### PR DESCRIPTION
## Purpose
> This PR removes the unnecessary transitive log library bindings added to ballerina-core. The presence of these log bindings caused the following logs to be printed:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/travis/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-log4j12/1.7.25/110cefe2df103412849d72ef7a67e4e91e4266b4/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/travis/.gradle/caches/modules-2/files-2.1/org.ops4j.pax.logging/pax-logging-api/1.10.0/56cfd0505e45d13743fb594935a19915688b8e32/pax-logging-api-1.10.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
[io.netty.util.internal.logging.InternalLoggerFactory] : Using Log4J as the default logging framework
[io.netty.util.ResourceLeakDetector] : -Dio.netty.leakDetection.level: simple
[io.netty.util.ResourceLeakDetector] : -Dio.netty.leakDetection.targetRecords: 4
[io.netty.util.internal.PlatformDependent0] : -Dio.netty.noUnsafe: false
[io.netty.util.internal.PlatformDependent0] : Java version: 8
[io.netty.util.internal.PlatformDependent0] : sun.misc.Unsafe.theUnsafe: available
[io.netty.util.internal.PlatformDependent0] : sun.misc.Unsafe.copyMemory: available
[io.netty.util.internal.PlatformDependent0] : java.nio.Buffer.address: available
[io.netty.util.internal.PlatformDependent0] : direct buffer constructor: available
[io.netty.util.internal.PlatformDependent0] : java.nio.Bits.unaligned: available, true
[io.netty.util.internal.PlatformDependent0] : jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9
[io.netty.util.internal.PlatformDependent0] : java.nio.DirectByteBuffer.<init>(long, int): available
[io.netty.util.internal.PlatformDependent] : sun.misc.Unsafe: available
[io.netty.util.internal.PlatformDependent] : -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
[io.netty.util.internal.PlatformDependent] : -Dio.netty.bitMode: 64 (sun.arch.data.model)
[io.netty.util.internal.PlatformDependent] : -Dio.netty.maxDirectMemory: 3504865280 bytes
[io.netty.util.internal.PlatformDependent] : -Dio.netty.uninitializedArrayAllocationThreshold: -1
[io.netty.util.internal.CleanerJava6] : java.nio.ByteBuffer.cleaner(): available
[io.netty.util.internal.PlatformDependent] : -Dio.netty.noPreferDirect: false
[io.netty.buffer.AbstractByteBuf] : -Dio.netty.buffer.checkAccessible: true
[io.netty.buffer.AbstractByteBuf] : -Dio.netty.buffer.checkBounds: true
[io.netty.util.ResourceLeakDetectorFactory] : Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@589da3f3
```