### PR TITLE
Add a pre-build step in Travis to Install Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,6 @@ jobs:
       os: windows
       language: node_js
       node_js: 8,
-      before_install:
-          - nvm install 8
-          - nvm use 8
-          - npm install -g npm@'5.6.0'
       install:
         - choco install jdk8 -params 'installdir=c:\\java8'
         - export JAVA_HOME="c:\\java8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
       name:  "Tests - windows"
       os: windows
       language: node_js
-      node_js: 8,
+      node_js: 8
       install:
         - choco install jdk8 -params 'installdir=c:\\java8'
         - export JAVA_HOME="c:\\java8"
@@ -95,7 +95,7 @@ jobs:
       os: linux
       language: java
       jdk: openjdk8
-      node_js: 8,
+      node_js: 8
       before_install:
           - nvm install 8
           - nvm use 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
       jdk: openjdk8
       node_js: 8
       before_install:
+          - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
     - stage: "Tests"
@@ -64,6 +65,7 @@ jobs:
       jdk: openjdk8
       node_js: 8
       before_install:
+          - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
       install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,11 @@ jobs:
       name:  "Tests - windows"
       os: windows
       language: node_js
-      node_js: 8
+      node_js: 8,
+      before_install:
+          - nvm install 8
+          - nvm use 8
+          - npm install -g npm@'5.6.0'
       install:
         - choco install jdk8 -params 'installdir=c:\\java8'
         - export JAVA_HOME="c:\\java8"
@@ -95,6 +99,11 @@ jobs:
       os: linux
       language: java
       jdk: openjdk8
+      node_js: 8,
+      before_install:
+          - nvm install 8
+          - nvm use 8
+          - npm install -g npm@'5.6.0'
       name:  "Integration tests - Linux"
 
 


### PR DESCRIPTION
Seems the default NodeJs version available in travis
is changed recently and it now throws an error 
saying node 8 is not installed.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
