### PR TITLE
Fix for compiler crash when importing undefined module from two bal files in same module

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -258,8 +258,10 @@ public class SymbolEnter extends BLangNodeVisitor {
                 importPkgHolder.get(qualifiedName).unresolved.add(importNode);
                 return;
             }
-            importPkgHolder.put(qualifiedName, new ImportResolveHolder(importNode));
             defineNode(importNode, pkgEnv);
+            if (importNode.symbol != null) {
+                importPkgHolder.put(qualifiedName, new ImportResolveHolder(importNode));
+            }
         });
     
         for (ImportResolveHolder importHolder : importPkgHolder.values()) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/UndefinedModuleNegativeTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/UndefinedModuleNegativeTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.packaging;
+
+import org.ballerinalang.test.BaseTest;
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import static org.ballerinalang.test.packaging.PackerinaTestUtils.deleteFiles;
+
+/**
+ * Test case for running multiple bal files which imports undefined modules.
+ */
+public class UndefinedModuleNegativeTestCase extends BaseTest {
+    private BMainInstance balClient;
+    private Path testProjectPath;
+
+    @BeforeClass()
+    public void setUp() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+    }
+
+    @Test(description = "Test building bal files with undefined modules")
+    public void testBuildWithUndefinedModules() throws BallerinaTestException {
+        testProjectPath = Paths.get("src", "test", "resources", "packaging", "executable", "TestProject2")
+                               .toAbsolutePath();
+        // Run and see output
+        String msg1 = "error: bar/foo:9.9.9::b-bar.bal:16:1: cannot resolve module 'gg/y'";
+        String msg2 = "error: bar/foo:9.9.9::f-foo.bal:16:1: cannot resolve module 'gg/y'";
+        LogLeecher fooRunLeecher = new LogLeecher(msg1, LogLeecher.LeecherType.ERROR);
+        LogLeecher barRunLeecher = new LogLeecher(msg2, LogLeecher.LeecherType.ERROR);
+        balClient.runMain("build", new String[] { "foo" }, new HashMap<>(), new String[0],
+                          new LogLeecher[] { fooRunLeecher, barRunLeecher}, testProjectPath.toString());
+        fooRunLeecher.waitForText(1000);
+        barRunLeecher.waitForText(1000);
+    }
+
+    @AfterClass
+    private void cleanup() throws Exception {
+        deleteFiles(Paths.get(this.testProjectPath.toString(), "target").toAbsolutePath());
+    }
+}

--- a/tests/jballerina-integration-test/src/test/resources/packaging/executable/TestProject2/Ballerina.toml
+++ b/tests/jballerina-integration-test/src/test/resources/packaging/executable/TestProject2/Ballerina.toml
@@ -1,0 +1,3 @@
+[project]
+org-name = "bar"
+version = "9.9.9"

--- a/tests/jballerina-integration-test/src/test/resources/packaging/executable/TestProject2/src/foo/b-bar.bal
+++ b/tests/jballerina-integration-test/src/test/resources/packaging/executable/TestProject2/src/foo/b-bar.bal
@@ -1,0 +1,17 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import gg/y;
+string s3 = "and File name with -";

--- a/tests/jballerina-integration-test/src/test/resources/packaging/executable/TestProject2/src/foo/f-foo.bal
+++ b/tests/jballerina-integration-test/src/test/resources/packaging/executable/TestProject2/src/foo/f-foo.bal
@@ -1,0 +1,17 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import gg/y;
+string s2 = "and File name with . ";

--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -294,6 +294,7 @@
             <class name="org.ballerinalang.test.packaging.PathDependencyTestCase"/>
             <class name="org.ballerinalang.test.packaging.DirectoryTestCase"/>
             <class name="org.ballerinalang.test.packaging.SpiServicesTestCase"/>
+            <class name="org.ballerinalang.test.packaging.UndefinedModuleNegativeTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #19224

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
