### PR TITLE
Replace white-spaces in client URL with percent encoding

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -57,6 +57,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
@@ -77,7 +78,7 @@ public abstract class AbstractHTTPAction {
     private static final Logger logger = LoggerFactory.getLogger(AbstractHTTPAction.class);
 
     private static final String CACHE_BALLERINA_VERSION;
-
+    private static final String WHITESPACE = " ";
     static {
         CACHE_BALLERINA_VERSION = System.getProperty(BALLERINA_VERSION);
     }
@@ -121,7 +122,7 @@ public abstract class AbstractHTTPAction {
         }
         try {
             String uri = getServiceUri(serviceUri) + path;
-            URL url = new URL(uri);
+            URL url = new URL(encodeWhitespacesInUri(uri));
 
             int port = getOutboundReqPort(url);
             String host = url.getHost();
@@ -143,6 +144,14 @@ public abstract class AbstractHTTPAction {
             throw HttpUtil.createHttpError("service URI is not defined correctly.", HttpErrorType.GENERIC_CLIENT_ERROR);
         }
         return serviceUri;
+    }
+
+    private static String encodeWhitespacesInUri(String uri) throws UnsupportedEncodingException {
+        if (!uri.contains(WHITESPACE)) {
+            return uri;
+        }
+        // Uses Percent-Encoding as defined in spec(https://tools.ietf.org/html/rfc3986#section-2.1)
+        return uri.trim().replaceAll(WHITESPACE, "%20");
     }
 
     private static void setOutboundReqHeaders(HttpCarbonMessage outboundRequest, int port, String host) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -57,7 +57,6 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
@@ -146,7 +145,7 @@ public abstract class AbstractHTTPAction {
         return serviceUri;
     }
 
-    private static String encodeWhitespacesInUri(String uri) throws UnsupportedEncodingException {
+    private static String encodeWhitespacesInUri(String uri) {
         if (!uri.contains(WHITESPACE)) {
             return uri;
         }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPClientActionsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPClientActionsTestCase.java
@@ -112,6 +112,12 @@ public class HTTPClientActionsTestCase extends HttpBaseTest {
         sendAndAssert("handleStringJsonAlternate", "ab");
     }
 
+    @Test(description = "Test client path with whitespaces")
+    public void testClientPathWithWhitespaces() throws IOException {
+        sendAndAssert("literal", "dispatched to white_spaced literal");
+        sendAndAssert("expression", "dispatched to white_spaced expression");
+    }
+
     private void sendAndAssert(String path, String expectedResponse) throws IOException {
         HttpResponse response = HttpClientRequest.doGet(
                 serverInstance.getServiceURLHttp(servicePort, SERVICE_URL_PART + path));

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/08_http_client_actions.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/08_http_client_actions.bal
@@ -111,6 +111,20 @@ service backEndService on new http:Listener(9097) {
     resource function respond(http:Caller caller, http:Request request) {
         checkpanic caller->respond(checkpanic <@untainted> request.getTextPayload());
     }
+
+    @http:ResourceConfig {
+            path: "/{id}"
+    }
+    resource function withWhitespacedExpression(http:Caller caller, http:Request request, string id) {
+        var res = caller->respond(<@untainted> id);
+    }
+
+    @http:ResourceConfig {
+            path: "/a/b%20c/d"
+    }
+    resource function withWhitespacedLiteral(http:Caller caller, http:Request request) {
+        var res = caller->respond("dispatched to white_spaced literal");
+    }
 }
 
 @http:ServiceConfig {
@@ -394,5 +408,23 @@ service testService on new http:Listener(9098) {
             value = err.reason();
         }
         checkpanic caller->respond(<@untainted> value);
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/literal"
+    }
+    resource function testPathWithWhitespacesForLiteral(http:Caller caller, http:Request request) returns error? {
+        http:Response response = check clientEP2->get("/test1/a/b c/d ");
+        var res = caller->respond(<@untainted> response);
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/expression"
+    }
+    resource function testClientPathWithWhitespacesForExpression(http:Caller caller, http:Request request) returns error? {
+        http:Response response = check clientEP2->get("/test1/dispatched to white_spaced expression ");
+        var res = caller->respond(<@untainted> response);
     }
 }


### PR DESCRIPTION
## Purpose
> HTTP client does not replace spaces with `%20` and it leads to request failure

`decodeResult: failure(java.lang.IllegalArgumentException: invalid version format`

Fixes #<Issue Number>

## Approach
> According to the[ URI spec](https://tools.ietf.org/html/rfc3986#section-2.1) white space is replaced with percent encoding `%20`

## Samples
```ballerina
http:Response response = check clientEP2->get("/test1/a/b c/d ");
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
