### PR TITLE
Add Path parameter suffix support

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
@@ -38,7 +38,8 @@ import java.util.stream.Collectors;
  */
 public class URIUtil {
 
-    private static final String URI_PATH_DELIMITER = "/";
+    public static final String URI_PATH_DELIMITER = "/";
+    public static final char DOT_SEGMENT = '.';
 
     public static String[] getPathSegments(String path) {
         if (path.startsWith(URI_PATH_DELIMITER)) {

--- a/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/DotSuffixExpression.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/uri/parser/DotSuffixExpression.java
@@ -1,0 +1,83 @@
+/*
+*  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+package org.ballerinalang.net.uri.parser;
+
+import org.ballerinalang.net.http.HttpResourceArguments;
+import org.ballerinalang.net.uri.URITemplateException;
+import org.ballerinalang.net.uri.URIUtil;
+
+/**
+ * DotSuffixExpression represents path segments that have string suffix concatenated by dot.
+ * ex - /{foo}.bar/
+ *
+ * @param <DataType> Type of data which should be stored in the node.
+ * @param <InboundMsgType> Inbound message type for additional checks.
+ *
+ * @since 1.1
+ */
+public class DotSuffixExpression<DataType, InboundMsgType> extends SimpleStringExpression<DataType, InboundMsgType> {
+
+    public DotSuffixExpression(DataElement<DataType, InboundMsgType> dataElement, String token)
+            throws URITemplateException {
+        super(dataElement, token);
+    }
+
+    @Override
+    int match(String uriFragment, HttpResourceArguments variables) {
+        String pathSegment = uriFragment;
+        if (uriFragment.contains(URIUtil.URI_PATH_DELIMITER)) {
+            pathSegment = uriFragment.substring(0, uriFragment.indexOf(URIUtil.URI_PATH_DELIMITER));
+        }
+        String[] subSegments = pathSegment.split("\\.");
+
+        int endCharacterCount = subSegments.length - 1;
+        int dotSegmentCounter = 0;
+        int length = uriFragment.length();
+
+        for (int i = 0; i < length; i++) {
+            char ch = uriFragment.charAt(i);
+            if (isEndCharacter(ch)) {
+                dotSegmentCounter++;
+                if (dotSegmentCounter != endCharacterCount) {
+                    continue;
+                }
+
+                if (!setVariables(uriFragment.substring(0, i), variables)) {
+                    return -1;
+                }
+                return i;
+            } else if (i == length - 1) {
+                if (!setVariables(uriFragment, variables)) {
+                    return -1;
+                }
+                return length;
+            }
+        }
+        return 0;
+    }
+
+    protected boolean isEndCharacter(Character endCharacter) {
+        for (Node childNode : childNodesList) {
+            if (endCharacter == childNode.getFirstCharacter() && endCharacter == URIUtil.DOT_SEGMENT) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/UriTemplateBestMatchTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/dispatching/UriTemplateBestMatchTest.java
@@ -185,6 +185,84 @@ public class UriTemplateBestMatchTest {
                 , "Resource dispatched to wrong template");
     }
 
+    @Test(description = "Test dispatching with URL. /hello/echo2/suffix.id")
+    public void testPathParamWithSuffix() {
+        String path = "/hello/echo2/suffix.id";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invoke(TEST_EP_PORT, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "suffix"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/literal.id")
+    public void testBestMatchWhenPathLiteralHasSameSuffix() {
+        String path = "/hello/echo2/literal.id";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invoke(TEST_EP_PORT, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "literal invoked"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/ballerina.id/foo")
+    public void testSpecificMatchForPathParamWithSuffix() {
+        String path = "/hello/echo2/ballerina.id/foo";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invoke(TEST_EP_PORT, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "specific path invoked"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/suffix.hello")
+    public void testPathParamWithInvalidSuffix() {
+        String path = "/hello/echo2/suffix.hello";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invoke(TEST_EP_PORT, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo3").stringValue(), "suffix.hello"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/rs.654.58.id")
+    public void testPathSegmentContainsBothLeadingDotsAndSuffix() {
+        String path = "/hello/echo2/Rs.654.58.id";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invoke(TEST_EP_PORT, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "Rs.654.58"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test dispatching with URL. /hello/echo2/hello.identity")
+    public void testSpecificPathParamSuffix() {
+        String path = "/hello/echo2/hello.identity";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        HttpCarbonMessage response = Services.invoke(TEST_EP_PORT, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BValue bJson = JsonParser.parse(new HttpMessageDataStreamer(response).getInputStream());
+
+        Assert.assertEquals(((BMap<String, BValue>) bJson).get("echo6").stringValue(), "identity"
+                , "Resource dispatched to wrong template");
+    }
+
     @Test(description = "Test dispatching with URL. /hello")
     public void testRootPathDefaultValues() {
         String path = "/hello?foo=zzz";

--- a/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
+++ b/stdlib/http/src/test/resources/test-src/services/dispatching/uri-template-matching.bal
@@ -43,6 +43,49 @@ service echo11 on testEP {
         checkpanic caller->respond(res);
     }
 
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{xyz}.id"
+    }
+    resource function echo6(http:Caller caller, http:Request req, string xyz) {
+        http:Response res = new;
+        json responseJson = {"echo6":xyz};
+        res.setJsonPayload(<@untainted json> responseJson);
+        checkpanic caller->respond(res);
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/literal.id"
+    }
+    resource function echo6_1(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        json responseJson = {"echo6":"literal invoked"};
+        res.setJsonPayload(<@untainted json> responseJson);
+        checkpanic caller->respond(res);
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{zz}.id/foo"
+    }
+    resource function echo6_2(http:Caller caller, http:Request req, string zz) {
+        http:Response res = new;
+        json responseJson = {"echo6":"specific path invoked"};
+        res.setJsonPayload(<@untainted json> responseJson);
+        checkpanic caller->respond(res);
+    }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/echo2/{xyz}.identity"
+    }
+    resource function echo6_3(http:Caller caller, http:Request req, string xyz) {
+        http:Response res = new;
+        json responseJson = {"echo6":"identity"};
+        res.setJsonPayload(<@untainted json> responseJson);
+        checkpanic caller->respond(res);
+    }
 
     @http:ResourceConfig {
         methods:["GET"],
@@ -313,7 +356,6 @@ service echo44 on testEP {
         checkpanic caller->respond(res);
     }
 }
-
 
 service echo55 on testEP {
     @http:ResourceConfig {


### PR DESCRIPTION
## Purpose
> Support having suffix for path param segments concatenated by a "." (dot). ex - /{foo}.bar/

## Approach
> Add new node `DotSuffixExpression` extended by `SimpleStringExpression`
> Implement matching logic to look for '.' as expression ending character in the presence of child nodes.
> Update template parser logic to handle `DotSuffixExpression`

## Samples
```ballerina
    @http:ResourceConfig {
        methods:["GET"],
        path:"/echo2/{xyz}.id"
    }
    resource function echo6(http:Caller caller, http:Request req, string xyz) {
        http:Response res = new;
        json responseJson = {"echo6":xyz};
        res.setJsonPayload(untaint responseJson);
        _ = caller->respond(res);
    }
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
