### PR TITLE
Fix cannot start Language Server in debug mode

### DIFF
--- a/distribution/zip/jballerina/bin/ballerina
+++ b/distribution/zip/jballerina/bin/ballerina
@@ -164,6 +164,7 @@ if [ -n "${BAL_JAVA_DEBUG+set}" ]; then
 	if [ -n "$JAVA_OPTS" ]; then
 	  echo "Warning !!!. User specified JAVA_OPTS may interfere with BAL_JAVA_DEBUG"
 	fi
+	# 'quiet=y' avoids breaking LSP protocol in debug mode
 	JAVA_OPTS="$JAVA_OPTS -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$BAL_JAVA_DEBUG,quiet=y"
     fi
 fi

--- a/distribution/zip/jballerina/bin/ballerina
+++ b/distribution/zip/jballerina/bin/ballerina
@@ -164,8 +164,7 @@ if [ -n "${BAL_JAVA_DEBUG+set}" ]; then
 	if [ -n "$JAVA_OPTS" ]; then
 	  echo "Warning !!!. User specified JAVA_OPTS may interfere with BAL_JAVA_DEBUG"
 	fi
-	JAVA_OPTS="$JAVA_OPTS -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$BAL_JAVA_DEBUG"
-	echo "Please start the remote debugging client to continue..."
+	JAVA_OPTS="$JAVA_OPTS -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$BAL_JAVA_DEBUG,quiet=y"
     fi
 fi
 

--- a/distribution/zip/jballerina/bin/ballerina.bat
+++ b/distribution/zip/jballerina/bin/ballerina.bat
@@ -105,8 +105,7 @@ rem ----- commandDebug ---------------------------------------------------------
 :commandDebug
 if "%BAL_JAVA_DEBUG%"=="" goto noDebugPort
 if not "%JAVA_OPTS%"=="" echo Warning !!!. User specified JAVA_OPTS will be ignored, once you give the BAL_JAVA_DEBUG variable.
-set JAVA_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%BAL_JAVA_DEBUG%
-echo Please start the remote debugging client to continue...
+set JAVA_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%BAL_JAVA_DEBUG%,quiet=y
 goto runServer
 
 :noDebugPort

--- a/distribution/zip/jballerina/bin/ballerina.bat
+++ b/distribution/zip/jballerina/bin/ballerina.bat
@@ -105,6 +105,7 @@ rem ----- commandDebug ---------------------------------------------------------
 :commandDebug
 if "%BAL_JAVA_DEBUG%"=="" goto noDebugPort
 if not "%JAVA_OPTS%"=="" echo Warning !!!. User specified JAVA_OPTS will be ignored, once you give the BAL_JAVA_DEBUG variable.
+rem 'quiet=y' avoids breaking LSP protocol in debug mode
 set JAVA_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%BAL_JAVA_DEBUG%,quiet=y
 goto runServer
 

--- a/language-server/modules/langserver-cli/src/main/java/org/ballerinalang/langserver/cmd/LangServerStartCmd.java
+++ b/language-server/modules/langserver-cli/src/main/java/org/ballerinalang/langserver/cmd/LangServerStartCmd.java
@@ -51,9 +51,6 @@ public class LangServerStartCmd implements BLauncherCmd {
         BALLERINA_HOME = System.getProperty("ballerina.home");
     }
 
-    @CommandLine.Option(names = "--debug", description = "start language server in remote debugging mode")
-    private String debugPort;
-
     @CommandLine.Option(names = "--classpath", description = "custom class path for language server")
     private String customClasspath;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -26,6 +26,7 @@ import org.ballerinalang.langserver.command.CommandUtil;
 import org.ballerinalang.langserver.common.CommonKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
+import org.ballerinalang.langserver.compiler.LSClientLogger;
 import org.ballerinalang.langserver.compiler.LSCompilerCache;
 import org.ballerinalang.langserver.compiler.LSContext;
 import org.ballerinalang.langserver.compiler.LSModuleCompiler;
@@ -633,6 +634,8 @@ class BallerinaTextDocumentService implements TextDocumentService {
             Optional<Lock> lock = documentManager.lockFile(compilationPath);
             try {
                 documentManager.openFile(Paths.get(new URL(docUri).toURI()), content);
+                LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_OPEN + "' {fileUri: '" +
+                                                compilationPath + "'} updated}");
                 ExtendedLanguageClient client = this.languageServer.getClient();
                 LSServiceOperationContext context = new LSServiceOperationContext(LSContextOperation.TXT_DID_OPEN);
                 context.put(DocumentServiceKeys.FILE_URI_KEY, docUri);
@@ -667,6 +670,8 @@ class BallerinaTextDocumentService implements TextDocumentService {
             for (TextDocumentContentChangeEvent changeEvent : changes) {
                 documentManager.updateFile(compilationPath, changeEvent.getText());
             }
+            LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CHANGE + "' {fileUri: '" +
+                                            compilationPath + "'} updated}");
 
             // Schedule diagnostics
             ExtendedLanguageClient client = this.languageServer.getClient();
@@ -674,7 +679,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 // Need to lock since debouncer triggers later
                 Optional<Lock> nLock = documentManager.lockFile(compilationPath);
                 try {
-                    LSServiceOperationContext ctx = new LSServiceOperationContext(LSContextOperation.TXT_DID_CHANGE);
+                    LSServiceOperationContext ctx = new LSServiceOperationContext(LSContextOperation.DIAGNOSTICS);
                     String fileURI = params.getTextDocument().getUri();
                     ctx.put(DocumentServiceKeys.FILE_URI_KEY, fileURI);
                     LSDocument lsDocument = new LSDocument(fileURI);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSContextOperation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSContextOperation.java
@@ -23,6 +23,7 @@ package org.ballerinalang.langserver;
 public enum LSContextOperation implements org.ballerinalang.langserver.compiler.LSOperation {
     TXT_COMPLETION("text/completion"),
     TXT_DID_CHANGE("text/didChange"),
+    DIAGNOSTICS("debouncer/diagnostics"),
     TXT_DID_OPEN("text/didOpen"),
     TXT_HOVER("text/hover"),
     TXT_SIGNATURE("text/signature"),

--- a/misc/debug-adapter/modules/debug-adapter-cli/src/main/java/org/ballerinalang/debugadapter/cmd/DebugAdapterStartCmd.java
+++ b/misc/debug-adapter/modules/debug-adapter-cli/src/main/java/org/ballerinalang/debugadapter/cmd/DebugAdapterStartCmd.java
@@ -39,9 +39,6 @@ public class DebugAdapterStartCmd implements BLauncherCmd {
     @CommandLine.Parameters
     private List<String> argList;
 
-    @CommandLine.Option(names = "--debug", description = "start language server in remote debugging mode")
-    private String debugPort;
-
     @CommandLine.Option(names = {"-h", "--help"}, hidden = true)
     private boolean helpFlag;
 

--- a/tool-plugins/vscode/src/server/server.ts
+++ b/tool-plugins/vscode/src/server/server.ts
@@ -30,8 +30,7 @@ export function getServerOptions(ballerinaCmd: string, experimental: boolean, de
     opt.env = Object.assign({}, process.env);
     if (process.env.LSDEBUG === "true") {
         debug('Language Server is starting in debug mode.');
-        args.push('--debug');
-        args.push('5005');
+        opt.env.BAL_JAVA_DEBUG = 5005;
     }
     if (debugLogsEnabled || traceLogsEnabled) {
         let str = [];


### PR DESCRIPTION
## Purpose
> Fix LSDEBUG=true is not honored with the new CLI commands for language server.

Fixes #20272

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
