### PR TITLE
Add default values to optional fields to generated record types

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/Message.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/Message.java
@@ -104,7 +104,8 @@ public class Message {
             if (bMapValue != null) {
                 for (Map.Entry<Integer, Descriptors.FieldDescriptor> entry : fieldDescriptors.entrySet()) {
                     if (entry.getValue().getType().toProto().getNumber() ==
-                            DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE_VALUE) {
+                            DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE_VALUE &&
+                            !entry.getValue().isRepeated()) {
                         bMapValue.put(entry.getValue().getName(), null);
                     } else if (entry.getValue().getType().toProto().getNumber() ==
                             DescriptorProtos.FieldDescriptorProto.Type.TYPE_ENUM_VALUE) {

--- a/stdlib/grpc/src/main/resources/templates/skeleton/message.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/message.mustache
@@ -1,5 +1,5 @@
 public type {{messageName}} record {|
-    {{#fieldList}}{{fieldType}}{{#isNull defaultValue}}?{{/isNull}}{{fieldLabel}} {{{fieldName}}}{{#isNotNull defaultValue}} = {{#equals fieldType "string"}}{{#if fieldLabel}}{{defaultValue}}{{else}}"{{defaultValue}}"{{/if}}{{/equals}}{{#not_equal fieldType "string"}}{{defaultValue}}{{/not_equal}}{{/isNotNull}};
+    {{#fieldList}}{{fieldType}}{{#isNull defaultValue}}?{{/isNull}}{{fieldLabel}} {{{fieldName}}}{{#isNull defaultValue}} = (){{/isNull}}{{#isNotNull defaultValue}} = {{#equals fieldType "string"}}{{#if fieldLabel}}{{defaultValue}}{{else}}"{{defaultValue}}"{{/if}}{{/equals}}{{#not_equal fieldType "string"}}{{defaultValue}}{{/not_equal}}{{/isNotNull}};
     {{/fieldList}}{{#each oneofFieldMap as |value key|}}{{camelcase @key}} {{@key}};
     {{/each}}
 |};

--- a/stdlib/grpc/src/main/resources/templates/skeleton/stub.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/stub.mustache
@@ -22,12 +22,9 @@ public type {{serviceName}}{{#equals stubType "blocking"}}Blocking{{/equals}}Cli
         grpc:Headers resHeaders = new;
         {{#if outputType}}anydata result = ();
         [result, resHeaders] = payload;
-        {{#not_equal outputType "string"}}var value = typedesc<{{outputType}}>.constructFrom(result);
-        if (value is {{outputType}}) {
-            return [value, resHeaders];
-        } else {
-            return grpc:prepareError(grpc:INTERNAL_ERROR, "Error while constructing the message", value);
-        }{{/not_equal}}{{#equals outputType "string"}}return [result.toString(), resHeaders];{{/equals}}{{else}}[_, resHeaders] = payload;
+        {{#not_equal outputType "string"}}
+        return [<{{outputType}}>result, resHeaders];
+        {{/not_equal}}{{#equals outputType "string"}}return [result.toString(), resHeaders];{{/equals}}{{else}}[_, resHeaders] = payload;
         return resHeaders;{{/if}}
     }
 {{/blockingFunctions}}{{#nonBlockingFunctions}}

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -83,15 +83,15 @@ public class StubGeneratorTestCase {
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithDependency.proto",
                 "helloWorldWithDependency_pb.bal");
-        assertEquals(compileResult.getDiagnostics().length, 12);
+        assertEquals(compileResult.getDiagnostics().length, 8);
         assertEquals(compileResult.getDiagnostics()[0].toString(),
                 "ERROR: .::helloWorldWithDependency_pb.bal:21:34:: unknown type 'HelloRequest'");
         assertEquals(compileResult.getDiagnostics()[1].toString(),
                 "ERROR: .::helloWorldWithDependency_pb.bal:21:90:: unknown type 'HelloResponse'");
         assertEquals(compileResult.getDiagnostics()[5].toString(),
-                "ERROR: .::helloWorldWithDependency_pb.bal:35:32:: unknown type 'ByeRequest'");
+                "ERROR: .::helloWorldWithDependency_pb.bal:32:32:: unknown type 'ByeRequest'");
         assertEquals(compileResult.getDiagnostics()[6].toString(),
-                "ERROR: .::helloWorldWithDependency_pb.bal:35:86:: unknown type 'ByeResponse'");
+                "ERROR: .::helloWorldWithDependency_pb.bal:32:86:: unknown type 'ByeResponse'");
     }
 
     @Test(description = "Test service stub generation for service definition with enum messages")


### PR DESCRIPTION
## Purpose
Add default values to optional fields to generated record types.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
