### PR TITLE
Performance improvements for the places that uses Boolean objects

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONParser.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONParser.java
@@ -818,14 +818,14 @@ public class JSONParser {
                 if (ch == 't' && TRUE.equals(str)) {
                     switch (type) {
                         case ARRAY_ELEMENT:
-                            ((ArrayValue) this.currentJsonNode).append(new Boolean(true));
+                            ((ArrayValue) this.currentJsonNode).append(Boolean.TRUE);
                             break;
                         case FIELD:
                             ((MapValueImpl<String, Object>) this.currentJsonNode).put(this.fieldNames.pop(),
-                                    new Boolean(true));
+                                    Boolean.TRUE);
                             break;
                         case VALUE:
-                            currentJsonNode = new Boolean(true);
+                            currentJsonNode = Boolean.TRUE;
                             break;
                         default:
                             break;
@@ -833,14 +833,14 @@ public class JSONParser {
                 } else if (ch == 'f' && FALSE.equals(str)) {
                     switch (type) {
                         case ARRAY_ELEMENT:
-                            ((ArrayValue) this.currentJsonNode).append(new Boolean(false));
+                            ((ArrayValue) this.currentJsonNode).append(Boolean.FALSE);
                             break;
                         case FIELD:
                             ((MapValueImpl<String, Object>) this.currentJsonNode).put(this.fieldNames.pop(),
-                                    new Boolean(false));
+                                    Boolean.FALSE);
                             break;
                         case VALUE:
-                            currentJsonNode = new Boolean(false);
+                            currentJsonNode = Boolean.FALSE;
                             break;
                         default:
                             break;

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONUtils.java
@@ -793,7 +793,7 @@ public class JSONUtils {
         ArrayValue json = new ArrayValueImpl(new BArrayType(BTypes.typeJSON));
         for (int i = 0; i < booleanArray.size(); i++) {
             boolean value = booleanArray.getBoolean(i);
-            json.append(new Boolean(value));
+            json.append(Boolean.valueOf(value));
         }
         return json;
     }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Lists.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/Lists.java
@@ -37,7 +37,7 @@ public class Lists {
 
         switch (((BArrayType) array.getType()).getElementType().getTag()) {
             case TypeTags.BOOLEAN_TAG:
-                return new Boolean(array.getBoolean(index));
+                return Boolean.valueOf(array.getBoolean(index));
             case TypeTags.BYTE_TAG:
                 return new Long(array.getByte(index));
             case TypeTags.FLOAT_TAG:

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/ExtendedLSCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/ExtendedLSCompiler.java
@@ -106,7 +106,7 @@ public class ExtendedLSCompiler extends LSModuleCompiler {
         String phase = compilerPhase.toString().equals(CompilerPhase.COMPILER_PLUGIN.toString()) ? "annotationProcess"
                 : compilerPhase.toString();
         options.put(COMPILER_PHASE, phase);
-        options.put(PRESERVE_WHITESPACE, Boolean.valueOf(true).toString());
+        options.put(PRESERVE_WHITESPACE, Boolean.TRUE.toString());
         options.put(TEST_ENABLED, String.valueOf(true));
         options.put(SKIP_TESTS, String.valueOf(false));
         BLangDiagnosticLog.getInstance(context).errorCount = 0;

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
@@ -129,7 +129,7 @@ public class LSCompilerUtil {
                 : compilerPhase.toString();
 
         options.put(COMPILER_PHASE, phase);
-        options.put(PRESERVE_WHITESPACE, Boolean.valueOf(true).toString());
+        options.put(PRESERVE_WHITESPACE, Boolean.TRUE.toString());
         options.put(TEST_ENABLED, String.valueOf(true));
         options.put(SKIP_TESTS, String.valueOf(false));
         options.put(TOOLING_COMPILATION, String.valueOf(stopOnSemanticErrors));


### PR DESCRIPTION
## Purpose
 This code change is aimed to improve performance of ballerina language. 
## Approach
The reason is that `new Boolean`  always returns a new object. Because of that creating many objects would decrease the performance. Possible replacements are `Boolean.TRUE, Boolean.FALSE, or call Boolean.valueOf()`
## Remarks
 * Related issues in stack overflow (https://stackoverflow.com/questions/24797155/why-is-avoiding-boolean-instantiation-a-good-idea)
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
