### PR TITLE
Remove reverse DNS look-up

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -710,9 +710,7 @@ public class HttpUtil {
         Object remoteSocketAddress = inboundMsg.getProperty(HttpConstants.REMOTE_ADDRESS);
         if (remoteSocketAddress instanceof InetSocketAddress) {
             InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteSocketAddress;
-            String remoteHost = inetSocketAddress.getHostName();
             long remotePort = inetSocketAddress.getPort();
-            remote.put(HttpConstants.REMOTE_HOST_FIELD, remoteHost);
             remote.put(HttpConstants.REMOTE_PORT_FIELD, remotePort);
         }
         httpCaller.set(HttpConstants.REMOTE_STRUCT_FIELD, remote);


### PR DESCRIPTION
## Purpose
> Doing a reverse DNS look-up can have a huge performance impact. Hence, removing it.
