### PR TITLE
Build -a command not accepts too many arguments

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -164,7 +164,7 @@ public class BuildCommand implements BLauncherCmd {
                 .initConfigurations(this.argList == null ? new String[0] : this.argList.toArray(new String[0]));
 
         // check if there are too many arguments.
-        if (args.length > 0) {
+        if (args.length > 1) {
             CommandUtil.printError(this.errStream, "too many arguments.", buildCmd, false);
             CommandUtil.exitError(this.exitWhenFinish);
             return;
@@ -228,6 +228,12 @@ public class BuildCommand implements BLauncherCmd {
             }
         
             targetPath = this.sourceRootPath.resolve(ProjectDirConstants.TARGET_DIR_NAME);
+
+            if (args.length > 0) {
+                CommandUtil.printError(this.errStream, "too many arguments.", buildCmd, false);
+                CommandUtil.exitError(this.exitWhenFinish);
+                return;
+            }
         } else if (this.argList.get(0).endsWith(BLangConstants.BLANG_SRC_FILE_SUFFIX)) {
             // when a single bal file is provided.
             if (this.compile) {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -164,7 +164,7 @@ public class BuildCommand implements BLauncherCmd {
                 .initConfigurations(this.argList == null ? new String[0] : this.argList.toArray(new String[0]));
 
         // check if there are too many arguments.
-        if (args.length > 1) {
+        if (args.length > 0) {
             CommandUtil.printError(this.errStream, "too many arguments.", buildCmd, false);
             CommandUtil.exitError(this.exitWhenFinish);
             return;

--- a/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/cmd/BuildCommandTest.java
+++ b/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/cmd/BuildCommandTest.java
@@ -279,13 +279,12 @@ public class BuildCommandTest extends CommandTest {
     @Test(description = "Build all modules with passing arguments")
     public void testBuildAllWithArg() throws IOException {
         // valid source root path
-        Path validBalFilePath = this.testResources.resolve("valid-bal-file");
+        Path validBalFilePath = this.testResources.resolve("valid-project");
         BuildCommand buildCommand = new BuildCommand(validBalFilePath, printStream, printStream, false, true);
-        // non existing bal file
         new CommandLine(buildCommand).parse("-a", "hello2");
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertTrue(buildLog.contains("ballerina: you are trying to build/compile a Ballerina project but there is no Ballerina.toml file.\n"));
+        Assert.assertTrue(buildLog.contains("too many arguments.\n"));
     }
 
     @Test(description = "Build bal file with no entry")

--- a/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/cmd/BuildCommandTest.java
+++ b/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/cmd/BuildCommandTest.java
@@ -275,7 +275,19 @@ public class BuildCommandTest extends CommandTest {
                                       "USAGE:\n" +
                                       "    ballerina build {<ballerina-file> | <module-name> | -a | --all}\n");
     }
-    
+
+    @Test(description = "Build all modules with passing arguments")
+    public void testBuildAllWithArg() throws IOException {
+        // valid source root path
+        Path validBalFilePath = this.testResources.resolve("valid-bal-file");
+        BuildCommand buildCommand = new BuildCommand(validBalFilePath, printStream, printStream, false, true);
+        // non existing bal file
+        new CommandLine(buildCommand).parse("-a", "hello2");
+        buildCommand.execute();
+        String buildLog = readOutput(true);
+        Assert.assertTrue(buildLog.contains("ballerina: you are trying to build/compile a Ballerina project but there is no Ballerina.toml file.\n"));
+    }
+
     @Test(description = "Build bal file with no entry")
     public void testBuildBalFileWithNoEntry() throws IOException {
         // valid source root path


### PR DESCRIPTION
## Purpose
> Build -a command builds only when no other arguments provided.

Fixes #18902

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
