### PR TITLE
Fix constructFrom failing even with one match in a union

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -967,7 +967,10 @@ public class TypeChecker {
                     List<BType> compatibleTypesWithNumConversion = new ArrayList<>();
                     List<BType> compatibleTypesWithoutNumConversion = new ArrayList<>();
                     for (BType type : ((BUnionType) targetType).getMemberTypes()) {
-                        if (checkIsLikeType(sourceValue, type, unresolvedValues, false)) {
+                        List<TypeValuePair> tempList = new ArrayList<>(unresolvedValues.size());
+                        tempList.addAll(unresolvedValues);
+
+                        if (checkIsLikeType(sourceValue, type, tempList, false)) {
                             compatibleTypesWithoutNumConversion.add(type);
                         }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTypedescTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTypedescTest.java
@@ -75,6 +75,12 @@ public class LangLibTypedescTest {
     }
 
     @Test
+    public void testConvertingToUnionConstrainedType() {
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testConvertingToUnionConstrainedType");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
     public void testConstructFromForNil() {
         BValue[] returns = BRunUtil.invokeFunction(compileResult, "testConstructFromForNilPositive");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());

--- a/langlib/langlib-test/src/test/resources/test-src/typedesclib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/typedesclib_test.bal
@@ -178,3 +178,21 @@ function testSettingRecordDefaultValuesOnConversion() returns boolean {
     A|error d = A.constructFrom(c);
     return d is A && d.i == 4 && d.s == "test" && d.b.p == "hello" && d.b.q == "world" && d.f == 34.0;
 }
+
+type D record {
+    int i;
+};
+
+type E record {
+    string s;
+};
+
+type F record {
+    float f;
+};
+
+function testConvertingToUnionConstrainedType() returns boolean {
+    map<D> f = {x:{i:1}};
+    json j = <json> json.constructFrom(f);
+    return map<D|E|F>.constructFrom(j) == f;
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19559


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
