### PR TITLE
Prevent compiling of test bal files when not required

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -357,7 +357,7 @@ public class BuildCommand implements BLauncherCmd {
         options.put(COMPILER_PHASE, CompilerPhase.BIR_GEN.toString());
         options.put(LOCK_ENABLED, Boolean.toString(!this.skipLock));
         options.put(SKIP_TESTS, Boolean.toString(this.skipTests));
-        options.put(TEST_ENABLED, "true");
+        options.put(TEST_ENABLED, Boolean.toString(!this.skipTests));
         options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(this.experimentalFlag));
         options.put(PRESERVE_WHITESPACE, "true");
         // create builder context

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
@@ -255,7 +255,7 @@ public class RunCommand implements BLauncherCmd {
         options.put(COMPILER_PHASE, CompilerPhase.BIR_GEN.toString());
         options.put(LOCK_ENABLED, Boolean.toString(true));
         options.put(SKIP_TESTS, Boolean.toString(true));
-        options.put(TEST_ENABLED, "true");
+        options.put(TEST_ENABLED, Boolean.toString(false));
         options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(this.experimentalFlag));
 
         // create builder context

--- a/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/cmd/BuildCommandTest.java
+++ b/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/cmd/BuildCommandTest.java
@@ -744,6 +744,23 @@ public class BuildCommandTest extends CommandTest {
         Path execJar = tmpDir.resolve("sample.jar");
         Assert.assertTrue(Files.exists(execJar), "Check if jar gets created");
     }
+
+    @Test(description = "Test the --skip-tests flag in the build command to ensure it avoids compiling tests")
+    public void testBuildWithSkipTests() throws IOException {
+        // valid source root path where the project contains test bal files with compilation errors
+        Path projectWithTestErrors = this.testResources.resolve("project-with-test-errors");
+        BuildCommand buildCommand = new BuildCommand(projectWithTestErrors, printStream, printStream, false, true);
+        new CommandLine(buildCommand).parse("--skip-tests", "-a");
+        buildCommand.execute();
+
+        String buildLog = readOutput(true);
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), "Compiling source\n" +
+                "\ttestOrg/module1:0.1.0\n" +
+                "\nCreating balos\n" +
+                "\ttarget/balo/module1-2019r3-any-0.1.0.balo\n" +
+                "\nGenerating executables\n" +
+                "\ttarget/bin/module1.jar\n");
+    }
     
     // Check compile command inside a module directory
 

--- a/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/Ballerina.toml
+++ b/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/Ballerina.toml
@@ -1,0 +1,5 @@
+[project]
+org-name= "testOrg"
+version= "0.1.0"
+
+[dependencies]

--- a/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/src/module1/Module.md
+++ b/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/src/module1/Module.md
@@ -1,0 +1,6 @@
+Resource project for integration tests.
+[//]: # (above is the module summary)
+
+# Module Overview
+This module is a integration test resource which contains compilation errors in the main_test.bal file. It is used to 
+check if the *--skip-tests* flag in the Ballerina build command skips the compilation and execution of tests.

--- a/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/src/module1/main.bal
+++ b/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/src/module1/main.bal
@@ -1,0 +1,7 @@
+import ballerina/io;
+
+# Prints `Hello World`.
+
+public function main() {
+    io:println("Hello World!");
+}

--- a/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/src/module1/tests/main_test.bal
+++ b/cli/ballerina-packerina/src/test/resources/test-resources/project-with-test-errors/src/module1/tests/main_test.bal
@@ -1,0 +1,40 @@
+import ballerina/io;
+import ballerina/test;
+
+# Before Suite Function
+
+@test:BeforeSuite
+function beforeSuiteFunc() {
+    io:println("I'm the before suite function!");
+    C // Cause a compilation error
+}
+
+# Before test function
+
+function beforeFunc() {
+    io:println("I'm the before function!");
+}
+
+# Test function
+
+@test:Config {
+    before: "beforeFunc",
+    after: "afterFunc"
+}
+function testFunction() {
+    io:println("I'm in test function!");
+    test:assertTrue(true, msg = "Failed!");
+}
+
+# After test function
+
+function afterFunc() {
+    io:println("I'm the after function!");
+}
+
+# After Suite Function
+
+@test:AfterSuite
+function afterSuiteFunc() {
+    io:println("I'm the after suite function!");
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
@@ -43,9 +43,8 @@ class FilterSearch extends SimpleFileVisitor {
      *
      * @param path directory path to be traversed
      * @return if the directory is to be excluded or not
-     * @throws IOException exception
      */
-    private boolean isExcluded(Path path) throws IOException {
+    private boolean isExcluded(Path path) {
         Path name = path.getFileName();
         return (name != null) && excludeDir.contains(name);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FilterSearch.java
@@ -14,10 +14,10 @@ import java.util.List;
  */
 class FilterSearch extends SimpleFileVisitor {
 
-    private final Path excludeDir;
+    private final List<Path> excludeDir;
     private List<Path> pathList = new ArrayList<>();
 
-    FilterSearch(Path exclude) {
+    FilterSearch(List<Path> exclude) {
         this.excludeDir = exclude;
     }
 
@@ -47,7 +47,7 @@ class FilterSearch extends SimpleFileVisitor {
      */
     private boolean isExcluded(Path path) throws IOException {
         Path name = path.getFileName();
-        return (name != null) && name.equals(excludeDir);
+        return (name != null) && excludeDir.contains(name);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/PathConverter.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -120,7 +121,10 @@ public class PathConverter implements Converter<Path> {
     public Stream<Path> expandBal(Path path) {
         if (Files.isDirectory(path)) {
             try {
-                FilterSearch filterSearch = new FilterSearch(Paths.get(ProjectDirConstants.TEST_DIR_NAME));
+                List<Path> excludePaths = new ArrayList<>();
+                excludePaths.add(Paths.get(ProjectDirConstants.TEST_DIR_NAME));
+                excludePaths.add(Paths.get(ProjectDirConstants.RESOURCE_DIR_NAME));
+                FilterSearch filterSearch = new FilterSearch(excludePaths);
                 Files.walkFileTree(path, filterSearch);
                 return filterSearch.getPathList().stream().sorted();
             } catch (IOException ignore) {


### PR DESCRIPTION
## Purpose
Currently, the _--skip-tests_ flag in the Ballerina build command compiles the tests even though they are not executed. This PR changes this behavior to ensure that the tests are not compiled when the     _--skip-tests_ flag is used.

The existing implementation compiles the tests in the run command as well. This is also removed through this PR.

An integration test is added to check if the compilation of tests is skipped when the _--skip-tests_ flag is used in the build command.

Fixes #19229

## Approach
The TEST_ENABLED parameter of the BuildCommand and the RunCommand are changed to reflect the following requirements.
- Build Command - compiles test cases when _--skip-tests_ flag is not used
- Build Command - does not compile test cases when _--skip-tests_ flag is used
- Run Command - does not compile test cases

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [X] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples