### PR TITLE
Use the new process builder for backend llvm invocation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BootstrapRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BootstrapRunner.java
@@ -57,7 +57,7 @@ public class BootstrapRunner {
             jarFilePaths.add(path.toString());
         }
         List<String> commands =
-                createArgsForJBalCompilerBackend(entryBir, jarOutputPath, dumpBir, true, jarFilePaths, birCachePaths);
+                createArgsForJBalCompilerBackend(entryBir, jarOutputPath, dumpBir, jarFilePaths, birCachePaths);
         generateJarBinaryInProc(commands);
     }
 
@@ -175,12 +175,12 @@ public class BootstrapRunner {
     }
 
     public static List<String> createArgsForJBalCompilerBackend(String entryBir, String jarOutputPath, boolean dumpBir,
-            boolean useSystemClassLoader, List<String> jarFilePaths, String... birCachePaths) {
+            List<String> jarFilePaths, String... birCachePaths) {
         List<String> commands = new ArrayList<>();
         commands.add("java");
         setSystemProperty(commands, "ballerina.bstring");
         commands.add(COMPILER_BACKEND_JVM);
-        commands.addAll(createArgsForCompilerBackend(entryBir, jarOutputPath, dumpBir, useSystemClassLoader,
+        commands.addAll(createArgsForCompilerBackend(entryBir, jarOutputPath, dumpBir, true,
                 birCachePaths, jarFilePaths));
         return commands;
     }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BootstrapRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BootstrapRunner.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,13 +46,19 @@ public class BootstrapRunner {
     private static final PrintStream err = System.err;
     private static final String CLASSPATH = "CLASSPATH";
     private static final String TMP_OBJECT_FILE_NAME = "ballerina_native_objf.o";
+    private static final String COMPILER_BACKEND_JVM = "ballerina.compiler_backend_jvm.___init";
+    private static final String COMPILER_BACKEND_LLVM = "ballerina.compiler_backend_llvm.___init";
 
     public static void loadTargetAndGenerateJarBinary(String entryBir, String jarOutputPath, boolean dumpBir,
                                                       HashSet<Path> moduleDependencySet, String... birCachePaths) {
         //Load all Jars from module dependency set.
         List<String> jarFilePaths = new ArrayList<>(moduleDependencySet.size());
-        moduleDependencySet.forEach(path -> jarFilePaths.add(path.toString()));
-        generateJarBinaryInProc(entryBir, jarOutputPath, dumpBir, jarFilePaths, birCachePaths);
+        for (Path path : moduleDependencySet) {
+            jarFilePaths.add(path.toString());
+        }
+        List<String> commands =
+                createArgsForJBalCompilerBackend(entryBir, jarOutputPath, dumpBir, true, jarFilePaths, birCachePaths);
+        generateJarBinaryInProc(commands);
     }
 
     public static void genNativeCode(String entryBir, boolean dumpLLVM, boolean noOptimizeLLVM) {
@@ -68,16 +72,8 @@ public class BootstrapRunner {
 
     private static void genObjectFile(String entryBir, String objFileOutputPath, boolean dumpLLVM,
             boolean noOptimizeLLVM) {
-        try {
-            Class<?> backendMain = Class.forName("ballerina.compiler_backend_llvm.___init");
-            Method backendMainMethod = backendMain.getMethod("main", String[].class);
-            List<String> params = createArgsForCompilerBackend(entryBir, objFileOutputPath, dumpLLVM, noOptimizeLLVM);
-            backendMainMethod.invoke(null, new Object[]{params.toArray(new String[0])});
-        } catch (InvocationTargetException e) {
-            throw new BLangCompilerException(e.getTargetException().getMessage(), e);
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
-            throw new BLangCompilerException("could not invoke compiler backend", e);
-        }
+        List<String> commands = createArgsForNBalCompilerBackend(entryBir, objFileOutputPath, dumpLLVM, noOptimizeLLVM);
+        generateJarBinaryInProc(commands);
     }
 
     private static void genExecutable(Path objectFilePath, String execFilename) {
@@ -138,16 +134,8 @@ public class BootstrapRunner {
         }
     }
 
-    public static void generateJarBinaryInProc(String entryBir, String jarOutputPath, boolean dumpBir,
-                                                List<String> jarFilePaths, String... birCachePaths) {
+    public static void generateJarBinaryInProc(List<String> commands) {
         try {
-            List<String> commands = new ArrayList<>();
-            commands.add("java");
-            setSystemProperty(commands, "ballerina.bstring");
-            commands.add("ballerina.compiler_backend_jvm.___init");
-            commands.addAll(createArgsForCompilerBackend(entryBir, jarOutputPath, dumpBir, true, birCachePaths,
-                    jarFilePaths));
-
             // pass the classpath for the sub-process
             ProcessBuilder pb = new ProcessBuilder(commands);
             Map<String, String> env = pb.environment();
@@ -186,9 +174,19 @@ public class BootstrapRunner {
         return sj.toString();
     }
 
+    public static List<String> createArgsForJBalCompilerBackend(String entryBir, String jarOutputPath, boolean dumpBir,
+            boolean useSystemClassLoader, List<String> jarFilePaths, String... birCachePaths) {
+        List<String> commands = new ArrayList<>();
+        commands.add("java");
+        setSystemProperty(commands, "ballerina.bstring");
+        commands.add(COMPILER_BACKEND_JVM);
+        commands.addAll(createArgsForCompilerBackend(entryBir, jarOutputPath, dumpBir, useSystemClassLoader,
+                birCachePaths, jarFilePaths));
+        return commands;
+    }
+
     public static List<String> createArgsForCompilerBackend(String entryBir, String jarOutputPath, boolean dumpBir,
-                                                             boolean useSystemClassLoader, String[] birCachePaths,
-                                                             List<String> jarFilePaths) {
+            boolean useSystemClassLoader, String[] birCachePaths, List<String> jarFilePaths) {
         List<String> commands = new ArrayList<>();
         commands.add(entryBir);
         commands.add(getMapPath());
@@ -201,9 +199,11 @@ public class BootstrapRunner {
         return commands;
     }
 
-    private static List<String> createArgsForCompilerBackend(String entryBir, String objFileOutputPath,
+    private static List<String> createArgsForNBalCompilerBackend(String entryBir, String objFileOutputPath,
             boolean dumpLLVM, boolean noOptimizeLLVM) {
         List<String> commands = new ArrayList<>();
+        commands.add("java");
+        commands.add(COMPILER_BACKEND_LLVM);
         commands.add(entryBir);
         commands.add(objFileOutputPath);
         commands.add(dumpLLVM ? "true" : "false"); // dump LLVM-IR

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -652,8 +652,10 @@ public class BCompileUtil {
 
         writeNonEntryPkgs(bLangPackage.symbol.imports, systemBirCache, importsBirCache, importsTarget, dumpBir);
         if (inProc) {
-            BootstrapRunner.generateJarBinaryInProc(entryBir.toString(), jarTarget.toString(), dumpBir,
-                    Collections.emptyList(), systemBirCache.toString(), importsBirCache.toString());
+            List<String> commands = BootstrapRunner.createArgsForJBalCompilerBackend(entryBir.toString(),
+                    jarTarget.toString(), dumpBir, true, Collections.emptyList(),
+                    systemBirCache.toString(), importsBirCache.toString());
+            BootstrapRunner.generateJarBinaryInProc(commands);
         } else {
             generateJarBinary(entryBir.toString(), jarTarget.toString(), dumpBir, Collections.emptyList(),
                     systemBirCache.toString(), importsBirCache.toString());

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -653,8 +653,8 @@ public class BCompileUtil {
         writeNonEntryPkgs(bLangPackage.symbol.imports, systemBirCache, importsBirCache, importsTarget, dumpBir);
         if (inProc) {
             List<String> commands = BootstrapRunner.createArgsForJBalCompilerBackend(entryBir.toString(),
-                    jarTarget.toString(), dumpBir, true, Collections.emptyList(),
-                    systemBirCache.toString(), importsBirCache.toString());
+                    jarTarget.toString(), dumpBir, Collections.emptyList(), systemBirCache.toString(),
+                    importsBirCache.toString());
             BootstrapRunner.generateJarBinaryInProc(commands);
         } else {
             generateJarBinary(entryBir.toString(), jarTarget.toString(), dumpBir, Collections.emptyList(),


### PR DESCRIPTION
LLVM code generation is stopped at the object file generation due to it using the previous single process backend invocation. 

This PR has changed the code to use the new process builder for backend llvm invocation.

Fixes #20187 