### PR TITLE
Decouple test suit

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -31,6 +31,7 @@ import org.ballerinalang.packerina.task.CreateBaloTask;
 import org.ballerinalang.packerina.task.CreateBirTask;
 import org.ballerinalang.packerina.task.CreateExecutableTask;
 import org.ballerinalang.packerina.task.CreateJarTask;
+import org.ballerinalang.packerina.task.CreateJsonTask;
 import org.ballerinalang.packerina.task.CreateLockFileTask;
 import org.ballerinalang.packerina.task.CreateTargetDirTask;
 import org.ballerinalang.packerina.task.PrintExecutablePathTask;
@@ -382,6 +383,7 @@ public class BuildCommand implements BLauncherCmd {
                 .addTask(new CreateJarTask(this.dumpBIR, skipCopyLibsFromDist, this.nativeBinary, this.dumpLLVMIR,
                         this.noOptimizeLlvm))
                 .addTask(new CopyModuleJarTask(skipCopyLibsFromDist))
+                .addTask(new CreateJsonTask(), isSingleFileBuild) // create the json to store test init data
                 .addTask(new RunTestsTask(), this.skipTests || isSingleFileBuild) // run tests
                                                                                                 // (projects only)
                 .addTask(new CreateExecutableTask(), this.compile)  // create the executable.jar
@@ -393,7 +395,7 @@ public class BuildCommand implements BLauncherCmd {
                 .build();
         
         taskExecutor.executeTasks(buildContext);
-        
+
         if (this.exitWhenFinish) {
             Runtime.getRuntime().exit(0);
         }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
@@ -29,6 +29,7 @@ import org.ballerinalang.packerina.task.CopyNativeLibTask;
 import org.ballerinalang.packerina.task.CreateBaloTask;
 import org.ballerinalang.packerina.task.CreateBirTask;
 import org.ballerinalang.packerina.task.CreateJarTask;
+import org.ballerinalang.packerina.task.CreateJsonTask;
 import org.ballerinalang.packerina.task.CreateTargetDirTask;
 import org.ballerinalang.packerina.task.RunTestsTask;
 import org.ballerinalang.tool.BLauncherCmd;
@@ -276,6 +277,7 @@ public class TestCommand implements BLauncherCmd {
                 .addTask(new CreateJarTask(this.dumpBIR, this.skipCopyLibsFromDist, this.nativeBinary, this.dumpLLVMIR,
                         this.noOptimizeLLVM))
                 .addTask(new CopyModuleJarTask(skipCopyLibsFromDist))
+                .addTask(new CreateJsonTask()) // // create the json to store test init data
                 .addTask(new RunTestsTask()) // run tests
                 .build();
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateJsonTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateJsonTask.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.packerina.task;
+
+import com.google.gson.Gson;
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.packerina.buildcontext.BuildContext;
+import org.ballerinalang.packerina.buildcontext.BuildContextField;
+import org.ballerinalang.testerina.core.TesterinaConstants;
+import org.ballerinalang.testerina.core.entity.TestJsonData;
+import org.ballerinalang.tool.LauncherUtils;
+import org.ballerinalang.tool.util.BFileUtil;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
+import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Task for create json for test execution.
+ */
+public class CreateJsonTask implements Task {
+
+    @Override
+    public void execute(BuildContext buildContext) {
+        buildContext.out().println();
+        buildContext.out().println("Creating json");
+        Path sourceRootPath = buildContext.get(BuildContextField.SOURCE_ROOT);
+        Path targetPath = buildContext.get(BuildContextField.TARGET_DIR);
+
+        List<BLangPackage> moduleBirMap = buildContext.getModules();
+        // Only tests in packages are executed so default packages i.e. single bal files which has the package name
+        // as "." are ignored. This is to be consistent with the "ballerina test" command which only executes tests
+        // in packages.
+        moduleBirMap.stream()
+                .forEach(bLangPackage -> {
+
+                    Map<BLangPackage, String> programFileMap = new HashMap<>();
+                    Path jarPath = buildContext.getTestJarPathFromTargetCache(bLangPackage.packageID);
+                    Path modulejarPath = buildContext.getJarPathFromTargetCache(bLangPackage.packageID).getFileName();
+                    // subsitute test jar if module jar if tests not exists
+                    if (Files.notExists(jarPath)) {
+                        jarPath = modulejarPath;
+                    }
+                    HashSet<Path> moduleDependencies = buildContext.moduleDependencyPathMap
+                            .get(bLangPackage.packageID).platformLibs;
+                    if (bLangPackage.containsTestablePkg()) {
+                        for (BLangTestablePackage testablePackage : bLangPackage.getTestablePkgs()) {
+                            // find the set of dependency jar paths for running test for this module and update
+                            updateDependencyJarPaths(testablePackage.symbol.imports, buildContext, moduleDependencies);
+                        }
+                    }
+                    String modulejarName = modulejarPath != null ? modulejarPath.toString() : "";
+                    programFileMap.put(bLangPackage, modulejarName);
+                    Path jsonPath = targetPath
+                            .resolve(ProjectDirConstants.CACHES_DIR_NAME)
+                            .resolve(ProjectDirConstants.JSON_CACHE_DIR_NAME)
+                            .resolve(modulejarName);
+                    try {
+                        Files.createDirectories(jsonPath);
+                    } catch (Exception e) {
+                        throw LauncherUtils.createLauncherException("Couldn't create the directories: " + e.toString());
+                    }
+                    extractDataFromBLangPackage(programFileMap, sourceRootPath, jarPath, modulejarName, jsonPath,
+                            moduleDependencies);
+                    buildContext.out().println("\t" + modulejarName + "/" + TesterinaConstants.TESTERINA_TEST_SUITE);
+                });
+    }
+
+    /**
+     * Write the content into a json.
+     *
+     * @param testMetaData Data that are parsed to the json
+     */
+    private static void writeToJson(TestJsonData testMetaData, Path jsonPath) {
+        Path tmpJsonPath = Paths.get(jsonPath.toString(), TesterinaConstants.TESTERINA_TEST_SUITE);
+        File jsonFile = new File(tmpJsonPath.toString());
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(jsonFile),  StandardCharsets.UTF_8)) {
+            Gson gson = new Gson();
+
+            String json = gson.toJson(testMetaData);
+            writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw LauncherUtils.createLauncherException("Couldn't read data from the Json file : " + e.toString());
+        }
+    }
+
+    /**
+     * Extract data from the given bLangPackage.
+     *
+     * @param programFileMap map of the bLangPackage and TesterinaClassLoader
+     */
+    private static void extractDataFromBLangPackage(Map<BLangPackage, String> programFileMap,
+                                                    Path sourceRootPath, Path jarPath, String moduleJarName,
+                                                    Path jsonPath, HashSet<Path> moduleDependencies) {
+        programFileMap.forEach((source, jarName) -> {
+            String initFunctionName = source.initFunction.name.value;
+            String startFunctionName = source.startFunction.name.value;
+            String stopFunctionName = source.stopFunction.name.value;
+            String testInitFunctionName = source.getTestablePkg().initFunction.name.value;
+            String testStartFunctionName = source.getTestablePkg().startFunction.name.value;
+            String testStopFunctionName = source.getTestablePkg().stopFunction.name.value;
+            String orgName = source.packageID.getOrgName().value;
+            String version = source.packageID.getPackageVersion().value;
+            String packageName;
+            if (source.packageID.getName().getValue().equals(".")) {
+                packageName = source.packageID.getName().getValue();
+            } else {
+                packageName = orgName + "/" + source.packageID.getName().value + ":" + version;
+                //packageName = TesterinaUtils.getFullModuleName(source.packageID.getName().getValue());
+            }
+            String hasTestablePackages = Boolean.toString(source.hasTestablePackage());
+
+            HashMap<String, String> normalFunctionNames = new HashMap<>();
+            HashMap<String, String> testFunctionNames = new HashMap<>();
+
+            source.functions.stream().forEach(function -> {
+                try {
+                    String functionClassName = BFileUtil.getQualifiedClassName(source.packageID.orgName.value,
+                            source.packageID.name.value,
+                            getClassName(function.pos.src.cUnitName));
+                    normalFunctionNames.put(function.name.value, functionClassName);
+                } catch (RuntimeException e) {
+                    // we do nothing here
+                }
+            });
+
+            source.getTestablePkg().functions.stream().forEach(function -> {
+                try {
+                    String functionClassName = BFileUtil.getQualifiedClassName(source.packageID.orgName.value,
+                            source.packageID.name.value,
+                            getClassName(function.pos.src.cUnitName));
+                    testFunctionNames.put(function.name.value, functionClassName);
+                } catch (RuntimeException e) {
+                    // we do nothing here
+                }
+            });
+
+            String [] pathList = new String[moduleDependencies.size()];
+            int iterator = 0;
+            for (Path path : moduleDependencies) {
+                pathList[iterator++] = path.toString();
+            }
+            // set data
+            TestJsonData testJsonData = new TestJsonData();
+            testJsonData.setInitFunctionName(initFunctionName);
+            testJsonData.setStartFunctionName(startFunctionName);
+            testJsonData.setStopFunctionName(stopFunctionName);
+            testJsonData.setTestInitFunctionName(testInitFunctionName);
+            testJsonData.setTestStartFunctionName(testStartFunctionName);
+            testJsonData.setTestStopFunctionName(testStopFunctionName);
+            testJsonData.setCallableFunctionNames(normalFunctionNames);
+            testJsonData.setTestFunctionNames(testFunctionNames);
+            testJsonData.setPackageName(packageName);
+            testJsonData.setHasTestablePackages(hasTestablePackages);
+            testJsonData.setSourceRootPath(sourceRootPath.toString());
+            testJsonData.setJarPath(jarPath.toString());
+            testJsonData.setModuleJarName(moduleJarName);
+            testJsonData.setPackageID(source.packageID);
+            testJsonData.setDependencyJarPaths(pathList);
+            // write to json
+            writeToJson(testJsonData, jsonPath);
+        });
+    }
+
+    /**
+     * return the function name.
+     *
+     * @param function String value of a function
+     * @return function name
+     */
+    private static String getClassName(String function) {
+        return function.replace(".bal", "").replace("/", ".");
+    }
+
+    private void updateDependencyJarPaths(List<BPackageSymbol> importPackageSymbols, BuildContext buildContext,
+                                          HashSet<Path> dependencyJarPaths) {
+        for (BPackageSymbol importPackageSymbol : importPackageSymbols) {
+            PackageID importPkgId = importPackageSymbol.pkgID;
+            if (!buildContext.moduleDependencyPathMap.containsKey(importPkgId)) {
+                continue;
+            }
+            // add imported module's dependent jar paths
+            HashSet<Path> testDependencies = buildContext.moduleDependencyPathMap.get(importPkgId).platformLibs;
+            dependencyJarPaths.addAll(testDependencies);
+
+            // add imported module's jar path
+            Path testJarPath = buildContext.getTestJarPathFromTargetCache(importPkgId);
+            Path moduleJarPath = buildContext.getJarPathFromTargetCache(importPkgId);
+            if (Files.exists(testJarPath)) {
+                dependencyJarPaths.add(testJarPath);
+            } else if (Files.exists(moduleJarPath)) {
+                dependencyJarPaths.add(moduleJarPath);
+            }
+            updateDependencyJarPaths(importPackageSymbol.imports, buildContext, dependencyJarPaths);
+        }
+    }
+
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ProjectDirConstants.java
@@ -91,6 +91,7 @@ public class ProjectDirConstants {
     public static final String BALO_CACHE_DIR_NAME = "balo_cache";
     public static final String BIR_CACHE_DIR_NAME = "bir_cache";
     public static final String JAR_CACHE_DIR_NAME = "jar_cache";
+    public static final String JSON_CACHE_DIR_NAME = "json_cache";
 
     public static final String BLANG_PKG_DEFAULT_VERSION = "0.0.0";
 }

--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     dist project(':openapi-ballerina:ballerina-client-generator')
     dist project(':docerina')
     dist project(':protobuf-ballerina')
+    dist project(':testerina:testerina-launcher')
     docerina project(':docerina-gradle-plugin')
 
     langserverLib project(path: ':language-server:language-server-core', configuration: 'libs')

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -42,11 +42,11 @@ import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.XMLValue;
 import org.ballerinalang.testerina.core.entity.Test;
+import org.ballerinalang.testerina.core.entity.TestMetaData;
 import org.ballerinalang.testerina.core.entity.TestSuite;
 import org.ballerinalang.testerina.core.entity.TesterinaFunction;
 import org.ballerinalang.testerina.core.entity.TesterinaReport;
 import org.ballerinalang.testerina.core.entity.TesterinaResult;
-import org.ballerinalang.testerina.util.TestarinaClassLoader;
 import org.ballerinalang.testerina.util.TesterinaUtils;
 import org.ballerinalang.tool.BLauncherException;
 import org.ballerinalang.tool.LauncherUtils;
@@ -56,9 +56,6 @@ import org.ballerinalang.tool.util.CompileResult;
 import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.ballerinalang.util.diagnostic.DiagnosticListener;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.ballerinalang.compiler.tree.BLangFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangPackage;
-import org.wso2.ballerinalang.compiler.tree.types.BLangType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
@@ -150,7 +147,7 @@ public class BTestRunner {
      *
      * @param packageList map containing bLangPackage nodes along with their compiled program files
      */
-    public void runTest(Map<BLangPackage, TestarinaClassLoader> packageList) {
+    public void runTest(Map<TestMetaData, String> packageList) {
         registry.setGroups(Collections.emptyList());
         registry.setShouldIncludeGroups(true);
         buildSuites(packageList);
@@ -269,20 +266,20 @@ public class BTestRunner {
      *
      * @param packageList map containing bLangPackage nodes along with their compiled program files
      */
-    private void buildSuites(Map<BLangPackage, TestarinaClassLoader> packageList) {
-        packageList.forEach((sourcePackage, classLoader) -> {
+    private void buildSuites(Map<TestMetaData, String> packageList) {
+        packageList.forEach((metaData, testName) -> {
             String packageName;
-            if (sourcePackage.packageID.getName().getValue().equals(".")) {
-                packageName = sourcePackage.packageID.getName().getValue();
+            if (metaData.getPackageID().getName().getValue().equals(".")) {
+                packageName = metaData.getPackageID().getName().getValue();
             } else {
-                packageName = TesterinaUtils.getFullModuleName(sourcePackage.packageID.getName().getValue());
+                packageName = TesterinaUtils.getFullModuleName(metaData.getPackageID().getName().getValue());
             }
             // Add a test suite to registry if not added. In this module there are no tests to be executed. But we need
             // to say that there are no tests found in the module to be executed
             addTestSuite(packageName);
             // Keeps a track of the sources that are being built
             sourcePackages.add(packageName);
-            processProgramFile(sourcePackage, classLoader);
+            processProgramFile(metaData, testName);
         });
 
         registry.setTestSuitesCompiled(true);
@@ -302,13 +299,13 @@ public class BTestRunner {
      *
      * @param programFile program file generated
      */
-    private void processProgramFile(BLangPackage programFile, TestarinaClassLoader classLoader) {
+    private void processProgramFile(TestMetaData programFile, String testName) {
         // process the compiled files
         ServiceLoader<CompilerPlugin> processorServiceLoader = ServiceLoader.load(CompilerPlugin.class);
         processorServiceLoader.forEach(plugin -> {
             if (plugin instanceof TestAnnotationProcessor) {
                 try {
-                    packageProcessed(programFile, classLoader);
+                    packageProcessed(programFile, testName);
                 } catch (BLauncherException e) {
                     throw e;
                 } catch (Exception e) {
@@ -323,21 +320,21 @@ public class BTestRunner {
     /**
      * This method will process BLangPackage and assign functions to test suite.
      *
-     * @param bLangPackage compiled package.
-     * @param classLoader  class loader to load and run package tests.
+     * @param testMetaData compiled package.
+     * @param testName  class loader to load and run package tests.
      */
-    public void packageProcessed(BLangPackage bLangPackage, TestarinaClassLoader classLoader) {
+    private void packageProcessed(TestMetaData testMetaData, String testName) {
         //packageInit = false;
         // TODO the below line is required since this method is currently getting explicitly called from BTestRunner
-        TestSuite suite = TesterinaRegistry.getInstance().getTestSuites().get(bLangPackage.packageID.toString());
+        TestSuite suite = TesterinaRegistry.getInstance().getTestSuites().get(testMetaData.getPackageID().toString());
 
-        if (!bLangPackage.hasTestablePackage()) {
+        if (!testMetaData.isHasTestablePackages()) {
             return;
         }
 
         if (suite == null) {
             throw LauncherUtils.createLauncherException("No test suite found for [module]: "
-                    + bLangPackage.packageID.getName());
+                    + testMetaData.getPackageID().getName());
         }
         // By default the test init function is set as the init function of the test suite
         // FunctionInfo initFunction = programFile.getEntryPackage().getTestInitFunctionInfo();
@@ -346,57 +343,59 @@ public class BTestRunner {
         //if (initFunction == null) {
         //    initFunction = programFile.getEntryPackage().getInitFunctionInfo();
         //}
-        String initClassName = BFileUtil.getQualifiedClassName(bLangPackage.packageID.orgName.value,
-                bLangPackage.packageID.name.value,
+        String initClassName = BFileUtil.getQualifiedClassName(testMetaData.getPackageID().orgName.value,
+                testMetaData.getPackageID().name.value,
                 MODULE_INIT_CLASS_NAME);
-        Class<?> initClazz = classLoader.loadClass(initClassName);
 
-        suite.setInitFunction(new TesterinaFunction(initClazz, bLangPackage.initFunction));
-        suite.setStartFunction(new TesterinaFunction(initClazz, bLangPackage.startFunction));
-        suite.setStopFunction(new TesterinaFunction(initClazz, bLangPackage.stopFunction));
-        // add all functions of the package as utility functions
-        addTestUtilityFunctions(bLangPackage, classLoader, suite, bLangPackage);
-        // Add all functions of the test function to test suite
-        if (bLangPackage.hasTestablePackage()) {
-            BLangPackage testablePackage = bLangPackage.getTestablePkg();
-            String testClassName = BFileUtil.getQualifiedClassName(bLangPackage.packageID.orgName.value,
-                    bLangPackage.packageID.name.value,
-                    bLangPackage.packageID.name.value);
+        try {
+            Class<?> initClazz = ClassLoader.getSystemClassLoader().loadClass(initClassName);
 
-            Class<?> testInitClazz = classLoader.loadClass(testClassName);
-            suite.setTestInitFunction(new TesterinaFunction(testInitClazz,
-                    testablePackage.initFunction));
-            suite.setTestStartFunction(new TesterinaFunction(testInitClazz,
-                    testablePackage.startFunction));
-            suite.setTestStopFunction(new TesterinaFunction(testInitClazz,
-                    testablePackage.stopFunction));
+            suite.setInitFunction(new TesterinaFunction(initClazz,
+                    testMetaData.getInitFunctionName()));
+            suite.setStartFunction(new TesterinaFunction(initClazz,
+                    testMetaData.getStartFunctionName()));
+            suite.setStopFunction(new TesterinaFunction(initClazz,
+                    testMetaData.getStopFunctionName()));
+            // add all functions of the package as utility functions
+            for (Map.Entry<String, String> entry : testMetaData.getNormalFunctionNames().entrySet()) {
+                String functionName = entry.getKey();
+                String functionClassName = entry.getValue();
+                Class<?> functionClass = ClassLoader.getSystemClassLoader().loadClass(functionClassName);
 
-            addTestUtilityFunctions(bLangPackage, classLoader, suite, testablePackage);
-        }
-
-        resolveFunctions(suite);
-        int[] testExecutionOrder = checkCyclicDependencies(suite.getTests());
-        List<Test> sortedTests = orderTests(suite.getTests(), testExecutionOrder);
-        suite.setTests(sortedTests);
-        suite.setProgramFile(classLoader);
-    }
-
-    private void addTestUtilityFunctions(BLangPackage bLangPackage, TestarinaClassLoader classLoader, TestSuite suite,
-                                         BLangPackage testablePackage) {
-        for (BLangFunction function : testablePackage.functions) {
-            try {
-                String functionClassName = BFileUtil.getQualifiedClassName(bLangPackage.packageID.orgName.value,
-                        bLangPackage.packageID.name.value, getClassName(function));
-                Class<?> functionClass = classLoader.loadClass(functionClassName);
-                suite.addTestUtilityFunction(new TesterinaFunction(functionClass, function));
-            } catch (RuntimeException e) {
-                // we do nothing here
+                suite.addTestUtilityFunction(new TesterinaFunction(functionClass, functionName));
             }
-        }
-    }
 
-    private String getClassName(BLangFunction function) {
-        return function.pos.src.cUnitName.replace(".bal", "").replace("/", ".");
+            // Add all functions of the test function to test suite
+            String testClassName = BFileUtil.getQualifiedClassName(testMetaData.getPackageID().orgName.value,
+                    testMetaData.getPackageID().name.value,
+                    testMetaData.getPackageID().name.value);
+
+            Class<?> testInitClazz = ClassLoader.getSystemClassLoader().loadClass(testClassName);
+            suite.setTestInitFunction(new TesterinaFunction(testInitClazz,
+                    testMetaData.getTestInitFunctionName()));
+            suite.setTestStartFunction(new TesterinaFunction(testInitClazz,
+                    testMetaData.getTestStartFunctionName()));
+            suite.setTestStopFunction(new TesterinaFunction(testInitClazz,
+                    testMetaData.getTestStopFunctionName()));
+
+            for (Map.Entry<String, String> entry : testMetaData.getTestFunctionNames().entrySet()) {
+                String functionName = entry.getKey();
+                String functionClassName = entry.getValue();
+                Class<?> functionClass = ClassLoader.getSystemClassLoader().loadClass(functionClassName);
+
+                suite.addTestUtilityFunction(new TesterinaFunction(functionClass, functionName));
+            }
+
+            resolveFunctions(suite);
+            int[] testExecutionOrder = checkCyclicDependencies(suite.getTests());
+            List<Test> sortedTests = orderTests(suite.getTests(), testExecutionOrder);
+            suite.setTests(sortedTests);
+            suite.setProgramFile(ClassLoader.getSystemClassLoader());
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw LauncherUtils.createLauncherException(e.toString());
+        }
     }
 
     private static List<Test> orderTests(List<Test> tests, int[] testExecutionOrder) {
@@ -452,26 +451,26 @@ public class BTestRunner {
                 test.setDataProviderFunction(functions.stream().filter(e -> e.getName().equals(test.getDataProvider()
                 )).findFirst().map(func -> {
                     // TODO these validations are not working properly with the latest refactoring
-                    if (func.getbFunction().getReturnTypeNode() != null) {
-                        BLangType bType = func.getbFunction().getReturnTypeNode();
-                        /*if (bType.getTag() == TypeTags.ARRAY_TAG) {
-                            BArrayType bArrayType = (BArrayType) bType;
-                            int tag = bArrayType.getElementType().getTag();
-                            if (!(tag == TypeTags.ARRAY_TAG || tag == TypeTags.TUPLE_TAG)) {
-                                String message = String.format("Data provider function [%s] should return an array of" +
-                                        " arrays or an array of tuples.", dataProvider);
-                                throw LauncherUtils.createLauncherException(message);
-                            }
-                        } else {
-                            String message = String.format("Data provider function [%s] should return an array of " +
-                                    "arrays or an array of tuples.", dataProvider);
-                            throw LauncherUtils.createLauncherException(message);
-                        }*/
-                    } else {
-                        String message = String.format("Data provider function [%s] should have only one return type" +
-                                ".", dataProvider);
-                        throw LauncherUtils.createLauncherException(message);
-                    }
+//                    if (func.getbFunction().getReturnTypeNode() != null) {
+//                        BLangType bType = func.getbFunction().getReturnTypeNode();
+//                        /*if (bType.getTag() == TypeTags.ARRAY_TAG) {
+//                            BArrayType bArrayType = (BArrayType) bType;
+//                            int tag = bArrayType.getElementType().getTag();
+//                            if (!(tag == TypeTags.ARRAY_TAG || tag == TypeTags.TUPLE_TAG)) {
+//                                String message = String.format("Data provider function [%s] should return an " +
+//                                        "array of arrays or an array of tuples.", dataProvider);
+//                                throw LauncherUtils.createLauncherException(message);
+//                            }
+//                        } else {
+//                            String message = String.format("Data provider function [%s] should return an array of " +
+//                                    "arrays or an array of tuples.", dataProvider);
+//                            throw LauncherUtils.createLauncherException(message);
+//                        }*/
+//                    } else {
+//                        String message = String.format("Data provider function [%s] should have only one " +
+//                                "return type.", dataProvider);
+//                        throw LauncherUtils.createLauncherException(message);
+//                    }
                     return func;
                 }).get());
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TesterinaConstants.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TesterinaConstants.java
@@ -27,5 +27,7 @@ public class TesterinaConstants {
 
     public static final String BALLERINA_SOURCE_ROOT = "ballerina.source.root";
     public static final String TESTERINA_TEMP_DIR = ".testerina";
+    public static final String TESTERINA_TEST_SUITE = "test_suit.json";
+    public static final String TESTERINA_LAUNCHER_CLASS_NAME = "org.ballerinalang.test.launcher.Launch";
 
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TestJsonData.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TestJsonData.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.testerina.core.entity;
+
+import org.ballerinalang.model.elements.PackageID;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * Java class to store and get data from a json (for a test run).
+ */
+public class TestJsonData {
+    private String orgName;
+    private String version;
+    private String initFunctionName;
+    private String startFunctionName;
+    private String stopFunctionName;
+    private String testInitFunctionName;
+    private String testStartFunctionName;
+    private String testStopFunctionName;
+    private String hasTestablePackages;
+    private String packageName;
+    private String sourceRootPath;
+    private String jarPath;
+    private String moduleJarName;
+    private HashMap<String, String> callableFunctionNames;
+    private HashMap<String, String> testFunctionNames;
+    private PackageID packageID;
+    private String [] dependencyJarPaths;
+
+    public String[] getDependencyJarPaths() {
+        String[] tmpDependencyJarPaths = this.dependencyJarPaths;
+        return tmpDependencyJarPaths;
+    }
+
+    public void setDependencyJarPaths(String [] dependencyJarPaths) {
+        this.dependencyJarPaths = Arrays.copyOf(dependencyJarPaths, dependencyJarPaths.length);
+    }
+
+    public PackageID getPackageID() {
+        return packageID;
+    }
+
+    public void setPackageID(PackageID packageID) {
+        this.packageID = packageID;
+    }
+
+    public String getSourceRootPath() {
+        return sourceRootPath;
+    }
+
+    public void setSourceRootPath(String sourceRootPath) {
+        this.sourceRootPath = sourceRootPath;
+    }
+
+    public String getJarPath() {
+        return jarPath;
+    }
+
+    public void setJarPath(String jarPath) {
+        this.jarPath = jarPath;
+    }
+
+    public String getModuleJarName() {
+        return moduleJarName;
+    }
+
+    public void setModuleJarName(String moduleJarName) {
+        this.moduleJarName = moduleJarName;
+    }
+
+    public String getOrgName() {
+        return orgName;
+    }
+
+    public void setOrgName(String orgName) {
+        this.orgName = orgName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getInitFunctionName() {
+        return initFunctionName;
+    }
+
+    public void setInitFunctionName(String initFunctionName) {
+        this.initFunctionName = initFunctionName;
+    }
+
+    public String getStartFunctionName() {
+        return startFunctionName;
+    }
+
+    public void setStartFunctionName(String startFunctionName) {
+        this.startFunctionName = startFunctionName;
+    }
+
+    public String getStopFunctionName() {
+        return stopFunctionName;
+    }
+
+    public void setStopFunctionName(String stopFunctionName) {
+        this.stopFunctionName = stopFunctionName;
+    }
+
+    public String getTestInitFunctionName() {
+        return testInitFunctionName;
+    }
+
+    public void setTestInitFunctionName(String testInitFunctionName) {
+        this.testInitFunctionName = testInitFunctionName;
+    }
+
+    public String getTestStartFunctionName() {
+        return testStartFunctionName;
+    }
+
+    public void setTestStartFunctionName(String testStartFunctionName) {
+        this.testStartFunctionName = testStartFunctionName;
+    }
+
+    public String getTestStopFunctionName() {
+        return testStopFunctionName;
+    }
+
+    public void setTestStopFunctionName(String testStopFunctionName) {
+        this.testStopFunctionName = testStopFunctionName;
+    }
+
+    public String isHasTestablePackages() {
+        return hasTestablePackages;
+    }
+
+    public void setHasTestablePackages(String hasTestablePackages) {
+        this.hasTestablePackages = hasTestablePackages;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public void setPackageName(String packageName) {
+        this.packageName = packageName;
+    }
+
+    public HashMap<String, String> getCallableFunctionNames() {
+        return callableFunctionNames;
+    }
+
+    public void setCallableFunctionNames(HashMap<String, String> callableFunctionNames) {
+        this.callableFunctionNames = callableFunctionNames;
+    }
+
+    public HashMap<String, String> getTestFunctionNames() {
+        return testFunctionNames;
+    }
+
+    public void setTestFunctionNames(HashMap<String, String> testFunctionNames) {
+        this.testFunctionNames = testFunctionNames;
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TestMetaData.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TestMetaData.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.testerina.core.entity;
+
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.tool.util.BFileUtil;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+
+import java.util.HashMap;
+
+/**
+ * Java class to hold the meta data of a specific module's test suit.
+ */
+public class TestMetaData {
+    private String initFunctionName;
+    private String startFunctionName;
+    private String stopFunctionName;
+    private String testInitFunctionName;
+    private String testStartFunctionName;
+    private String testStopFunctionName;
+    private PackageID packageID;
+    private boolean hasTestablePackages;
+    private String packageName;
+    private HashMap<String, String> callableFunctionNames;
+    private HashMap<String, String> testFunctionNames;
+
+    public TestMetaData(BLangPackage bLangPackage, String packageName) {
+        this.initFunctionName = bLangPackage.initFunction.name.value;
+        this.startFunctionName = bLangPackage.startFunction.name.value;
+        this.stopFunctionName = bLangPackage.stopFunction.name.value;
+        this.testInitFunctionName = bLangPackage.getTestablePkg().initFunction.name.value;
+        this.testStartFunctionName = bLangPackage.getTestablePkg().startFunction.name.value;
+        this.testStopFunctionName = bLangPackage.getTestablePkg().stopFunction.name.value;
+        this.packageID = bLangPackage.packageID;
+        this.hasTestablePackages = bLangPackage.hasTestablePackage();
+        this.packageName = packageName;
+        this.computePackageFunctions(bLangPackage);
+    }
+
+    public void setStartFunctionName(String startFunctionName) {
+        this.startFunctionName = startFunctionName;
+    }
+
+    public void setStopFunctionName(String stopFunctionName) {
+        this.stopFunctionName = stopFunctionName;
+    }
+
+    public void setTestInitFunctionName(String testInitFunctionName) {
+        this.testInitFunctionName = testInitFunctionName;
+    }
+
+    public void setTestStartFunctionName(String testStartFunctionName) {
+        this.testStartFunctionName = testStartFunctionName;
+    }
+
+    public void setTestStopFunctionName(String testStopFunctionName) {
+        this.testStopFunctionName = testStopFunctionName;
+    }
+
+    public void setHasTestablePackages(boolean hasTestablePackages) {
+        this.hasTestablePackages = hasTestablePackages;
+    }
+
+    public void setPackageName(String packageName) {
+        this.packageName = packageName;
+    }
+
+    public TestMetaData () {}
+
+    public String getInitFunctionName() {
+        return initFunctionName;
+    }
+
+    public void setInitFunctionName(String initFunctionName) {
+        this.initFunctionName = initFunctionName;
+    }
+
+    public String getStartFunctionName() {
+        return startFunctionName;
+    }
+
+    public String getStopFunctionName() {
+        return stopFunctionName;
+    }
+
+    public String getTestInitFunctionName() {
+        return testInitFunctionName;
+    }
+
+    public String getTestStartFunctionName() {
+        return testStartFunctionName;
+    }
+
+    public String getTestStopFunctionName() {
+        return testStopFunctionName;
+    }
+
+    public PackageID getPackageID() {
+        return packageID;
+    }
+
+    public void setPackageID(PackageID packageID) {
+        this.packageID = packageID;
+    }
+
+    public void setCallableFunctionNames(HashMap<String, String> callableFunctionNames) {
+        this.callableFunctionNames = callableFunctionNames;
+    }
+
+    public void setTestFunctionNames(HashMap<String, String> testFunctionNames) {
+        this.testFunctionNames = testFunctionNames;
+    }
+
+    private void computePackageFunctions(BLangPackage bLangPackage) {
+        this.callableFunctionNames = new HashMap<>();
+        this.testFunctionNames = new HashMap<>();
+
+        bLangPackage.functions.stream().forEach(function -> {
+            try {
+                String functionClassName = BFileUtil.getQualifiedClassName(bLangPackage.packageID.orgName.value,
+                        bLangPackage.packageID.name.value,
+                        getClassName(function.pos.src.cUnitName));
+                callableFunctionNames.put(function.name.value, functionClassName);
+            } catch (RuntimeException e) {
+                // we do nothing here
+            }
+        });
+
+        bLangPackage.getTestablePkg().functions.stream().forEach(function -> {
+            try {
+                String functionClassName = BFileUtil.getQualifiedClassName(bLangPackage.packageID.orgName.value,
+                        bLangPackage.packageID.name.value,
+                        getClassName(function.pos.src.cUnitName));
+                testFunctionNames.put(function.name.value, functionClassName);
+            } catch (RuntimeException e) {
+                // we do nothing here
+            }
+        });
+    }
+
+    private static String getClassName(String function) {
+        return function.replace(".bal", "").replace("/", ".");
+    }
+
+    public HashMap<String, String> getNormalFunctionNames() {
+        return callableFunctionNames;
+    }
+
+    public HashMap<String, String> getTestFunctionNames() {
+        return testFunctionNames;
+    }
+
+    public boolean isHasTestablePackages() {
+        return hasTestablePackages;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TestSuite.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TestSuite.java
@@ -19,7 +19,6 @@
 package org.ballerinalang.testerina.core.entity;
 
 import org.ballerinalang.jvm.scheduling.Scheduler;
-import org.ballerinalang.testerina.util.TestarinaClassLoader;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,7 +40,7 @@ public class TestSuite {
     private TesterinaFunction testStartFunction;
     private TesterinaFunction testStopFunction;
     private List<Test> tests = new ArrayList<>();
-    private TestarinaClassLoader programFile;
+    private ClassLoader programFile;
     private List<String> beforeSuiteFunctionNames = new ArrayList<>();
     private List<String> afterSuiteFunctionNames = new ArrayList<>();
 
@@ -121,7 +120,7 @@ public class TestSuite {
         this.suiteName = suiteName;
     }
 
-    public TestarinaClassLoader getProgramFile() {
+    public ClassLoader getProgramFile() {
         return programFile;
     }
 
@@ -248,7 +247,7 @@ public class TestSuite {
         this.afterSuiteFunctions = afterSuiteFunctions;
     }
 
-    public void setProgramFile(TestarinaClassLoader programFile) {
+    public void setProgramFile(ClassLoader programFile) {
         this.programFile = programFile;
     }
 
@@ -299,7 +298,7 @@ public class TestSuite {
         if (initFunction != null && startFunction != null) {
             // As the init function we need to use $moduleInit to initialize all the dependent modules
             // properly.
-            initFunction.bFunction.name.value = "$moduleInit";
+            initFunction.setName("$moduleInit");
             initFunction.scheduler = initScheduler;
             initFunction.invoke();
             // Now we initialize the init of testable module.
@@ -309,7 +308,7 @@ public class TestSuite {
             }
             // As the start function we need to use $moduleStart to start all the dependent modules
             // properly.
-            startFunction.bFunction.name.value = "$moduleStart";
+            startFunction.setName("$moduleStart");
             startFunction.scheduler = initScheduler;
             startFunction.invoke();
 
@@ -337,7 +336,7 @@ public class TestSuite {
                 testStopFunction.invoke();
             }
 
-            stopFunction.bFunction.name.value = "$moduleStop";
+            stopFunction.setName("$moduleStop");
             stopFunction.directInvoke(new Class[]{});
         }
         // this.initScheduler.poison();

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaFunction.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaFunction.java
@@ -24,8 +24,6 @@ import org.ballerinalang.jvm.types.BTypes;
 import org.ballerinalang.jvm.values.ErrorValue;
 import org.ballerinalang.jvm.values.FutureValue;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.ballerinalang.compiler.tree.BLangFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -39,38 +37,36 @@ import java.util.function.Function;
  */
 public class TesterinaFunction {
 
-    private String name;
     public Scheduler scheduler;
 
-    public BLangFunction getbFunction() {
-        return bFunction;
-    }
+//    public BLangFunction getbFunction() {
+//        return bFunction;
+//    }
 
-    public BLangFunction bFunction;
+    private String bFunctionName;
     private Class<?> programFile;
     private boolean runTest = true;
 
     // Annotation info
     private List<String> groups = new ArrayList<>();
 
-    public TesterinaFunction(Class<?> programFile, BLangFunction bFunction) {
-        this.name = bFunction.getName().getValue();
-        this.bFunction = bFunction;
+    public TesterinaFunction(Class<?> programFile, String bFunctionName) {
+        this.bFunctionName = bFunctionName;
         this.programFile = programFile;
     }
 
     public Object invoke() throws BallerinaException {
         if (scheduler == null) {
-            throw new AssertionError("Scheduler is not initialized in " + bFunction.name);
+            throw new AssertionError("Scheduler is not initialized in " + bFunctionName);
         }
-        return runOnSchedule(programFile, bFunction.name, scheduler, new Class[]{Strand.class}, new Object[1]);
+        return runOnSchedule(programFile, bFunctionName, scheduler, new Class[]{Strand.class}, new Object[1]);
     }
 
     public Object invoke(Class[] types, Object[] args) {
         if (scheduler == null) {
-            throw new AssertionError("Scheduler is not initialized in " + bFunction.name);
+            throw new AssertionError("Scheduler is not initialized in " + bFunctionName);
         }
-        return runOnSchedule(programFile, bFunction.name, scheduler, types, args);
+        return runOnSchedule(programFile, bFunctionName, scheduler, types, args);
     }
 
     /**
@@ -80,15 +76,15 @@ public class TesterinaFunction {
      * @return output
      */
     public Object directInvoke(Class[] types) {
-        return run(programFile, bFunction.name, scheduler, types);
+        return run(programFile, bFunctionName, scheduler, types);
     }
 
     public String getName() {
-        return name;
+        return bFunctionName;
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.bFunctionName = name;
     }
 
     public List<String> getGroups() {
@@ -107,7 +103,7 @@ public class TesterinaFunction {
         this.runTest = false;
     }
 
-    private static Object run(Class<?> initClazz, BLangIdentifier name, Scheduler scheduler,
+    private static Object run(Class<?> initClazz, String name, Scheduler scheduler,
                               Class[] paramTypes) {
         String funcName = cleanupFunctionName(name);
         try {
@@ -119,7 +115,7 @@ public class TesterinaFunction {
         }
     }
 
-    private static Object runOnSchedule(Class<?> initClazz, BLangIdentifier name, Scheduler scheduler,
+    private static Object runOnSchedule(Class<?> initClazz, String name, Scheduler scheduler,
                                         Class[] paramTypes, Object[] params) {
         String funcName = cleanupFunctionName(name);
         try {
@@ -156,8 +152,8 @@ public class TesterinaFunction {
         }
     }
 
-    private static String cleanupFunctionName(BLangIdentifier name) {
-        return name.value.replaceAll("[.:/<>]", "_");
+    private static String cleanupFunctionName(String name) {
+        return name.replaceAll("[.:/<>]", "_");
     }
 
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/util/TesterinaUtils.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/util/TesterinaUtils.java
@@ -20,8 +20,8 @@ package org.ballerinalang.testerina.util;
 import org.ballerinalang.testerina.core.BTestRunner;
 import org.ballerinalang.testerina.core.TesterinaConstants;
 import org.ballerinalang.testerina.core.TesterinaRegistry;
+import org.ballerinalang.testerina.core.entity.TestMetaData;
 import org.ballerinalang.toml.model.Manifest;
-import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.TomlParserUtils;
 
@@ -107,37 +107,24 @@ public class TesterinaUtils {
      * Execute tests in build.
      *
      * @param sourceRootPath source root path
-     * @param programFileMap map containing bLangPackage nodes along with their compiled program files
-     */
-    public static void executeTests(Path sourceRootPath, Map<BLangPackage, TestarinaClassLoader>
-            programFileMap) {
-        executeTests(sourceRootPath, programFileMap, System.out, System.err);
-    }
-    
-    /**
-     * Execute tests in build.
-     *
-     * @param sourceRootPath source root path
-     * @param programFileMap map containing bLangPackage nodes along with their compiled program files
+     * @param testMetaDataMap map containing testMetaData nodes along with their compiled program files
      * @param outStream      error stream for logging.
      * @param errStream      info stream for logging.
      */
-    public static void executeTests(Path sourceRootPath, Map<BLangPackage, TestarinaClassLoader> programFileMap,
+    public static void executeTests(Path sourceRootPath, Map<TestMetaData, String> testMetaDataMap,
                                     PrintStream outStream, PrintStream errStream) {
-        // Set org-name and version to the Testerina Registry.
         setManifestConfigs(sourceRootPath);
-        
+
         BTestRunner testRunner = new BTestRunner(outStream, errStream);
         // Run the tests
-        testRunner.runTest(programFileMap);
-        
+        testRunner.runTest(testMetaDataMap);
+
         if (testRunner.getTesterinaReport().isFailure()) {
             cleanUpDir(sourceRootPath.resolve(TesterinaConstants.TESTERINA_TEMP_DIR));
             Runtime.getRuntime().exit(1);
         }
         cleanUpDir(sourceRootPath.resolve(TesterinaConstants.TESTERINA_TEMP_DIR));
     }
-
     /**
      * Format error message.
      *

--- a/misc/testerina/modules/testerina-launcher/build.gradle
+++ b/misc/testerina/modules/testerina-launcher/build.gradle
@@ -1,0 +1,15 @@
+apply from: "$rootDir/gradle/javaProject.gradle"
+
+dependencies {
+    implementation project(':ballerina-tool')
+    implementation project(':ballerina-lang')
+    implementation project(':ballerina-runtime')
+    implementation project(':ballerina-config')
+    implementation project(':toml-parser')
+    implementation project(':testerina:testerina-core')
+    implementation 'com.moandjiezana.toml:toml4j'
+
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+}
+
+description = 'Ballerina - Test starter'

--- a/misc/testerina/modules/testerina-launcher/src/main/java/org/ballerinalang/test/launcher/Launch.java
+++ b/misc/testerina/modules/testerina-launcher/src/main/java/org/ballerinalang/test/launcher/Launch.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.launcher;
+
+import com.google.gson.Gson;
+import org.ballerinalang.testerina.core.TesterinaConstants;
+import org.ballerinalang.testerina.core.TesterinaRegistry;
+import org.ballerinalang.testerina.core.entity.Test;
+import org.ballerinalang.testerina.core.entity.TestJsonData;
+import org.ballerinalang.testerina.core.entity.TestMetaData;
+import org.ballerinalang.testerina.core.entity.TestSuite;
+import org.ballerinalang.testerina.util.TesterinaUtils;
+
+import java.io.BufferedReader;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Main class to init the test suit.
+ */
+public class Launch {
+
+    private static PrintStream outsStream = System.out;
+    private static PrintStream errStream = System.err;
+
+    public static void main(String[] args) {
+
+        Path jsonCachePath = Paths.get(args[0], TesterinaConstants.TESTERINA_TEST_SUITE);
+        try {
+            BufferedReader br = Files.newBufferedReader(jsonCachePath, StandardCharsets.UTF_8);
+
+            //convert the json string back to object
+            Gson gson = new Gson();
+            TestJsonData response = gson.fromJson(br, TestJsonData.class);
+            HashMap<TestMetaData, String> testMetaDataMap = initTestSuit(response);
+            startTestSuit(Paths.get(response.getSourceRootPath()), testMetaDataMap);
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            errStream.println(e);
+        }
+    }
+
+    private static HashMap<TestMetaData, String> initTestSuit(TestJsonData testJsonData) {
+        TestMetaData testMetaData = new TestMetaData();
+
+        // set the PackageID
+        testMetaData.setPackageID(testJsonData.getPackageID());
+
+        // set the tests into the test suit and init the test suit
+        List<Test> testNames = new ArrayList<>();
+        Map<String, String> tmpTestMap = testJsonData.getTestFunctionNames();
+        tmpTestMap.forEach((functionName, className) -> {
+            if (!functionName.contains("$")) {
+                Test test = new Test();
+                test.setTestName(functionName);
+                testNames.add(test);
+            }
+        });
+        TestSuite testSuite = new TestSuite(testJsonData.getPackageName());
+        testSuite.setTests(testNames);
+
+        // create the test suit map
+        Map<String, TestSuite> testSuiteMap = new HashMap<>();
+        testSuiteMap.put(testJsonData.getPackageName(), testSuite);
+
+        // set the test suit into the Testerina registry
+        TesterinaRegistry testerinaRegistry = TesterinaRegistry.getInstance();
+        testerinaRegistry.setTestSuites(testSuiteMap);
+
+        // setting the function name maps with class names
+        HashMap<String, String> callableFunctionNames = testJsonData.getCallableFunctionNames();
+        HashMap<String, String> testFunctionNames = testJsonData.getTestFunctionNames();
+        testMetaData.setCallableFunctionNames(callableFunctionNames);
+        testMetaData.setTestFunctionNames(testFunctionNames);
+
+        // set the init/start/stop function names for both normal and test functions
+        testMetaData.setInitFunctionName(testJsonData.getInitFunctionName());
+        testMetaData.setStartFunctionName(testJsonData.getStartFunctionName());
+        testMetaData.setStopFunctionName(testJsonData.getStopFunctionName());
+        testMetaData.setTestInitFunctionName(testJsonData.getTestInitFunctionName());
+        testMetaData.setTestStartFunctionName(testJsonData.getTestStartFunctionName());
+        testMetaData.setTestStopFunctionName(testJsonData.getTestStopFunctionName());
+
+        // set rest required data
+        testMetaData.setPackageName(testJsonData.getPackageName());
+        testMetaData.setHasTestablePackages(Boolean.parseBoolean(testJsonData.isHasTestablePackages()));
+
+        String testName = testJsonData.getPackageName();
+
+        HashMap<TestMetaData, String> testMetaDataMap = new HashMap<>();
+        testMetaDataMap.put(testMetaData, testName);
+
+        return testMetaDataMap;
+    }
+
+    private static void startTestSuit(Path sourceRootPath, Map<TestMetaData, String> classLoaderMap) {
+        TesterinaUtils.executeTests(sourceRootPath, classLoaderMap, outsStream, errStream);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -114,7 +114,7 @@ include(':ballerina-llvm')
 // include(':composer-integration-test')
 // include(':ballerina-tools-integration-test')
 include(':ballerina-jsonutils')
-
+include(':testerina:testerina-launcher')
 // include(':examples-test')
 // TODO: enable at 'dependsOn' of tools-intergration-tests
 // and 'mustRunAfter' of vs-code-pluggin
@@ -254,6 +254,7 @@ project(':ballerina-openshift').projectDir = file('stdlib/openshift')
 project(':ballerina-istio').projectDir = file('stdlib/istio')
 project(':ballerina-xmlutils').projectDir = file('stdlib/xmlutils')
 project(':ballerina-llvm').projectDir = file('stdlib/llvm')
+project(':testerina:testerina-launcher').projectDir = file('misc/testerina/modules/testerina-launcher')
 
 project(':debug-adapter:debug-adapter-core').projectDir = file('misc/debug-adapter/modules/debug-adapter-core')
 project(':debug-adapter:debug-adapter-cli').projectDir = file('misc/debug-adapter/modules/debug-adapter-cli')


### PR DESCRIPTION
## Purpose
This PR is to decouple the test suit in ballerina. And also this changes would remove the dependency of bLangPackage and TesterinaClassLoader dependency from the test suit while introducing TestMetaData (to store the details that are needed to run the test suit) and TestJsonData (store and retrieve data from a JSON file that are needed to init the test suit) entities.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19755
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/19756

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
