### PR TITLE
Add default init function to object to hold fields

### DIFF
--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_type_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_type_gen.bal
@@ -312,29 +312,41 @@ function generateObjectValueCreateMethod(jvm:ClassWriter cw, bir:TypeDef?[] obje
                                     kind: "LOCAL" };
         int strandVarIndex = indexMap.getIndex(strandVar);
         mv.visitVarInsn(ASTORE, strandVarIndex);
-        
+
         mv.visitVarInsn(ALOAD, tempVarIndex);
         mv.visitVarInsn(ALOAD, strandVarIndex);
 
-        mv.visitLdcInsn("__init");        
-        mv.visitVarInsn(ALOAD, argsIndex);
+        mv.visitLdcInsn("$__init$");
+        mv.visitInsn(ACONST_NULL);
 
         string methodDesc = io:sprintf("(L%s;L%s;[L%s;)L%s;", STRAND, STRING_VALUE, OBJECT, OBJECT);
         mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "call", methodDesc, true);
 
-        bir:VariableDcl tempResult = { typeValue: "any",
-                                    name: { value: "tempResult" },
-                                    kind: "LOCAL" };
-        int tempResultIndex = indexMap.getIndex(tempResult);
-        mv.visitVarInsn(ASTORE, tempResultIndex);
-        mv.visitVarInsn(ALOAD, tempResultIndex);
-        mv.visitTypeInsn(INSTANCEOF, ERROR_VALUE);
-        jvm:Label noErrorLabel = new jvm:Label();
-        mv.visitJumpInsn(IFEQ, noErrorLabel);
-        mv.visitVarInsn(ALOAD, tempResultIndex);
-        mv.visitTypeInsn(CHECKCAST, ERROR_VALUE);
-        mv.visitInsn(ATHROW);
-        mv.visitLabel(noErrorLabel);
+        mv.visitInsn(POP);
+        bir:BObjectType objType = <bir:BObjectType> typeDef.typeValue;
+        if !(objType.constructor is ()) {
+            mv.visitVarInsn(ALOAD, tempVarIndex);
+            mv.visitVarInsn(ALOAD, strandVarIndex);
+            mv.visitLdcInsn("__init");
+            mv.visitVarInsn(ALOAD, argsIndex);
+
+            mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "call", methodDesc, true);
+
+            bir:VariableDcl tempResult = { typeValue: "any",
+                                        name: { value: "tempResult" },
+                                        kind: "LOCAL" };
+            int tempResultIndex = indexMap.getIndex(tempResult);
+            mv.visitVarInsn(ASTORE, tempResultIndex);
+            mv.visitVarInsn(ALOAD, tempResultIndex);
+            mv.visitTypeInsn(INSTANCEOF, ERROR_VALUE);
+            jvm:Label noErrorLabel = new jvm:Label();
+            mv.visitJumpInsn(IFEQ, noErrorLabel);
+            mv.visitVarInsn(ALOAD, tempResultIndex);
+            mv.visitTypeInsn(CHECKCAST, ERROR_VALUE);
+            mv.visitInsn(ATHROW);
+            mv.visitLabel(noErrorLabel);
+        }
+
         mv.visitVarInsn(ALOAD, tempVarIndex);
         mv.visitInsn(ARETURN);
 

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_type_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_type_gen.bal
@@ -316,25 +316,38 @@ function generateObjectValueCreateMethod(jvm:ClassWriter cw, bir:TypeDef?[] obje
         mv.visitVarInsn(ALOAD, tempVarIndex);
         mv.visitVarInsn(ALOAD, strandVarIndex);
 
-        mv.visitLdcInsn("__init");
-        mv.visitVarInsn(ALOAD, argsIndex);
+        mv.visitLdcInsn("$__init$");
+        mv.visitInsn(ACONST_NULL);
 
         string methodDesc = io:sprintf("(L%s;L%s;[L%s;)L%s;", STRAND, STRING_VALUE, OBJECT, OBJECT);
         mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "call", methodDesc, true);
 
-        bir:VariableDcl tempResult = { typeValue: "any",
-                                    name: { value: "tempResult" },
-                                    kind: "LOCAL" };
-        int tempResultIndex = indexMap.getIndex(tempResult);
-        mv.visitVarInsn(ASTORE, tempResultIndex);
-        mv.visitVarInsn(ALOAD, tempResultIndex);
-        mv.visitTypeInsn(INSTANCEOF, ERROR_VALUE);
-        jvm:Label noErrorLabel = new jvm:Label();
-        mv.visitJumpInsn(IFEQ, noErrorLabel);
-        mv.visitVarInsn(ALOAD, tempResultIndex);
-        mv.visitTypeInsn(CHECKCAST, ERROR_VALUE);
-        mv.visitInsn(ATHROW);
-        mv.visitLabel(noErrorLabel);
+        mv.visitInsn(POP);
+
+        bir:BObjectType objType = <bir:BObjectType> typeDef.typeValue;
+        if !(objType.constructor is ()) {
+            mv.visitVarInsn(ALOAD, tempVarIndex);
+            mv.visitVarInsn(ALOAD, strandVarIndex);
+            mv.visitLdcInsn("__init");
+            mv.visitVarInsn(ALOAD, argsIndex);
+
+            mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "call", methodDesc, true);
+
+            bir:VariableDcl tempResult = { typeValue: "any",
+                                        name: { value: "tempResult" },
+                                        kind: "LOCAL" };
+            int tempResultIndex = indexMap.getIndex(tempResult);
+            mv.visitVarInsn(ASTORE, tempResultIndex);
+            mv.visitVarInsn(ALOAD, tempResultIndex);
+            mv.visitTypeInsn(INSTANCEOF, ERROR_VALUE);
+            jvm:Label noErrorLabel = new jvm:Label();
+            mv.visitJumpInsn(IFEQ, noErrorLabel);
+            mv.visitVarInsn(ALOAD, tempResultIndex);
+            mv.visitTypeInsn(CHECKCAST, ERROR_VALUE);
+            mv.visitInsn(ATHROW);
+            mv.visitLabel(noErrorLabel);
+        }
+
         mv.visitVarInsn(ALOAD, tempVarIndex);
         mv.visitInsn(ARETURN);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -367,7 +367,7 @@ public class BIRPackageSymbolEnter {
                         || funcName.equals(Names.INIT_FUNCTION_SUFFIX.value)) {
                     structureTypeSymbol.initializerFunc = attachedFunc;
                 } else if (funcName.equals(Names.DEFAULT_INIT_SUFFIX.value)) {
-                    structureTypeSymbol.defaultInitializerFunc = attachedFunc;
+                    ((BObjectTypeSymbol) structureTypeSymbol).defaultInitializerFunc = attachedFunc;
                 }
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1021,6 +1021,10 @@ public class BIRPackageSymbolEnter {
                         objectType.fields.add(structField);
                         objectSymbol.scope.define(objectVarSymbol.name, objectVarSymbol);
                     }
+                    boolean defaultConstructorPresent = inputStream.readBoolean();
+                    if (defaultConstructorPresent) {
+                        ignoreAttachedFunc();
+                    }
                     boolean constructorPresent = inputStream.readBoolean();
                     if (constructorPresent) {
                         ignoreAttachedFunc();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -366,6 +366,8 @@ public class BIRPackageSymbolEnter {
                 if (Names.USER_DEFINED_INIT_SUFFIX.value.equals(funcName)
                         || funcName.equals(Names.INIT_FUNCTION_SUFFIX.value)) {
                     structureTypeSymbol.initializerFunc = attachedFunc;
+                } else if (funcName.equals(Names.DEFAULT_INIT_SUFFIX.value)) {
+                    structureTypeSymbol.defaultInitializerFunc = attachedFunc;
                 }
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.ballerinalang.model.elements.MarkdownDocAttachment;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.ByteCPEntry;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.FloatCPEntry;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.IntegerCPEntry;
@@ -343,9 +344,17 @@ public class BIRTypeWriter implements TypeVisitor {
             attachedFuncs = new ArrayList<>();
             buff.writeByte(0); // constructor not present
         }
-        buff.writeInt(attachedFuncs.size());
+
+        List<BAttachedFunction> writableAttachedFunctions = new ArrayList<>();
         for (BAttachedFunction attachedFunc : attachedFuncs) {
-            writeAttachFunction(attachedFunc);
+            if (bObjectType.getKind() == TypeKind.SERVICE && attachedFunc.funcName == Names.DEFAULT_INIT_SUFFIX) {
+                continue;
+            }
+            writableAttachedFunctions.add(attachedFunc);
+        }
+        buff.writeInt(writableAttachedFunctions.size());
+        for (BAttachedFunction writableAttachedFunc : writableAttachedFunctions) {
+            writeAttachFunction(writableAttachedFunc);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -650,7 +650,6 @@ public class ASTBuilderUtil {
         objectInitNode.type = type;
 
         BLangInvocation invocationNode = (BLangInvocation) TreeBuilder.createInvocationNode();
-        invocationNode.symbol = ((BObjectTypeSymbol) type.tsymbol).initializerFunc.symbol;
         invocationNode.type = type;
 
         BLangIdentifier pkgNameNode = (BLangIdentifier) TreeBuilder.createIdentifierNode();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -29,7 +29,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.BLangBuiltInMethod;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BCastOperatorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BOperatorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -347,7 +347,6 @@ public class Desugar extends BLangNodeVisitor {
                 if (objectTypeNode.flagSet.contains(Flag.ABSTRACT)) {
                     continue;
                 }
-
                 objectTypeNode.defaultInitFunction = createInitFunctionForObjectType(objectTypeNode, env);
 
                 // Add default init function to the attached function list

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BObjectTypeSymbol.java
@@ -36,6 +36,7 @@ public class BObjectTypeSymbol extends BStructureTypeSymbol {
 
     // This is a cache of the functions referred through the type references
     public List<BAttachedFunction> referencedFunctions;
+    public BAttachedFunction defaultInitializerFunc;
 
     // The scope in which the object methods are defined
     public Scope methodScope;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BStructureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BStructureTypeSymbol.java
@@ -34,7 +34,6 @@ public abstract class BStructureTypeSymbol extends BTypeSymbol {
 
     public List<BAttachedFunction> attachedFuncs;
     public BAttachedFunction initializerFunc;
-    public BAttachedFunction defaultInitializerFunc;
 
     BStructureTypeSymbol(SymbolKind kind, int symTag, int flags, Name name, PackageID pkgID, BType type,
                          BSymbol owner) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BStructureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BStructureTypeSymbol.java
@@ -34,6 +34,7 @@ public abstract class BStructureTypeSymbol extends BTypeSymbol {
 
     public List<BAttachedFunction> attachedFuncs;
     public BAttachedFunction initializerFunc;
+    public BAttachedFunction defaultInitializerFunc;
 
     BStructureTypeSymbol(SymbolKind kind, int symTag, int flags, Name name, PackageID pkgID, BType type,
                          BSymbol owner) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
@@ -41,6 +41,7 @@ public class BLangObjectTypeNode extends BLangStructureTypeNode implements Objec
 
     public List<BLangFunction> functions;
     public BLangFunction initFunction;
+    public BLangFunction defInitFunction;
     public BLangSimpleVariable receiver;
 
     public Set<Flag> flagSet;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
@@ -40,8 +40,7 @@ import java.util.Set;
 public class BLangObjectTypeNode extends BLangStructureTypeNode implements ObjectTypeNode {
 
     public List<BLangFunction> functions;
-    public BLangFunction initFunction;
-    public BLangFunction defInitFunction;
+    public BLangFunction defaultInitFunction;
     public BLangSimpleVariable receiver;
 
     public Set<Flag> flagSet;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
@@ -68,6 +68,7 @@ public class Names {
     public static final Name STOP_FUNCTION_SUFFIX = new Name(".<stop>");
     public static final Name SELF = new Name("self");
     public static final Name USER_DEFINED_INIT_SUFFIX = new Name("__init");
+    public static final Name DEFAULT_INIT_SUFFIX = new Name("$__init$");
     // TODO remove when current project name is read from manifest
     public static final Name ANON_ORG = new Name("$anon");
     public static final Name NIL_VALUE = new Name("()");

--- a/stdlib/bir-old/src/main/ballerina/src/bir/bir_model.bal
+++ b/stdlib/bir-old/src/main/ballerina/src/bir/bir_model.bal
@@ -404,6 +404,7 @@ public type BObjectType record {|
     BObjectField?[] fields = [];
     BAttachedFunction?[] attachedFunctions = [];
     BAttachedFunction? constructor;
+    BAttachedFunction? defaultConstructor;
 |};
 
 public type BTypeHandle record {

--- a/stdlib/bir-old/src/main/ballerina/src/bir/type_parser.bal
+++ b/stdlib/bir-old/src/main/ballerina/src/bir/type_parser.bal
@@ -287,10 +287,14 @@ public type TypeParser object {
             isAbstract: isAbstract,
             fields: [],
             attachedFunctions: [],
-            constructor: () };
+            constructor: (),
+            defaultConstructor: () };
         self.cp.types[self.cpI] = obj;
         obj.fields = self.parseObjectFields();
-
+        boolean defaultConstructorPresent = self.readBoolean();
+        if (defaultConstructorPresent) {
+            obj.defaultConstructor = self.readAttachFunction();
+        }
         boolean constructorPresent = self.readBoolean();
         if (constructorPresent) {
             obj.constructor = self.readAttachFunction();

--- a/stdlib/bir/src/main/ballerina/src/bir/bir_model.bal
+++ b/stdlib/bir/src/main/ballerina/src/bir/bir_model.bal
@@ -404,6 +404,7 @@ public type BObjectType record {|
     BObjectField?[] fields = [];
     BAttachedFunction?[] attachedFunctions = [];
     BAttachedFunction? constructor;
+    BAttachedFunction? defaultConstructor;
 |};
 
 public type BTypeHandle record {

--- a/stdlib/bir/src/main/ballerina/src/bir/type_parser.bal
+++ b/stdlib/bir/src/main/ballerina/src/bir/type_parser.bal
@@ -287,10 +287,14 @@ public type TypeParser object {
             isAbstract: isAbstract,
             fields: [],
             attachedFunctions: [],
-            constructor: () };
+            constructor: (),
+            defaultConstructor: () };
         self.cp.types[self.cpI] = obj;
         obj.fields = self.parseObjectFields();
-
+        boolean defaultConstructorPresent = self.readBoolean();
+        if (defaultConstructorPresent) {
+            obj.defaultConstructor = self.readAttachFunction();
+        }
         boolean constructorPresent = self.readBoolean();
         if (constructorPresent) {
             obj.constructor = self.readAttachFunction();

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/ServiceDefinition.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/ServiceDefinition.java
@@ -144,6 +144,9 @@ public final class ServiceDefinition {
         AttachedFunction[] attachedFunctions = clientEndpointType.getAttachedFunctions();
         for (AttachedFunction attachedFunction : attachedFunctions) {
             String methodName = attachedFunction.getName();
+            if (methodName.equals("$__init$")) {
+                continue;
+            }
             Descriptors.MethodDescriptor methodDescriptor = serviceDescriptor.findMethodByName(methodName);
             if (methodDescriptor == null) {
                 throw new GrpcClientException("Error while initializing client stub. Couldn't find method descriptor " +

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/ServiceDefinition.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/ServiceDefinition.java
@@ -30,6 +30,7 @@ import org.ballerinalang.jvm.types.BUnionType;
 import org.ballerinalang.jvm.types.TypeTags;
 import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.net.grpc.exception.GrpcClientException;
+import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -144,7 +145,7 @@ public final class ServiceDefinition {
         AttachedFunction[] attachedFunctions = clientEndpointType.getAttachedFunctions();
         for (AttachedFunction attachedFunction : attachedFunctions) {
             String methodName = attachedFunction.getName();
-            if (methodName.equals("$__init$")) {
+            if (methodName.equals(Names.DEFAULT_INIT_SUFFIX.getValue())) {
                 continue;
             }
             Descriptors.MethodDescriptor methodDescriptor = serviceDescriptor.findMethodByName(methodName);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -191,4 +191,20 @@ public class ObjectInitializerTest {
         Assert.assertEquals(returns[0].getType().getTag(), TypeTags.STRING);
         Assert.assertEquals(returns[0].stringValue(), "Ballerina");
     }
+
+    @Test(description = "Test invoking '__init' function in a function inside object descriptor when field values are" +
+            " being changed.")
+    public void testInitInvocationInsideObjectForChangingFieldValues() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationInsideObjectForChangingFieldValues");
+
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 80);
+    }
+
+    @Test(description = "Test invoking '__init' function with args in a function inside object descriptor when field " +
+            "values are being changed.")
+    public void testInitInvocationInsideObjectForChangingFieldValuesWithArgs() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationInsideObjectForChangingFieldValues");
+
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 80);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -203,8 +203,9 @@ public class ObjectInitializerTest {
     @Test(description = "Test invoking '__init' function with args in a function inside object descriptor when field " +
             "values are being changed.")
     public void testInitInvocationInsideObjectForChangingFieldValuesWithArgs() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationInsideObjectForChangingFieldValues");
+        BValue[] returns = BRunUtil.invoke(compileResult,
+                "testInitInvocationInsideObjectForChangingFieldValuesWithArgs");
 
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 80);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 82);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -241,3 +241,42 @@ function testCheckPanicInObjectInitArg() returns error {
 function testObjectInitPanic() returns error|PanicReceiver {
     return trap new PanicReceiver("Mr. Panic");
 }
+
+type Student1 object {
+    public int marks = 75;
+
+    public function __init() {
+        string grade = "B";
+    }
+
+    public function getMarks() returns int {
+        self.__init();
+        return self.marks;
+    }
+};
+
+function testInitInvocationInsideObjectForChangingFieldValues() returns int {
+    Student1 student = new;
+    student.marks = 80;
+    return student.getMarks();
+}
+
+type Student2 object {
+    public int marks = 75;
+    public string grade;
+
+    public function __init(string grade) {
+        self.grade = grade;
+    }
+
+    public function getMarks() returns int {
+        self.__init("B+");
+        return self.marks;
+    }
+};
+
+function testInitInvocationInsideObjectForChangingFieldValuesWithArgs() returns int {
+    Student2 student = new("B");
+    student.marks = 82;
+    return student.getMarks();
+}


### PR DESCRIPTION
## Purpose
According to the previous implementation, the initialization of fields of an object is done inside the __init() function. Because of that, initialization happens each and every time we call the self.__init(). This PR fixes that issue. 

Fixes #15240

## Approach
Create another init function called default init function and initialization of fields are done inside the methods.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
