### PR TITLE
Fix potentially uninitialized variable detection with while

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -471,8 +471,14 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangWhile whileNode) {
+        Map<BSymbol, InitStatus> prevUninitializedVars = this.uninitializedVars;
         analyzeNode(whileNode.expr, env);
         analyzeNode(whileNode.body, env);
+        for (BSymbol symbol : prevUninitializedVars.keySet()) {
+            if (!this.uninitializedVars.containsKey(symbol)) {
+                this.uninitializedVars.put(symbol, InitStatus.PARTIAL_INIT);
+            }
+        }
     }
 
     @Override

--- a/stdlib/jdbc/src/test/resources/test-src/table/table_type_test.bal
+++ b/stdlib/jdbc/src/test/resources/test-src/table/table_type_test.bal
@@ -903,7 +903,7 @@ function testCloseConnectionPool(string jdbcURL) returns int {
     });
 
     var selectRet = testDB->select("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SESSIONS", ResultCount);
-    int retVal;
+    int retVal = -3;
     if (selectRet is table<ResultCount>) {
         while (selectRet.hasNext()) {
             var rs = selectRet.getNext();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
@@ -86,6 +86,9 @@ public class DataflowAnalysisTest {
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 628, 12);
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 650, 12);
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 673, 12);
+        BAssertUtil.validateError(result, i++, "variable 'a' may not have been initialized", 686, 13);
+        BAssertUtil.validateError(result, i++, "variable 'b' may not have been initialized", 697, 13);
+        BAssertUtil.validateError(result, i++, "variable 'a' may not have been initialized", 711, 13);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
@@ -88,7 +88,9 @@ public class DataflowAnalysisTest {
         BAssertUtil.validateError(result, i++, "variable 'k' may not have been initialized", 673, 12);
         BAssertUtil.validateError(result, i++, "variable 'a' may not have been initialized", 686, 13);
         BAssertUtil.validateError(result, i++, "variable 'b' may not have been initialized", 697, 13);
-        BAssertUtil.validateError(result, i++, "variable 'a' may not have been initialized", 711, 13);
+        BAssertUtil.validateError(result, i++, "variable 'a' may not have been initialized", 712, 13);
+        BAssertUtil.validateError(result, i++, "variable 'b' is not initialized", 713, 16);
+        BAssertUtil.validateError(result, i++, "variable 'a' is not initialized", 722, 13);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
@@ -697,8 +697,9 @@ function testUninitializedVarWithContinueAndBreakInWhile() {
     int k = b; // variable 'b' may not have been initialized
 }
 
-function testUninitializedVarWithWhile() {
+function testUninitializedVarWithWhile1() {
     int a;
+    string b;
     boolean e = false;
     while e {
         if e {
@@ -709,4 +710,14 @@ function testUninitializedVarWithWhile() {
         a = 10;
     }
     int j = a; // variable 'a' may not have been initialized
+    string k = b; // variable 'b' is not initialized
+}
+
+function testUninitializedVarWithWhile2() {
+    int a;
+
+    while true {
+        break;
+    }
+    int j = a; // variable 'a' is not initialized
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
@@ -672,3 +672,41 @@ function testMatch8() returns int {
     }
     return k; // variable 'k' may not have been initialized
 }
+
+function testUninitializedVarWithContinueAndBreakInWhile() {
+    int a;
+    while false {
+        if true {
+            continue;
+        } else {
+            a = 1;
+        }
+        int i = a; // OK
+    }
+    int j = a; // variable 'a' may not have been initialized
+
+    int b;
+    while false {
+        if true {
+            break;
+        } else {
+            b = 1;
+        }
+        int i = b; // OK
+    }
+    int k = b; // variable 'b' may not have been initialized
+}
+
+function testUninitializedVarWithWhile() {
+    int a;
+    boolean e = false;
+    while e {
+        if e {
+            a = 1;
+        } else {
+            a = 5;
+        }
+        a = 10;
+    }
+    int j = a; // variable 'a' may not have been initialized
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19679

## Approach
Any variables that are potentially updated within the while are currently marked as initialized, instead this PR marks them as potentially uninitialized. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
