### PR TITLE
Update link to NATS Installation

### DIFF
--- a/examples/nats-basic-client/nats_basic_client.description
+++ b/examples/nats-basic-client/nats_basic_client.description
@@ -1,4 +1,4 @@
 // The NATS client is used either to produce a message to a subject or consume a message from a subject.
 // In order to execute this example, it is required that a NATS server is up and running on its default host, port, and cluster.
 // For instructions on installing the NATS server,
-// go to [NATS Server Installation](https://nats-io.github.io/docs/nats_server/installation.html).
+// go to [NATS Server Installation](https://docs.nats.io/nats-server/installation).


### PR DESCRIPTION


## Purpose
> The NATS team has updated its documentation to the new Gitbook at https://docs.nats.io
Updated the link to the installation instructions for NATS on the learn by example Basic Publisher and Subscriber.
