### PR TITLE
Add Path parameter suffix support

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 public class URIUtil {
 
-    private static final String URI_PATH_DELIMITER = "/";
+    public static final String URI_PATH_DELIMITER = "/";
     public static final char DOT_SEGMENT = '.';
 
     public static String[] getPathSegments(String path) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
@@ -35,7 +35,8 @@ import java.util.Map;
  */
 public class URIUtil {
 
-    public static final String URI_PATH_DELIMITER = "/";
+    private static final String URI_PATH_DELIMITER = "/";
+    public static final char DOT_SEGMENT = '.';
 
     public static String[] getPathSegments(String path) {
         if (path.startsWith(URI_PATH_DELIMITER)) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/DotSuffixExpression.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/DotSuffixExpression.java
@@ -1,0 +1,46 @@
+/*
+*  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+package org.ballerinalang.net.uri.parser;
+
+import org.ballerinalang.net.uri.URITemplateException;
+import org.ballerinalang.net.uri.URIUtil;
+
+/**
+ * DotSuffixExpression represents path segments that have string suffix concatenated by dot.
+ * ex - /{foo}.bar/
+ *
+ * @param <DataType> Type of data which should be stored in the node.
+ * @param <InboundMsgType> Inbound message type for additional checks.
+ */
+public class DotSuffixExpression<DataType, InboundMsgType> extends SimpleStringExpression<DataType, InboundMsgType> {
+
+    public DotSuffixExpression(DataElement<DataType, InboundMsgType> dataElement, String token)
+            throws URITemplateException {
+        super(dataElement, token);
+    }
+
+    protected boolean isEndCharacter(Character endCharacter) {
+        for (Node childNode : childNodesList) {
+            if (endCharacter == childNode.getFirstCharacter() && endCharacter == URIUtil.DOT_SEGMENT) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
@@ -130,7 +130,6 @@ public abstract class Node<DataType, InboundMsgType> {
 
     abstract char getFirstCharacter();
 
-    @SuppressWarnings("unchecked")
     private Node<DataType, InboundMsgType> getMatchingChildNode(Node<DataType, InboundMsgType> prospectiveChild,
             List<Node<DataType, InboundMsgType>> existingChildren) throws URITemplateException {
         boolean dotSuffixExpression = prospectiveChild instanceof DotSuffixExpression;
@@ -157,6 +156,7 @@ public abstract class Node<DataType, InboundMsgType> {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     private Node<DataType, InboundMsgType> getExistingChildNode(Node<DataType, InboundMsgType> prospectiveChild,
                                                                 Node<DataType, InboundMsgType> existingChild)
             throws URITemplateException {
@@ -171,7 +171,7 @@ public abstract class Node<DataType, InboundMsgType> {
                 return 0;
             }
             return node.getToken().length() + 5;
-        } else if (node instanceof DotSuffixExpression){
+        } else if (node instanceof DotSuffixExpression) {
             return 2;
         } else {
             return 1;

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
@@ -133,18 +133,21 @@ public abstract class Node<DataType, InboundMsgType> {
     @SuppressWarnings("unchecked")
     private Node<DataType, InboundMsgType> getMatchingChildNode(Node<DataType, InboundMsgType> prospectiveChild,
             List<Node<DataType, InboundMsgType>> existingChildren) throws URITemplateException {
-//        boolean isExpression = prospectiveChild instanceof Expression;
-        boolean isDotSuffixExpression = prospectiveChild instanceof DotSuffixExpression;
-        boolean isSimpleStringExpression = prospectiveChild instanceof SimpleStringExpression;
+        boolean dotSuffixExpression = prospectiveChild instanceof DotSuffixExpression;
+        boolean simpleStringExpression = prospectiveChild instanceof SimpleStringExpression;
         String prospectiveChildToken = prospectiveChild.getToken();
 
         for (Node<DataType, InboundMsgType> existingChild : existingChildren) {
-            if ((isDotSuffixExpression && existingChild instanceof DotSuffixExpression) ||
-                    (isSimpleStringExpression && existingChild instanceof SimpleStringExpression)) {
-//            if (isExpression && existingChild instanceof Expression) {
-                ((Expression) existingChild).variableList.add(new Variable(prospectiveChild.token));
-                existingChild.token = existingChild.token + "+" + prospectiveChild.token;
-                return existingChild;
+            if (dotSuffixExpression) {
+                if (existingChild instanceof DotSuffixExpression) {
+                    return getExistingChildNode(prospectiveChild, existingChild);
+                } else {
+                    continue;
+                }
+            }
+            if (simpleStringExpression && existingChild instanceof Expression
+                    && !(existingChild instanceof DotSuffixExpression)) {
+                return getExistingChildNode(prospectiveChild, existingChild);
             }
             if (existingChild.getToken().equals(prospectiveChildToken)) {
                 return existingChild;
@@ -154,12 +157,22 @@ public abstract class Node<DataType, InboundMsgType> {
         return null;
     }
 
+    private Node<DataType, InboundMsgType> getExistingChildNode(Node<DataType, InboundMsgType> prospectiveChild,
+                                                                Node<DataType, InboundMsgType> existingChild)
+            throws URITemplateException {
+        ((Expression) existingChild).variableList.add(new Variable(prospectiveChild.token));
+        existingChild.token = existingChild.token + "+" + prospectiveChild.token;
+        return existingChild;
+    }
+
     private int getIntValue(Node node) {
         if (node instanceof Literal) {
             if (node.getToken().equals("*")) {
                 return 0;
             }
             return node.getToken().length() + 5;
+        } else if (node instanceof DotSuffixExpression){
+            return 2;
         } else {
             return 1;
         }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
@@ -133,11 +133,15 @@ public abstract class Node<DataType, InboundMsgType> {
     @SuppressWarnings("unchecked")
     private Node<DataType, InboundMsgType> getMatchingChildNode(Node<DataType, InboundMsgType> prospectiveChild,
             List<Node<DataType, InboundMsgType>> existingChildren) throws URITemplateException {
-        boolean isExpression = prospectiveChild instanceof Expression;
+//        boolean isExpression = prospectiveChild instanceof Expression;
+        boolean isDotSuffixExpression = prospectiveChild instanceof DotSuffixExpression;
+        boolean isSimpleStringExpression = prospectiveChild instanceof SimpleStringExpression;
         String prospectiveChildToken = prospectiveChild.getToken();
 
         for (Node<DataType, InboundMsgType> existingChild : existingChildren) {
-            if (isExpression && existingChild instanceof Expression) {
+            if ((isDotSuffixExpression && existingChild instanceof DotSuffixExpression) ||
+                    (isSimpleStringExpression && existingChild instanceof SimpleStringExpression)) {
+//            if (isExpression && existingChild instanceof Expression) {
                 ((Expression) existingChild).variableList.add(new Variable(prospectiveChild.token));
                 existingChild.token = existingChild.token + "+" + prospectiveChild.token;
                 return existingChild;

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/URITemplateParser.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/URITemplateParser.java
@@ -131,7 +131,7 @@ public class URITemplateParser<DataType, InboundMgsType> {
         } else if (maxIndex > pointerIndex && segment.charAt(pointerIndex + 1) == URIUtil.DOT_SEGMENT) {
             node = new DotSuffixExpression<>(createElement(), expression);
         } else {
-            throw new URITemplateException("Template expression: " + segment + " not implemented");
+            throw new URITemplateException("Template expression: " + segment + " is not implemented");
         }
 
         if (expression.length() < 1) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/URITemplateParser.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/URITemplateParser.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.net.uri.parser;
 
 import org.ballerinalang.net.uri.URITemplateException;
+import org.ballerinalang.net.uri.URIUtil;
 
 import java.io.UnsupportedEncodingException;
 
@@ -89,7 +90,7 @@ public class URITemplateParser<DataType, InboundMgsType> {
                         }
                         expression = false;
                         String token = segment.substring(startIndex, pointerIndex);
-                        createExpressionNode(token);
+                        createExpressionNode(token, segment, maxIndex, pointerIndex);
                         startIndex = pointerIndex + 1;
                         break;
                     case '*':
@@ -102,7 +103,7 @@ public class URITemplateParser<DataType, InboundMgsType> {
                         if (pointerIndex == maxIndex) {
                             String tokenVal = segment.substring(startIndex);
                             if (expression) {
-                                createExpressionNode(tokenVal);
+                                createExpressionNode(tokenVal, segment, maxIndex, pointerIndex);
                             } else {
                                 addNode(new Literal<>(createElement(), tokenVal));
                             }
@@ -122,9 +123,17 @@ public class URITemplateParser<DataType, InboundMgsType> {
         currentNode = currentNode.addChild(node);
     }
 
-    private void createExpressionNode(String expression) throws URITemplateException {
+    private void createExpressionNode(String expression, String segment, int maxIndex, int pointerIndex)
+            throws URITemplateException {
         Node<DataType, InboundMgsType> node;
-        node = new SimpleStringExpression<>(createElement(), expression);
+        if (maxIndex == pointerIndex) {
+            node = new SimpleStringExpression<>(createElement(), expression);
+        } else if (maxIndex > pointerIndex && segment.charAt(pointerIndex + 1) == URIUtil.DOT_SEGMENT) {
+            node = new DotSuffixExpression<>(createElement(), expression);
+        } else {
+            throw new URITemplateException("Template expression: " + segment + " not implemented");
+        }
+
         if (expression.length() < 1) {
             throw new URITemplateException("Invalid template expression: {" + expression + "}");
         }

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/UriTemplateBestMatchTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/UriTemplateBestMatchTest.java
@@ -184,6 +184,84 @@ public class UriTemplateBestMatchTest {
                 , "Resource dispatched to wrong template");
     }
 
+    @Test(description = "Test dispatching with URL. /hello/echo2/suffix.id")
+    public void testPathParamWithSuffix() {
+        String path = "/hello/echo2/suffix.id";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invokeNew(application, TEST_EP, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "suffix"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/literal.id")
+    public void testBestMatchWhenPathLiteralHasSameSuffix() {
+        String path = "/hello/echo2/literal.id";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invokeNew(application, TEST_EP, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "literal invoked"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/ballerina.id/foo")
+    public void testSpecificMatchForPathParamWithSuffix() {
+        String path = "/hello/echo2/ballerina.id/foo";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invokeNew(application, TEST_EP, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "specific path invoked"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/suffix.hello")
+    public void testPathParamWithInvalidSuffix() {
+        String path = "/hello/echo2/suffix.hello";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invokeNew(application, TEST_EP, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo3").stringValue(), "suffix.hello"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/rs.654.58.id")
+    public void testPathSegmentContainsBothLeadingDotsAndSuffix() {
+        String path = "/hello/echo2/Rs.654.58.id";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invokeNew(application, TEST_EP, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "Rs.654.58"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/hello.identity")
+    public void testSpecificPathParamSuffix() {
+        String path = "/hello/echo2/hello.identity";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invokeNew(application, TEST_EP, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "identity"
+                , "Resource dispatched to wrong template");
+    }
+
     @Test(description = "Test dispatching with URL. /hello")
     public void testRootPathDefaultValues() {
         String path = "/hello?foo=zzz";

--- a/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
+++ b/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
@@ -261,6 +261,17 @@ service echo44 on testEP {
         res.setJsonPayload(responseJson);
         _ = caller->respond(res);
     }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{xyz}.id"
+    }
+    resource function echo6(http:Caller caller, http:Request req, string xyz) {
+        http:Response res = new;
+        json responseJson = {"echo6":xyz};
+        res.setJsonPayload(<@untainted json> responseJson);
+        checkpanic caller->respond(res);
+    }
 }
 
 

--- a/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
+++ b/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
@@ -40,6 +40,49 @@ service echo11 on testEP {
         _ = caller->respond(res);
     }
 
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{xyz}.id"
+    }
+    resource function echo6(http:Caller caller, http:Request req, string xyz) {
+        http:Response res = new;
+        json responseJson = {"echo6":xyz};
+        res.setJsonPayload(untaint responseJson);
+        _ = caller->respond(res);
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/literal.id"
+    }
+    resource function echo6_1(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        json responseJson = {"echo6":"literal invoked"};
+        res.setJsonPayload(untaint responseJson);
+        _ = caller->respond(res);
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{zz}.id/foo"
+    }
+    resource function echo6_2(http:Caller caller, http:Request req, string zz) {
+        http:Response res = new;
+        json responseJson = {"echo6":"specific path invoked"};
+        res.setJsonPayload(untaint responseJson);
+        _ = caller->respond(res);
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{xyz}.identity"
+    }
+    resource function echo6_3(http:Caller caller, http:Request req, string xyz) {
+        http:Response res = new;
+        json responseJson = {"echo6":"identity"};
+        res.setJsonPayload(untaint responseJson);
+        _ = caller->respond(res);
+    }
 
     @http:ResourceConfig {
         methods:["GET"],
@@ -261,19 +304,7 @@ service echo44 on testEP {
         res.setJsonPayload(responseJson);
         _ = caller->respond(res);
     }
-
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/echo2/{xyz}.id"
-    }
-    resource function echo6(http:Caller caller, http:Request req, string xyz) {
-        http:Response res = new;
-        json responseJson = {"echo6":xyz};
-        res.setJsonPayload(<@untainted json> responseJson);
-        checkpanic caller->respond(res);
-    }
 }
-
 
 service echo55 on testEP {
     @http:ResourceConfig {


### PR DESCRIPTION
## Purpose
> Support having suffix for path param segments concatenated by a "." (dot). ex - /{foo}.bar/
Fixes #19957

## Approach
> Add new node `DotSuffixExpression` extended by `SimpleStringExpression`
> Implement matching logic to look for '.' as expression ending character in the presence of child nodes.
> Update template parser logic to handle `DotSuffixExpression`

## Samples
```ballerina
    @http:ResourceConfig {
        methods:["GET"],
        path:"/echo2/{xyz}.id"
    }
    resource function echo6(http:Caller caller, http:Request req, string xyz) {
        http:Response res = new;
        json responseJson = {"echo6":xyz};
        res.setJsonPayload(untaint responseJson);
        _ = caller->respond(res);
    }
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
