### PR TITLE
Fix NPE found on list constructor type checking

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -604,11 +604,11 @@ public class TypeChecker extends BLangNodeVisitor {
         // Check whether the expected type is an array type
         // var a = []; and var a = [1,2,3,4]; are illegal statements, because we cannot infer the type here.
         BType actualType = symTable.semanticError;
+        resultType = symTable.semanticError;
 
         if ((expType.tag == TypeTags.ANY || expType.tag == TypeTags.ANYDATA || expType.tag == TypeTags.NONE)
                 && listConstructor.exprs.isEmpty()) {
             dlog.error(listConstructor.pos, DiagnosticCode.INVALID_LIST_CONSTRUCTOR, expType);
-            resultType = symTable.semanticError;
             return;
         }
 
@@ -624,7 +624,6 @@ public class TypeChecker extends BLangNodeVisitor {
             } else if (arrayType.state != BArrayState.UNSEALED && arrayType.size != listConstructor.exprs.size()) {
                 dlog.error(listConstructor.pos,
                         DiagnosticCode.MISMATCHING_ARRAY_LITERAL_VALUES, arrayType.size, listConstructor.exprs.size());
-                resultType = symTable.semanticError;
                 return;
             }
             checkExprs(listConstructor.exprs, this.env, arrayType.eType);
@@ -658,7 +657,6 @@ public class TypeChecker extends BLangNodeVisitor {
                                 // tuple type size != list constructor exprs
                                 dlog.error(listConstructor.pos, DiagnosticCode.SYNTAX_ERROR,
                                         "tuple and expression size does not match");
-                                resultType = symTable.semanticError;
                                 return;
                             }
                         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -32,9 +32,13 @@ public class ListConstructorExprTest {
     public void diagnosticsTest() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/expressions/listconstructor/list_constructor_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 1);
-        BAssertUtil.validateError(result, 0,
-                                  "invalid list constructor expression: types cannot be inferred for '[v1, v2, v3]'",
-                                  18, 24);
+        int i = 0;
+        BAssertUtil.validateError(result, i++, "invalid list constructor expression: " +
+                "types cannot be inferred for '[v1, v2, v3]'", 18, 24);
+        BAssertUtil.validateError(result, i++, "tuple and expression size does not match",
+                22, 20);
+        BAssertUtil.validateError(result, i++, "tuple and expression size does not match",
+                23, 34);
+        Assert.assertEquals(result.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_negative.bal
@@ -14,6 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function testIncompatibleListConstructorExprs() {
+function testIncompatibleListConstructorExprs1() {
     var [v1, v2, v3] = ["hello", 123, 34.56];
+}
+
+function testIncompatibleListConstructorExprs2() {
+    [int, int] a = [];
+    [[int, int], [int, int]] b = [];
 }


### PR DESCRIPTION
## Purpose
$title on the master

Fixes #19673

## Approach
n/a

## Samples
```ballerina
[[int, int], [int, int]] b = []; // will now show semantic error instead of a NPE
```
## Remarks
- 1.1.x - https://github.com/ballerina-platform/ballerina-lang/pull/20536

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
