### PR TITLE
Allow record binding patterns within a tuple binding pattern

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1985,6 +1985,10 @@ public class Desugar extends BLangNodeVisitor {
                 }
                 createVarRefAssignmentStmts((BLangRecordVarRef) expression, parentBlockStmt, tupleVarSymbol,
                         arrayAccessExpr);
+
+                createTypeDefinition(recordVarRef.type, recordVarRef.type.tsymbol,
+                        createRecordTypeNode((BRecordType) recordVarRef.type));
+
                 continue;
             }
 
@@ -2052,6 +2056,22 @@ public class Desugar extends BLangNodeVisitor {
             assignmentExpr = arrayAccess;
         }
         return assignmentExpr;
+    }
+
+    private BLangRecordTypeNode createRecordTypeNode(BRecordType recordType) {
+        List<BLangSimpleVariable> fieldList = new ArrayList<>();
+        for (BField field : recordType.fields) {
+            BVarSymbol symbol = field.symbol;
+            if (symbol == null) {
+                symbol = new BVarSymbol(Flags.PUBLIC, field.name,
+                        this.env.enclPkg.packageID, symTable.pureType, null);
+            }
+
+            BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(
+                    field.pos, symbol.name.value, field.type, null, symbol);
+            fieldList.add(fieldVar);
+        }
+        return createRecordTypeNode(fieldList, recordType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
@@ -64,7 +64,7 @@ public class BLangAnonymousModelHelper {
         return helper;
     }
 
-    String getNextAnonymousTypeKey(PackageID packageID) {
+    public String getNextAnonymousTypeKey(PackageID packageID) {
         Integer nextValue = Optional.ofNullable(anonTypeCount.get(packageID)).orElse(0);
         anonTypeCount.put(packageID, nextValue + 1);
         if (PackageID.ANNOTATIONS.equals(packageID)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -29,6 +29,7 @@ import org.ballerinalang.model.tree.clauses.SelectExpressionNode;
 import org.ballerinalang.model.tree.expressions.NamedArgNode;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.util.diagnostic.DiagnosticCode;
+import org.wso2.ballerinalang.compiler.parser.BLangAnonymousModelHelper;
 import org.wso2.ballerinalang.compiler.semantics.model.BLangBuiltInMethod;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
@@ -177,6 +178,7 @@ public class TypeChecker extends BLangNodeVisitor {
     private boolean isTypeChecked;
     private TypeNarrower typeNarrower;
     private TypeParamAnalyzer typeParamAnalyzer;
+    private BLangAnonymousModelHelper anonymousModelHelper;
 
     /**
      * Expected types or inherited types.
@@ -206,6 +208,7 @@ public class TypeChecker extends BLangNodeVisitor {
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.typeNarrower = TypeNarrower.getInstance(context);
         this.typeParamAnalyzer = TypeParamAnalyzer.getInstance(context);
+        this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
     }
 
     public BType checkExpr(BLangExpression expr, SymbolEnv env) {
@@ -1244,8 +1247,9 @@ public class TypeChecker extends BLangNodeVisitor {
     @Override
     public void visit(BLangRecordVarRef varRefExpr) {
         List<BField> fields = new ArrayList<>();
-        BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(0, Names.EMPTY, env.enclPkg.symbol.pkgID,
-                null, env.scope.owner);
+        BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(0,
+                names.fromString(this.anonymousModelHelper.getNextAnonymousTypeKey(env.enclPkg.symbol.pkgID)),
+                env.enclPkg.symbol.pkgID, null, env.scope.owner);
         boolean unresolvedReference = false;
         for (BLangRecordVarRef.BLangRecordVarRefKeyValue recordRefField : varRefExpr.recordRefFields) {
             ((BLangVariableReference) recordRefField.variableReference).lhsVar = true;
@@ -1275,10 +1279,12 @@ public class TypeChecker extends BLangNodeVisitor {
         BRecordType bRecordType = new BRecordType(recordSymbol);
         bRecordType.fields = fields;
         recordSymbol.type = bRecordType;
-        varRefExpr.symbol = new BVarSymbol(0, Names.EMPTY, env.enclPkg.symbol.pkgID, bRecordType, env.scope.owner);
+        varRefExpr.symbol = new BVarSymbol(0, recordSymbol.name,
+                env.enclPkg.symbol.pkgID, bRecordType, env.scope.owner);
 
         if (varRefExpr.restParam == null) {
             bRecordType.sealed = true;
+            bRecordType.restFieldType = symTable.noType;
         } else {
             bRecordType.restFieldType = symTable.mapType;
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleDestructureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleDestructureTest.java
@@ -80,6 +80,12 @@ public class TupleDestructureTest {
         Assert.assertEquals(returns[0].stringValue(), "1");
         Assert.assertEquals(returns[1].stringValue(), "a");
         Assert.assertEquals(returns[2].stringValue(), "[\"b\"]");
+
+        returns = BRunUtil.invoke(result, "tupleDestructureTest9", new BValue[]{});
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(returns[0].stringValue(), "true");
+        Assert.assertEquals(returns[1].stringValue(), "string value");
+        Assert.assertEquals(returns[2].stringValue(), "[25, 12.5]");
     }
 
     @Test(description = "Test positive tuple destructure scenarios")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_destructure_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_destructure_test.bal
@@ -90,3 +90,22 @@ function tupleDestructureTest8() returns [int, string, string[]] {
     [a, b, ...c] = x;
     return [a, b, c];
 }
+
+type FooRecord record {|
+    string field1;
+    [int, float] field2;
+|};
+
+function tupleDestructureTest9() returns [boolean, string, [int, float]] {
+    FooRecord foo = {
+        field1: "string value",
+        field2: [25, 12.5]
+    };
+
+    boolean a;
+    string b;
+    [int, float] c;
+    [a, { field1: b, field2: c }] = [true, foo];
+
+    return [a, b, c];
+}


### PR DESCRIPTION
## Purpose
Purpose of this PR is to allow record binding patterns within a tuple binding pattern, so that following should work.

```ballerina
type FooRecord record {|
    string field1;
    [int, float] field2;
|};

function tupleDestructure() returns [boolean, string, [int, float]] {
    FooRecord foo = {
        field1: "string value",
        field2: [25, 12.5]
    };

    boolean a;
    string b;
    [int, float] c;
    [a, { field1: b, field2: c }] = [true, foo]; // this should work

    return [a, b, c];
}
```

Fixes #19040

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
