### PR TITLE
Extend taint analysis to inline listener decl

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -1499,9 +1499,17 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         // Taintedness of a service variable depends on taintedness of listeners attached to this service.
         // If any listener is tainted then the service variable is tainted.
 
-        boolean anyListenerstainted = serviceConstructorExpr.serviceNode.attachedExprs.stream()
-                .filter(expr -> expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF)
-                .anyMatch(attached -> ((BLangSimpleVarRef) attached).symbol.tainted);
+        boolean anyListenerstainted = false;
+        for (BLangExpression expr : serviceConstructorExpr.serviceNode.attachedExprs) {
+            if (expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF && ((BLangSimpleVarRef) expr).symbol.tainted) {
+                anyListenerstainted = true;
+                break;
+            }
+            if (expr.getKind() == NodeKind.TYPE_INIT_EXPR) {
+                anyListenerstainted = true;
+                break;
+            }
+        }
 
         if (anyListenerstainted || serviceConstructorExpr.type.tsymbol.tainted) {
             // Service type tainted due to listeners being tainted.

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/35_http_client_100_continue.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/35_http_client_100_continue.bal
@@ -79,7 +79,7 @@ service continueClientTest on new http:Listener(9242)  {
         req.addHeader("content-type", "text/plain");
         req.addHeader("Expect", "100-continue");
         req.setPayload("Hi");
-        var response = continueClient->post("/continue", req);
+        var response = continueClient->post("/continue", <@untainted> req);
         if (response is http:Response) {
             checkpanic caller->respond(<@untainted> response);
         } else {
@@ -95,7 +95,7 @@ service continueClientTest on new http:Listener(9242)  {
         req.addHeader("Expect", "100-continue");
         req.addHeader("content-type", "application/json");
         req.setPayload({ name: "apple", color: "red" });
-        var response = continueClient->post("/continue", req);
+        var response = continueClient->post("/continue", <@untainted> req);
         if (response is http:Response) {
             checkpanic caller->respond(<@untainted> response);
         } else {

--- a/tests/jballerina-integration-test/src/test/resources/http2/src/http2services/10_http_2.0_forwarded_header.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http2/src/http2services/10_http_2.0_forwarded_header.bal
@@ -23,7 +23,7 @@ service initiatingService on new http:Listener(9105) {
                                        {forwarded: "enable", httpVersion: "2.0",
                                         http2Settings: { http2PriorKnowledge: true }});
         var responseFromForwardBackend = forwadingClient->get(
-                                        "/forwardedBackend/forwardedResource", request);
+                                        "/forwardedBackend/forwardedResource", <@untainted> request);
         if (responseFromForwardBackend is http:Response) {
             var resultSentToClient = caller->respond(responseFromForwardBackend);
         }

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/tracingservices/05_trace_test_error.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/tracingservices/05_trace_test_error.bal
@@ -46,7 +46,7 @@ service echoService4 on new http:Listener(9094) {
             error e = error("Custom Panic in Service 1");
             panic e;
         }
-        var response = callNextResource4(id);
+        var response = callNextResource4(<@untainted> id);
         if (response is http:Response) {
             outResponse.setTextPayload("Hello, World!");
             checkpanic caller->respond(outResponse);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -372,6 +372,17 @@ public class TaintedStatusPropagationTest {
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'payload'", 22, 37);
     }
 
+
+    @Test
+    public void testHttpServiceInlineListenerDecl() {
+        CompileResult result = BCompileUtil.compile(
+                "test-src/taintchecking/propagation/http-service-in-line-listener.bal");
+        Assert.assertEquals(result.getDiagnostics().length, 3);
+        BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 28, 24);
+        BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 29, 24);
+        BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'payload'", 36, 37);
+    }
+
     @Test
     public void testCompoundAssignment() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/compound-assignment.bal");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/http-service-in-line-listener.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/http-service-in-line-listener.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+
+service sample on new http:Listener(9090) {
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/path/{foo}"
+    }
+    resource function params (http:Caller caller, http:Request req, string foo) {
+        var bar = req.getQueryParamValue("bar");
+
+        secureFunction(foo, foo);
+        secureFunction(bar, bar);
+    }
+
+    resource function hi(http:Caller caller, http:Request request) {
+        http:Response response = new;
+        var req = request.getJsonPayload();
+        if (req is json) {
+            response.setJsonPayload(req);
+        } else {
+             log:printError("Invalid JSON!");
+        }
+        var result = caller->respond(response);
+        if (result is error) {
+            log:printError("Error sending response", err = result);
+        }
+    }
+}
+
+public function secureFunction (@untainted any secureIn, any insecureIn) {
+
+}


### PR DESCRIPTION
## Purpose

```ballerina
// We have missed analyzing the taintedness of listeners when declared inline such as below
service mediator on new http:Listener(9090) {
    @http:ResourceConfig {
        methods: ["GET"],
        path: "/hello/{name}"
    }
    resource function hi(http:Caller caller, http:Request request, string name) {
        var err = caller -> respond("hello "+ name);
    }
}
```



Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19954

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
