### PR TITLE
Fix incorrect array length when sliced

### DIFF
--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
@@ -77,8 +77,9 @@ public class Slice {
 
         switch (arrType.getTag()) {
             case TypeTags.ARRAY_TAG:
-                slicedArr = new ArrayValueImpl((BArrayType) arrType, sliceSize);
-                elemTypeTag = ((BArrayType) arrType).getElementType().getTag();
+                BType elementType = ((BArrayType) arrType).getElementType();
+                slicedArr = new ArrayValueImpl(new BArrayType(elementType));
+                elemTypeTag = elementType.getTag();
                 getFn = ArrayValue::get;
                 break;
             case TypeTags.TUPLE_TAG:

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
@@ -77,7 +77,7 @@ public class Slice {
 
         switch (arrType.getTag()) {
             case TypeTags.ARRAY_TAG:
-                slicedArr = new ArrayValueImpl((BArrayType) arrType);
+                slicedArr = new ArrayValueImpl((BArrayType) arrType, sliceSize);
                 elemTypeTag = ((BArrayType) arrType).getElementType().getTag();
                 getFn = ArrayValue::get;
                 break;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -120,19 +120,22 @@ public class LangLibArrayTest {
         assertEquals(arr.getFloat(0), 23.45);
         assertEquals(arr.getFloat(1), 34.56);
         assertEquals(arr.getFloat(2), 45.67);
+        assertEquals(((BInteger) result.getRefValue(1)).intValue(), 3);
 
-        arr = (BValueArray) result.getRefValue(1);
+        arr = (BValueArray) result.getRefValue(2);
         assertEquals(arr.elementType.getTag(), TypeTags.FLOAT_TAG);
         assertEquals(arr.size(), 3);
         assertEquals(arr.getFloat(0), 34.56);
         assertEquals(arr.getFloat(1), 45.67);
         assertEquals(arr.getFloat(2), 56.78);
+        assertEquals(((BInteger) result.getRefValue(3)).intValue(), 3);
 
-        arr = (BValueArray) result.getRefValue(2);
+        arr = (BValueArray) result.getRefValue(4);
         assertEquals(arr.elementType.getTag(), TypeTags.FLOAT_TAG);
         assertEquals(arr.size(), 2);
         assertEquals(arr.getFloat(0), 45.67);
         assertEquals(arr.getFloat(1), 56.78);
+        assertEquals(((BInteger) result.getRefValue(5)).intValue(), 2);
     }
 
     @Test

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -139,6 +139,39 @@ public class LangLibArrayTest {
     }
 
     @Test
+    public void testPushAfterSlice() {
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testPushAfterSlice");
+        BValueArray result = (BValueArray) returns[0];
+
+        assertEquals(((BInteger) result.getRefValue(0)).intValue(), 3);
+        assertEquals(((BInteger) result.getRefValue(1)).intValue(), 4);
+
+        BValueArray arr = (BValueArray) result.getRefValue(2);
+        assertEquals(arr.elementType.getTag(), TypeTags.FLOAT_TAG);
+        assertEquals(arr.size(), 4);
+        assertEquals(arr.getFloat(0), 23.45);
+        assertEquals(arr.getFloat(1), 34.56);
+        assertEquals(arr.getFloat(2), 45.67);
+        assertEquals(arr.getFloat(3), 20.1);
+    }
+
+    @Test
+    public void testPushAfterSliceFixed() {
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testPushAfterSliceFixed");
+        BValueArray result = (BValueArray) returns[0];
+
+        assertEquals(((BInteger) result.getRefValue(0)).intValue(), 2);
+        assertEquals(((BInteger) result.getRefValue(1)).intValue(), 3);
+
+        BValueArray arr = (BValueArray) result.getRefValue(2);
+        assertEquals(arr.elementType.getTag(), TypeTags.INT_TAG);
+        assertEquals(arr.size(), 3);
+        assertEquals(arr.getInt(0), 4);
+        assertEquals(arr.getInt(1), 5);
+        assertEquals(arr.getInt(2), 88);
+    }
+
+    @Test
     public void testRemove() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testRemove");
         assertEquals(returns[0].stringValue(), "FooFoo");

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -63,12 +63,12 @@ function testForeach() returns string {
     return result;
 }
 
-function testSlice() returns [float[], float[], float[]] {
+function testSlice() returns [float[], int, float[], int, float[], int] {
     float[] arr = [12.34, 23.45, 34.56, 45.67, 56.78];
     float[] r1 = arr.slice(1, 4);
     float[] r2 = arr.slice(2);
     float[] r3 = array:slice(arr, 3);
-    return [r1, r2, r3];
+    return [r1, r1.length(), r2, r2.length(), r3, r3.length()];
 }
 
 function testRemove() returns [string, string[]] {

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -71,6 +71,24 @@ function testSlice() returns [float[], int, float[], int, float[], int] {
     return [r1, r1.length(), r2, r2.length(), r3, r3.length()];
 }
 
+function testPushAfterSlice() returns [int, int, float[]] {
+     float[] arr = [12.34, 23.45, 34.56, 45.67, 56.78];
+     float[] s = arr.slice(1, 4);
+     int sl = s.length();
+     s.push(20.1);
+     int slp = s.length();
+     return [sl, slp, s];
+}
+
+function testPushAfterSliceFixed() returns [int, int, int[]] {
+     int[5] arr = [1, 2, 3, 4, 5];
+     int[] s = arr.slice(3);
+     int sl = s.length();
+     s.push(88);
+     int slp = s.length();
+     return [sl, slp, s];
+}
+
 function testRemove() returns [string, string[]] {
     string[] arr = ["Foo", "Bar", "FooFoo", "BarBar"];
     string elem = arr.remove(2);


### PR DESCRIPTION
## Purpose
$title

```ballerina
    int [*] arr = [1,2,3,4,5,6];
    io:println("arr : ", arr);
    io:println("arr.length() : ", arr.length());    

    int [] myNewArray = arr.slice(0,2);
    io:println("myNewArray : ", myNewArray);
    io:println("myNewArray.length() : ", myNewArray.length());

```

Previously
```
arr : 1 2 3 4 5 6
arr.length() : 6
myNewArray : 1 2 0 0 0 0
myNewArray.length() : 6
```

With this PR
```
arr : 1 2 3 4 5 6
arr.length() : 6
myNewArray : 1 2
myNewArray.length() : 2

```

With this, a sliced array will have a fixed size and pushing an element will throw a runtime error. 
I'll create an issue on spec repository to clarify if this is the expected outcome.  
Edit: Created https://github.com/ballerina-platform/ballerina-spec/issues/391

Fixes #20574 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
