### PR TITLE
Improve taint propagation analysis for 'check' expressions

### DIFF
--- a/cli/ballerina-cli-module-pull/src/main/ballerina/src/module_pull/module_pull.bal
+++ b/cli/ballerina-cli-module-pull/src/main/ballerina/src/module_pull/module_pull.bal
@@ -276,7 +276,7 @@ function defineEndpointWithoutProxy(string url) returns http:Client{
 # + byteChannel - Byte channel
 # + numberOfBytes - Number of bytes to be read
 # + return - Read content as byte[] along with the number of bytes read, or error if read failed
-function readBytes(io:ReadableByteChannel byteChannel, int numberOfBytes) returns [byte[], int]|error {
+function readBytes(io:ReadableByteChannel byteChannel, int numberOfBytes) returns @tainted [byte[], int]|error {
     byte[] bytes = check (byteChannel.read(numberOfBytes));
     return <@untainted>[bytes, bytes.length()];
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -1484,6 +1484,9 @@ public class TaintAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangCheckedExpr match) {
         match.expr.accept(this);
+        if (getCurrentAnalysisState().taintedStatus == TaintedStatus.TAINTED) {
+            getCurrentAnalysisState().returnTaintedStatus = TaintedStatus.TAINTED;
+        }
     }
 
     @Override

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/http_retry_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/http_retry_client.bal
@@ -69,7 +69,7 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_POST, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -85,7 +85,7 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function head(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(string path, public RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_HEAD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -101,7 +101,7 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PUT, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -116,7 +116,7 @@ public type RetryClient client object {
     # + path - Resource path
     # + request - An HTTP inbound request message
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function forward(string path, Request request) returns Response|ClientError {
+    public remote function forward(string path, Request request) returns @tainted Response|ClientError {
         var result = performRetryAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -134,7 +134,8 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns
+            @tainted Response|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, httpVerb, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -150,7 +151,7 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PATCH, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -166,7 +167,8 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function delete(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(string path, public RequestMessage message = ()) returns
+            @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_DELETE, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -182,7 +184,7 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function get(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(string path, public RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_GET, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -198,7 +200,8 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The HTTP `Response` message, or an error if the invocation fails
-    public remote function options(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, public RequestMessage message = ()) returns
+            @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -216,7 +219,8 @@ public type RetryClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `HttpFuture` that represents an asynchronous service invocation, or an error if the submission fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns
+            @tainted HttpFuture|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, HTTP_SUBMIT, self, verb = httpVerb);
         if (result is Response) {
             return getInvalidTypeError();
@@ -272,14 +276,14 @@ public type RetryClient client object {
 // of the http verb and invokes the perform action method.
 // verb is used for submit methods only.
 function performRetryClientExecuteAction(@untainted string path, Request request, @untainted string httpVerb,
-                                         RetryClient retryClient, string verb = "") returns HttpResponse|ClientError {
+                                         RetryClient retryClient, string verb = "") returns @tainted HttpResponse|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     return performRetryAction(path, request, connectorAction, retryClient, verb = verb);
 }
 
 // Handles all the actions exposed through the retry client.
 function performRetryAction(@untainted string path, Request request, HttpOperation requestAction,
-                            RetryClient retryClient, string verb = "") returns HttpResponse|ClientError {
+                            RetryClient retryClient, string verb = "") returns @tainted HttpResponse|ClientError {
     HttpClient httpClient = retryClient.httpClient;
     int currentRetryCount = 0;
     int retryCount = retryClient.retryInferredConfig.count;

--- a/stdlib/http/src/test/resources/test-src/services/echo-service.bal
+++ b/stdlib/http/src/test/resources/test-src/services/echo-service.bal
@@ -143,7 +143,7 @@ service echo on echoEP {
         methods:["POST"],
         path:"/parseJSON"
     }
-    resource function errorReturn(http:Caller caller, http:Request req) returns error? {
+    resource function errorReturn(http:Caller caller, http:Request req) returns @tainted error? {
         json payload = check req.getJsonPayload();
         http:Response res = new;
         res.setPayload(<@untainted json> payload);

--- a/stdlib/io/src/test/resources/test-src/io/char_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/char_io.bal
@@ -29,12 +29,12 @@ function initReadableChannel(string filePath, string encoding) returns @tainted 
     }
 }
 
-function initWritableChannel(string filePath, string encoding) returns io:Error? {
+function initWritableChannel(string filePath, string encoding) returns @tainted io:Error? {
     io:WritableByteChannel byteChannel = check io:openWritableFile(filePath);
     wch = <@untainted> new io:WritableCharacterChannel(byteChannel, encoding);
 }
 
-function initWritableChannelToAppend(string filePath, string encoding) returns io:Error? {
+function initWritableChannelToAppend(string filePath, string encoding) returns @tainted io:Error? {
     io:WritableByteChannel byteChannel = check io:openWritableFile(filePath, true);
     wca = <@untainted> new io:WritableCharacterChannel(byteChannel, encoding);
 }

--- a/stdlib/io/src/test/resources/test-src/io/data_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/data_io.bal
@@ -16,7 +16,7 @@
 
 import ballerina/io;
 
-function testWriteFixedSignedInt(int value, string path, io:ByteOrder byteOrder) returns io:Error? {
+function testWriteFixedSignedInt(int value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeInt64(value);
@@ -35,7 +35,7 @@ function testReadFixedSignedInt(string path, io:ByteOrder byteOrder) returns @ta
     }
 }
 
-function testWriteVarInt(int value, string path, io:ByteOrder byteOrder) returns io:Error? {
+function testWriteVarInt(int value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeVarInt(value);
@@ -54,7 +54,7 @@ function testReadVarInt(string path, io:ByteOrder byteOrder) returns @tainted in
     }
 }
 
-function testWriteFixedFloat(float value, string path, io:ByteOrder byteOrder) returns io:Error? {
+function testWriteFixedFloat(float value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeFloat64(value);
@@ -73,7 +73,7 @@ function testReadFixedFloat(string path, io:ByteOrder byteOrder) returns @tainte
     }
 }
 
-function testWriteBool(boolean value, string path, io:ByteOrder byteOrder) returns io:Error? {
+function testWriteBool(boolean value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeBool(value);

--- a/stdlib/io/src/test/resources/test-src/io/record_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/record_io.bal
@@ -31,7 +31,7 @@ function initReadableChannel(string filePath, string encoding, string recordSepa
 }
 
 function initWritableChannel(string filePath, string encoding, string recordSeparator,
-                             string fieldSeparator) returns io:Error? {
+                             string fieldSeparator) returns @tainted io:Error? {
     io:WritableByteChannel byteChannel = check io:openWritableFile(filePath);
     io:WritableCharacterChannel charChannel = new io:WritableCharacterChannel(byteChannel, encoding);
     wch = <@untainted io:WritableTextRecordChannel> new io:WritableTextRecordChannel(charChannel, fieldSeparator, recordSeparator);

--- a/stdlib/jdbc/src/test/resources/test-src/table/table_type_test.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/table/table_type_test.bal
@@ -1619,7 +1619,7 @@ function getXMLConversionResult(table<record {}> | error tableOrError) returns x
     return retVal;
 }
 
-function testSelectQueryWithCursorTable(string jdbcURL) returns error? {
+function testSelectQueryWithCursorTable(string jdbcURL) returns @tainted error? {
     jdbc:Client testDB = new ({
         url: jdbcURL,
         username: "SA",
@@ -1639,7 +1639,7 @@ function testSelectQueryWithCursorTableHelper(table<IntData> t1) {
     select *;
 }
 
-function testJoinQueryWithCursorTable(string jdbcURL) returns error? {
+function testJoinQueryWithCursorTable(string jdbcURL) returns @tainted error? {
     jdbc:Client testDB = new ({
         url: jdbcURL,
         username: "SA",

--- a/stdlib/transactions/src/main/ballerina/src/transactions/2pc_participant.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/2pc_participant.bal
@@ -56,7 +56,7 @@ type RemoteParticipant object {
         self.participantProtocols = participantProtocols;
     }
 
-    function prepare(string protocol) returns [(PrepareResult|error)?, Participant] {
+    function prepare(string protocol) returns @tainted [(PrepareResult|error)?, Participant] {
         foreach var remoteProto in self.participantProtocols {
             if (remoteProto.name == protocol) {
                 // We are assuming a participant will have only one instance of a protocol
@@ -89,7 +89,7 @@ type RemoteParticipant object {
         return (); // No matching protocol
     }
 
-    function prepareMe(string protocolUrl) returns PrepareResult|error {
+    function prepareMe(string protocolUrl) returns @tainted PrepareResult|error {
         Participant2pcClientEP participantEP  = getParticipant2pcClient(protocolUrl);
 
         // Let's set this to true and change it to false only if a participant aborted or an error occurred while trying

--- a/stdlib/transactions/src/main/ballerina/src/transactions/commons.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/commons.bal
@@ -28,7 +28,7 @@ string localParticipantId = system:uuid();
 map<TwoPhaseCommitTransaction> initiatedTransactions = {};
 
 # This map is used for caching transaction that are this Ballerina instance participates in.
-map<TwoPhaseCommitTransaction> participatedTransactions = {};
+@tainted map<TwoPhaseCommitTransaction> participatedTransactions = {};
 
 # This cache is used for caching HTTP connectors against the URL, since creating connectors is expensive.
 cache:Cache httpClientCache = new;

--- a/stdlib/transactions/src/main/ballerina/src/transactions/connector_initiator.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/connector_initiator.bal
@@ -40,7 +40,7 @@ type InitiatorClientEP client object {
     }
 
     remote function register(string transactionId, string transactionBlockId, RemoteProtocol[] participantProtocols)
-                 returns RegistrationResponse|error {
+                 returns @tainted RegistrationResponse|error {
         http:Client httpClient = self.httpClient;
         string participantId = getParticipantId(transactionBlockId);
         RegistrationRequest regReq = {

--- a/stdlib/transactions/src/main/ballerina/src/transactions/connector_participant_2pc.bal
+++ b/stdlib/transactions/src/main/ballerina/src/transactions/connector_participant_2pc.bal
@@ -41,7 +41,7 @@ type Participant2pcClientEP client object {
         self.conf = c;
     }
 
-    remote function prepare(string transactionId) returns string|error {
+    remote function prepare(string transactionId) returns @tainted string|error {
         http:Client httpClient = self.httpClient;
         http:Request req = new;
         PrepareRequest prepareReq = {transactionId:transactionId};
@@ -64,7 +64,7 @@ type Participant2pcClientEP client object {
         }
     }
 
-    remote function notify(string transactionId, string message) returns string|error {
+    remote function notify(string transactionId, string message) returns @tainted string|error {
         http:Client httpClient = self.httpClient;
         http:Request req = new;
         NotifyRequest notifyReq = {transactionId:transactionId, message:message};

--- a/tests/jballerina-integration-test/src/test/resources/websub/subscriber/test_subscribers_at_basic_auth_secured_hub.bal
+++ b/tests/jballerina-integration-test/src/test/resources/websub/subscriber/test_subscribers_at_basic_auth_secured_hub.bal
@@ -45,7 +45,7 @@ http:BasicAuthHandler basicAuthHandler1 = new(basicAuthProvider1);
     }
 }
 service websubSubscriber on websubEP {
-    resource function onNotification (websub:Notification notification) returns error? {
+    resource function onNotification (websub:Notification notification) returns @tainted error? {
         json payload = check notification.getJsonPayload();
         io:println("WebSub Notification Received by One: " + payload.toJsonString());
     }
@@ -74,7 +74,7 @@ http:BasicAuthHandler basicAuthHandler2 = new(basicAuthProvider2);
     }
 }
 service websubSubscriberTwo on websubEP {
-    resource function onNotification (websub:Notification notification) returns error? {
+    resource function onNotification (websub:Notification notification) returns @tainted error? {
         json payload = check notification.getJsonPayload();
         io:println("WebSub Notification Received by Two: " + payload.toJsonString());
     }
@@ -103,7 +103,7 @@ http:BasicAuthHandler basicAuthHandler3 = new(basicAuthProvider3);
     }
 }
 service websubSubscriberThree on websubEP {
-    resource function onNotification (websub:Notification notification) returns error? {
+    resource function onNotification (websub:Notification notification) returns @tainted error? {
         json payload = check notification.getJsonPayload();
         io:println("WebSub Notification Received by Three: " + payload.toJsonString());
     }
@@ -131,7 +131,7 @@ http:BasicAuthHandler basicAuthHandler4 = new(basicAuthProvider4);
     }
 }
 service websubSubscriberFour on websubEP {
-    resource function onNotification (websub:Notification notification) returns error? {
+    resource function onNotification (websub:Notification notification) returns @tainted error? {
         json payload = check notification.getJsonPayload();
         io:println("WebSub Notification Received by Four: " + payload.toJsonString());
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -600,4 +600,13 @@ public class TaintedStatusPropagationTest {
         Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'arg'", 21, 13);
     }
+
+    @Test
+    public void testTaintednessPropagationCheckExpressionNegative() {
+        CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/check-expression-negative.bal");
+        Assert.assertEquals(result.getDiagnostics().length, 2);
+        BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'arg'", 19, 9);
+        BAssertUtil.validateError(result, 1,
+                "functions returning tainted value are required to annotate return signature @tainted: 'foo'", 22, 24);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/check-expression-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/check-expression-negative.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main(string... args) {
+    error? e = foo();
+    sec(<error>e);
+}
+
+function foo() returns error? {
+    _ = check bar();
+}
+
+function bar() returns @tainted error|string {
+    return error("error with some tainted data");
+}
+
+function sec(@untainted error arg) {
+
+}


### PR DESCRIPTION
## Purpose
$subject

As `check` expression may cause a function to return with provided error, we need to consider check expressions when calculating the return value taintedness of a function.

```ballerina
public function main(string... args) {
    error? k = foo();
}

function foo() returns error? {
    _ = check bar(); // check may return the error, which is tainted
}

function bar() returns @tainted string|error {
    return error("reason", message = "tainted data here");
}
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19610

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
