### PR TITLE
Migrate ldap module into java interop

### DIFF
--- a/stdlib/ldap/build.gradle
+++ b/stdlib/ldap/build.gradle
@@ -28,12 +28,14 @@ dependencies {
     implementation project(':ballerina-auth')
     implementation project(':ballerina-crypto')
     implementation project(':ballerina-runtime-api')
+    implementation project(':ballerina-java')
 
     baloImplementation project(path: ':ballerina-lang:annotations', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-utils', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-auth', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-crypto', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-runtime-api', configuration: 'baloImplementation')
+    baloImplementation project(path: ':ballerina-java', configuration: 'baloImplementation')
 
     interopImports project(':ballerina-config-api')
     interopImports project(':ballerina-io')

--- a/stdlib/ldap/src/main/ballerina/src/ldap/inbound_ldap_auth_provider.bal
+++ b/stdlib/ldap/src/main/ballerina/src/ldap/inbound_ldap_auth_provider.bal
@@ -16,6 +16,7 @@
 
 import ballerina/auth;
 import ballerina/crypto;
+import ballerinax/java;
 
 # Represents Ballerina configuration for LDAP based auth provider.
 #
@@ -142,7 +143,14 @@ public type LdapConnection record {|
 # + ldapConnection - `LdapConnection` instance
 # + username - Username of the user to check the groups
 # + return - Array of groups for the user denoted by the username or `Error` if error occurred
-public function getGroups(LdapConnection ldapConnection, string username) returns string[]|Error = external;
+public function getGroups(LdapConnection ldapConnection, string username) returns string[]|Error {
+    return externGetGroups(ldapConnection, java:fromString(username));
+}
+
+function externGetGroups(LdapConnection ldapConnection, handle username) returns string[]|Error = @java:Method {
+    name: "getGroups",
+    class: "org.ballerinalang.stdlib.ldap.nativeimpl.GetGroups"
+} external;
 
 # Authenticate with username and password.
 #
@@ -150,8 +158,15 @@ public function getGroups(LdapConnection ldapConnection, string username) return
 # + username - Username of the user to be authenticated
 # + password - Password of the user to be authenticated
 # + return - true if authentication is a success, else false or `Error` if error occurred
-public function doAuthenticate(LdapConnection ldapConnection, string username, string password)
-                               returns boolean|Error = external;
+public function doAuthenticate(LdapConnection ldapConnection, string username, string password) returns boolean|Error {
+    return externDoAuthenticate(ldapConnection, java:fromString(username), java:fromString(password));
+}
+
+public function externDoAuthenticate(LdapConnection ldapConnection, handle username, handle password)
+                                     returns boolean|Error = @java:Method {
+    name: "doAuthenticate",
+    class: "org.ballerinalang.stdlib.ldap.nativeimpl.Authenticate"
+} external;
 
 # Initailizes LDAP connection context.
 #
@@ -159,4 +174,12 @@ public function doAuthenticate(LdapConnection ldapConnection, string username, s
 # + instanceId - Unique id generated to identify an endpoint
 # + return - `LdapConnection` instance, or `Error` if error occurred
 public function initLdapConnectionContext(LdapConnectionConfig ldapConnectionConfig, string instanceId)
-                                          returns LdapConnection|Error = external;
+                                          returns LdapConnection|Error {
+    return externInitLdapConnectionContext(ldapConnectionConfig, java:fromString(instanceId));
+}
+
+public function externInitLdapConnectionContext(LdapConnectionConfig ldapConnectionConfig, handle instanceId)
+                                                returns LdapConnection|Error = @java:Method {
+    name: "initLdapConnectionContext",
+    class: "org.ballerinalang.stdlib.ldap.nativeimpl.InitLdapConnectionContext"
+} external;

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/Authenticate.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/Authenticate.java
@@ -18,9 +18,7 @@
 
 package org.ballerinalang.stdlib.ldap.nativeimpl;
 
-import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.MapValue;
-import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.stdlib.ldap.CommonLdapConfiguration;
 import org.ballerinalang.stdlib.ldap.LdapConnectionContext;
 import org.ballerinalang.stdlib.ldap.LdapConstants;
@@ -29,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
-
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.ldap.LdapContext;
@@ -39,16 +36,12 @@ import javax.naming.ldap.LdapContext;
  *
  * @since 0.983.0
  */
-@BallerinaFunction(
-        orgName = "ballerina", packageName = "ldap",
-        functionName = "doAuthenticate", isPublic = true)
 public class Authenticate {
 
     private static final Logger LOG = LoggerFactory.getLogger(Authenticate.class);
     private static LdapConnectionContext connectionSource;
 
-    public static Object doAuthenticate(Strand strand, MapValue<?, ?> ldapConnection, String userName,
-                                        String password) {
+    public static Object doAuthenticate(MapValue<?, ?> ldapConnection, String userName, String password) {
         if (userName == null || userName.isEmpty()) {
             return LdapUtils.createError("Username is null or empty.");
         }

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/Authenticate.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/Authenticate.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.ldap.LdapContext;

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/GetGroups.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/GetGroups.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/GetGroups.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/GetGroups.java
@@ -19,11 +19,9 @@
 package org.ballerinalang.stdlib.ldap.nativeimpl;
 
 import org.ballerinalang.jvm.BallerinaErrors;
-import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.ArrayValueImpl;
 import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.MapValue;
-import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.stdlib.ldap.CommonLdapConfiguration;
 import org.ballerinalang.stdlib.ldap.LdapConstants;
 import org.ballerinalang.stdlib.ldap.util.LdapUtils;
@@ -33,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
@@ -48,14 +45,11 @@ import javax.naming.ldap.Rdn;
  *
  * @since 0.983.0
  */
-@BallerinaFunction(
-        orgName = "ballerina", packageName = "ldap",
-        functionName = "getGroups", isPublic = true)
 public class GetGroups {
 
     private static final Logger LOG = LoggerFactory.getLogger(GetGroups.class);
 
-    public static Object getGroups(Strand strand, MapValue<?, ?> ldapConnection, String userName) {
+    public static Object getGroups(MapValue<?, ?> ldapConnection, String userName) {
         try {
             LdapUtils.setServiceName((String) ldapConnection.getNativeData(LdapConstants.ENDPOINT_INSTANCE_ID));
             DirContext ldapConnectionContext = (DirContext) ldapConnection.getNativeData(

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/InitLdapConnectionContext.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/InitLdapConnectionContext.java
@@ -19,9 +19,7 @@
 package org.ballerinalang.stdlib.ldap.nativeimpl;
 
 import org.ballerinalang.jvm.BallerinaValues;
-import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.MapValue;
-import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.stdlib.ldap.CommonLdapConfiguration;
 import org.ballerinalang.stdlib.ldap.LdapConnectionContext;
 import org.ballerinalang.stdlib.ldap.LdapConstants;
@@ -37,7 +35,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.net.ssl.SSLContext;
@@ -48,13 +45,9 @@ import javax.net.ssl.SSLContext;
  *
  * @since 0.983.0
  */
-@BallerinaFunction(
-        orgName = "ballerina", packageName = "ldap",
-        functionName = "initLdapConnectionContext", isPublic = true)
 public class InitLdapConnectionContext {
 
-    public static Object initLdapConnectionContext(Strand strand, MapValue<?, ?> authProviderConfig,
-                                                   String instanceId) {
+    public static Object initLdapConnectionContext(MapValue<?, ?> authProviderConfig, String instanceId) {
         CommonLdapConfiguration commonLdapConfiguration = new CommonLdapConfiguration();
 
         commonLdapConfiguration.setDomainName(authProviderConfig.getStringValue(LdapConstants.DOMAIN_NAME));

--- a/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/InitLdapConnectionContext.java
+++ b/stdlib/ldap/src/main/java/org/ballerinalang/stdlib/ldap/nativeimpl/InitLdapConnectionContext.java
@@ -35,6 +35,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.net.ssl.SSLContext;


### PR DESCRIPTION
## Purpose
This PR migrates ballerina/ldap module into Java Interoperability and fix the Gradle build compatibility for java Interoperability usages.

Fixes #20129 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
