### PR TITLE
Move return var init before the frame class value reloading

### DIFF
--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -134,6 +134,11 @@ function genJMethodForBFunc(bir:Function func,
         k += 1;
     }
 
+    bir:VariableDcl varDcl = getVariableDcl(localVars[0]);
+    returnVarRefIndex = indexMap.getIndex(varDcl);
+    bir:BType returnType = <bir:BType> func.typeValue?.retType;
+    genDefaultValue(mv, returnType, returnVarRefIndex);
+
     bir:VariableDcl stateVar = { typeValue: "string", //should  be javaInt
                                  name: { value: "state" },
                                  kind: "TEMP" };
@@ -148,11 +153,6 @@ function genJMethodForBFunc(bir:Function func,
 
     jvm:Label varinitLable = labelGen.getLabel(funcName + "varinit");
     mv.visitLabel(varinitLable);
-
-    bir:VariableDcl varDcl = getVariableDcl(localVars[0]);
-    returnVarRefIndex = indexMap.getIndex(varDcl);
-    bir:BType returnType = <bir:BType> func.typeValue?.retType;
-    genDefaultValue(mv, returnType, returnVarRefIndex);
 
     // uncomment to test yield
     // mv.visitFieldInsn(GETSTATIC, className, "i", "I");

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -135,6 +135,11 @@ function genJMethodForBFunc(bir:Function func,
         k += 1;
     }
 
+    bir:VariableDcl varDcl = getVariableDcl(localVars[0]);
+    returnVarRefIndex = indexMap.getIndex(varDcl);
+    bir:BType returnType = <bir:BType> func.typeValue?.retType;
+    genDefaultValue(mv, returnType, returnVarRefIndex);
+
     bir:VariableDcl stateVar = { typeValue: "string", //should  be javaInt
                                  name: { value: "state" },
                                  kind: "TEMP" };
@@ -149,11 +154,6 @@ function genJMethodForBFunc(bir:Function func,
 
     jvm:Label varinitLable = labelGen.getLabel(funcName + "varinit");
     mv.visitLabel(varinitLable);
-
-    bir:VariableDcl varDcl = getVariableDcl(localVars[0]);
-    returnVarRefIndex = indexMap.getIndex(varDcl);
-    bir:BType returnType = <bir:BType> func.typeValue?.retType;
-    genDefaultValue(mv, returnType, returnVarRefIndex);
 
     // uncomment to test yield
     // mv.visitFieldInsn(GETSTATIC, className, "i", "I");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -337,4 +337,14 @@ public class WorkerTest {
             Assert.assertTrue(e.getMessage().contains("worker w5 panic"));
         }
     }
+
+    @Test
+    public void waitInReturn() {
+        BValue[] returns = BRunUtil.invoke(result, "waitInReturn");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertTrue(returns[0] instanceof BMap);
+        BMap mapResult = (BMap) returns[0];
+        Assert.assertEquals(mapResult.get("w1").stringValue(), "w1");
+        Assert.assertEquals(mapResult.get("w2").stringValue(), "w2");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -530,3 +530,15 @@ function panicFunc() {
     }
     int k = <- w5;
 }
+
+function waitInReturn() returns any {
+    worker w1 returns string {
+        return "w1";
+    }
+
+    worker w2 returns string {
+        return "w2";
+    }
+
+    return wait {w1, w2};
+}


### PR DESCRIPTION
## Purpose
> Avoid NPE when a wait statement is in the return statement.

Fixes #19990

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
