### PR TITLE
Hide Ballerina cache usage for JWT cache

### DIFF
--- a/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -75,11 +75,11 @@ public type InboundJwtAuthProvider object {
 };
 
 function authenticateFromCache(cache:Cache jwtCache, string jwtToken) returns JwtPayload? {
-    var cachedJwtInfo = trap <InboundCachedJwtInfo>jwtCache.get(jwtToken);
-    if (cachedJwtInfo is InboundCachedJwtInfo) {
+    var jwtCacheEntry = trap <InboundJwtCacheEntry>jwtCache.get(jwtToken);
+    if (jwtCacheEntry is InboundJwtCacheEntry) {
         // convert to current time and check the expiry time
-        if (cachedJwtInfo.expiryTime > (time:currentTime().time / 1000)) {
-            JwtPayload payload = cachedJwtInfo.jwtPayload;
+        if (jwtCacheEntry.expiryTime > (time:currentTime().time / 1000)) {
+            JwtPayload payload = jwtCacheEntry.jwtPayload;
             string? sub = payload?.sub;
             if (sub is string) {
                 string printMsg = sub;
@@ -95,8 +95,8 @@ function authenticateFromCache(cache:Cache jwtCache, string jwtToken) returns Jw
 }
 
 function addToAuthenticationCache(cache:Cache jwtCache, string jwtToken, int? exp, JwtPayload payload) {
-    InboundCachedJwtInfo cachedJwtInfo = {jwtPayload : payload, expiryTime : exp is () ? 0 : exp};
-    jwtCache.put(jwtToken, cachedJwtInfo);
+    InboundJwtCacheEntry jwtCacheEntry = {jwtPayload : payload, expiryTime : exp is () ? 0 : exp};
+    jwtCache.put(jwtToken, jwtCacheEntry);
     string? sub = payload?.sub;
     if (sub is string) {
         string printMsg = sub;

--- a/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -50,8 +50,8 @@ public type InboundJwtAuthProvider object {
             return false;
         }
 
-        if (self.jwtCache.hasKey(credential)) {
-            var payload = authenticateFromCache(jwtCache, credential);
+        if (self.inboundJwtCache.hasKey(credential)) {
+            var payload = authenticateFromCache(self.inboundJwtCache, credential);
             if (payload is JwtPayload) {
                 auth:setAuthenticationContext("jwt", credential);
                 setPrincipal(payload);
@@ -65,7 +65,7 @@ public type InboundJwtAuthProvider object {
         if (validationResult is JwtPayload) {
             auth:setAuthenticationContext("jwt", credential);
             setPrincipal(validationResult);
-            addToAuthenticationCache(self.jwtCache, credential, <@untainted> validationResult?.exp,
+            addToAuthenticationCache(self.inboundJwtCache, credential, <@untainted> validationResult?.exp,
                 <@untainted> validationResult);
             return true;
         } else {
@@ -75,8 +75,8 @@ public type InboundJwtAuthProvider object {
 };
 
 function authenticateFromCache(cache:Cache jwtCache, string jwtToken) returns JwtPayload? {
-    var cachedJwtInfo = trap <CachedJwtInfo>jwtCache.get(jwtToken);
-    if (cachedJwtInfo is CachedJwtInfo) {
+    var cachedJwtInfo = trap <InboundCachedJwtInfo>jwtCache.get(jwtToken);
+    if (cachedJwtInfo is InboundCachedJwtInfo) {
         // convert to current time and check the expiry time
         if (cachedJwtInfo.expiryTime > (time:currentTime().time / 1000)) {
             JwtPayload payload = cachedJwtInfo.jwtPayload;
@@ -95,7 +95,7 @@ function authenticateFromCache(cache:Cache jwtCache, string jwtToken) returns Jw
 }
 
 function addToAuthenticationCache(cache:Cache jwtCache, string jwtToken, int? exp, JwtPayload payload) {
-    CachedJwtInfo cachedJwtInfo = {jwtPayload : payload, expiryTime : exp is () ? 0 : exp};
+    InboundCachedJwtInfo cachedJwtInfo = {jwtPayload : payload, expiryTime : exp is () ? 0 : exp};
     jwtCache.put(jwtToken, cachedJwtInfo);
     string? sub = payload?.sub;
     if (sub is string) {

--- a/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -35,9 +35,9 @@ public type InboundJwtAuthProvider object {
     # + jwtValidatorConfig - JWT validator configurations
     public function __init(JwtValidatorConfig jwtValidatorConfig) {
         self.jwtValidatorConfig = jwtValidatorConfig;
-        self.inboundJwtCache = new(jwtValidatorConfig.jwtCache.capacity,
-                                   jwtValidatorConfig.jwtCache.expTimeInSeconds * 1000,
-                                   jwtValidatorConfig.jwtCache.evictionFactor);
+        self.inboundJwtCache = new(jwtValidatorConfig.jwtCacheConfig.capacity,
+                                   jwtValidatorConfig.jwtCacheConfig.expTimeInSeconds * 1000,
+                                   jwtValidatorConfig.jwtCacheConfig.evictionFactor);
     }
 
     # Authenticate with a JWT token.

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -28,13 +28,13 @@ import ballerina/time;
 # + audience - Expected audience
 # + clockSkewInSeconds - Clock skew in seconds
 # + trustStoreConfig - JWT trust store configurations
-# + jwtCache - Configurations for the cache used to store parsed JWT information
+# + jwtCacheConfig - Configurations for the cache used to store parsed JWT information
 public type JwtValidatorConfig record {|
     string issuer?;
     string|string[] audience?;
     int clockSkewInSeconds = 0;
     JwtTrustStoreConfig trustStoreConfig?;
-    InboundJwtCache jwtCache = {};
+    InboundJwtCacheConfig jwtCacheConfig = {};
 |};
 
 # Represents JWT trust store configurations.
@@ -51,7 +51,7 @@ public type JwtTrustStoreConfig record {|
 # + capacity - Maximum number of entries allowed
 # + expTimeInSeconds - Time since its last access in which the cache will be expired
 # + evictionFactor - The factor which the entries will be evicted once the cache full
-public type InboundJwtCache record {|
+public type InboundJwtCacheConfig record {|
     int capacity = 900000;
     int expTimeInSeconds = 1;
     float evictionFactor = 0.25;

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/cache;
 import ballerina/crypto;
 import ballerina/encoding;
 import ballerina/io;
@@ -29,13 +28,13 @@ import ballerina/time;
 # + audience - Expected audience
 # + clockSkewInSeconds - Clock skew in seconds
 # + trustStoreConfig - JWT trust store configurations
-# + jwtCache - Cache used to store parsed JWT information as CachedJwt
+# + jwtCache - Configurations for the cache used to store parsed JWT information
 public type JwtValidatorConfig record {|
     string issuer?;
     string|string[] audience?;
     int clockSkewInSeconds = 0;
     JwtTrustStoreConfig trustStoreConfig?;
-    cache:Cache jwtCache = new(900000, 1000, 0.25);
+    InboundJwtCache jwtCache = {};
 |};
 
 # Represents JWT trust store configurations.
@@ -47,11 +46,22 @@ public type JwtTrustStoreConfig record {|
     string certificateAlias;
 |};
 
-# Represents parsed and cached JWT.
+# Represents inbound JWT cache configurations.
+#
+# + capacity - Maximum number of entries allowed
+# + expTimeInSeconds - Time since its last access in which the cache will be expired
+# + evictionFactor - The factor which the entries will be evicted once the cache full
+public type InboundJwtCache record {|
+    int capacity = 900000;
+    int expTimeInSeconds = 1;
+    float evictionFactor = 0.25;
+|};
+
+# Represents parsed and cached JWT information.
 #
 # + jwtPayload - Parsed JWT payload
-# + expiryTime - Expiry time of the JWT
-public type CachedJwt record {|
+# + expiryTime - Expiry time of the parsed JWT
+public type InboundCachedJwtInfo record {|
     JwtPayload jwtPayload;
     int expiryTime;
 |};

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -28,7 +28,7 @@ import ballerina/time;
 # + audience - Expected audience
 # + clockSkewInSeconds - Clock skew in seconds
 # + trustStoreConfig - JWT trust store configurations
-# + jwtCacheConfig - Configurations for the cache used to store parsed JWT information
+# + jwtCacheConfig - Configurations for the JWT cache
 public type JwtValidatorConfig record {|
     string issuer?;
     string|string[] audience?;
@@ -57,11 +57,11 @@ public type InboundJwtCacheConfig record {|
     float evictionFactor = 0.25;
 |};
 
-# Represents parsed and cached JWT information.
+# Represents an entry of JWT cache.
 #
 # + jwtPayload - Parsed JWT payload
 # + expiryTime - Expiry time of the parsed JWT
-public type InboundCachedJwtInfo record {|
+public type InboundJwtCacheEntry record {|
     JwtPayload jwtPayload;
     int expiryTime;
 |};


### PR DESCRIPTION
## Purpose
This PR hides the Ballerina cache usage for the cache of inbound JWT authentication. This was discussed as a part of the implementation of cache for OAuth2 outbound authentication.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
