### PR TITLE
Remove padding for base64 url encode - [1.1.x]

### DIFF
--- a/stdlib/encoding/src/main/java/org/ballerinalang/stdlib/encoding/nativeimpl/Encode.java
+++ b/stdlib/encoding/src/main/java/org/ballerinalang/stdlib/encoding/nativeimpl/Encode.java
@@ -33,7 +33,7 @@ import java.util.Base64;
 public class Encode {
 
     public static String encodeBase64Url(ArrayValue input) {
-        byte[] encodedValue = Base64.getUrlEncoder().encode(input.getBytes());
+        byte[] encodedValue = Base64.getUrlEncoder().withoutPadding().encode(input.getBytes());
         return new String(encodedValue, StandardCharsets.ISO_8859_1);
     }
 

--- a/stdlib/encoding/src/test/java/org/ballerinalang/stdlib/encoding/Base64UrlEncodingTest.java
+++ b/stdlib/encoding/src/test/java/org/ballerinalang/stdlib/encoding/Base64UrlEncodingTest.java
@@ -46,7 +46,7 @@ public class Base64UrlEncodingTest {
     public void testEncodeBase64Url() {
         String input = "Ballerina Base64 URL encoding test";
         byte[] inputArray = input.getBytes(StandardCharsets.UTF_8);
-        String expectedValue = "QmFsbGVyaW5hIEJhc2U2NCBVUkwgZW5jb2RpbmcgdGVzdA==";
+        String expectedValue = "QmFsbGVyaW5hIEJhc2U2NCBVUkwgZW5jb2RpbmcgdGVzdA";
         BValue[] args = {new BValueArray(inputArray)};
         BValue[] returnValues = BRunUtil.invoke(compileResult, "testEncodeBase64Url", args);
         Assert.assertFalse(returnValues == null || returnValues.length == 0 || returnValues[0] == null);
@@ -55,7 +55,7 @@ public class Base64UrlEncodingTest {
 
     @Test(description = "Check Base64 URL decoding")
     public void testDecodeBase64Url() {
-        String input = "QmFsbGVyaW5hIEJhc2U2NCBVUkwgZW5jb2RpbmcgdGVzdA==";
+        String input = "QmFsbGVyaW5hIEJhc2U2NCBVUkwgZW5jb2RpbmcgdGVzdA";
         byte[] expectedValue = "Ballerina Base64 URL encoding test".getBytes(StandardCharsets.UTF_8);
         BValue[] args = {new BString(input)};
         BValue[] returnValues = BRunUtil.invoke(compileResult, "testDecodeBase64Url", args);

--- a/stdlib/jwt/src/test/java/org.ballerinalang.stdlib.jwt/JwtAuthProviderTest.java
+++ b/stdlib/jwt/src/test/java/org.ballerinalang.stdlib.jwt/JwtAuthProviderTest.java
@@ -114,7 +114,7 @@ public class JwtAuthProviderTest {
         BValue[] inputBValues = {new BString(keyStorePath)};
         BValue[] returns = BRunUtil.invoke(compileResult, "generateJwt", inputBValues);
         Assert.assertTrue(returns[0] instanceof BString);
-        Assert.assertTrue(returns[0].stringValue().startsWith("eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ==.eyJzdWIiO" +
+        Assert.assertTrue(returns[0].stringValue().startsWith("eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJzdWIiO" +
                 "iJKb2huIiwgImlzcyI6IndzbzIiLCAiZXhwIjozMjQ3NTI1MTE4OTAwMCwgImF1ZCI6ImJhbGxlcmluYSJ9."));
 
         jwtToken = returns[0].stringValue();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/AuthnConfigPatternTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/AuthnConfigPatternTest.java
@@ -506,13 +506,13 @@ public class AuthnConfigPatternTest extends AuthBaseTest {
         // }
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ==.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
+        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
                 "aXNzIjoiZXhhbXBsZTQiLCAiZXhwIjoyODE4NDE1MDE5LCAiaWF0IjoxNTI0NTc1MDE5LCAianRpIjoiZjVhZGVkNTA1ODVjN" +
                 "DZmMmI4Y2EyMzNkMGMyYTNjOWQiLCAiYXVkIjpbImJhbGxlcmluYSIsICJiYWxsZXJpbmEub3JnIiwgImJhbGxlcmluYS5pby" +
-                "JdfQ==.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
+                "JdfQ.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
                 "73C_tf7OPuYO1GQGbkYtXaynngxZ-xELZDdUXa0RYY4x-Sf7UM6tg7SPht8BreBig6QH_rnRuuTSQAYLbynxX3BgMbguA5BDQ" +
                 "wj-JEdWdFdTknBlCHU4-pSV_77jRRZ9Lb51aVE7MT-G69X4oQMZCvFh935I5FVx2kfh6-RL3RDvvkKJMz5MEL7vtnHIqNmGMO" +
-                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw==");
+                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw");
         HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test1"),
                 headers, serverInstance.getServerHome());
         assertUnauthorized(response);
@@ -535,13 +535,13 @@ public class AuthnConfigPatternTest extends AuthBaseTest {
         // }
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ==.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
+        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
                 "aXNzIjoiZXhhbXBsZTQiLCAiZXhwIjoyODE4NDE1MDE5LCAiaWF0IjoxNTI0NTc1MDE5LCAianRpIjoiZjVhZGVkNTA1ODVjN" +
                 "DZmMmI4Y2EyMzNkMGMyYTNjOWQiLCAiYXVkIjpbImJhbGxlcmluYSIsICJiYWxsZXJpbmEub3JnIiwgImJhbGxlcmluYS5pby" +
-                "JdfQ==.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
+                "JdfQ.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
                 "73C_tf7OPuYO1GQGbkYtXaynngxZ-xELZDdUXa0RYY4x-Sf7UM6tg7SPht8BreBig6QH_rnRuuTSQAYLbynxX3BgMbguA5BDQ" +
                 "wj-JEdWdFdTknBlCHU4-pSV_77jRRZ9Lb51aVE7MT-G69X4oQMZCvFh935I5FVx2kfh6-RL3RDvvkKJMz5MEL7vtnHIqNmGMO" +
-                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw==");
+                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw");
         HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test2"),
                 headers, serverInstance.getServerHome());
         assertUnauthorized(response);
@@ -564,13 +564,13 @@ public class AuthnConfigPatternTest extends AuthBaseTest {
         // }
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ==.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
+        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
                 "aXNzIjoiZXhhbXBsZTQiLCAiZXhwIjoyODE4NDE1MDE5LCAiaWF0IjoxNTI0NTc1MDE5LCAianRpIjoiZjVhZGVkNTA1ODVjN" +
                 "DZmMmI4Y2EyMzNkMGMyYTNjOWQiLCAiYXVkIjpbImJhbGxlcmluYSIsICJiYWxsZXJpbmEub3JnIiwgImJhbGxlcmluYS5pby" +
-                "JdfQ==.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
+                "JdfQ.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
                 "73C_tf7OPuYO1GQGbkYtXaynngxZ-xELZDdUXa0RYY4x-Sf7UM6tg7SPht8BreBig6QH_rnRuuTSQAYLbynxX3BgMbguA5BDQ" +
                 "wj-JEdWdFdTknBlCHU4-pSV_77jRRZ9Lb51aVE7MT-G69X4oQMZCvFh935I5FVx2kfh6-RL3RDvvkKJMz5MEL7vtnHIqNmGMO" +
-                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw==");
+                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw");
         HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test3"),
                 headers, serverInstance.getServerHome());
         assertUnauthorized(response);
@@ -593,13 +593,13 @@ public class AuthnConfigPatternTest extends AuthBaseTest {
         // }
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ==.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
+        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
                 "aXNzIjoiZXhhbXBsZTQiLCAiZXhwIjoyODE4NDE1MDE5LCAiaWF0IjoxNTI0NTc1MDE5LCAianRpIjoiZjVhZGVkNTA1ODVjN" +
                 "DZmMmI4Y2EyMzNkMGMyYTNjOWQiLCAiYXVkIjpbImJhbGxlcmluYSIsICJiYWxsZXJpbmEub3JnIiwgImJhbGxlcmluYS5pby" +
-                "JdfQ==.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
+                "JdfQ.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
                 "73C_tf7OPuYO1GQGbkYtXaynngxZ-xELZDdUXa0RYY4x-Sf7UM6tg7SPht8BreBig6QH_rnRuuTSQAYLbynxX3BgMbguA5BDQ" +
                 "wj-JEdWdFdTknBlCHU4-pSV_77jRRZ9Lb51aVE7MT-G69X4oQMZCvFh935I5FVx2kfh6-RL3RDvvkKJMz5MEL7vtnHIqNmGMO" +
-                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw==");
+                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw");
         HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test4"),
                 headers, serverInstance.getServerHome());
         assertUnauthorized(response);
@@ -622,13 +622,13 @@ public class AuthnConfigPatternTest extends AuthBaseTest {
         // }
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ==.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
+        headers.put("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJzdWIiOiJiYWxsZXJpbmEiLCAi" +
                 "aXNzIjoiZXhhbXBsZTQiLCAiZXhwIjoyODE4NDE1MDE5LCAiaWF0IjoxNTI0NTc1MDE5LCAianRpIjoiZjVhZGVkNTA1ODVjN" +
                 "DZmMmI4Y2EyMzNkMGMyYTNjOWQiLCAiYXVkIjpbImJhbGxlcmluYSIsICJiYWxsZXJpbmEub3JnIiwgImJhbGxlcmluYS5pby" +
-                "JdfQ==.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
+                "JdfQ.B0S-9DbmFMvNcjmlQU0-ApKZjBKSxu9pQ-99GBV3oVklVYjYHQZ0FSfzN7bQu__Ap2EPkSVv3ugZbMc59FOxnO_580" +
                 "73C_tf7OPuYO1GQGbkYtXaynngxZ-xELZDdUXa0RYY4x-Sf7UM6tg7SPht8BreBig6QH_rnRuuTSQAYLbynxX3BgMbguA5BDQ" +
                 "wj-JEdWdFdTknBlCHU4-pSV_77jRRZ9Lb51aVE7MT-G69X4oQMZCvFh935I5FVx2kfh6-RL3RDvvkKJMz5MEL7vtnHIqNmGMO" +
-                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw==");
+                "TdlJG9xtLnzfGc17UnJD7WP-Cb4s1ZKZnwuDJQsODTtAbtIKYC52aTomGw");
         HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test5"),
                 headers, serverInstance.getServerHome());
         assertUnauthorized(response);


### PR DESCRIPTION
## Purpose
Remove padding for base64 URL encode according to the RFC [1].

```
   The pad character "=" is typically percent-encoded when used in an
   URI [9], but if the data length is known implicitly, this can be
   avoided by skipping the padding; see section 3.2.
```

[1] https://tools.ietf.org/html/rfc4648#section-5

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/20566

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
