### PR TITLE
Improve fillmember op in array store of multi-demensional array

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -856,7 +856,18 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangStatementExpression statementExpression) {
+        boolean variableStore = this.varAssignment;
+        BIROperand prevTargetOperand = null;
+        if (variableStore) {
+            prevTargetOperand = this.env.targetOperand;
+        }
+        this.varAssignment = false;
         statementExpression.stmt.accept(this);
+        this.varAssignment = variableStore;
+
+        if (variableStore) {
+            this.env.targetOperand = prevTargetOperand;
+        }
         statementExpression.expr.accept(this);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -833,9 +833,10 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangAssignment astAssignStmt) {
         astAssignStmt.expr.accept(this);
 
+        boolean prevVarAssignmentStatus = this.varAssignment;
         this.varAssignment = true;
         astAssignStmt.varRef.accept(this);
-        this.varAssignment = false;
+        this.varAssignment = prevVarAssignmentStatus;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -857,10 +857,13 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangStatementExpression statementExpression) {
         boolean variableStore = this.varAssignment;
+
+        // Bypass targetOperand to statementExpression.expr
         BIROperand prevTargetOperand = null;
         if (variableStore) {
             prevTargetOperand = this.env.targetOperand;
         }
+        // Stop varAssignment status propagation to statement block's code gen.
         this.varAssignment = false;
         statementExpression.stmt.accept(this);
         this.varAssignment = variableStore;
@@ -868,6 +871,7 @@ public class BIRGen extends BLangNodeVisitor {
         if (variableStore) {
             this.env.targetOperand = prevTargetOperand;
         }
+
         statementExpression.expr.accept(this);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3280,6 +3280,14 @@ public class Desugar extends BLangNodeVisitor {
         // First get the type and then visit the expr. Order matters, since the desugar
         // can change the type of the expression, if it is type narrowed.
         BType varRefType = indexAccessExpr.expr.type;
+        if (indexAccessExpr.lhsVar && varRefType.tag == TypeTags.ARRAY
+                && indexAccessExpr.indexExpr.type.tag == TypeTags.INT
+                && indexAccessExpr.expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR
+                && ((BLangIndexBasedAccess) indexAccessExpr.expr).indexExpr.type.tag == TypeTags.INT) {
+            result = rewriteMultiDimensionalLValAccess(indexAccessExpr, varRefType);
+            return;
+        }
+
         indexAccessExpr.expr = rewriteExpr(indexAccessExpr.expr);
         if (!types.isSameType(indexAccessExpr.expr.type, varRefType)) {
             indexAccessExpr.expr = addConversionExprIfRequired(indexAccessExpr.expr, varRefType);
@@ -3305,6 +3313,54 @@ public class Desugar extends BLangNodeVisitor {
         targetVarRef.lhsVar = indexAccessExpr.lhsVar;
         targetVarRef.type = indexAccessExpr.type;
         result = targetVarRef;
+    }
+
+    private BLangExpression rewriteMultiDimensionalLValAccess(BLangIndexBasedAccess indexAccessExpr, BType varRefType) {
+        // ar[i][j] = n; -> ar[i] = []; ar[i][j] = n;
+
+        DiagnosticPos pos = indexAccessExpr.pos;
+        BLangIndexBasedAccess expr = (BLangIndexBasedAccess) indexAccessExpr.expr;
+        BLangStatementExpression bLangStatementExpression = new BLangStatementExpression();
+        BLangBlockStmt bLangBlockStmt = new BLangBlockStmt();
+        BLangIf ifStmt = ASTBuilderUtil.createIfStmt(pos, bLangBlockStmt);
+
+        BLangInvocation invocationNode = createInvocationNode("length", new ArrayList<>(), symTable.intType);
+        invocationNode.expr = expr.expr;
+        invocationNode.symbol = symResolver.lookupLangLibMethod(symTable.arrayType, names.fromString("length"));
+        invocationNode.requiredArgs = Collections.singletonList(expr.expr);
+        invocationNode.type = symTable.intType;
+
+        BLangBinaryExpr addOneToIndex = ASTBuilderUtil.createBinaryExpr(pos,
+                expr.indexExpr,
+                ASTBuilderUtil.createLiteral(pos, symTable.intType, Long.valueOf(1)),
+                symTable.intType,
+                OperatorKind.ADD, null);
+        ifStmt.expr = ASTBuilderUtil.createBinaryExpr(pos,
+                invocationNode,
+                addOneToIndex,
+                symTable.booleanType, OperatorKind.LESS_THAN, null);
+
+        BLangArrayAccessExpr arrayAccessExpr = new BLangArrayAccessExpr(pos, indexAccessExpr.expr,
+                indexAccessExpr.indexExpr);
+        arrayAccessExpr.lhsVar = true;
+        arrayAccessExpr.type = varRefType;
+        bLangStatementExpression.expr = arrayAccessExpr;
+        bLangStatementExpression.stmt = bLangBlockStmt;
+        BLangAssignment assignment = new BLangAssignment();
+        ifStmt.body = ASTBuilderUtil.createBlockStmt(pos);
+        ifStmt.body.addStatement(assignment);
+//        bLangBlockStmt.addStatement(assignment);
+        assignment.varRef = rewrite(expr, env);
+
+
+        BLangArrayLiteral arrayLiteral = new BLangArrayLiteral();
+        arrayLiteral.pos = indexAccessExpr.expr.pos;
+        assignment.expr = arrayLiteral;
+        arrayLiteral.type = expr.type;
+        assignment.type = expr.type;
+
+        bLangStatementExpression.type = indexAccessExpr.type;
+        return rewriteExpr(bLangStatementExpression);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3280,8 +3280,8 @@ public class Desugar extends BLangNodeVisitor {
         // First get the type and then visit the expr. Order matters, since the desugar
         // can change the type of the expression, if it is type narrowed.
         BType varRefType = indexAccessExpr.expr.type;
-        if (indexAccessExpr.lhsVar && varRefType.tag == TypeTags.ARRAY
-                && indexAccessExpr.indexExpr.type.tag == TypeTags.INT
+        if (indexAccessExpr.lhsVar
+                && varRefType.tag == TypeTags.ARRAY
                 && indexAccessExpr.expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR
                 && ((BLangIndexBasedAccess) indexAccessExpr.expr).indexExpr.type.tag == TypeTags.INT) {
             result = rewriteMultiDimensionalLValAccess(indexAccessExpr, varRefType);
@@ -3316,7 +3316,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangExpression rewriteMultiDimensionalLValAccess(BLangIndexBasedAccess indexAccessExpr, BType varRefType) {
-        // ar[i][j] = n; -> int $t = i; if $t < ar.length() { ar[$t] = []; } ar[$t][j] = n;
+        // ar[i][j] = n; -> int $t = i; if ($t < ar.length() + 1) { ar[$t] = []; } ar[$t][j] = n;
 
         DiagnosticPos pos = indexAccessExpr.pos;
         BLangIndexBasedAccess expr = (BLangIndexBasedAccess) indexAccessExpr.expr;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -118,11 +118,11 @@ public class ArrayAccessExprTest {
     }
 
     @Test
-    public void testFoo() {
+    public void testAssignToNonExistingFirstDimensionOfTwoDimensionArray() {
         BValue[] args = {};
-        BValue[] returns = BRunUtil.invoke(compileResult, "foo", args);
+        BValue[] returns = BRunUtil.invoke(compileResult, "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
 
-        Assert.assertEquals(returns[0], "");
+        Assert.assertEquals(returns[0].stringValue(), "[0, 2]");
     }
 
     @Test(description = "Test accessing an out of bound arrays-index",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -117,6 +117,14 @@ public class ArrayAccessExprTest {
         Assert.assertEquals(actual, expected);
     }
 
+    @Test
+    public void testFoo() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(compileResult, "foo", args);
+
+        Assert.assertEquals(returns[0], "");
+    }
+
     @Test(description = "Test accessing an out of bound arrays-index",
           expectedExceptions = { BLangRuntimeException.class },
           expectedExceptionsMessageRegExp = ".*array index out of range: index: 5, size: 2.*")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -120,7 +120,8 @@ public class ArrayAccessExprTest {
     @Test
     public void testAssignToNonExistingFirstDimensionOfTwoDimensionArray() {
         BValue[] args = {};
-        BValue[] returns = BRunUtil.invoke(compileResult, "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
+        BValue[] returns = BRunUtil.invoke(compileResult,
+                "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
 
         Assert.assertEquals(returns[0].stringValue(), "[0, 2]");
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
@@ -1,3 +1,10 @@
+function foo() returns int[][] {
+    int[][] x = [];
+    //x[0] = [];
+    x[0][1] = 2;
+    return x;
+}
+
 function testNonInitArrayAccess() returns (string){
     string[] fruits = [];
     return fruits[5];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
@@ -1,9 +1,3 @@
-function foo() returns int[][] {
-    int[][] x = [];
-    //x[0] = [];
-    x[0][1] = 2;
-    return x;
-}
 
 function testNonInitArrayAccess() returns (string){
     string[] fruits = [];
@@ -112,4 +106,10 @@ function testArrayIndexOutOfRangeErrorWithUnionWithFiniteTypesIndex() {
     animals = ["Lion", "Cat"];
     OneToFive ot = 4;
     name = animals[ot];
+}
+
+function testAssignToNonExistingFirstDimensionOfTwoDimensionArray() returns int[][] {
+    int[][] x = [];
+    x[0][1] = 2;
+    return x;
 }


### PR DESCRIPTION
## Purpose

```ballerina
    int[][] x = [];
    x[0][1] = 2;
```

In the above snippet when we assign an element to a non-existing first dimension, the first dimension should be a filling read. According to the spec, when we access an array in left-hand side of an assignment, it should perform a filling read. Check under https://ballerina.io/spec/lang/2019R3/#section_7.14.1

In this PR we desugar above snippet to something like:
```ballerina
int[][] x = [];
int $1 = 0;
if (x.length() < $1 + 1) {
  x[$1] = [];
}
 x[$1][1] = 2;
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/20198 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
