### PR TITLE
Warning when an array is passed for rest argument on function pointers

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
@@ -52,5 +52,7 @@ public enum SymbolKind {
     SCOPE,
     OTHER,
 
-    ERROR_CONSTRUCTOR
+    ERROR_CONSTRUCTOR,
+
+    INVOKABLE_TYPE
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -206,7 +206,7 @@ public enum DiagnosticCode {
     INVALID_FUNCTION_POINTER_INVOCATION("invalid.function.pointer.invocation"),
     AMBIGUOUS_TYPES("ambiguous.type"),
 
-    FUNCTION_POINTER_REST_ARG_ARRAY_PASSED("function.pointer.rest.arg"),
+    ARRAY_PASSED_TO_REST_ARG("array.passed.to.rest.param"),
     TOO_MANY_ARGS_FUNC_CALL("too.many.args.call"),
     NON_PUBLIC_ARG_ACCESSED_WITH_NAMED_ARG("non.public.arg.accessed.with.named.arg"),
     ASSIGNMENT_COUNT_MISMATCH("assignment.count.mismatch"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -206,6 +206,7 @@ public enum DiagnosticCode {
     INVALID_FUNCTION_POINTER_INVOCATION("invalid.function.pointer.invocation"),
     AMBIGUOUS_TYPES("ambiguous.type"),
 
+    FUNCTION_POINTER_REST_ARG_ARRAY_PASSED("function.pointer.rest.arg"),
     TOO_MANY_ARGS_FUNC_CALL("too.many.args.call"),
     NON_PUBLIC_ARG_ACCESSED_WITH_NAMED_ARG("non.public.arg.accessed.with.named.arg"),
     ASSIGNMENT_COUNT_MISMATCH("assignment.count.mismatch"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -41,6 +41,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
@@ -1396,9 +1397,13 @@ public class SymbolEnter extends BLangNodeVisitor {
             paramTypes.add(invokableSymbol.restParam.type);
         }
         invokableSymbol.type = new BInvokableType(paramTypes, invokableNode.returnTypeNode.type, null);
-        invokableSymbol.type.tsymbol = Symbols.createTypeSymbol(SymTag.FUNCTION_TYPE, invokableSymbol.flags,
-                                                                Names.EMPTY, env.enclPkg.symbol.pkgID,
-                                                                invokableSymbol.type, env.scope.owner);
+
+        BInvokableTypeSymbol functionTypeSymbol = Symbols.createBInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
+                invokableSymbol.flags,
+                Names.EMPTY, env.enclPkg.symbol.pkgID,
+                invokableSymbol.type, env.scope.owner);
+        functionTypeSymbol.restParam = invokableSymbol.restParam;
+        invokableSymbol.type.tsymbol = functionTypeSymbol;
     }
 
     private void defineSymbol(DiagnosticPos pos, BSymbol symbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1398,7 +1398,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
         invokableSymbol.type = new BInvokableType(paramTypes, invokableNode.returnTypeNode.type, null);
 
-        BInvokableTypeSymbol functionTypeSymbol = Symbols.createBInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
+        BInvokableTypeSymbol functionTypeSymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
                 invokableSymbol.flags,
                 Names.EMPTY, env.enclPkg.symbol.pkgID,
                 invokableSymbol.type, env.scope.owner);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -39,6 +39,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BOperatorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
@@ -3380,6 +3381,13 @@ public class TypeChecker extends BLangNodeVisitor {
                 .collect(Collectors.toList());
 
         List<BVarSymbol> valueProvidedParams = new ArrayList<>();
+
+        BType symbolType = iExpr.symbol.type;
+        boolean hasRestParamAndArg = symbolType != null && symbolType.tsymbol != null
+                && symbolType.tsymbol.getKind() == SymbolKind.INVOKABLE_TYPE
+                && ((BInvokableTypeSymbol) symbolType.tsymbol).restParam != null
+                && !nonRestArgs.isEmpty() && paramTypes.size() == nonRestArgs.size();
+
         for (int i = 0; i < nonRestArgs.size(); i++) {
             BLangExpression arg = nonRestArgs.get(i);
             final BType expectedType = paramTypes.get(i);
@@ -3396,6 +3404,12 @@ public class TypeChecker extends BLangNodeVisitor {
             if (iExpr.symbol.tag == SymTag.VARIABLE) {
                 if (i < paramTypes.size()) {
                     checkTypeParamExpr(arg, this.env, expectedType);
+                    // Functions pointers takes rest parameters as arrays. This is incorrect, this should be fixed.
+                    // A warning is printed here for the above scenario mentioning this will fixed in a future release.
+                    if (hasRestParamAndArg && i == nonRestArgs.size() - 1
+                            && types.isAssignable(arg.type, expectedType)) {
+                        dlog.warning(iExpr.pos, DiagnosticCode.FUNCTION_POINTER_REST_ARG_ARRAY_PASSED);
+                    }
                     if (nonRestParams.size() > i) {
                         requiredParams.remove(nonRestParams.get(i));
                     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3408,7 +3408,7 @@ public class TypeChecker extends BLangNodeVisitor {
                     // A warning is printed here for the above scenario mentioning this will fixed in a future release.
                     if (hasRestParamAndArg && i == nonRestArgs.size() - 1
                             && types.isAssignable(arg.type, expectedType)) {
-                        dlog.warning(iExpr.pos, DiagnosticCode.FUNCTION_POINTER_REST_ARG_ARRAY_PASSED);
+                        dlog.warning(iExpr.pos, DiagnosticCode.ARRAY_PASSED_TO_REST_ARG);
                     }
                     if (nonRestParams.size() > i) {
                         requiredParams.remove(nonRestParams.get(i));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.semantics.model.symbols;
+
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.SymbolKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.Name;
+
+/**
+ * Represents a function type symbol.
+ *
+ * @since 1.0.3
+ */
+public class BInvokableTypeSymbol extends BTypeSymbol {
+
+    public BVarSymbol restParam;
+    // params and return-param should be added when this class is used further
+    // currently not added because of spot-bugs `UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD` warning
+
+    public BInvokableTypeSymbol(int symTag, int flags, Name name, PackageID pkgID, BType type, BSymbol owner) {
+        super(symTag, flags, name, pkgID, type, owner);
+    }
+
+    @Override
+    public SymbolKind getKind() {
+        return SymbolKind.INVOKABLE_TYPE;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -146,12 +146,12 @@ public class Symbols {
         return new BTypeSymbol(symTag, flags, name, pkgID, type, owner);
     }
 
-    public static BInvokableTypeSymbol createBInvokableTypeSymbol(int symTag,
-                                               int flags,
-                                               Name name,
-                                               PackageID pkgID,
-                                               BType type,
-                                               BSymbol owner) {
+    public static BInvokableTypeSymbol createInvokableTypeSymbol(int symTag,
+                                                                 int flags,
+                                                                 Name name,
+                                                                 PackageID pkgID,
+                                                                 BType type,
+                                                                 BSymbol owner) {
         return new BInvokableTypeSymbol(symTag, flags, name, pkgID, type, owner);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -146,6 +146,15 @@ public class Symbols {
         return new BTypeSymbol(symTag, flags, name, pkgID, type, owner);
     }
 
+    public static BInvokableTypeSymbol createBInvokableTypeSymbol(int symTag,
+                                               int flags,
+                                               Name name,
+                                               PackageID pkgID,
+                                               BType type,
+                                               BSymbol owner) {
+        return new BInvokableTypeSymbol(symTag, flags, name, pkgID, type, owner);
+    }
+
     public static BInvokableSymbol createInvokableSymbol(int kind,
                                                          int flags,
                                                          Name name,

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1057,6 +1057,10 @@ error.not.supported.source.for.stamp=\
 # Compiler warning messages
 # -------------------------
 
+warning.function.pointer.rest.arg=\
+  passing an array in place of rest parameter is allowed due to a bug in the compiler (https://git.io/Je0oe) \
+  and will be fixed in a future release.
+
 warning.undocumented.parameter=\
   undocumented parameter ''{0}''
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1057,9 +1057,9 @@ error.not.supported.source.for.stamp=\
 # Compiler warning messages
 # -------------------------
 
-warning.function.pointer.rest.arg=\
-  passing an array in place of rest parameter is allowed due to a bug in the compiler (https://git.io/Je0oe) \
-  and will be fixed in a future release.
+warning.array.passed.to.rest.param=\
+  invalid argument: passing an array argument for a rest parameter is currently allowed due to \
+  a bug in the compiler (https://git.io/Je0oe) and will be fixed in a future release.
 
 warning.undocumented.parameter=\
   undocumented parameter ''{0}''

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
@@ -102,4 +102,16 @@ public class FunctionPointersNegativeTest {
         BAssertUtil.validateError(result, i++, "too many arguments in call to 'fn()'", 31, 16);
         BAssertUtil.validateError(result, i++, "too many arguments in call to 'fn()'", 42, 16);
     }
+
+    @Test()
+    public void testFpRestParameterWarning() {
+        CompileResult result = BCompileUtil.compile("test-src/expressions/lambda/negative" +
+                "/fp_rest_warning_test.bal");
+        Assert.assertEquals(result.getWarnCount(), 2);
+        int i = 0;
+        BAssertUtil.validateWarning(result, i++, "passing an array in place of rest parameter is allowed due to a " +
+                "bug in the compiler (https://git.io/Je0oe) and will be fixed in a future release.", 3, 8);
+        BAssertUtil.validateWarning(result, i, "passing an array in place of rest parameter is allowed due to a " +
+                "bug in the compiler (https://git.io/Je0oe) and will be fixed in a future release.", 4, 8);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
@@ -109,9 +109,11 @@ public class FunctionPointersNegativeTest {
                 "/fp_rest_warning_test.bal");
         Assert.assertEquals(result.getWarnCount(), 2);
         int i = 0;
-        BAssertUtil.validateWarning(result, i++, "passing an array in place of rest parameter is allowed due to a " +
-                "bug in the compiler (https://git.io/Je0oe) and will be fixed in a future release.", 3, 8);
-        BAssertUtil.validateWarning(result, i, "passing an array in place of rest parameter is allowed due to a " +
-                "bug in the compiler (https://git.io/Je0oe) and will be fixed in a future release.", 4, 8);
+        BAssertUtil.validateWarning(result, i++, "invalid argument: passing an array argument for a rest parameter " +
+                "is currently allowed due to a bug in the compiler (https://git.io/Je0oe) and will be fixed in a " +
+                "future release.", 3, 8);
+        BAssertUtil.validateWarning(result, i, "invalid argument: passing an array argument for a rest parameter " +
+                "is currently allowed due to a bug in the compiler (https://git.io/Je0oe) and will " +
+                "be fixed in a future release.", 4, 8);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/negative/fp_rest_warning_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/negative/fp_rest_warning_test.bal
@@ -1,0 +1,13 @@
+public function testFpRestParameterWarning() {
+   var bar = foo; 
+   _ = bar("", [1,2,3]);
+   _ = bar("", getArray());
+}
+
+function foo(string b, int... c) returns string {
+    return b;
+}
+
+function getArray() returns int[] {
+    return [1,2,3];
+}


### PR DESCRIPTION
## Purpose
The following code snippet works in the current implementation
```ballerina
public function main() {
   var bar = foo; 
   _ = bar("a", [1, 2, 3]); 
}

function foo(string b, int... c) returns string {
    return b;
}
```
See #19538

This PR (which goes to the patch branch) prints out a warning that this is a bug in compiler and will be fixed (in a minor release)

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
