### PR TITLE
Fix semantic analysis and narrowed type resetting for binding patterns

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1286,14 +1286,30 @@ public class BLangPackageBuilder {
         switch (variable.getKind()) {
             case TUPLE_VARIABLE:
                 // If the variable is a tuple variable, we need to set the final flag to the all member variables.
-                ((BLangTupleVariable) variable).memberVariables.forEach(this::markVariableAsFinal);
+                BLangTupleVariable tupleVariable = (BLangTupleVariable) variable;
+                tupleVariable.memberVariables.forEach(this::markVariableAsFinal);
+                if (tupleVariable.restVariable != null) {
+                    markVariableAsFinal(tupleVariable.restVariable);
+                }
                 break;
             case RECORD_VARIABLE:
                 // If the variable is a record variable, we need to set the final flag to the all the variables in
                 // the record.
-                ((BLangRecordVariable) variable).variableList.stream()
+                BLangRecordVariable recordVariable = (BLangRecordVariable) variable;
+                recordVariable.variableList.stream()
                         .map(BLangRecordVariableKeyValue::getValue)
                         .forEach(this::markVariableAsFinal);
+                if (recordVariable.restParam != null) {
+                    markVariableAsFinal((BLangVariable) recordVariable.restParam);
+                }
+                break;
+            case ERROR_VARIABLE:
+                BLangErrorVariable errorVariable = (BLangErrorVariable) variable;
+                markVariableAsFinal(errorVariable.reason);
+                errorVariable.detail.forEach(entry -> markVariableAsFinal(entry.valueBindingPattern));
+                if (errorVariable.restDetail != null) {
+                    markVariableAsFinal(errorVariable.restDetail);
+                }
                 break;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1941,11 +1941,12 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 matchedType = matchedDetailItem.type;
             }
 
+            checkErrorDetailRefItem(detailItem.pos, rhsPos, detailItem, matchedType);
+            resetTypeNarrowing(detailItem.expr, matchedType);
             if (!types.isAssignable(matchedType, detailItem.expr.type)) {
                 dlog.error(detailItem.pos, DiagnosticCode.INCOMPATIBLE_TYPES,
                         detailItem.expr.type, matchedType);
             }
-            checkErrorDetailRefItem(detailItem.pos, rhsPos, detailItem, matchedType);
         }
         if (lhsRef.restVar != null && !isIgnoreVar(lhsRef)) {
             setTypeOfVarRefInErrorBindingAssignment(lhsRef.restVar);
@@ -1955,6 +1956,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 dlog.error(lhsRef.restVar.pos, DiagnosticCode.INCOMPATIBLE_TYPES, lhsRef.restVar.type, expRestType);
                 return;
             }
+            resetTypeNarrowing(lhsRef.restVar, expRestType);
             typeChecker.checkExpr(lhsRef.restVar, env);
         }
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
@@ -204,7 +204,7 @@ public class ErrorVariableReferenceTest {
     public void testErrorVariablesSemanticsNegative() {
         CompileResult resultNegative = BCompileUtil.compile(
                 "test-src/expressions/varref/error_variable_reference_semantics_negative.bal");
-        Assert.assertEquals(resultNegative.getErrorCount(), 17);
+        Assert.assertEquals(resultNegative.getErrorCount(), 25);
         int i = -1;
         String incompatibleTypes = "incompatible types: ";
         BAssertUtil.validateError(resultNegative, ++i,
@@ -244,6 +244,14 @@ public class ErrorVariableReferenceTest {
                                   "incompatible types: expected 'map', found 'map<(error|string|int)>'", 135, 32);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'string', found 'string?'", 145, 19);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'r'", 157, 11);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'message'", 157, 24);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'abc'", 157, 39);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'r2'", 160, 11);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'message2'", 160, 25);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'rest'", 160, 38);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'message3'", 164, 21);
+        BAssertUtil.validateError(resultNegative, ++i, "cannot assign a value to final 'abc3'", 164, 37);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/ErrorVariableReferenceTest.java
@@ -204,7 +204,7 @@ public class ErrorVariableReferenceTest {
     public void testErrorVariablesSemanticsNegative() {
         CompileResult resultNegative = BCompileUtil.compile(
                 "test-src/expressions/varref/error_variable_reference_semantics_negative.bal");
-        Assert.assertEquals(resultNegative.getErrorCount(), 16);
+        Assert.assertEquals(resultNegative.getErrorCount(), 17);
         int i = -1;
         String incompatibleTypes = "incompatible types: ";
         BAssertUtil.validateError(resultNegative, ++i,
@@ -230,6 +230,8 @@ public class ErrorVariableReferenceTest {
                 incompatibleTypes + "expected 'boolean', found 'string'", 94, 20);
         BAssertUtil.validateError(resultNegative, ++i, "invalid binding pattern, variable reference " +
                 "'results[res1][reason]' cannot be used with binding pattern", 111, 12);
+        BAssertUtil.validateError(resultNegative, ++i, "invalid binding pattern, variable reference 'results[rec]' " +
+                "cannot be used with binding pattern", 111, 42);
         BAssertUtil.validateError(resultNegative, ++i, "invalid binding pattern, variable reference " +
                 "'results[res2][reason]' cannot be used with binding pattern", 112, 12);
         BAssertUtil.validateError(resultNegative, ++i,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/RecordVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/RecordVariableReferenceTest.java
@@ -217,6 +217,13 @@ public class RecordVariableReferenceTest {
                 "invalid binding pattern, variable reference 'm[var1]' cannot be used with binding pattern", 198, 12);
         BAssertUtil.validateError(resultSemanticsNegative, ++i,
                 "invalid binding pattern, variable reference 'm[var2]' cannot be used with binding pattern", 198, 36);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 's'", 213, 6);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'i'", 213, 9);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'f'", 213, 12);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 's2'", 231, 6);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'iv'", 231, 19);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'b3'", 231, 23);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'm2'", 231, 31);
 
         Assert.assertEquals(resultSemanticsNegative.getErrorCount(), i + 1);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/TupleVariableReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/varref/TupleVariableReferenceTest.java
@@ -279,7 +279,7 @@ public class TupleVariableReferenceTest {
 
     @Test
     public void testTupleVariablesReferencesSemanticsNegative() {
-        Assert.assertEquals(resultSemanticsNegative.getErrorCount(), 35);
+        Assert.assertEquals(resultSemanticsNegative.getErrorCount(), 44);
         int i = -1;
         String errorMsg1 = "incompatible types: expected ";
 
@@ -326,6 +326,15 @@ public class TupleVariableReferenceTest {
                 "invalid binding pattern, variable reference 'm[var1]' cannot be used with binding pattern", 160, 6);
         BAssertUtil.validateError(resultSemanticsNegative, ++i,
                 "invalid binding pattern, variable reference 'm[var2]' cannot be used with binding pattern", 160, 18);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 's1'", 167, 6);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'f1'", 167, 10);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 's2'", 171, 6);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'f2'", 171, 11);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'b2'", 171, 15);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'n2'", 171, 23);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 's2'", 172, 5);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'f2'", 173, 6);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "cannot assign a value to final 'b2'", 173, 10);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -540,4 +540,28 @@ public class TypeGuardTest {
         BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForCustomErrorNegative");
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
     }
+
+    @Test
+    public void testTypeGuardForTupleDestructuringAssignmentPositive() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForTupleDestructuringAssignmentPositive");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
+    public void testTypeGuardForTupleDestructuringAssignmentNegative() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForTupleDestructuringAssignmentNegative");
+        Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
+    public void testTypeGuardForRecordDestructuringAssignmentPositive() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForRecordDestructuringAssignmentPositive");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
+    public void testTypeGuardForRecordDestructuringAssignmentNegative() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForRecordDestructuringAssignmentNegative");
+        Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -80,7 +80,7 @@ public class TypeGuardTest {
     public void testTypeGuardSemanticsNegative() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/statements/ifelse/type-guard-semantics-negative" +
                 ".bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 39);
+        Assert.assertEquals(negativeResult.getErrorCount(), 42);
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 22, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 25, 20);
@@ -148,8 +148,12 @@ public class TypeGuardTest {
                 "incompatible types: expected 'string', found '(int|string|boolean)'", 308, 20);
         BAssertUtil.validateError(negativeResult, i++,
                                   "incompatible types: expected 'string', found '(string|int)'", 318, 21);
-        BAssertUtil.validateError(negativeResult, i,
+        BAssertUtil.validateError(negativeResult, i++,
                                   "incompatible types: expected 'int', found '(string|int)'", 320, 17);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'string?'", 328,
+                                  25);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'int?'", 343, 22);
+        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'int', found 'int?'", 355, 22);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -564,4 +564,16 @@ public class TypeGuardTest {
         BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForRecordDestructuringAssignmentNegative");
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
     }
+
+    @Test
+    public void testTypeGuardForErrorDestructuringAssignmentPositive() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForErrorDestructuringAssignmentPositive");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test
+    public void testTypeGuardForErrorDestructuringAssignmentNegative() {
+        BValue[] returns = BRunUtil.invoke(result, "testTypeGuardForErrorDestructuringAssignmentNegative");
+        Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference_semantics_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/error_variable_reference_semantics_negative.bal
@@ -150,3 +150,20 @@ function testDuplicateBinding() {
     SMS err1 = error("Error One", message = "Msg One", detail = "Detail Msg");
     error(s, message = s, detail = s) = err1;
 }
+
+public function testAssigningValuesToFinalVars() {
+    error e = error("ErrReason", message = "error message", abc = 1, def = 2.0);
+    final var error(r, message = message, abc = abc) = e;
+    error(r, message = message, abc = abc) = e;
+
+    final var error(r2, message = message2, ...rest) = e;
+    error(r2, message = message2, ...rest) = e;
+
+    BarError e3 = BarError(message = "error message", code = 1);
+    final var BarError(message = message3, abc = abc3) = e3;
+    error(message = message3, abc = abc3) = e3;
+}
+
+const BAR = "bar";
+
+type BarError error<BAR, record {string message?; error cause?; int code;}>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/record-variable-reference-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/record-variable-reference-semantics-negative.bal
@@ -198,3 +198,41 @@ function testFieldAndIndexBasedVarRefs() returns [anydata, anydata] {
     {name: m["var1"], yearAndAge: [m["var2"], _]} = ch3;
     return [m["var1"], m["var2"]];
 }
+
+public function testAssigningValuesToFinalVars() {
+    record {
+        string s;
+        int i;
+        float f;
+    } rec1 = {
+        s: "hello",
+        i: 2,
+        f: 1.0
+    };
+    final Baz {s, i, f} = rec1;
+    {s, i, f} = rec1;
+
+    record {
+        string s2;
+        record {
+            int i3;
+            boolean b3;
+        } r2;
+        float f2;
+    } rec2 = {
+        s2: "hello",
+        r2: {
+            i3: 1,
+            b3: true
+        },
+        f2: 1.0
+    };
+    final var {s2, r2: {i3: iv, b3}, ...m2} = rec2;
+    {s2, r2: {i3: iv, b3}, ...m2} = rec2;
+}
+
+type Baz record {
+    string s;
+    int i;
+    float f;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference-semantics-negative.bal
@@ -160,3 +160,15 @@ function testFieldAndIndexBasedVarRefs() returns [anydata, anydata] {
     [m["var1"], [m["var2"], _]] = t1;
     return [m["var1"], m["var2"]];
 }
+
+function testAssigningValuesToFinalVars() {
+    [string, float] t1 = ["hello", 1.0];
+    final var [s1, f1] = t1;
+    [s1, f1] = t1;
+
+    [string?, [float, boolean], int...] t2 = ["hi", [1.0, true], 1, 2];
+    final [string?, [float, boolean], int...] [s2, [f2, b2], ...n2] = t2;
+    [s2, [f2, b2], ...n2] = t2;
+    s2 = "hello";
+    [f2, b2] = [2.0, false];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
@@ -320,3 +320,48 @@ function testGlobalVarInTypeGuard() {
         int i = si;
     }
 }
+
+function testTupleDestructuringAssignmentTypeResetting() {
+    [string?, int] [s, i] = tupleReturningFunc("str");
+    if (s is string) {
+        [s, i] = tupleReturningFunc(());
+        string strVal = s;
+    }
+}
+
+function tupleReturningFunc(string? s) returns [string?, int] {
+    return [s, 1];
+}
+
+function testRecordDestructuringAssignmentTypeResetting() {
+    record {
+        string s;
+        int? i;
+    } {s, i, ...rest} = recordReturningFunc(1);
+    if (i is int) {
+        {s: s, i: i, ...rest} = recordReturningFunc(2);
+        int intVal = i;
+    }
+}
+
+function recordReturningFunc(int? i) returns record {string s; int? i;} {
+    return {s: "hello", i: i, "f": 1.0};
+}
+
+function testErrorDestructuringAssignmentTypeResetting() {
+    var error(s, message = message, code = code) = errorReturningFunc(1);
+    if (code is int) {
+        error(s, message = message, code = code) = errorReturningFunc(());
+        int intVal = code;
+    }
+}
+
+type Detail record {
+    string message?;
+    error cause?;
+    int? code;
+};
+
+function errorReturningFunc(int? i) returns error<string, Detail> {
+    return error("hello", message = "hello", code = i, f = 1.0);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -945,3 +945,55 @@ function testTypeGuardForCustomErrorNegative() returns boolean {
         return false;
     }
 }
+
+function testTypeGuardForTupleDestructuringAssignmentPositive() returns boolean {
+    [string?, int] [s, i] = tupleReturningFunc("str");
+    if (s is string) {
+        string strVal = s;
+        [s, i] = tupleReturningFunc(());
+        return s is ();
+    }
+
+    return false;
+}
+
+function testTypeGuardForTupleDestructuringAssignmentNegative() returns boolean {
+    [string?, int] [s, i] = tupleReturningFunc("str");
+    if (s is string) {
+        string strVal = s;
+        [s, i] = tupleReturningFunc(strVal);
+        return s is ();
+    }
+
+    return true;
+}
+
+function tupleReturningFunc(string? s) returns [string?, int] {
+    return [s, 1];
+}
+
+function testTypeGuardForRecordDestructuringAssignmentPositive() returns boolean {
+    var {s: s, i: i, ...rest} = recordReturningFunc(1);
+    if (i is int) {
+        int intVal = i;
+        {s: s, i: i, ...rest} = recordReturningFunc(());
+        return i is ();
+    }
+
+    return false;
+}
+
+function testTypeGuardForRecordDestructuringAssignmentNegative() returns boolean {
+    var {s: s, i: i, ...rest} = recordReturningFunc(1);
+    if (i is int) {
+        int intVal = i;
+        {s: s, i: i, ...rest} = recordReturningFunc(2);
+        return i is ();
+    }
+
+    return true;
+}
+
+function recordReturningFunc(int? i) returns record {string s; int? i;} {
+    return {s: "hello", i: i, "f": 1.0};
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -958,7 +958,7 @@ function testTypeGuardForTupleDestructuringAssignmentPositive() returns boolean 
 }
 
 function testTypeGuardForTupleDestructuringAssignmentNegative() returns boolean {
-    [string?, int] [s, i] = tupleReturningFunc("str");
+    var [s, i] = tupleReturningFunc("str");
     if (s is string) {
         string strVal = s;
         [s, i] = tupleReturningFunc(strVal);
@@ -984,7 +984,10 @@ function testTypeGuardForRecordDestructuringAssignmentPositive() returns boolean
 }
 
 function testTypeGuardForRecordDestructuringAssignmentNegative() returns boolean {
-    var {s: s, i: i, ...rest} = recordReturningFunc(1);
+    record {
+        string s;
+        int? i;
+    } {s, i, ...rest} = recordReturningFunc(1);
     if (i is int) {
         int intVal = i;
         {s: s, i: i, ...rest} = recordReturningFunc(2);
@@ -996,4 +999,36 @@ function testTypeGuardForRecordDestructuringAssignmentNegative() returns boolean
 
 function recordReturningFunc(int? i) returns record {string s; int? i;} {
     return {s: "hello", i: i, "f": 1.0};
+}
+
+function testTypeGuardForErrorDestructuringAssignmentPositive() returns boolean {
+    var error(s, message = message, code = code) = errorReturningFunc(1);
+    if (code is int) {
+        int intVal = code;
+        error(s, message = message, code = code) = errorReturningFunc(());
+        return code is ();
+    }
+
+    return false;
+}
+
+function testTypeGuardForErrorDestructuringAssignmentNegative() returns boolean {
+    error<string, Detail> error(s, message = message, code = code) = errorReturningFunc(1);
+    if (code is int) {
+        int intVal = code;
+        error(s, message = message, code = code) = errorReturningFunc(3);
+        return code is ();
+    }
+
+    return true;
+}
+
+type Detail record {
+    string message?;
+    error cause?;
+    int? code;
+};
+
+function errorReturningFunc(int? i) returns error<string, Detail> {
+    return error("hello", message = "hello", code = i, f = 1.0);
 }


### PR DESCRIPTION
## Purpose
$title.

Fixes #19499 - Some semantic analysis checks not done for destructuring assignments
Fixed #19352 - Type not reset for destructuring assignment within a type guard

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
