### PR TITLE
Fix HANA DB update queries-"Invalid argument autoGeneratedKeys"

### DIFF
--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/datasource/SQLDatasource.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/datasource/SQLDatasource.java
@@ -50,6 +50,7 @@ public class SQLDatasource {
     private AtomicInteger clientCounter = new AtomicInteger(0);
     private Lock mutex = new ReentrantLock();
     private boolean poolShutdown = false;
+    private boolean supportsGetGeneratedKeys;
 
     public SQLDatasource init(SQLDatasourceParams sqlDatasourceParams) {
         this.globalDatasource = sqlDatasourceParams.isGlobalDatasource;
@@ -60,8 +61,10 @@ public class SQLDatasource {
         } catch (PanickingDatabaseException e) {
             throw ErrorGenerator.getSQLDatabaseError(e);
         }
+
         try (Connection con = getSQLConnection()) {
             databaseProductName = con.getMetaData().getDatabaseProductName().toLowerCase(Locale.ENGLISH);
+            supportsGetGeneratedKeys = con.getMetaData().supportsGetGeneratedKeys();
         } catch (SQLException e) {
             throw ErrorGenerator
                     .getSQLDatabaseError(e, "error while obtaining connection for " + Constants.CONNECTOR_NAME + ", ");
@@ -117,6 +120,10 @@ public class SQLDatasource {
 
     public boolean isPoolShutdown() {
         return poolShutdown;
+    }
+
+    public boolean supportsGetGeneratedKeys() {
+        return supportsGetGeneratedKeys;
     }
 
     public void incrementClientCounter() {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/BatchUpdateStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/BatchUpdateStatement.java
@@ -83,7 +83,7 @@ public class BatchUpdateStatement extends AbstractSQLStatement {
         String errorMessagePrefix = "failed to execute batch update";
         try {
             conn = getDatabaseConnection(strand, client, datasource);
-            boolean generatedKeyReturningSupported = isGeneratedKeyReturningSupported();
+            boolean generatedKeyReturningSupported = datasource.supportsGetGeneratedKeys();
             if (generatedKeyReturningSupported) {
                 stmt = conn.prepareStatement(query, PreparedStatement.RETURN_GENERATED_KEYS);
             } else {
@@ -145,15 +145,6 @@ public class BatchUpdateStatement extends AbstractSQLStatement {
         } finally {
             cleanupResources(stmt, conn, !isInTransaction);
         }
-    }
-
-    // It has been identified that Oracle and MS SQL Server does not support returning generated keys along with
-    // batch update. And such effort would result in an exception causing batch update failure.
-    // If such other databases are identified they can be included here.
-    // The name of the database is being checked because there is no way to identify through the API.
-    private boolean isGeneratedKeyReturningSupported() {
-        return !Constants.DatabaseNames.ORACLE.equals(datasource.getDatabaseProductName())
-                && !Constants.DatabaseNames.MSSQL_SERVER.equals(datasource.getDatabaseProductName());
     }
 
     private ArrayValue createUpdatedCountArray(int[] updatedCounts, int paramArrayCount) {


### PR DESCRIPTION
## Purpose
Prevent requesting generated keys from unsupported JDBC drivers

Fixes #20673

## Approach
JDBC already have an API called `supportsGetGeneratedKeys` [1] to check if the JDBC driver supports retrieving auto-generated keys.

[1] [supportsGetGeneratedKeys - https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#supportsGetGeneratedKeys](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#supportsGetGeneratedKeys--)

## Remarks
Cannot create a unit test case as we need to install HANA DB separately. Tested with a Hana DB installation in a virtual box.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
