### PR TITLE
Fix ballerina service test failures in unit tests

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -141,6 +141,19 @@ public class BCompileUtil {
         return compileOnJBallerina(sourceFilePath, temp, true);
     }
 
+    // This is a temp fix until service test are fix
+    public static CompileResult compileOffline(boolean temp, String sourceFilePath) {
+        Path sourcePath = Paths.get(sourceFilePath);
+        String packageName = sourcePath.getFileName().toString();
+        Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
+
+        CompilerContext context = new CompilerContext();
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        options.put(OFFLINE, "true");
+        context.put(CompilerOptions.class, options);
+        return compileOnJBallerina(context, sourceRoot.toString(), packageName, temp, true, false);
+    }
+
     private static void runInit(BLangPackage bLangPackage, ClassLoader classLoader, boolean temp)
             throws ClassNotFoundException {
         String initClassName = BFileUtil.getQualifiedClassName(bLangPackage.packageID.orgName.value,


### PR DESCRIPTION
## Purpose
> Add method to run ballerina services in unit tests, when inter-op is used. This is a temporary fix.


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
