### PR TITLE
Stringify RPC messages which are posted to webview communication channel

### DIFF
--- a/tool-plugins/vscode/resources/utils/messaging.js
+++ b/tool-plugins/vscode/resources/utils/messaging.js
@@ -19,7 +19,7 @@ class WebViewRPCHandler {
                     .then((response) => {
                         vscode.postMessage({
                             originId: msg.id,
-                            response: response
+                            response: JSON.stringify(response)
                         });
                     });
             }
@@ -27,7 +27,7 @@ class WebViewRPCHandler {
             // this is a response from remote
             const seqId = msg.originId;
             if (this._callbacks[seqId]) {
-                this._callbacks[seqId](msg.response);
+                this._callbacks[seqId](JSON.parse(msg.response));
                 delete this._callbacks[seqId];
             }
         }

--- a/tool-plugins/vscode/src/utils/rpc/handler.ts
+++ b/tool-plugins/vscode/src/utils/rpc/handler.ts
@@ -163,7 +163,7 @@ export class WebViewRPCHandler {
                     .then((response: Thenable<any>) => {
                         this.webViewPanel.webview.postMessage({
                             originId: msg.id,
-                            response,
+                            response: JSON.stringify(response)
                         });
                     });
             }
@@ -171,7 +171,7 @@ export class WebViewRPCHandler {
             // this is a response from remote to one of our requests
             const callback = this._callbacks.get(msg.originId);
             if (callback) {
-                callback(msg.response);
+                callback(JSON.parse(msg.response));
                 this._callbacks.delete(msg.originId);
             }
         }


### PR DESCRIPTION
Since VSCode 1.40.1, Webview gets stuck while deserializing
some Ballerina ASTs implicitly. Hence, manually stringify the messages
and parse them back to JSON after consumption by each RPC client.
