### PR TITLE
Fix 'nvm use 8' command failure in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
       jdk: openjdk8
       node_js: 8
       before_install:
+          - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
     - stage: "Tests"
@@ -64,6 +65,7 @@ jobs:
       jdk: openjdk8
       node_js: 8
       before_install:
+          - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
       install: 


### PR DESCRIPTION
## Purpose
> Fix 'nvm use 8"' command failure in Travis

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
