### PR TITLE
Use version provided via sys prop & remove org name

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -163,7 +163,11 @@ public class BallerinaDocGenerator {
             Module module = new Module();
             module.id = moduleDoc.bLangPackage.packageID.name.toString();
             module.orgName = moduleDoc.bLangPackage.packageID.orgName.toString();
-            module.version = moduleDoc.bLangPackage.packageID.version.toString();
+            String moduleVersion = moduleDoc.bLangPackage.packageID.version.toString();
+            // get version from system property if not found in bLangPackage
+            module.version = moduleVersion.equals("")
+                    ? System.getProperty(BallerinaDocConstants.VERSION)
+                    : moduleVersion;
             module.summary = moduleDoc.summary;
             module.description = moduleDoc.description;
 

--- a/misc/docerina/src/main/resources/template/html/currentModule.hbs
+++ b/misc/docerina/src/main/resources/template/html/currentModule.hbs
@@ -1,7 +1,9 @@
+
 {{#if project.isSingleFile}}
 {{else}}
-    <div class="org">org:{{ module.orgName }}</div>
-    <div class="version">v{{ module.version }}</div>
+    {{#if module.version}}
+        <div class="version">v{{ module.version }}</div>
+    {{/if}}
 {{/if}}
 
 <div class="primary-list module">


### PR DESCRIPTION
Until we provide a better way to display FQN of a module, we have removed displaying it in left column in API docs. Furthermore, to fix version used in standard library doc generation, we have to honor a system prop if module version is empty.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
