### PR TITLE
Install nodejs 8 on travis unix envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
       jdk: openjdk8
       node_js: 8
       before_install:
+          - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
     - stage: "Tests"
@@ -64,6 +65,7 @@ jobs:
       jdk: openjdk8
       node_js: 8
       before_install:
+          - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
       install: 
@@ -93,6 +95,11 @@ jobs:
       os: linux
       language: java
       jdk: openjdk8
+      node_js: 8
+      before_install:
+          - nvm install 8
+          - nvm use 8
+          - npm install -g npm@'5.6.0'
       name:  "Integration tests - Linux"
 
 


### PR DESCRIPTION
We fixed travis configuration to always install NodeJs 8 as it recently has changed default node js to 12.x.

This is to back port the same fix for 1.0.x branch.

## Check List 
- [ X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
