### PR TITLE
Fix usages of "invalid literal for type" error message

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -190,7 +190,6 @@ public enum DiagnosticCode {
 
     INVALID_LITERAL_FOR_TYPE("invalid.literal.for.type"),
     INCOMPATIBLE_MAPPING_CONSTRUCTOR("incompatible.mapping.constructor.expression"),
-    MISSING_FIELDS_IN_MAPPING_CONSTRUCTOR("missing.fields.in.mapping.constructor"),
     MAPPING_CONSTRUCTOR_COMPATIBLE_TYPE_NOT_FOUND("mapping.constructor.compatible.type.not.found"),
     CANNOT_INFER_TYPES_FOR_TUPLE_BINDING("cannot.infer.types.for.tuple.binding"),
     INVALID_LITERAL_FOR_MATCH_PATTERN("invalid.literal.for.match.pattern"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -189,6 +189,8 @@ public enum DiagnosticCode {
     UNSAFE_CONVERSION_ATTEMPT("unsafe.conversion.attempt"),
 
     INVALID_LITERAL_FOR_TYPE("invalid.literal.for.type"),
+    INCOMPATIBLE_MAPPING_CONSTRUCTOR("incompatible.mapping.constructor.expression"),
+    MAPPING_CONSTRUCTOR_COMPATIBLE_TYPE_NOT_FOUND("mapping.constructor.compatible.type.not.found"),
     INVALID_LITERAL_FOR_MATCH_PATTERN("invalid.literal.for.match.pattern"),
     INVALID_EXPR_WITH_TYPE_GUARD_FOR_MATCH_PATTERN("invalid.expr.with.type.guard.for.match"),
     ARRAY_LITERAL_NOT_ALLOWED("array.literal.not.allowed"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -190,6 +190,7 @@ public enum DiagnosticCode {
 
     INVALID_LITERAL_FOR_TYPE("invalid.literal.for.type"),
     INCOMPATIBLE_MAPPING_CONSTRUCTOR("incompatible.mapping.constructor.expression"),
+    MISSING_FIELDS_IN_MAPPING_CONSTRUCTOR("missing.fields.in.mapping.constructor"),
     MAPPING_CONSTRUCTOR_COMPATIBLE_TYPE_NOT_FOUND("mapping.constructor.compatible.type.not.found"),
     CANNOT_INFER_TYPES_FOR_TUPLE_BINDING("cannot.infer.types.for.tuple.binding"),
     INVALID_LITERAL_FOR_MATCH_PATTERN("invalid.literal.for.match.pattern"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -191,6 +191,7 @@ public enum DiagnosticCode {
     INVALID_LITERAL_FOR_TYPE("invalid.literal.for.type"),
     INCOMPATIBLE_MAPPING_CONSTRUCTOR("incompatible.mapping.constructor.expression"),
     MAPPING_CONSTRUCTOR_COMPATIBLE_TYPE_NOT_FOUND("mapping.constructor.compatible.type.not.found"),
+    CANNOT_INFER_TYPES_FOR_TUPLE_BINDING("cannot.infer.types.for.tuple.binding"),
     INVALID_LITERAL_FOR_MATCH_PATTERN("invalid.literal.for.match.pattern"),
     INVALID_EXPR_WITH_TYPE_GUARD_FOR_MATCH_PATTERN("invalid.expr.with.type.guard.for.match"),
     ARRAY_LITERAL_NOT_ALLOWED("array.literal.not.allowed"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -808,7 +808,12 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 break;
             case TUPLE_VARIABLE:
                 if (variable.isDeclaredWithVar && variable.expr.getKind() == NodeKind.LIST_CONSTRUCTOR_EXPR) {
-                    dlog.error(varRefExpr.pos, DiagnosticCode.INVALID_LITERAL_FOR_TYPE, "tuple binding pattern");
+                    List<String> bindingPatternVars = new ArrayList<>();
+                    List<BLangVariable> members = ((BLangTupleVariable) variable).memberVariables;
+                    for (BLangVariable var : members) {
+                        bindingPatternVars.add(((BLangSimpleVariable) var).name.value);
+                    }
+                    dlog.error(varRefExpr.pos, DiagnosticCode.CANNOT_INFER_TYPES_FOR_TUPLE_BINDING, bindingPatternVars);
                     variable.type = symTable.semanticError;
                     return;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -153,6 +153,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1930,10 +1930,18 @@ public class TypeChecker extends BLangNodeVisitor {
         BRecordType retType = new BRecordType(null);
         
         for (BLangWaitForAllExpr.BLangWaitKeyValue keyVal : keyVals) {
-            BSymbol symbol = symResolver.lookupSymbol(env, names.fromIdNode(keyVal.key), SymTag.VARIABLE);
+            BLangIdentifier fieldName;
+            if (keyVal.valueExpr == null || keyVal.valueExpr.getKind() != NodeKind.SIMPLE_VARIABLE_REF) {
+                fieldName = keyVal.key;
+            } else {
+                fieldName = ((BLangSimpleVarRef) keyVal.valueExpr).variableName;
+            }
+
+            BSymbol symbol = symResolver.lookupSymbol(env, names.fromIdNode(fieldName), SymTag.VARIABLE);
+            BType fieldType = symbol.type.tag == TypeTags.FUTURE ? ((BFutureType) symbol.type).constraint : symbol.type;
             BField field = new BField(names.fromIdNode(keyVal.key), null,
                                       new BVarSymbol(0, names.fromIdNode(keyVal.key), env.enclPkg.packageID,
-                                                     symbol.type, null));
+                                                     fieldType, null));
             retType.fields.add(field);
         }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1186,3 +1186,9 @@ error.invalid.package.name.qualifier=\
 
 error.identifier.literal.only.supports.alphanumerics=\
   identifier literal only supports alphanumeric characters
+
+error.incompatible.mapping.constructor.expression=\
+  incompatible mapping constructor expression for type ''{0}''
+
+error.mapping.constructor.compatible.type.not.found =\
+  a type compatible with mapping constructor expressions not found in type ''{0}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1193,5 +1193,8 @@ error.incompatible.mapping.constructor.expression=\
 error.mapping.constructor.compatible.type.not.found =\
   a type compatible with mapping constructor expressions not found in type ''{0}''
 
-error.cannot.infer.types.for.tuple.binding =\
-  invalid list constructor expression: types cannot be inferred for ''{0}'' 
+error.cannot.infer.types.for.tuple.binding=\
+  invalid list constructor expression: types cannot be inferred for ''{0}''
+
+error.missing.fields.in.mapping.constructor=\
+  incompatible mapping constructor expression: field(s) ''{0}'' not found in type ''{1}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1195,6 +1195,3 @@ error.mapping.constructor.compatible.type.not.found =\
 
 error.cannot.infer.types.for.tuple.binding=\
   invalid list constructor expression: types cannot be inferred for ''{0}''
-
-error.missing.fields.in.mapping.constructor=\
-  incompatible mapping constructor expression: field(s) ''{0}'' not found in type ''{1}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1192,3 +1192,6 @@ error.incompatible.mapping.constructor.expression=\
 
 error.mapping.constructor.compatible.type.not.found =\
   a type compatible with mapping constructor expressions not found in type ''{0}''
+
+error.cannot.infer.types.for.tuple.binding =\
+  invalid expression: types cannot be inferred for ''{0}'' 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1194,4 +1194,4 @@ error.mapping.constructor.compatible.type.not.found =\
   a type compatible with mapping constructor expressions not found in type ''{0}''
 
 error.cannot.infer.types.for.tuple.binding =\
-  invalid expression: types cannot be inferred for ''{0}'' 
+  invalid list constructor expression: types cannot be inferred for ''{0}'' 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.expressions.listconstructor;
+
+import org.ballerinalang.test.util.BAssertUtil;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for list constructor expressions.
+ */
+public class ListConstructorExprTest {
+
+    @Test
+    public void diagnosticsTest() {
+        CompileResult result = BCompileUtil.compile(
+                "test-src/expressions/listconstructor/list_constructor_negative.bal");
+        Assert.assertEquals(result.getErrorCount(), 1);
+        BAssertUtil.validateError(result, 0,
+                                  "invalid list constructor expression: types cannot be inferred for '[v1, v2, v3]'",
+                                  18, 24);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.expressions.mappingconstructor;
+
+import org.ballerinalang.test.util.BAssertUtil;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for mapping constructor expressions.
+ */
+public class MappingConstructorExprTest {
+
+    @Test
+    public void diagnosticsTest() {
+        CompileResult result = BCompileUtil.compile(
+                "test-src/expressions/mappingconstructor/mapping_constructor_negative.bal");
+        Assert.assertEquals(result.getErrorCount(), 2);
+        BAssertUtil.validateError(result, 0, "incompatible mapping constructor expression for type '(string|Person)'",
+                                  22, 23);
+        BAssertUtil.validateError(result, 1,
+                                  "a type compatible with mapping constructor expressions not found in type '" +
+                                          "(int|float)'",
+                                  26, 19);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
@@ -308,12 +308,19 @@ public class ClosedRecordTest {
     @Test
     public void testInvalidExprsAsRecordLiteralKeys() {
         CompileResult result = BCompileUtil.compile("test-src/record/closed_record_invalid_key_expr_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 6);
-        BAssertUtil.validateError(result, 0, "incompatible types: expected 'string', found 'float'", 34, 27);
-        BAssertUtil.validateError(result, 1, "missing non-defaultable required record field 's'", 35, 14);
-        BAssertUtil.validateError(result, 2, "incompatible types: expected 'string', found 'int'", 36, 27);
-        BAssertUtil.validateError(result, 3, "incompatible types: expected 'string', found 'boolean'", 37, 37);
-        BAssertUtil.validateError(result, 4, "missing non-defaultable required record field 's'", 38, 14);
-        BAssertUtil.validateError(result, 5, "incompatible types: expected '(string|int)', found 'error'", 41, 44);
+        int index = 0;
+
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'string', found 'float'", 34, 27);
+        BAssertUtil.validateError(result, index++, "missing non-defaultable required record field 's'", 35, 14);
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'string', found 'int'", 36, 27);
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'string', found 'boolean'", 37, 37);
+        BAssertUtil.validateError(result, index++, "missing non-defaultable required record field 's'", 38, 14);
+        BAssertUtil.validateError(result, index++, "incompatible types: expected '(string|int)', found 'error'",
+                                  41, 44);
+        BAssertUtil.validateError(result, index++, "undefined field 'invalid' in record 'Foo'", 45, 26);
+        BAssertUtil.validateError(result, index++, "undefined field 'x' in record 'Foo'", 46, 28);
+        BAssertUtil.validateError(result, index++, "undefined field 'y' in record 'Foo'", 46, 36);
+        BAssertUtil.validateError(result, index++, "undefined field 'z' in record 'Foo'", 46, 48);
+        Assert.assertEquals(result.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordFieldsAccessNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordFieldsAccessNegativeTest.java
@@ -42,7 +42,9 @@ public class RecordFieldsAccessNegativeTest {
         BAssertUtil.validateError(result, i++, "attempt to expose non-public symbol 'FooFamily'", 12, 5);
         BAssertUtil.validateError(result, i++, "attempt to refer to non-accessible symbol 'PrivatePerson'", 20, 5);
         BAssertUtil.validateError(result, i++, "unknown type 'PrivatePerson'", 20, 5);
-        BAssertUtil.validateError(result, i++, "invalid literal for type 'other'", 20, 27);
+        BAssertUtil.validateError(result, i++,
+                                  "a type compatible with mapping constructor expressions not found in type 'other'",
+                                  20, 27);
     }
 
     @Test(description = "Test private fields access in record 02")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -94,7 +94,9 @@ public class TypeGuardTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 131, 22);
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: expected '(int|string|boolean)', found 'float'", 133, 13);
-        BAssertUtil.validateError(negativeResult, i++, "invalid literal for type '(int|string|boolean)'", 137, 9);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "a type compatible with mapping constructor expressions not found in type '(int|string|boolean)'",
+                                  137, 9);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found '(int|string)'", 154,
                 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found '(int|string)'", 167,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -95,8 +95,8 @@ public class TypeGuardTest {
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: expected '(int|string|boolean)', found 'float'", 133, 13);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "a type compatible with mapping constructor expressions not found in type '(int|string|boolean)'",
-                                  137, 9);
+                                  "a type compatible with mapping constructor expressions not found in " +
+                                          "type '(int|string|boolean)'", 137, 9);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found '(int|string)'", 154,
                 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found '(int|string)'", 167,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
@@ -48,7 +48,9 @@ public class StructNegativeTest {
         // test undeclared struct init
         BAssertUtil.validateError(result, 2, "unknown type 'Department123'", 18, 5);
 
-        BAssertUtil.validateError(result, 3, "invalid literal for type 'other'", 18, 26);
+        BAssertUtil.validateError(result, 3,
+                                  "a type compatible with mapping constructor expressions not found in type 'other'",
+                                  18, 26);
 
         // test undeclared struct access
         BAssertUtil.validateError(result, 4, "undefined symbol 'dpt1'", 23, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantNegativeTest.java
@@ -60,7 +60,9 @@ public class SimpleConstantNegativeTest {
         BAssertUtil.validateError(compileResult, index++, "cannot update constant value", 33, 9);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected 'string', found 'int'",
                 40, 21);
-        BAssertUtil.validateError(compileResult, index++, "invalid literal for type 'string'", 42, 18);
+        BAssertUtil.validateError(compileResult, index++,
+                                  "a type compatible with mapping constructor expressions not found in type 'string'",
+                                  42, 18);
         BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'abc'", 47, 7);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected 'GET', found 'XYZ'",
                 64, 21);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
@@ -80,8 +80,7 @@ public class WaitActionsNegativeTest {
                 "missing non-defaultable required record field 'f2'", 86, 25);
         BAssertUtil.validateError(resultNegative, index++,
                                   "incompatible types: expected 'sealedRec', found 'record {| other id; other name; " +
-                                          "other status; |}",
-                                  87, 26);
+                                          "other status; |}'", 87, 26);
         BAssertUtil.validateError(resultNegative, index++,
                 "invalid field name 'status' in type 'sealedRec'", 88, 26);
         BAssertUtil.validateError(resultNegative, index++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
@@ -79,7 +79,9 @@ public class WaitActionsNegativeTest {
         BAssertUtil.validateError(resultNegative, index++,
                 "missing non-defaultable required record field 'f2'", 86, 25);
         BAssertUtil.validateError(resultNegative, index++,
-                "invalid literal for type 'sealedRec'", 87, 26);
+                                  "incompatible types: expected 'sealedRec', found 'record {| other id; other name; " +
+                                          "other status; |}",
+                                  87, 26);
         BAssertUtil.validateError(resultNegative, index++,
                 "invalid field name 'status' in type 'sealedRec'", 88, 26);
         BAssertUtil.validateError(resultNegative, index++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
@@ -79,8 +79,8 @@ public class WaitActionsNegativeTest {
         BAssertUtil.validateError(resultNegative, index++,
                 "missing non-defaultable required record field 'f2'", 86, 25);
         BAssertUtil.validateError(resultNegative, index++,
-                                  "incompatible types: expected 'sealedRec', found 'record {| other id; other name; " +
-                                          "other status; |}'", 87, 26);
+                                  "incompatible types: expected 'sealedRec', found 'record {| int id; string name; " +
+                                          "boolean status; |}'", 87, 26);
         BAssertUtil.validateError(resultNegative, index++,
                 "invalid field name 'status' in type 'sealedRec'", 88, 26);
         BAssertUtil.validateError(resultNegative, index++,

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_negative.bal
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testIncompatibleListConstructorExprs() {
+    var [v1, v2, v3] = ["hello", 123, 34.56];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_negative.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Person record {|
+    string name;
+|};
+
+function testUnionsWithTypesSupportingMappingConstructors() {
+    string|Person x = {name: "John", age: 25};
+}
+
+function testUnionsOfTypesWithoutSupportForMappingConstructors() {
+    int|float x = {name: "John", age: 25};
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/closed_record_invalid_key_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/closed_record_invalid_key_expr_negative.bal
@@ -40,3 +40,8 @@ function testInvalidExprAsRecordKey() {
     error e = error("test error");
     Foo f6 = { s: "str", [getString("e")]: e };
 }
+
+function testNonExistentKeyInOptionalType() {
+    Foo? f1 = {s: "foo", invalid: 123};
+    ()|Foo f2 = {s: "foo", x: 123, y: "hello", z: 34.56};
+}

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -101,6 +101,8 @@
             <package name="org.ballerinalang.test.expressions.stamp.*"/>
             <package name="org.ballerinalang.test.expressions.lambda.*"/>
             <package name="org.ballerinalang.test.expressions.invocations.*"/>
+            <package name="org.ballerinalang.test.expressions.mappingconstructor.*"/>
+            <package name="org.ballerinalang.test.expressions.listconstructor.*"/>
             <package name="org.ballerinalang.test.object.*" />
             <package name="org.ballerinalang.test.dataflow.analysis.*" />
             <package name="org.ballerinalang.test.documentation.*" />


### PR DESCRIPTION
## Purpose
> For mapping constructor expressions, there was an error message which said "invalid literal for type 'T'". This PR replaces the usage of this error message with improved/other error messages.

Fixes #17360

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
