### PR TITLE
Fix trx closure var un init issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -356,6 +356,13 @@ public class ClosureDesugar extends BLangNodeVisitor {
             BLangAssignment stmt = createAssignment(varDefNode);
             result = rewrite(stmt, env);
         } else {
+            // Note: Although it's illegal to use a closure variable without initializing it in it's declared scope,
+            // when we access (initialize) a variable from outer scope, since we desugar transaction block into a
+            // lambda invocation, we need to create the `mapSymbol` in the outer node.
+            BLangBlockStmt blockStmt = (BLangBlockStmt) env.node;
+            if (blockStmt.mapSymbol == null) {
+                blockStmt.mapSymbol = createMapSymbol("$map$block$" + blockClosureMapCount, env);
+            }
             result = varDefNode;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2909,7 +2909,7 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         // Iterate through parent nodes until a function node is met to find if the variable is used inside
-        // a transaction block to mark it as a closure
+        // a transaction block to mark it as a closure, blocks inside transactions are desugared into functions later.
         BLangNode node = env.node;
         SymbolEnv cEnv = env;
         while (node != null && node.getKind() != NodeKind.FUNCTION) {
@@ -2919,6 +2919,7 @@ public class TypeChecker extends BLangNodeVisitor {
                         SymTag.VARIABLE);
                 if (resolvedSymbol != symTable.notFoundSymbol) {
                     resolvedSymbol.closure = true;
+                    ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
                 }
                 break;
             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2919,7 +2919,6 @@ public class TypeChecker extends BLangNodeVisitor {
                         SymTag.VARIABLE);
                 if (resolvedSymbol != symTable.notFoundSymbol) {
                     resolvedSymbol.closure = true;
-                    ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
                 }
                 break;
             } else {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/TransactionBlockTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/TransactionBlockTest.java
@@ -211,6 +211,12 @@ public class TransactionBlockTest {
     }
 
     @Test
+    public void testAssignmentToUninitializedVariableOfOuterScopeFromTrxBlock() {
+        BValue[] result = BRunUtil.invoke(programFile, "testAssignmentToUninitializedVariableOfOuterScopeFromTrxBlock");
+        Assert.assertEquals(result[0].stringValue(), "init-in-transaction-block");
+    }
+
+    @Test
     public void testMultipleCommittedAbortedBlocks() {
         Assert.assertTrue(negativeProgramFile.getErrorCount() > 0);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/transaction/transaction_block_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/transaction/transaction_block_test.bal
@@ -305,3 +305,11 @@ public function testArrowFunctionInsideTransaction() returns int {
     }
     return a;
 }
+
+public function testAssignmentToUninitializedVariableOfOuterScopeFromTrxBlock() returns int|string {
+    int|string s;
+    transaction with retries = 1 {
+      s = "init-in-transaction-block";
+    }
+    return s;
+}


### PR DESCRIPTION
## Purpose
Fix bad-sad error when uninitialized variable from a outer scope is assigned within a transaction block.

```ballerina
public function main() {
    int|string s;
    transaction with retries = 1 {
      s = "empty";
    }
}
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19914

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
