### PR TITLE
Fix NPE found with list constructor var ref

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -727,17 +727,18 @@ public class TypeChecker extends BLangNodeVisitor {
             ((BTupleType) actualType).restType = restType;
         } else if (listConstructor.exprs.size() > 1) {
             // This is an array.
-            List<BType> narrowTypes = new ArrayList<>();
-            for (int i = 0; i < listConstructor.exprs.size(); i++) {
-                narrowTypes.add(checkExpr(listConstructor.exprs.get(i), env, symTable.noType));
-            }
-            Set<BType> narrowTypesSet = new LinkedHashSet<>(narrowTypes);
+            LinkedHashSet<BType> narrowTypes = new LinkedHashSet<>();
             LinkedHashSet<BType> broadTypesSet = new LinkedHashSet<>();
-            BType[] uniqueNarrowTypes = narrowTypesSet.toArray(new BType[0]);
+            BType[] inferredTypes = checkArrayExpr(listConstructor, env);
+            for (BType type : inferredTypes) {
+                if (narrowTypes.stream().noneMatch(nType -> types.isSameType(type, nType))) {
+                    narrowTypes.add(type);
+                }
+            }
             BType broadType;
-            for (BType t1 : uniqueNarrowTypes) {
+            for (BType t1 : narrowTypes) {
                 broadType = t1;
-                for (BType t2 : uniqueNarrowTypes) {
+                for (BType t2 : narrowTypes) {
                     if (types.isAssignable(t2, t1)) {
                         broadType = t1;
                     } else if (types.isAssignable(t1, t2)) {
@@ -759,7 +760,6 @@ public class TypeChecker extends BLangNodeVisitor {
         } else if (expTypeTag != TypeTags.SEMANTIC_ERROR) {
             actualType = checkArrayLiteralExpr(listConstructor);
         }
-
         resultType = types.checkType(listConstructor, actualType, expType);
     }
 
@@ -3280,7 +3280,9 @@ public class TypeChecker extends BLangNodeVisitor {
         iExpr.langLibInvocation = true;
         SymbolEnv enclEnv = this.env;
         this.env = SymbolEnv.createInvocationEnv(iExpr, this.env);
-        iExpr.argExprs.add(0, iExpr.expr);
+        if (iExpr.argExprs.isEmpty() || !iExpr.argExprs.get(0).equals(iExpr.expr)) {
+            iExpr.argExprs.add(0, iExpr.expr);
+        }
         checkInvocationParamAndReturnType(iExpr);
         this.env = enclEnv;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -17,10 +17,14 @@
  */
 package org.ballerinalang.test.expressions.listconstructor;
 
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -28,17 +32,31 @@ import org.testng.annotations.Test;
  */
 public class ListConstructorExprTest {
 
+    private CompileResult result, resultNegative;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/expressions/listconstructor/list_constructor.bal");
+        resultNegative = BCompileUtil.compile(
+                "test-src/expressions/listconstructor/list_constructor_negative.bal");
+    }
+
+    @Test
+    public void testListConstructorExpr() {
+        BValue[] returns = BRunUtil.invoke(result, "testListConstructorExpr");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
     @Test
     public void diagnosticsTest() {
-        CompileResult result = BCompileUtil.compile(
-                "test-src/expressions/listconstructor/list_constructor_negative.bal");
         int i = 0;
-        BAssertUtil.validateError(result, i++, "invalid list constructor expression: " +
+        BAssertUtil.validateError(resultNegative, i++, "invalid list constructor expression: " +
                 "types cannot be inferred for '[v1, v2, v3]'", 18, 24);
-        BAssertUtil.validateError(result, i++, "tuple and expression size does not match",
+        BAssertUtil.validateError(resultNegative, i++, "tuple and expression size does not match",
                 22, 20);
-        BAssertUtil.validateError(result, i++, "tuple and expression size does not match",
+        BAssertUtil.validateError(resultNegative, i++, "tuple and expression size does not match",
                 23, 34);
-        Assert.assertEquals(result.getErrorCount(), i);
+        Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testListConstructorExpr() returns boolean {
+    var fooList = [
+        ["AAA", 111],
+        ["BBB", 222]
+    ];
+
+    foreach var foo in fooList {}
+
+    var barList = ["CCC", 333];
+
+    (int|string)[] fooArr = ["DDD", 444];
+
+    return fooList[0][0] == "AAA"
+        && fooList[0][1] == 111
+        && fooList[1][0] == "BBB"
+        && fooList[1][1] == 222
+        && barList[0] == "CCC"
+        && barList[1] == 333
+        && fooArr[0] == "DDD"
+        && fooArr[1] == 444;
+}


### PR DESCRIPTION
## Purpose
$title on 1.1.x branch

Fixes #20532

## Approach
n/a

## Samples
Now allows;
```ballerina
    var fooList = [
        ["AAA", 111],
        ["BBB", 222]
    ];

    foreach var foo in fooList {}

    var barList = ["CCC", 333];

    (int|string)[] fooArr = ["DDD", 444];
```

## Remarks
- master - https://github.com/ballerina-platform/ballerina-lang/pull/20564

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
