### PR TITLE
Disallow check expr within trx block

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -138,6 +138,7 @@ public enum DiagnosticCode {
     RETRY_CANNOT_BE_OUTSIDE_TRANSACTION_BLOCK("retry.cannot.be.outside.transaction.block"),
     BREAK_CANNOT_BE_USED_TO_EXIT_TRANSACTION("break.statement.cannot.be.used.to.exit.from.a.transaction"),
     CONTINUE_CANNOT_BE_USED_TO_EXIT_TRANSACTION("continue.statement.cannot.be.used.to.exit.from.a.transaction"),
+    CHECK_EXPRESSION_INVALID_USAGE_WITHIN_TRANSACTION_BLOCK("check.expression.invalid.usage.within.transaction.block"),
     RETURN_CANNOT_BE_USED_TO_EXIT_TRANSACTION("return.statement.cannot.be.used.to.exit.from.a.transaction"),
     DONE_CANNOT_BE_USED_TO_EXIT_TRANSACTION("done.statement.cannot.be.used.to.exit.from.a.transaction"),
     INVALID_RETRY_COUNT("invalid.retry.count"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2259,6 +2259,11 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             dlog.error(checkedExpr.pos, DiagnosticCode.CHECKED_EXPR_NO_MATCHING_ERROR_RETURN_IN_ENCL_INVOKABLE);
         }
 
+        if (checkReturnValidityInTransaction()) {
+            this.dlog.error(checkedExpr.pos, DiagnosticCode.CHECK_EXPRESSION_INVALID_USAGE_WITHIN_TRANSACTION_BLOCK);
+            return;
+        }
+
         returnTypes.peek().add(exprType);
     }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -164,6 +164,9 @@ error.break.statement.cannot.be.used.to.exit.from.a.transaction=\
 error.continue.statement.cannot.be.used.to.exit.from.a.transaction=\
   continue statement cannot be used to exit from a transaction
 
+error.check.expression.invalid.usage.within.transaction.block=\
+  ''check'' expression cannot be used within transaction block
+
 error.return.statement.cannot.be.used.to.exit.from.a.transaction=\
   return statement cannot be used to exit from a transaction
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/TransactionBlockTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/TransactionBlockTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
@@ -218,6 +219,12 @@ public class TransactionBlockTest {
 
     @Test
     public void testMultipleCommittedAbortedBlocks() {
-        Assert.assertTrue(negativeProgramFile.getErrorCount() > 0);
+        int i = 0;
+        BAssertUtil.validateError(negativeProgramFile, i++,
+                "transaction statement cannot be nested within another transaction block", 17, 9);
+        BAssertUtil.validateError(negativeProgramFile, i++,
+                "'check' expression cannot be used within transaction block", 30, 17);
+
+        Assert.assertEquals(negativeProgramFile.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/transaction/transaction_block_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/transaction/transaction_block_negative.bal
@@ -11,32 +11,6 @@ function testCorrectTransactionBlock() returns (string) {
     return a;
 }
 
-function testTwoAbortedBlocks() returns (string) {
-    string a = "";
-    transaction with retries=2 {
-    } onretry {
-        a = a + " retry";
-    } aborted {
-        a = a + " committed";
-    } aborted {
-        a = a + " aborted";
-    }
-    return a;
-}
-
-function testTwoCommittedBlocks() returns (string) {
-    string a = "";
-    transaction with retries=2 {
-    } onretry {
-        a = a + " retry";
-    } committed {
-        a = a + " committed";
-    } committed {
-        a = a + " aborted";
-    }
-    return a;
-}
-
 function testNestedTrxBlocks() returns (string) {
     string a = "";
     transaction with retries=2 {
@@ -49,4 +23,10 @@ function testNestedTrxBlocks() returns (string) {
         a = a + " committed";
     }
     return a;
+}
+
+function testCheckExprWithinTransactionBlock() returns error? {
+    transaction with retries=2 {
+        var e = check int.constructFrom("five");
+    }
 }


### PR DESCRIPTION
## Purpose
Similar to `return`, `check` expression is also disallowed within the transaction block as `check` expression has `return` like semantic when the RHS value is an error. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19623

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Required Balo version update
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
