### PR TITLE
Upgrade Bytedeco LLVM from 6 to 9.

### DIFF
--- a/distribution/zip/nballerina-tools/build.gradle
+++ b/distribution/zip/nballerina-tools/build.gradle
@@ -69,15 +69,15 @@ configurations {
 }
 
 dependencies {
-    dist 'org.bytedeco:javacpp:1.4.2'
+    dist 'org.bytedeco:javacpp:1.5.2'
 
-    dist 'org.bytedeco.javacpp-presets:llvm-platform:6.0.1-1.4.2'
-    dist 'org.bytedeco.javacpp-presets:llvm:6.0.1-1.4.2:linux-x86'
-    dist 'org.bytedeco.javacpp-presets:llvm:6.0.1-1.4.2:windows-x86'
-    dist 'org.bytedeco.javacpp-presets:llvm:6.0.1-1.4.2:macosx-x86_64'
-    dist 'org.bytedeco.javacpp-presets:llvm:6.0.1-1.4.2:windows-x86_64'
-    dist 'org.bytedeco.javacpp-presets:llvm:6.0.1-1.4.2:linux-x86_64'
-    dist 'org.bytedeco.javacpp-presets:llvm:6.0.1-1.4.2'
+    dist 'org.bytedeco:llvm-platform:9.0.0-1.5.2'
+    dist 'org.bytedeco:llvm:9.0.0-1.5.2:linux-x86'
+    dist 'org.bytedeco:llvm:9.0.0-1.5.2:windows-x86'
+    dist 'org.bytedeco:llvm:9.0.0-1.5.2:macosx-x86_64'
+    dist 'org.bytedeco:llvm:9.0.0-1.5.2:windows-x86_64'
+    dist 'org.bytedeco:llvm:9.0.0-1.5.2:linux-x86_64'
+    dist 'org.bytedeco:llvm:9.0.0-1.5.2'
 
     dist project(':ballerina-tool')
     dist project(':ballerina-llvm')

--- a/stdlib/llvm/build.gradle
+++ b/stdlib/llvm/build.gradle
@@ -21,8 +21,8 @@ apply from: "$rootDir/gradle/baseNativeStdLibProject.gradle"
 dependencies {
     baloImplementation project(path: ':ballerina-lang:annotations', configuration: 'baloImplementation')
 
-    implementation 'org.bytedeco.javacpp-presets:llvm-platform'
-    implementation 'org.bytedeco.javacpp-presets:llvm'
+    implementation 'org.bytedeco:llvm-platform:9.0.0-1.5.2'
+    implementation 'org.bytedeco:llvm:9.0.0-1.5.2'
     baloCreat project(':lib-creator')
     implementation project(':ballerina-lang')
     implementation project(':ballerina-runtime')

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAddFunction.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAddFunction.java
@@ -23,8 +23,10 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.global.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMModuleRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
@@ -51,8 +53,8 @@ public class LLVMAddFunction {
     public static MapValue<String, Object> llvmAddFunction(Strand strand, MapValue<String, Object> m, String name,
                                                            MapValue<String, Object> functionTy) {
 
-        LLVM.LLVMModuleRef mRef = (LLVM.LLVMModuleRef) FFIUtil.getRecodeArgumentNative(m);
-        LLVM.LLVMTypeRef functionTyRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(functionTy);
+        LLVMModuleRef mRef = (LLVMModuleRef) FFIUtil.getRecodeArgumentNative(m);
+        LLVMTypeRef functionTyRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(functionTy);
         LLVMValueRef returnValue = LLVM.LLVMAddFunction(mRef, name, functionTyRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAddFunction.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAddFunction.java
@@ -23,10 +23,10 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.global.LLVM;
-import org.bytedeco.llvm.LLVM.LLVMValueRef;
 import org.bytedeco.llvm.LLVM.LLVMModuleRef;
 import org.bytedeco.llvm.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.global.LLVM;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAppendBasicBlock.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAppendBasicBlock.java
@@ -23,8 +23,9 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMBasicBlockRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.global.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
@@ -50,7 +51,7 @@ public class LLVMAppendBasicBlock {
     public static MapValue<String, Object> llvmAppendBasicBlock(Strand strand, MapValue<String, Object> fn,
                                                                 String name) {
 
-        LLVM.LLVMValueRef fnRef = (LLVM.LLVMValueRef) FFIUtil.getRecodeArgumentNative(fn);
+        LLVMValueRef fnRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(fn);
         LLVMBasicBlockRef returnValue = LLVM.LLVMAppendBasicBlock(fnRef, name);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMBasicBlockRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAppendBasicBlock.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMAppendBasicBlock.java
@@ -23,9 +23,9 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
+import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
 import org.bytedeco.llvm.LLVM.LLVMValueRef;
 import org.bytedeco.llvm.global.LLVM;
-import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildAdd.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildAdd.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildAdd;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildAdd;
 
 /**
  * Auto generated class.
@@ -53,7 +53,7 @@ public class LLVMBuildAdd {
     public static MapValue<String, Object> llvmBuildAdd(Strand strand, MapValue<String, Object> arg0,
                                             MapValue<String, Object> lhs, MapValue<String, Object> rhs, String name) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
         LLVMValueRef lhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(lhs);
         LLVMValueRef rhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(rhs);
         LLVMValueRef returnValue = LLVMBuildAdd(arg0Ref, lhsRef, rhsRef, name);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildAlloca.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildAlloca.java
@@ -23,8 +23,10 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.global.LLVM;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
@@ -51,8 +53,8 @@ public class LLVMBuildAlloca {
     public static MapValue<String, Object> llvmBuildAlloca(Strand strand, MapValue<String, Object> arg0,
                                                            MapValue<String, Object> ty, String name) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMTypeRef tyRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(ty);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMTypeRef tyRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(ty);
         LLVMValueRef returnValue = LLVM.LLVMBuildAlloca(arg0Ref, tyRef, name);
         MapValue<String, Object> returnWrapperRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBitCast.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBitCast.java
@@ -23,10 +23,10 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.global.LLVM;
-import org.bytedeco.llvm.LLVM.LLVMValueRef;
 import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 import org.bytedeco.llvm.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.global.LLVM;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBitCast.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBitCast.java
@@ -23,12 +23,13 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.global.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildBitCast;
 
 /**
  * Auto generated class.
@@ -50,10 +51,10 @@ public class LLVMBuildBitCast {
 
     public static MapValue<String, Object> llvmBuildBitCast(Strand strand, MapValue<String, Object> arg0,
             MapValue<String, Object> val, MapValue<String, Object> destTy, String name) {
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMValueRef valRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(val);
-        LLVM.LLVMTypeRef destTyRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(destTy);
-        LLVMValueRef returnValue = LLVMBuildBitCast(arg0Ref, valRef, destTyRef, name);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMValueRef valRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(val);
+        LLVMTypeRef destTyRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(destTy);
+        LLVMValueRef returnValue = LLVM.LLVMBuildBitCast(arg0Ref, valRef, destTyRef, name);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBr.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBr.java
@@ -23,11 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildBr;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildBr;
 
 /**
  * Auto generated class.
@@ -50,8 +51,8 @@ public class LLVMBuildBr {
     public static MapValue<String, Object> llvmBuildBr(Strand strand, MapValue<String, Object> arg0, MapValue<String,
             Object> dest) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMBasicBlockRef destRef = (LLVM.LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(dest);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMBasicBlockRef destRef = (LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(dest);
         LLVMValueRef returnValue = LLVMBuildBr(arg0Ref, destRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBr.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildBr.java
@@ -23,8 +23,8 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildCall.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildCall.java
@@ -24,10 +24,10 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
-import org.bytedeco.llvm.LLVM.LLVMValueRef;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.INT;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildCall.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildCall.java
@@ -24,8 +24,8 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
 
@@ -33,7 +33,7 @@ import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildCall;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildCall;
 
 /**
  * Auto generated class.
@@ -60,8 +60,8 @@ public class LLVMBuildCall {
                                                          MapValue<String, Object> fn, ArrayValue args, long numArgs,
                                                          String name) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMValueRef fnRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(fn);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMValueRef fnRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(fn);
         Pointer[] argsRef = FFIUtil.getRecodeArrayArgumentNative(args);
         PointerPointer<LLVMValueRef> argsWrapped = new PointerPointer(argsRef);
         int numArgsRef = (int) numArgs;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildCondBr.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildCondBr.java
@@ -23,11 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildCondBr;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildCondBr;
 
 /**
  * Auto generated class.
@@ -54,10 +55,10 @@ public class LLVMBuildCondBr {
                                                            MapValue<String, Object> then,
                                                            MapValue<String, Object> elseValue) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMValueRef ifValueRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(ifValue);
-        LLVM.LLVMBasicBlockRef thenRef = (LLVM.LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(then);
-        LLVM.LLVMBasicBlockRef elseValueRef = (LLVM.LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(elseValue);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMValueRef ifValueRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(ifValue);
+        LLVMBasicBlockRef thenRef = (LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(then);
+        LLVMBasicBlockRef elseValueRef = (LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(elseValue);
         LLVMValueRef returnValue = LLVMBuildCondBr(arg0Ref, ifValueRef, thenRef, elseValueRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildGlobalStringPtr.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildGlobalStringPtr.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildGlobalStringPtr;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildGlobalStringPtr;
 
 /**
  * Auto generated class.
@@ -51,7 +51,7 @@ public class LLVMBuildGlobalStringPtr {
 
     public static MapValue<String, Object> llvmBuildGlobalStringPtr(Strand strand, MapValue<String, Object> b,
             String str, String name) {
-        LLVM.LLVMBuilderRef bRef = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(b);
+        LLVMBuilderRef bRef = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(b);
         LLVMValueRef returnValue = LLVMBuildGlobalStringPtr(bRef, str, name);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildICmp.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildICmp.java
@@ -23,13 +23,13 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildICmp;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildICmp;
 
 /**
  * Auto generated class.
@@ -56,7 +56,7 @@ public class LLVMBuildICmp {
                                                          MapValue<String, Object> lhs,
                                                          MapValue<String, Object> rhs, String name) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
         int opRef = (int) op;
         LLVMValueRef lhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(lhs);
         LLVMValueRef rhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(rhs);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildLoad.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildLoad.java
@@ -23,11 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildLoad;
 
 /**
  * Auto generated class.
@@ -52,9 +53,9 @@ public class LLVMBuildLoad {
                                                          MapValue<String, Object> pointerVal,
                                                          String name) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMValueRef pointerValRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(pointerVal);
-        LLVMValueRef returnValue = LLVM.LLVMBuildLoad(arg0Ref, pointerValRef, name);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMValueRef pointerValRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(pointerVal);
+        LLVMValueRef returnValue = LLVMBuildLoad(arg0Ref, pointerValRef, name);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildMul.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildMul.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildMul;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildMul;
 
 /**
  * Auto generated class.
@@ -52,7 +52,7 @@ public class LLVMBuildMul {
 
         public static MapValue<String, Object> llvmBuildMul(Strand strand, MapValue<String, Object> arg0,
                 MapValue<String, Object> lhs, MapValue<String, Object> rhs, String name) {
-                LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+                LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
                 LLVMValueRef lhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(lhs);
                 LLVMValueRef rhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(rhs);
                 LLVMValueRef returnValue = LLVMBuildMul(arg0Ref, lhsRef, rhsRef, name);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildRet.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildRet.java
@@ -23,11 +23,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildRet;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildRet;
 
 /**
  * Auto generated class.
@@ -50,8 +50,8 @@ public class LLVMBuildRet {
     public static MapValue<String, Object> llvmBuildRet(Strand strand, MapValue<String, Object> arg0,
                                                         MapValue<String, Object> v) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMValueRef vRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(v);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMValueRef vRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(v);
         LLVMValueRef returnValue = LLVMBuildRet(arg0Ref, vRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildRetVoid.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildRetVoid.java
@@ -23,11 +23,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildRetVoid;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildRetVoid;
 
 /**
  * Auto generated class.
@@ -48,7 +48,7 @@ public class LLVMBuildRetVoid {
 
     public static MapValue<String, Object> llvmBuildRetVoid(Strand strand, MapValue<String, Object> arg0) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
         LLVMValueRef returnValue = LLVMBuildRetVoid(arg0Ref);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildSDiv.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildSDiv.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildSDiv;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildSDiv;
 
 /**
  * Auto generated class.
@@ -54,7 +54,7 @@ public class LLVMBuildSDiv {
                                                          MapValue<String, Object> lhs,
                                                          MapValue<String, Object> rhs, String name) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
         LLVMValueRef lhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(lhs);
         LLVMValueRef rhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(rhs);
         LLVMValueRef returnValue = LLVMBuildSDiv(arg0Ref, lhsRef, rhsRef, name);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildStore.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildStore.java
@@ -23,11 +23,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildStore;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildStore;
 
 /**
  * Auto generated class.
@@ -52,10 +52,10 @@ public class LLVMBuildStore {
                                                           MapValue<String, Object> val,
                                                           MapValue<String, Object> ptr) {
 
-        LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMValueRef valRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(val);
-        LLVM.LLVMValueRef ptrRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(ptr);
-        LLVMValueRef returnValue = LLVM.LLVMBuildStore(arg0Ref, valRef, ptrRef);
+        LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMValueRef valRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(val);
+        LLVMValueRef ptrRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(ptr);
+        LLVMValueRef returnValue = LLVMBuildStore(arg0Ref, valRef, ptrRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildStructGEP.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildStructGEP.java
@@ -23,13 +23,13 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildStructGEP;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildStructGEP;
 
 /**
  * Auto generated class.
@@ -51,8 +51,8 @@ public class LLVMBuildStructGEP {
 
     public static MapValue<String, Object> llvmBuildStructGEP(Strand strand, MapValue<String, Object> b,
             MapValue<String, Object> pointer, long idx, String name) {
-        LLVM.LLVMBuilderRef bRef = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(b);
-        LLVM.LLVMValueRef pointerRef = (LLVM.LLVMValueRef) FFIUtil.getRecodeArgumentNative(pointer);
+        LLVMBuilderRef bRef = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(b);
+        LLVMValueRef pointerRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(pointer);
         int idxRef = (int) idx;
         LLVMValueRef returnValue = LLVMBuildStructGEP(bRef, pointerRef, idxRef, name);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildSub.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMBuildSub.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMBuildSub;
+import static org.bytedeco.llvm.global.LLVM.LLVMBuildSub;
 
 /**
  * Auto generated class.
@@ -52,7 +52,7 @@ public class LLVMBuildSub {
 
         public static MapValue<String, Object> llvmBuildSub(Strand strand, MapValue<String, Object> arg0,
                 MapValue<String, Object> lhs, MapValue<String, Object> rhs, String name) {
-                LLVM.LLVMBuilderRef arg0Ref = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+                LLVMBuilderRef arg0Ref = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
                 LLVMValueRef lhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(lhs);
                 LLVMValueRef rhsRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(rhs);
                 LLVMValueRef returnValue = LLVMBuildSub(arg0Ref, lhsRef, rhsRef, name);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMConstInt.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMConstInt.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMConstInt;
+import static org.bytedeco.llvm.global.LLVM.LLVMConstInt;
 
 /**
  * Auto generated class.
@@ -52,7 +52,7 @@ public class LLVMConstInt {
     public static MapValue<String, Object> llvmConstInt(Strand strand, MapValue<String, Object> intTy,
                                                         long n, long signExtend) {
 
-        LLVM.LLVMTypeRef intTyRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(intTy);
+        LLVMTypeRef intTyRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(intTy);
         int signExtendRef = (int) signExtend;
         LLVMValueRef returnValue = LLVMConstInt(intTyRef, n, signExtendRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreateBuilder.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreateBuilder.java
@@ -23,10 +23,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMCreateBuilder;
+import static org.bytedeco.llvm.global.LLVM.LLVMCreateBuilder;
 
 /**
  * Auto generated class.
@@ -45,7 +45,7 @@ public class LLVMCreateBuilder {
 
     public static MapValue<String, Object> llvmCreateBuilder(Strand strand) {
 
-        LLVM.LLVMBuilderRef returnValue = LLVMCreateBuilder();
+        LLVMBuilderRef returnValue = LLVMCreateBuilder();
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreatePassManager.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreatePassManager.java
@@ -22,10 +22,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMCreatePassManager;
+import static org.bytedeco.llvm.global.LLVM.LLVMCreatePassManager;
 
 /**
  * Auto generated class.
@@ -43,7 +43,7 @@ public class LLVMCreatePassManager {
 
     public static MapValue<String, Object> llvmCreatePassManager(Strand strand) {
 
-        LLVM.LLVMPassManagerRef returnValue = LLVMCreatePassManager();
+        LLVMPassManagerRef returnValue = LLVMCreatePassManager();
         MapValue<String, Object> rerunWrapperRecode = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMPassManagerRef");
         FFIUtil.addNativeToRecode(returnValue, rerunWrapperRecode);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreateTargetMachine.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreateTargetMachine.java
@@ -24,11 +24,12 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.bytedeco.javacpp.BytePointer;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTargetRef;
+import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMCreateTargetMachine;
+import static org.bytedeco.llvm.global.LLVM.LLVMCreateTargetMachine;
 
 /**
  * Auto generated class.
@@ -59,11 +60,11 @@ public class LLVMCreateTargetMachine {
                                                                    MapValue<String, Object> arg3,
                                                                    long arg4, long arg5, long arg6) {
 
-        LLVM.LLVMTargetRef t = (LLVM.LLVMTargetRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMTargetRef t = (LLVMTargetRef) FFIUtil.getRecodeArgumentNative(arg0);
         BytePointer triple = (BytePointer) FFIUtil.getRecodeArgumentNative(arg1);
         BytePointer cpu = (BytePointer) FFIUtil.getRecodeArgumentNative(arg2);
         BytePointer features = (BytePointer) FFIUtil.getRecodeArgumentNative(arg3);
-        LLVM.LLVMTargetMachineRef returnValue = LLVMCreateTargetMachine(t, triple, cpu, features, (int) arg4,
+        LLVMTargetMachineRef returnValue = LLVMCreateTargetMachine(t, triple, cpu, features, (int) arg4,
                 (int) arg5, (int) arg6);
         MapValue<String, Object> rerunWrapperRecode = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMTargetMachineRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreateTargetMachine.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMCreateTargetMachine.java
@@ -24,8 +24,8 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.bytedeco.javacpp.BytePointer;
-import org.bytedeco.llvm.LLVM.LLVMTargetRef;
 import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
+import org.bytedeco.llvm.LLVM.LLVMTargetRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposeBuilder.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposeBuilder.java
@@ -21,10 +21,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMDisposeBuilder;
+import static org.bytedeco.llvm.global.LLVM.LLVMDisposeBuilder;
 
 /**
  * Auto generated class.
@@ -41,7 +41,7 @@ public class LLVMDisposeBuilder {
 
     public static void llvmDisposeBuilder(Strand strand, MapValue<String, Object> fn) {
 
-        LLVM.LLVMBuilderRef builder = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(fn);
+        LLVMBuilderRef builder = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(fn);
         LLVMDisposeBuilder(builder);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposePassManager.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposePassManager.java
@@ -21,10 +21,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMDisposePassManager;
+import static org.bytedeco.llvm.global.LLVM.LLVMDisposePassManager;
 
 /**
  * Auto generated class.
@@ -41,7 +41,7 @@ public class LLVMDisposePassManager {
 
     public static void llvmDisposePassManager(Strand strand, MapValue<String, Object> arg0) {
 
-        LLVM.LLVMPassManagerRef pm = (LLVM.LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMPassManagerRef pm = (LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg0);
         LLVMDisposePassManager(pm);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposeTargetMachine.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposeTargetMachine.java
@@ -22,9 +22,9 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
-import static org.bytedeco.llvm.global.LLVM.LLVMDisposeTargetMachine;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMDisposeTargetMachine;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposeTargetMachine.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDisposeTargetMachine.java
@@ -21,10 +21,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
+import static org.bytedeco.llvm.global.LLVM.LLVMDisposeTargetMachine;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMDisposeTargetMachine;
 
 /**
  * Auto generated class.
@@ -41,7 +41,7 @@ public class LLVMDisposeTargetMachine {
 
     public static void llvmDisposeTargetMachine(Strand strand, MapValue<String, Object> arg0) {
 
-        LLVM.LLVMTargetMachineRef t = (LLVM.LLVMTargetMachineRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMTargetMachineRef t = (LLVMTargetMachineRef) FFIUtil.getRecodeArgumentNative(arg0);
         LLVMDisposeTargetMachine(t);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDumpModule.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMDumpModule.java
@@ -21,10 +21,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMModuleRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMDumpModule;
+import static org.bytedeco.llvm.global.LLVM.LLVMDumpModule;
 
 /**
  * Auto generated class.
@@ -41,7 +41,7 @@ public class LLVMDumpModule {
 
     public static void llvmDumpModule(Strand strand, MapValue<String, Object> fn) {
 
-        LLVM.LLVMModuleRef m = (LLVM.LLVMModuleRef) FFIUtil.getRecodeArgumentNative(fn);
+        LLVMModuleRef m = (LLVMModuleRef) FFIUtil.getRecodeArgumentNative(fn);
         LLVMDumpModule(m);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMFunctionType1.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMFunctionType1.java
@@ -25,9 +25,9 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.INT;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMFunctionType1.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMFunctionType1.java
@@ -25,15 +25,14 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMFunctionType;
+import static org.bytedeco.llvm.global.LLVM.LLVMFunctionType;
 
 /**
  * Auto generated class.
@@ -59,7 +58,7 @@ public class LLVMFunctionType1 {
                                                              ArrayValue paramTypes, long paramCount,
                                                              long isVarArg) {
 
-        LLVM.LLVMTypeRef returnTypeRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(returnType);
+        LLVMTypeRef returnTypeRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(returnType);
         Pointer[] paramTypesRef = FFIUtil.getRecodeArrayArgumentNative(paramTypes);
         PointerPointer paramTypesWrapped = new PointerPointer(paramTypesRef);
         int paramCountRef = (int) paramCount;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetDefaultTargetTriple.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetDefaultTargetTriple.java
@@ -25,7 +25,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
 import org.bytedeco.javacpp.BytePointer;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMGetDefaultTargetTriple;
+import static org.bytedeco.llvm.global.LLVM.LLVMGetDefaultTargetTriple;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetFirstTarget.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetFirstTarget.java
@@ -22,10 +22,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTargetRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMGetFirstTarget;
+import static org.bytedeco.llvm.global.LLVM.LLVMGetFirstTarget;
 
 /**
  * Auto generated class.
@@ -43,7 +43,7 @@ public class LLVMGetFirstTarget {
 
     public static MapValue<String, Object> llvmGetFirstTarget(Strand strand) {
 
-        LLVM.LLVMTargetRef returnValue = LLVMGetFirstTarget();
+        LLVMTargetRef returnValue = LLVMGetFirstTarget();
         MapValue<String, Object> rerunWrapperRecode = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMTargetRef");
         FFIUtil.addNativeToRecode(returnValue, rerunWrapperRecode);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetGlobalContext.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetGlobalContext.java
@@ -22,10 +22,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM.LLVMContextRef;
+import org.bytedeco.llvm.LLVM.LLVMContextRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMGetGlobalContext;
+import static org.bytedeco.llvm.global.LLVM.LLVMGetGlobalContext;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetParam.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMGetParam.java
@@ -24,11 +24,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMGetParam;
 
 /**
  * Auto generated class.
@@ -50,9 +50,9 @@ public class LLVMGetParam {
 
     public static MapValue<String, Object> llvmGetParam(Strand strand, MapValue<String, Object> fn, long index) {
 
-        LLVM.LLVMValueRef fnRef = (LLVM.LLVMValueRef) FFIUtil.getRecodeArgumentNative(fn);
+        LLVMValueRef fnRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(fn);
         int indexRef = (int) index;
-        LLVMValueRef returnValue = LLVM.LLVMGetParam(fnRef, indexRef);
+        LLVMValueRef returnValue = LLVMGetParam(fnRef, indexRef);
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMValueRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllAsmParsers.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllAsmParsers.java
@@ -19,7 +19,7 @@ package org.ballerinalang.nativeimpl.llvm.gen;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
-import static org.bytedeco.javacpp.LLVM.LLVMInitializeAllAsmParsers;
+import static org.bytedeco.llvm.global.LLVM.LLVMInitializeAllAsmParsers;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllAsmPrinters.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllAsmPrinters.java
@@ -19,7 +19,7 @@ package org.ballerinalang.nativeimpl.llvm.gen;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
-import static org.bytedeco.javacpp.LLVM.LLVMInitializeAllAsmPrinters;
+import static org.bytedeco.llvm.global.LLVM.LLVMInitializeAllAsmPrinters;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllTargetInfos.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllTargetInfos.java
@@ -19,7 +19,7 @@ package org.ballerinalang.nativeimpl.llvm.gen;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
-import static org.bytedeco.javacpp.LLVM.LLVMInitializeAllTargetInfos;
+import static org.bytedeco.llvm.global.LLVM.LLVMInitializeAllTargetInfos;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllTargetMCs.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllTargetMCs.java
@@ -19,7 +19,7 @@ package org.ballerinalang.nativeimpl.llvm.gen;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
-import static org.bytedeco.javacpp.LLVM.LLVMInitializeAllTargetMCs;
+import static org.bytedeco.llvm.global.LLVM.LLVMInitializeAllTargetMCs;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllTargets.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInitializeAllTargets.java
@@ -19,7 +19,7 @@ package org.ballerinalang.nativeimpl.llvm.gen;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
-import static org.bytedeco.javacpp.LLVM.LLVMInitializeAllTargets;
+import static org.bytedeco.llvm.global.LLVM.LLVMInitializeAllTargets;
 
 /**
  * Auto generated class.

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt1Type.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt1Type.java
@@ -23,10 +23,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMInt1Type;
 
 /**
  * Auto generated class.
@@ -44,7 +44,7 @@ public class LLVMInt1Type {
 
     public static MapValue<String, Object> llvmInt1Type(Strand strand) {
 
-        LLVMTypeRef returnValue = LLVM.LLVMInt1Type();
+        LLVMTypeRef returnValue = LLVMInt1Type();
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt1TypeInContext.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt1TypeInContext.java
@@ -24,10 +24,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMContextRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMInt1TypeInContext;
 
 /**
  * Auto generated class.
@@ -48,8 +49,8 @@ public class LLVMInt1TypeInContext {
 
     public static MapValue<String, Object> llvmInt1TypeInContext(Strand strand, MapValue<String, Object> c) {
 
-        LLVM.LLVMContextRef cRef = (LLVM.LLVMContextRef) FFIUtil.getRecodeArgumentNative(c);
-        LLVMTypeRef returnValue = LLVM.LLVMInt1TypeInContext(cRef);
+        LLVMContextRef cRef = (LLVMContextRef) FFIUtil.getRecodeArgumentNative(c);
+        LLVMTypeRef returnValue = LLVMInt1TypeInContext(cRef);
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt32Type.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt32Type.java
@@ -21,10 +21,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMInt32Type;
+import static org.bytedeco.llvm.global.LLVM.LLVMInt32Type;
 
 /**
  * Auto generated class.
@@ -42,7 +42,7 @@ public class LLVMInt32Type {
 
     public static MapValue<String, Object> llvmInt32Type(Strand strand) {
 
-        LLVM.LLVMTypeRef returnValue = LLVMInt32Type();
+        LLVMTypeRef returnValue = LLVMInt32Type();
         MapValue<String, Object> rerunWrapperRecode = FFIUtil.newRecord();
         FFIUtil.addNativeToRecode(returnValue, rerunWrapperRecode);
         return rerunWrapperRecode;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt64Type.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt64Type.java
@@ -23,10 +23,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMInt64Type;
 
 /**
  * Auto generated class.
@@ -44,7 +44,7 @@ public class LLVMInt64Type {
 
     public static MapValue<String, Object> llvmInt64Type(Strand strand) {
 
-        LLVMTypeRef returnValue = LLVM.LLVMInt64Type();
+        LLVMTypeRef returnValue = LLVMInt64Type();
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt8Type.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMInt8Type.java
@@ -23,10 +23,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMInt8Type;
+import static org.bytedeco.llvm.global.LLVM.LLVMInt8Type;
 
 /**
  * Auto generated class.
@@ -44,7 +44,7 @@ public class LLVMInt8Type {
 
     public static MapValue<String, Object> llvmInt8Type(Strand strand) {
 
-        LLVM.LLVMTypeRef returnValue = LLVMInt8Type();
+        LLVMTypeRef returnValue = LLVMInt8Type();
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMModuleCreateWithName.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMModuleCreateWithName.java
@@ -24,11 +24,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMModuleRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMModuleCreateWithName;
+import static org.bytedeco.llvm.global.LLVM.LLVMModuleCreateWithName;
 
 /**
  * Auto generated class.
@@ -50,7 +50,7 @@ public class LLVMModuleCreateWithName {
 
     public static MapValue<String, Object> llvmModuleCreateWithName(Strand strand, String moduleID) {
 
-        LLVM.LLVMModuleRef returnValue = LLVMModuleCreateWithName(moduleID);
+        LLVMModuleRef returnValue = LLVMModuleCreateWithName(moduleID);
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMModuleRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderCreate.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderCreate.java
@@ -22,10 +22,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerBuilderRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPassManagerBuilderCreate;
+import static org.bytedeco.llvm.global.LLVM.LLVMPassManagerBuilderCreate;
 
 /**
  * Auto generated class.
@@ -43,7 +43,7 @@ public class LLVMPassManagerBuilderCreate {
 
     public static MapValue<String, Object> llvmPassManagerBuilderCreate(Strand strand) {
 
-        LLVM.LLVMPassManagerBuilderRef returnValue = LLVMPassManagerBuilderCreate();
+        LLVMPassManagerBuilderRef returnValue = LLVMPassManagerBuilderCreate();
         MapValue<String, Object> rerunWrapperRecode = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMPassManagerBuilderRef");
         FFIUtil.addNativeToRecode(returnValue, rerunWrapperRecode);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderDispose.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderDispose.java
@@ -21,10 +21,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerBuilderRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPassManagerBuilderDispose;
+import static org.bytedeco.llvm.global.LLVM.LLVMPassManagerBuilderDispose;
 
 /**
  * Auto generated class.
@@ -41,7 +41,7 @@ public class LLVMPassManagerBuilderDispose {
 
     public static void llvmPassManagerBuilderDispose(Strand strand, MapValue<String, Object> arg0) {
 
-        LLVM.LLVMPassManagerBuilderRef pmb = (LLVM.LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMPassManagerBuilderRef pmb = (LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
         LLVMPassManagerBuilderDispose(pmb);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderPopulateFunctionPassManager.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderPopulateFunctionPassManager.java
@@ -21,10 +21,11 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPassManagerBuilderPopulateFunctionPassManager;
+import static org.bytedeco.llvm.global.LLVM.LLVMPassManagerBuilderPopulateFunctionPassManager;
 
 /**
  * Auto generated class.
@@ -43,8 +44,8 @@ public class LLVMPassManagerBuilderPopulateFunctionPassManager {
     public static void llvmPassManagerBuilderPopulateFunctionPassManager(Strand strand, MapValue<String, Object> arg0,
                                                                          MapValue<String, Object> arg1) {
 
-        LLVM.LLVMPassManagerBuilderRef pmb = (LLVM.LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMPassManagerRef pm = (LLVM.LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg1);
+        LLVMPassManagerBuilderRef pmb = (LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMPassManagerRef pm = (LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg1);
         LLVMPassManagerBuilderPopulateFunctionPassManager(pmb, pm);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderPopulateModulePassManager.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderPopulateModulePassManager.java
@@ -21,10 +21,11 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPassManagerBuilderPopulateModulePassManager;
+import static org.bytedeco.llvm.global.LLVM.LLVMPassManagerBuilderPopulateModulePassManager;
 
 /**
  * Auto generated class.
@@ -43,8 +44,8 @@ public class LLVMPassManagerBuilderPopulateModulePassManager {
     public static void llvmPassManagerBuilderPopulateModulePassManager(Strand strand, MapValue<String, Object> arg0,
                                                                        MapValue<String, Object> arg1) {
 
-        LLVM.LLVMPassManagerBuilderRef pmb = (LLVM.LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMPassManagerRef pm = (LLVM.LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg1);
+        LLVMPassManagerBuilderRef pmb = (LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMPassManagerRef pm = (LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg1);
         LLVMPassManagerBuilderPopulateModulePassManager(pmb, pm);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderSetOptLevel.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPassManagerBuilderSetOptLevel.java
@@ -21,11 +21,11 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerBuilderRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPassManagerBuilderSetOptLevel;
+import static org.bytedeco.llvm.global.LLVM.LLVMPassManagerBuilderSetOptLevel;
 
 /**
  * Auto generated class.
@@ -43,7 +43,7 @@ public class LLVMPassManagerBuilderSetOptLevel {
 
     public static void llvmPassManagerBuilderSetOptLevel(Strand strand, MapValue<String, Object> m, long optLevel) {
 
-        LLVM.LLVMPassManagerBuilderRef pmb = (LLVM.LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(m);
+        LLVMPassManagerBuilderRef pmb = (LLVMPassManagerBuilderRef) FFIUtil.getRecodeArgumentNative(m);
         LLVMPassManagerBuilderSetOptLevel(pmb, (int) optLevel);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPointerType.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPointerType.java
@@ -24,11 +24,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPointerType;
+import static org.bytedeco.llvm.global.LLVM.LLVMPointerType;
 
 /**
  * Auto generated class.
@@ -52,8 +52,8 @@ public class LLVMPointerType {
     public static MapValue<String, Object> llvmPointerType(Strand strand, MapValue<String, Object> typeRef,
                                                            long addressSpace) {
 
-        LLVM.LLVMTypeRef elementType = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(typeRef);
-        LLVM.LLVMTypeRef returnValue = LLVMPointerType(elementType, (int) addressSpace);
+        LLVMTypeRef elementType = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(typeRef);
+        LLVMTypeRef returnValue = LLVMPointerType(elementType, (int) addressSpace);
         MapValue<String, Object> returnWrappedRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrappedRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPositionBuilderAtEnd.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPositionBuilderAtEnd.java
@@ -21,8 +21,8 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.bytedeco.llvm.global.LLVM.LLVMPositionBuilderAtEnd;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPositionBuilderAtEnd.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMPositionBuilderAtEnd.java
@@ -21,10 +21,11 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
+import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMPositionBuilderAtEnd;
+import static org.bytedeco.llvm.global.LLVM.LLVMPositionBuilderAtEnd;
 
 /**
  * Auto generated class.
@@ -43,8 +44,8 @@ public class LLVMPositionBuilderAtEnd {
     public static void llvmPositionBuilderAtEnd(Strand strand, MapValue<String, Object> builder,
                                                 MapValue<String, Object> block) {
 
-        LLVM.LLVMBuilderRef builderRef = (LLVM.LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(builder);
-        LLVM.LLVMBasicBlockRef blockRef = (LLVM.LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(block);
+        LLVMBuilderRef builderRef = (LLVMBuilderRef) FFIUtil.getRecodeArgumentNative(builder);
+        LLVMBasicBlockRef blockRef = (LLVMBasicBlockRef) FFIUtil.getRecodeArgumentNative(block);
         LLVMPositionBuilderAtEnd(builderRef, blockRef);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMRunPassManager.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMRunPassManager.java
@@ -22,8 +22,8 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
 import org.bytedeco.llvm.LLVM.LLVMModuleRef;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMRunPassManager.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMRunPassManager.java
@@ -22,11 +22,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef;
+import org.bytedeco.llvm.LLVM.LLVMModuleRef;
 
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMRunPassManager;
+import static org.bytedeco.llvm.global.LLVM.LLVMRunPassManager;
 
 /**
  * Auto generated class.
@@ -48,8 +49,8 @@ public class LLVMRunPassManager {
 
     public static long llvmRunPassManager(Strand strand, MapValue<String, Object> arg0, MapValue<String, Object> arg1) {
 
-        LLVM.LLVMPassManagerRef pm = (LLVM.LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMModuleRef m = (LLVM.LLVMModuleRef) FFIUtil.getRecodeArgumentNative(arg1);
+        LLVMPassManagerRef pm = (LLVMPassManagerRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMModuleRef m = (LLVMModuleRef) FFIUtil.getRecodeArgumentNative(arg1);
         return LLVMRunPassManager(pm, m);
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMStructCreateNamed.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMStructCreateNamed.java
@@ -23,12 +23,12 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMContextRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.ballerinalang.model.types.TypeKind.STRING;
-import static org.bytedeco.javacpp.LLVM.LLVMStructCreateNamed;
+import static org.bytedeco.llvm.global.LLVM.LLVMStructCreateNamed;
 
 /**
  * Auto generated class.
@@ -48,7 +48,7 @@ public class LLVMStructCreateNamed {
 
     public static MapValue<String, Object> llvmStructCreateNamed(Strand strand, MapValue<String, Object> c,
             String name) {
-        LLVM.LLVMContextRef cRef = (LLVM.LLVMContextRef) FFIUtil.getRecodeArgumentNative(c);
+        LLVMContextRef cRef = (LLVMContextRef) FFIUtil.getRecodeArgumentNative(c);
         LLVMTypeRef returnValue = LLVMStructCreateNamed(cRef, name);
         MapValue<String, Object> returnWrappedValue = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMStructSetBody1.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMStructSetBody1.java
@@ -22,9 +22,9 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.INT;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMStructSetBody1.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMStructSetBody1.java
@@ -22,14 +22,14 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMStructSetBody;
+import static org.bytedeco.llvm.global.LLVM.LLVMStructSetBody;
 
 /**
  * Auto generated class.
@@ -47,7 +47,7 @@ public class LLVMStructSetBody1 {
 
     public static void llvmStructSetBody1(Strand strand, MapValue<String, Object> structTy,
             ArrayValue elementTypes, long elementCount, long packed) {
-        LLVM.LLVMTypeRef structTyRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(structTy);
+        LLVMTypeRef structTyRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(structTy);
         Pointer[] elementTypesRef = FFIUtil.getRecodeArrayArgumentNative(elementTypes);
         int elementCountRef = (int) elementCount;
         int packedRef = (int) packed;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTargetMachineEmitToFile.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTargetMachineEmitToFile.java
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.ballerinalang.nativeimpl.llvm.gen;
 
 import org.ballerinalang.jvm.scheduling.Strand;
@@ -7,8 +23,8 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
 import org.bytedeco.llvm.LLVM.LLVMModuleRef;
+import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.BYTE;
@@ -19,7 +35,7 @@ import static org.bytedeco.llvm.global.LLVM.LLVMTargetMachineEmitToFile;
 /**
  * Auto generated class.
  *
- * @since 1.0.3
+ * @since 1.2.0
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "llvm",

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTargetMachineEmitToFile.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTargetMachineEmitToFile.java
@@ -7,12 +7,14 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTargetMachineRef;
+import org.bytedeco.llvm.LLVM.LLVMModuleRef;
 
 import static org.ballerinalang.model.types.TypeKind.ARRAY;
 import static org.ballerinalang.model.types.TypeKind.BYTE;
 import static org.ballerinalang.model.types.TypeKind.INT;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMTargetMachineEmitToFile;
 
 /**
  * Auto generated class.
@@ -38,9 +40,9 @@ public class LLVMTargetMachineEmitToFile {
     public static long llvmTargetMachineEmitToFile(Strand strand, MapValue<String, Object> arg0, MapValue<String,
             Object> arg1, ArrayValue arg2, long arg3, ArrayValue arg4) {
 
-        LLVM.LLVMTargetMachineRef t = (LLVM.LLVMTargetMachineRef) FFIUtil.getRecodeArgumentNative(arg0);
-        LLVM.LLVMModuleRef m = (LLVM.LLVMModuleRef) FFIUtil.getRecodeArgumentNative(arg1);
+        LLVMTargetMachineRef t = (LLVMTargetMachineRef) FFIUtil.getRecodeArgumentNative(arg0);
+        LLVMModuleRef m = (LLVMModuleRef) FFIUtil.getRecodeArgumentNative(arg1);
 
-        return LLVM.LLVMTargetMachineEmitToFile(t, m, arg2.getBytes(), (int) arg3, arg4.getBytes());
+        return LLVMTargetMachineEmitToFile(t, m, arg2.getBytes(), (int) arg3, arg4.getBytes());
     }
 }

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTypeOf.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTypeOf.java
@@ -23,8 +23,8 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.llvm.LLVM.LLVMValueRef;
 import org.bytedeco.llvm.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
 import static org.bytedeco.llvm.global.LLVM.LLVMTypeOf;

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTypeOf.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMTypeOf.java
@@ -23,11 +23,11 @@ import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMValueRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.bytedeco.javacpp.LLVM.LLVMTypeOf;
+import static org.bytedeco.llvm.global.LLVM.LLVMTypeOf;
 
 /**
  * Auto generated class.
@@ -45,7 +45,7 @@ import static org.bytedeco.javacpp.LLVM.LLVMTypeOf;
 public class LLVMTypeOf {
 
     public static MapValue<String, Object> llvmTypeOf(Strand strand, MapValue<String, Object> val) {
-        LLVM.LLVMValueRef valRef = (LLVM.LLVMValueRef) FFIUtil.getRecodeArgumentNative(val);
+        LLVMValueRef valRef = (LLVMValueRef) FFIUtil.getRecodeArgumentNative(val);
         LLVMTypeRef returnValue = LLVMTypeOf(valRef);
         MapValue<String, Object> returnWrappedRecord = FFIUtil.newRecord(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMVoidType.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/LLVMVoidType.java
@@ -23,10 +23,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.bytedeco.javacpp.LLVM;
-import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMVoidType;
 
 /**
  * Auto generated class.
@@ -43,7 +43,7 @@ import static org.ballerinalang.model.types.TypeKind.RECORD;
 public class LLVMVoidType {
 
     public static MapValue<String, Object> llvmVoidType(Strand strand) {
-        LLVMTypeRef returnValue = LLVM.LLVMVoidType();
+        LLVMTypeRef returnValue = LLVMVoidType();
         MapValue<String, Object> returnWrapperRecord = BallerinaValues.createRecordValue(new BPackage("ballerina",
                 "llvm"), "LLVMTypeRef");
         FFIUtil.addNativeToRecode(returnValue, returnWrapperRecord);

--- a/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/TypeCheck.java
+++ b/stdlib/llvm/src/main/java/org/ballerinalang/nativeimpl/llvm/gen/TypeCheck.java
@@ -23,9 +23,10 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.nativeimpl.llvm.FFIUtil;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.LLVM.LLVMTypeRef;
 
 import static org.ballerinalang.model.types.TypeKind.RECORD;
+import static org.bytedeco.llvm.global.LLVM.LLVMGetStructName;
 
 /**
  *
@@ -42,10 +43,10 @@ import static org.ballerinalang.model.types.TypeKind.RECORD;
 public class TypeCheck {
     public static boolean llvmCheckIfTypesMatch(Strand strand, MapValue<String, Object> castType,
             MapValue<String, Object> lhsType) {
-        LLVM.LLVMTypeRef castTypeRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(castType);
-        LLVM.LLVMTypeRef lhsTypeRef = (LLVM.LLVMTypeRef) FFIUtil.getRecodeArgumentNative(lhsType);
-        String castTypeName = LLVM.LLVMGetStructName(castTypeRef).getString();
-        String lhsTypeName = LLVM.LLVMGetStructName(lhsTypeRef).getString();
+        LLVMTypeRef castTypeRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(castType);
+        LLVMTypeRef lhsTypeRef = (LLVMTypeRef) FFIUtil.getRecodeArgumentNative(lhsType);
+        String castTypeName = LLVMGetStructName(castTypeRef).getString();
+        String lhsTypeName = LLVMGetStructName(lhsTypeRef).getString();
         return castTypeName.compareTo(lhsTypeName) == 0;
     }
 }

--- a/stdlib/llvm/src/test/java/BindingGenerator.java
+++ b/stdlib/llvm/src/test/java/BindingGenerator.java
@@ -1,4 +1,4 @@
-import org.bytedeco.javacpp.LLVM;
+import org.bytedeco.llvm.global.LLVM;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -64,8 +64,8 @@ public class BindingGenerator {
                                          "import org.ballerinalang.natives.annotations.ReturnType;\n" +
                                          "import org.bytedeco.javacpp.BytePointer;\n" +
                                          "import org.bytedeco.javacpp.IntPointer;\n" +
-                                         "import org.bytedeco.javacpp.LLVM.*;\n" +
-                                         "import org.bytedeco.javacpp.LLVM;\n" +
+                                         "import org.bytedeco.LLVM*;\n" +
+                                         "import org.bytedeco.llvm.LLVM;\n" +
                                          "import org.bytedeco.javacpp.Pointer;\n" +
                                          "import org.bytedeco.javacpp.PointerPointer;\n" +
                                          "import org.bytedeco.javacpp.SizeTPointer;\n" +
@@ -73,7 +73,7 @@ public class BindingGenerator {
                                          "import java.nio.ByteBuffer;\n" +
                                          "\n" +
                                          "import static org.ballerinalang.model.types.TypeKind.*;\n" +
-                                         "import static org.bytedeco.javacpp.LLVM.%s;\n" +
+                                         "import static org.bytedeco.LLVM%s;\n" +
                                          "\n" +
                                          "/**\n" +
                                          " * Auto generated class.\n" +
@@ -271,7 +271,7 @@ public class BindingGenerator {
             throw new RuntimeException("array arg type not supported yet");
         } else if (!paramType.isPrimitive()) {
             String typeName = paramType.getSimpleName();
-            if (paramType.getName().startsWith("org.bytedeco.javacpp.LLVM")) {
+            if (paramType.getName().startsWith("org.bytedeco.llvm.LLVM")) {
                 typeName = "LLVM." + typeName;
             }
             body.append(String.format(RECODE_BODY, typeName, paramName, regs[REG_REG]++));


### PR DESCRIPTION
## Purpose
>With this PR, we upgrade the ByteDeco LLVM version from 6 to 9, so that there are no compatibility issues coming out while using rust.

Fixes ##20559

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
>** If you have previously run the native backend, and if you get a linker error please delete
/usr/local/lib/libLLVM.dylib and retry**

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
