### PR TITLE
Get generated keys only if supported by JDBC

### DIFF
--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/datasource/SQLDatasource.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/datasource/SQLDatasource.java
@@ -50,6 +50,7 @@ public class SQLDatasource {
     private AtomicInteger clientCounter = new AtomicInteger(0);
     private Lock mutex = new ReentrantLock();
     private boolean poolShutdown = false;
+    private boolean supportsGetGeneratedKeys;
 
     public SQLDatasource init(SQLDatasourceParams sqlDatasourceParams) {
         this.globalDatasource = sqlDatasourceParams.isGlobalDatasource;
@@ -62,6 +63,7 @@ public class SQLDatasource {
         }
         try (Connection con = getSQLConnection()) {
             databaseProductName = con.getMetaData().getDatabaseProductName().toLowerCase(Locale.ENGLISH);
+            supportsGetGeneratedKeys = con.getMetaData().supportsGetGeneratedKeys();
         } catch (SQLException e) {
             throw ErrorGenerator
                     .getSQLDatabaseError(e, "error while obtaining connection for " + Constants.CONNECTOR_NAME + ", ");
@@ -117,6 +119,10 @@ public class SQLDatasource {
 
     public boolean isPoolShutdown() {
         return poolShutdown;
+    }
+
+    public boolean supportsGetGeneratedKeys() {
+        return supportsGetGeneratedKeys;
     }
 
     public void incrementClientCounter() {

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/BatchUpdateStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/BatchUpdateStatement.java
@@ -152,6 +152,9 @@ public class BatchUpdateStatement extends AbstractSQLStatement {
     // If such other databases are identified they can be included here.
     // The name of the database is being checked because there is no way to identify through the API.
     private boolean isGeneratedKeyReturningSupported() {
+        if (!datasource.supportsGetGeneratedKeys()) {
+            return false;
+        }
         return !Constants.DatabaseNames.ORACLE.equals(datasource.getDatabaseProductName())
                 && !Constants.DatabaseNames.MSSQL_SERVER.equals(datasource.getDatabaseProductName());
     }

--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/UpdateStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/UpdateStatement.java
@@ -37,7 +37,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -52,6 +51,7 @@ public class UpdateStatement extends AbstractSQLStatement {
     private final SQLDatasource datasource;
     private final String query;
     private final ArrayValue parameters;
+    private final boolean isKeyRetrievalSupported;
 
     public UpdateStatement(ObjectValue client, SQLDatasource datasource, String query, ArrayValue parameters,
                            Strand strand) {
@@ -60,6 +60,7 @@ public class UpdateStatement extends AbstractSQLStatement {
         this.datasource = datasource;
         this.query = query;
         this.parameters = parameters;
+        this.isKeyRetrievalSupported = isKeyRetrievalSupportedStatement();
     }
 
     @Override
@@ -74,13 +75,20 @@ public class UpdateStatement extends AbstractSQLStatement {
             ArrayValue generatedParams = constructParameters(parameters);
             conn = getDatabaseConnection(strand, client, datasource);
             String processedQuery = createProcessedQueryString(query, generatedParams);
-            stmt = conn.prepareStatement(processedQuery, Statement.RETURN_GENERATED_KEYS);
+
+            if (isKeyRetrievalSupported) {
+                stmt = conn.prepareStatement(processedQuery, PreparedStatement.RETURN_GENERATED_KEYS);
+            } else {
+                stmt = conn.prepareStatement(processedQuery);
+            }
+
             ProcessedStatement processedStatement = new ProcessedStatement(conn, stmt, generatedParams,
                     datasource.getDatabaseProductName());
             stmt = processedStatement.prepare();
             int count = stmt.executeUpdate();
             MapValue<String, Object> generatedKeys;
-            if (!isDdlStatement()) {
+
+            if (isKeyRetrievalSupported) {
                 rs = stmt.getGeneratedKeys();
                 //This result set contains the auto generated keys.
                 if (rs.next()) {
@@ -103,11 +111,6 @@ public class UpdateStatement extends AbstractSQLStatement {
         } finally {
             cleanupResources(rs, stmt, conn, !isInTransaction);
         }
-    }
-
-    private boolean isDdlStatement() {
-        String query = this.query.trim().toUpperCase(Locale.ENGLISH);
-        return Arrays.stream(DdlKeyword.values()).anyMatch(ddlKeyword -> query.startsWith(ddlKeyword.name()));
     }
 
     private MapValue<String, Object> getGeneratedKeys(ResultSet rs) throws SQLException {
@@ -133,7 +136,21 @@ public class UpdateStatement extends AbstractSQLStatement {
         return populatedUpdateResultRecord;
     }
 
-    private enum DdlKeyword {
-        CREATE, ALTER, DROP, TRUNCATE, COMMENT, RENAME
+    private enum GenKeyStmt {
+        INSERT, DELETE, UPDATE, MERGE
+    }
+
+    /**
+     * Check if the statement is one of INSERT, DELETE, UPDATE or MERGE.
+     * Oracle support INSERT only but does not throw exception on others
+     * IBM supports all
+     * HANA DB throws exception to all but can be guarded by supportsGetGeneratedKeys
+     */
+    private boolean isKeyRetrievalSupportedStatement() {
+        if (!datasource.supportsGetGeneratedKeys()) {
+            return false;
+        }
+        String query = this.query.trim().toUpperCase(Locale.ENGLISH);
+        return Arrays.stream(GenKeyStmt.values()).anyMatch(stmt -> query.startsWith(stmt.name()));
     }
 }


### PR DESCRIPTION
## Purpose
Prevent requesting generated keys from unsupported JDBC drivers.
Fixes #20673

## Approach
Getting generated keys from JDBC driver only if supported by JDBC
driver. This prevents exceptions for statements issued against HANA DB like databases where JDBC driver does not support returning generated keys.

## Remarks
Better to allow the user in the future to query whether the user expects to retrieve generated keys or not.

# Suggested Labels
Area/StandardLibs
Component/Data
Type/Bug 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
