### PR TITLE
Fill-in missing values by list constructor

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -1734,7 +1734,7 @@ public class TypeChecker {
             if (Flags.isFlagOn(field.flags, Flags.OPTIONAL)) {
                 continue;
             }
-            if ((!Flags.isFlagOn(field.flags, Flags.OPTIONAL) && !Flags.isFlagOn(field.flags, Flags.REQUIRED))) {
+            if (!Flags.isFlagOn(field.flags, Flags.REQUIRED)) {
                 continue;
             }
             return false;

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -996,7 +996,6 @@ public class TypeChecker {
      * if fails then falls back to checking the value.
      * 
      * @param sourceValue Value to check
-     * @param sourceType Type of the value
      * @param targetType Target type
      * @param unresolvedValues Values that are unresolved so far
      * @param allowNumericConversion Flag indicating whether to perform numeric conversions

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BArrayType.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BArrayType.java
@@ -37,7 +37,7 @@ public class BArrayType extends BType {
     private BType elementType;
     private int dimensions = 1;
     private int size = -1;
-    private boolean hasFillerValue = false;
+    private boolean hasFillerValue;
     private ArrayState state = ArrayState.UNSEALED;
 
     public BArrayType(BType elementType) {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BArrayType.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BArrayType.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.jvm.types;
 
+import org.ballerinalang.jvm.TypeChecker;
 import org.ballerinalang.jvm.commons.ArrayState;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.ArrayValueImpl;
@@ -36,6 +37,7 @@ public class BArrayType extends BType {
     private BType elementType;
     private int dimensions = 1;
     private int size = -1;
+    private boolean hasFillerValue = false;
     private ArrayState state = ArrayState.UNSEALED;
 
     public BArrayType(BType elementType) {
@@ -44,6 +46,7 @@ public class BArrayType extends BType {
         if (elementType instanceof BArrayType) {
             dimensions = ((BArrayType) elementType).getDimensions() + 1;
         }
+        hasFillerValue = TypeChecker.hasFillerValue(this.elementType);
     }
 
     public BArrayType(BType elemType, int size) {
@@ -56,6 +59,7 @@ public class BArrayType extends BType {
             state = ArrayState.CLOSED_SEALED;
             this.size = size;
         }
+        hasFillerValue = TypeChecker.hasFillerValue(this.elementType);
     }
 
     public BType getElementType() {
@@ -134,6 +138,10 @@ public class BArrayType extends BType {
 
     public int getSize() {
         return size;
+    }
+
+    public boolean hasFillerValue() {
+        return hasFillerValue;
     }
 
     public ArrayState getState() {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -813,7 +813,9 @@ public class ArrayValueImpl extends AbstractArrayValue {
             case TypeTags.BOOLEAN_TAG:
                 return;
             default:
-                Arrays.fill(refValues, size, index, elementType.getZeroValue());
+                if (arrayType.hasFillerValue()) {
+                    Arrays.fill(refValues, size, index, elementType.getZeroValue());
+                }
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -848,8 +848,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
 
     @Override
     protected void fillerValueCheck(int index, int size) {
-        // if there has been values added beyond the current index, that means filler values
-        // has already been checked. Therefore no need to check again.
         if (!hasFillerValue.isPresent()) {
             hasFillerValue = Optional.of(TypeChecker.hasFillerValue(this.elementType));
         }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -40,7 +40,6 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
@@ -71,8 +70,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private double[] floatValues;
     private String[] stringValues;
     private BString[] bStringValues;
-
-    private Optional<Boolean> hasFillerValue = Optional.empty();
 
     // ------------------------ Constructors -------------------------------------------------------------------
 
@@ -817,7 +814,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 return;
             default:
                 Arrays.fill(refValues, size, index, elementType.getZeroValue());
-
         }
     }
 
@@ -848,17 +844,13 @@ public class ArrayValueImpl extends AbstractArrayValue {
 
     @Override
     protected void fillerValueCheck(int index, int size) {
-        if (!hasFillerValue.isPresent()) {
-            hasFillerValue = Optional.of(TypeChecker.hasFillerValue(this.elementType));
-        }
-
         // if the elementType doesn't have an implicit initial value & if the insertion is not a consecutive append
         // to the array, then an exception will be thrown.
-        if (hasFillerValue.get()) {
+        if (arrayType.hasFillerValue()) {
             return;
         } else if (index > size) {
             throw BLangExceptionHelper.getRuntimeException(BallerinaErrorReasons.ILLEGAL_LIST_INSERTION_ERROR,
-                    RuntimeErrors.ILLEGAL_ARRAY_INSERTION, size, index + 1);
+                                                           RuntimeErrors.ILLEGAL_ARRAY_INSERTION, size, index + 1);
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
@@ -70,6 +71,8 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private double[] floatValues;
     private String[] stringValues;
     private BString[] bStringValues;
+
+    private Optional<Boolean> hasFillerValue = Optional.empty();;
 
     // ------------------------ Constructors -------------------------------------------------------------------
 
@@ -130,35 +133,40 @@ public class ArrayValueImpl extends AbstractArrayValue {
         this.arrayType = type;
         BArrayType arrayType = (BArrayType) type;
         this.elementType = arrayType.getElementType();
+        initArrayValues(elementType, false);
         if (arrayType.getState() == ArrayState.CLOSED_SEALED) {
             this.size = maxSize = arrayType.getSize();
         }
-        initArrayValues(this.elementType, false);
     }
 
     private void initArrayValues(BType elementType, boolean useBString) {
+        int initialArraySize = Math.max(DEFAULT_ARRAY_SIZE, arrayType.getSize());
         switch (elementType.getTag()) {
             case TypeTags.INT_TAG:
-                this.intValues = new long[DEFAULT_ARRAY_SIZE];
+                this.intValues = new long[initialArraySize];
                 break;
             case TypeTags.FLOAT_TAG:
-                this.floatValues = new double[DEFAULT_ARRAY_SIZE];
+                this.floatValues = new double[initialArraySize];
                 break;
             case TypeTags.STRING_TAG:
                 if (useBString) {
-                    this.bStringValues = new BString[DEFAULT_ARRAY_SIZE];
+                    this.bStringValues = new BString[initialArraySize];
                 } else {
-                    this.stringValues = new String[DEFAULT_ARRAY_SIZE];
+                    this.stringValues = new String[initialArraySize];
                 }
                 break;
             case TypeTags.BOOLEAN_TAG:
-                this.booleanValues = new boolean[DEFAULT_ARRAY_SIZE];
+                this.booleanValues = new boolean[initialArraySize];
                 break;
             case TypeTags.BYTE_TAG:
-                this.byteValues = new byte[DEFAULT_ARRAY_SIZE];
+                this.byteValues = new byte[initialArraySize];
                 break;
             default:
-                this.refValues = new Object[DEFAULT_ARRAY_SIZE];
+                this.refValues = new Object[initialArraySize];
+                if (arrayType.getState() == ArrayState.CLOSED_SEALED) {
+                    fillerValueCheck(initialArraySize, initialArraySize);
+                    fillValues(arrayType.getSize());
+                }
         }
     }
 
@@ -166,20 +174,20 @@ public class ArrayValueImpl extends AbstractArrayValue {
     public ArrayValueImpl(BArrayType type, long size) {
         this.arrayType = type;
         this.elementType = type.getElementType();
+        initArrayValues(this.elementType, false);
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-        initArrayValues(this.elementType, false);
     }
 
     @Deprecated
     public ArrayValueImpl(BArrayType type, long size, boolean useBString) {
         this.arrayType = type;
         this.elementType = type.getElementType();
+        initArrayValues(this.elementType, useBString);
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-        initArrayValues(this.elementType, useBString);
     }
 
     // ----------------------- get methods ----------------------------------------------------
@@ -842,13 +850,15 @@ public class ArrayValueImpl extends AbstractArrayValue {
     protected void fillerValueCheck(int index, int size) {
         // if there has been values added beyond the current index, that means filler values
         // has already been checked. Therefore no need to check again.
-        if (this.size >= index) {
-            return;
+        if (!hasFillerValue.isPresent()) {
+            hasFillerValue = Optional.of(TypeChecker.hasFillerValue(this.elementType));
         }
 
         // if the elementType doesn't have an implicit initial value & if the insertion is not a consecutive append
         // to the array, then an exception will be thrown.
-        if (!TypeChecker.hasFillerValue(this.elementType) && (index > size)) {
+        if (hasFillerValue.get()) {
+            return;
+        } else if (index > size) {
             throw BLangExceptionHelper.getRuntimeException(BallerinaErrorReasons.ILLEGAL_LIST_INSERTION_ERROR,
                     RuntimeErrors.ILLEGAL_ARRAY_INSERTION, size, index + 1);
         }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -72,7 +72,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private String[] stringValues;
     private BString[] bStringValues;
 
-    private Optional<Boolean> hasFillerValue = Optional.empty();;
+    private Optional<Boolean> hasFillerValue = Optional.empty();
 
     // ------------------------ Constructors -------------------------------------------------------------------
 
@@ -140,7 +140,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
     }
 
     private void initArrayValues(BType elementType, boolean useBString) {
-        int initialArraySize = Math.max(DEFAULT_ARRAY_SIZE, arrayType.getSize());
+        int initialArraySize = (arrayType.getSize() != -1) ? arrayType.getSize() : DEFAULT_ARRAY_SIZE;
         switch (elementType.getTag()) {
             case TypeTags.INT_TAG:
                 this.intValues = new long[initialArraySize];
@@ -165,7 +165,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 this.refValues = new Object[initialArraySize];
                 if (arrayType.getState() == ArrayState.CLOSED_SEALED) {
                     fillerValueCheck(initialArraySize, initialArraySize);
-                    fillValues(arrayType.getSize());
+                    fillValues(initialArraySize);
                 }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -265,6 +265,7 @@ public enum DiagnosticCode {
     INVALID_ARRAY_LITERAL("invalid.array.literal"),
     INVALID_TUPLE_LITERAL("invalid.tuple.literal"),
     INVALID_LIST_CONSTRUCTOR("invalid.list.constructor"),
+    INVALID_LIST_CONSTRUCTOR_ELEMENT_TYPE("invalid.list.constructor.type"),
     INVALID_ARRAY_ELEMENT_TYPE("invalid.array.element.type"),
     INVALID_TUPLE_BINDING_PATTERN("invalid.tuple.binding.pattern"),
     INVALID_TYPE_FOR_TUPLE_VAR_EXPRESSION("invalid.type.for.tuple.var.expr"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1166,7 +1166,7 @@ public class BIRPackageSymbolEnter {
 
         litExpr.type = valueType;
 
-        finiteType.valueSpace.add(litExpr);
+        finiteType.addValue(litExpr);
     }
 
     private BLangLiteral createLiteralBasedOnType(BType valueType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -173,6 +173,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.desugar.AnnotationDesugar.ANNOTATION_DATA;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -173,7 +173,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.desugar.AnnotationDesugar.ANNOTATION_DATA;
@@ -2055,7 +2054,7 @@ public class BIRGen extends BLangNodeVisitor {
         long size = -1L;
         if (listConstructorExpr.type.tag == TypeTags.ARRAY &&
                 ((BArrayType) listConstructorExpr.type).state != BArrayState.UNSEALED) {
-            size = (long) ((BArrayType) listConstructorExpr.type).size;
+            size = ((BArrayType) listConstructorExpr.type).size;
         } else if (listConstructorExpr.type.tag == TypeTags.TUPLE) {
             size = listConstructorExpr.exprs.size();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -138,8 +138,8 @@ public class BIRTypeWriter implements TypeVisitor {
         BTypeSymbol tsymbol = bFiniteType.tsymbol;
         buff.writeInt(addStringCPEntry(tsymbol.name.value));
         buff.writeInt(tsymbol.flags);
-        buff.writeInt(bFiniteType.valueSpace.size());
-        for (BLangExpression valueLiteral : bFiniteType.valueSpace) {
+        buff.writeInt(bFiniteType.getValueSpace().size());
+        for (BLangExpression valueLiteral : bFiniteType.getValueSpace()) {
             if (!(valueLiteral instanceof BLangLiteral)) {
                 throw new AssertionError(
                         "Type serialization is not implemented for finite type with value: " + valueLiteral.getKind());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -1171,7 +1171,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                         ((BLangSimpleVarRef) literal).symbol.getKind() == SymbolKind.CONSTANT) {
                     BConstantSymbol constSymbol = (BConstantSymbol) ((BLangSimpleVarRef) literal).symbol;
                     return types.isAssignableToFiniteType(matchType,
-                            (BLangLiteral) ((BFiniteType) constSymbol.type).valueSpace.iterator().next());
+                            (BLangLiteral) ((BFiniteType) constSymbol.type).getValueSpace().iterator().next());
                 }
                 break;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -515,7 +515,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 return;
             case TypeTags.FINITE:
                 BFiniteType finiteType = (BFiniteType) reasonType;
-                for (BLangExpression expr : finiteType.valueSpace) {
+                for (BLangExpression expr : finiteType.getValueSpace()) {
                     validateModuleQualifiedReason(pos, (String) ((BLangLiteral) expr).value);
                 }
                 return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -961,7 +961,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         BFiniteType finiteType = new BFiniteType(finiteTypeSymbol);
         for (BLangExpression literal : finiteTypeNode.valueSpace) {
             ((BLangLiteral) literal).type = symTable.getTypeFromTag(((BLangLiteral) literal).type.tag);
-            finiteType.valueSpace.add(literal);
+            finiteType.addValue(literal);
         }
         finiteTypeSymbol.type = finiteType;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -476,7 +476,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
     private boolean literalAssignableToFiniteType(BLangLiteral literalExpr, BFiniteType finiteType,
                                                   int targetMemberTypeTag) {
-        return finiteType.valueSpace.stream()
+        return finiteType.getValueSpace().stream()
                 .anyMatch(valueExpr -> valueExpr.type.tag == targetMemberTypeTag &&
                         types.checkLiteralAssignabilityBasedOnType((BLangLiteral) valueExpr, literalExpr));
     }
@@ -527,7 +527,7 @@ public class TypeChecker extends BLangNodeVisitor {
         Set<BLangExpression> matchedValueSpace = new LinkedHashSet<>();
 
         for (BFiniteType finiteType : finiteTypeMembers) {
-            matchedValueSpace.addAll(finiteType.valueSpace.stream()
+            matchedValueSpace.addAll(finiteType.getValueSpace().stream()
                                              .filter(expression -> expression.type.tag == tag)
                                              .collect(Collectors.toSet()));
         }
@@ -636,7 +636,7 @@ public class TypeChecker extends BLangNodeVisitor {
                     return;
                 }
                 if (!types.hasFillerValue(arrayType.eType)) {
-                    dlog.error(listConstructor.pos, DiagnosticCode.INVALID_LIST_CONSTRUCTOR, expType);
+                    dlog.error(listConstructor.pos, DiagnosticCode.INVALID_LIST_CONSTRUCTOR_ELEMENT_TYPE, expType);
                     return;
                 }
             }
@@ -3182,7 +3182,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 return false;
             } else {
                 BFiniteType reasonType = (BFiniteType) ctorType.reasonType;
-                if (reasonType.valueSpace.size() > 1) {
+                if (reasonType.getValueSpace().size() > 1) {
                     dlog.error(iExpr.pos, DiagnosticCode.INDIRECT_ERROR_CTOR_NOT_ALLOWED_ON_NON_CONST_REASON,
                             iExpr.type);
                     return false;
@@ -3211,7 +3211,7 @@ public class TypeChecker extends BLangNodeVisitor {
             return true;
         } else {
             BFiniteType finiteType = (BFiniteType) errorType.reasonType;
-            if (finiteType.valueSpace.size() != 1) {
+            if (finiteType.getValueSpace().size() != 1) {
                 if (errorType == symTable.errorType) {
                     dlog.error(pos, DiagnosticCode.CANNOT_INFER_ERROR_TYPE, expType.tsymbol.name);
                 } else {
@@ -3248,7 +3248,7 @@ public class TypeChecker extends BLangNodeVisitor {
     private void setErrorReasonParam(BLangInvocation iExpr, boolean reasonArgGiven, BErrorType ctorType) {
         if (!reasonArgGiven && ctorType.reasonType.getKind() == TypeKind.FINITE) {
             BFiniteType finiteType = (BFiniteType) ctorType.reasonType;
-            BLangExpression reasonExpr = (BLangExpression) finiteType.valueSpace.toArray()[0];
+            BLangExpression reasonExpr = (BLangExpression) finiteType.getValueSpace().toArray()[0];
             iExpr.requiredArgs.add(reasonExpr);
             return;
         }
@@ -4418,7 +4418,7 @@ public class TypeChecker extends BLangNodeVisitor {
             case TypeTags.FINITE:
                 BFiniteType finiteIndexExpr = (BFiniteType) indexExprType;
                 boolean validIndexExists = false;
-                for (BLangExpression finiteMember : finiteIndexExpr.valueSpace) {
+                for (BLangExpression finiteMember : finiteIndexExpr.getValueSpace()) {
                     int indexValue = ((Long) ((BLangLiteral) finiteMember).value).intValue();
                     if (indexValue >= 0 &&
                             (arrayType.state == BArrayState.UNSEALED || indexValue < arrayType.size)) {
@@ -4443,7 +4443,7 @@ public class TypeChecker extends BLangNodeVisitor {
                     finiteType = finiteTypes.get(0);
                 } else {
                     Set<BLangExpression> valueSpace = new LinkedHashSet<>();
-                    finiteTypes.forEach(constituent -> valueSpace.addAll(constituent.valueSpace));
+                    finiteTypes.forEach(constituent -> valueSpace.addAll(constituent.getValueSpace()));
                     finiteType = new BFiniteType(null, valueSpace);
                 }
 
@@ -4504,7 +4504,7 @@ public class TypeChecker extends BLangNodeVisitor {
             case TypeTags.FINITE:
                 BFiniteType finiteIndexExpr = (BFiniteType) currentType;
                 LinkedHashSet<BType> possibleTypes = new LinkedHashSet<>();
-                for (BLangExpression finiteMember : finiteIndexExpr.valueSpace) {
+                for (BLangExpression finiteMember : finiteIndexExpr.getValueSpace()) {
                     int indexValue = ((Long) ((BLangLiteral) finiteMember).value).intValue();
                     BType fieldType = checkTupleFieldType(tuple, indexValue);
                     if (fieldType.tag != TypeTags.SEMANTIC_ERROR) {
@@ -4539,7 +4539,7 @@ public class TypeChecker extends BLangNodeVisitor {
                     finiteType = finiteTypes.get(0);
                 } else {
                     Set<BLangExpression> valueSpace = new LinkedHashSet<>();
-                    finiteTypes.forEach(constituent -> valueSpace.addAll(constituent.valueSpace));
+                    finiteTypes.forEach(constituent -> valueSpace.addAll(constituent.getValueSpace()));
                     finiteType = new BFiniteType(null, valueSpace);
                 }
 
@@ -4655,7 +4655,7 @@ public class TypeChecker extends BLangNodeVisitor {
             case TypeTags.FINITE:
                 BFiniteType finiteIndexExpr = (BFiniteType) currentType;
                 LinkedHashSet<BType> possibleTypes = new LinkedHashSet<>();
-                for (BLangExpression finiteMember : finiteIndexExpr.valueSpace) {
+                for (BLangExpression finiteMember : finiteIndexExpr.getValueSpace()) {
                     String fieldName = (String) ((BLangLiteral) finiteMember).value;
                     BType fieldType = checkRecordRequiredFieldAccess(accessExpr, names.fromString(fieldName), record);
                     if (fieldType == symTable.semanticError) {
@@ -4707,7 +4707,7 @@ public class TypeChecker extends BLangNodeVisitor {
                     finiteType = finiteTypes.get(0);
                 } else {
                     Set<BLangExpression> valueSpace = new LinkedHashSet<>();
-                    finiteTypes.forEach(constituent -> valueSpace.addAll(constituent.valueSpace));
+                    finiteTypes.forEach(constituent -> valueSpace.addAll(constituent.getValueSpace()));
                     finiteType = new BFiniteType(null, valueSpace);
                 }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2711,6 +2711,9 @@ public class Types {
     }
 
     private boolean checkFillerValue(BArrayType type) {
+        if (type.size == -1) {
+            return true;
+        }
         return hasFillerValue(type.eType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2634,7 +2634,7 @@ public class Types {
      * This will handle two types.
      *  Singleton : As singleton can have one value that value should it self be a valid fill value
      *  Union :
-     *          1. if nil is a member it is the fill valus
+     *          1. if nil is a member it is the fill values
      *          2. else all the values should belong to same type and the default value for that type
      *              should be a member of the union
      * @param type BFiniteType union or finite

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2631,7 +2631,7 @@ public class Types {
     }
 
     /**
-     * This will handle two types
+     * This will handle two types.
      *  Singleton : As singleton can have one value that value should it self be a valid fill value
      *  Union :
      *          1. if nil is a member it is the fill valus

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2656,12 +2656,15 @@ public class Types {
         BLangExpression firstElement = (BLangExpression) iterator.next();
         BType firstElementType = firstElement.type;
         String defaultFillValue = getDefaultFillValue(firstElement);
+        if (defaultFillValue.equals(DefaultValues.UNKNOWN.getValue())) {
+            return false;
+        }
         if (firstElement.toString().equals(defaultFillValue)) {
             defaultFillValuePresent = true;
         }
 
         while (iterator.hasNext()) {
-            Object value =  iterator.next();
+            Object value = iterator.next();
             BType valueType = ((BLangExpression) value).type;
             if (!isSameType(valueType, firstElementType)) {
                 return false;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -117,7 +117,7 @@ public class BFiniteType extends BType implements FiniteType {
 
     public void addValue(BLangExpression value) {
         this.valueSpace.add(value);
-        if (!nullable && (value.type.tag == TypeTags.NIL)) {
+        if (!nullable && value.type.isNullable()) {
             nullable = true;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.TypeDescriptor;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -54,7 +55,7 @@ public class BFiniteType extends BType implements FiniteType {
 
     @Override
     public Set<BLangExpression> getValueSpace() {
-        return valueSpace;
+        return Collections.unmodifiableSet(valueSpace);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -37,8 +37,10 @@ import java.util.StringJoiner;
  */
 public class BFiniteType extends BType implements FiniteType {
 
-    public Set<BLangExpression> valueSpace;
+    private Set<BLangExpression> valueSpace;
+    private boolean nullable = false;
     private Optional<Boolean> isAnyData = Optional.empty();
+
 
     public BFiniteType(BTypeSymbol tsymbol) {
         super(TypeTags.FINITE, tsymbol);
@@ -92,7 +94,7 @@ public class BFiniteType extends BType implements FiniteType {
 
     @Override
     public boolean isNullable() {
-        return this.valueSpace.stream().anyMatch(v -> v.type.tag == TypeTags.NIL);
+        return nullable;
     }
 
     @Override
@@ -110,5 +112,12 @@ public class BFiniteType extends BType implements FiniteType {
 
         this.isAnyData = Optional.of(true);
         return true;
+    }
+
+    public void addValue(BLangExpression value) {
+        this.valueSpace.add(value);
+        if (!nullable && (value.type.tag == TypeTags.NIL)) {
+            nullable = true;
+        }
     }
 }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -844,7 +844,7 @@ error.invalid.record.literal=\
 
 error.duplicate.key.in.record.literal=\
   invalid usage of {0} literal: duplicate key ''{1}''
-
+        
 error.invalid.array.literal=\
   invalid usage of array literal with type ''{0}''
 
@@ -853,6 +853,9 @@ error.invalid.tuple.literal=\
 
 error.invalid.list.constructor=\
   invalid usage of list constructor with type ''{0}''
+
+error.invalid.list.constructor.type=\
+  invalid usage of list constructor: type ''{0}'' does not have a filler value
 
 error.invalid.array.element.type=\
   array element type ''{0}'' does not have an implicit initial value, use ''{1}''

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/testgen/ValueSpaceGenerator.java
@@ -136,7 +136,7 @@ public class ValueSpaceGenerator {
         } else if (bType instanceof BFiniteType) {
             // Check for finite set assignment
             BFiniteType bFiniteType = (BFiniteType) bType;
-            Set<BLangExpression> valueSpace = bFiniteType.valueSpace;
+            Set<BLangExpression> valueSpace = bFiniteType.getValueSpace();
             if (!valueSpace.isEmpty()) {
                 return getValueSpaceByNode(importsAcceptor, currentPkgId, valueSpace.stream().findFirst().get(),
                                            template);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -448,7 +448,7 @@ public class CommonUtil {
                 typeString = "new()";
                 break;
             case FINITE:
-                List<BLangExpression> valueSpace = new ArrayList<>(((BFiniteType) bType).valueSpace);
+                List<BLangExpression> valueSpace = new ArrayList<>(((BFiniteType) bType).getValueSpace());
                 String value = valueSpace.get(0).toString();
                 BType type = valueSpace.get(0).type;
                 typeString = value;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FunctionGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FunctionGenerator.java
@@ -415,7 +415,7 @@ public class FunctionGenerator {
         } else if (bType instanceof BFiniteType) {
             // Check for finite set assignment
             BFiniteType bFiniteType = (BFiniteType) bType;
-            Set<BLangExpression> valueSpace = bFiniteType.valueSpace;
+            Set<BLangExpression> valueSpace = bFiniteType.getValueSpace();
             if (!valueSpace.isEmpty()) {
                 return generateReturnValue(importsAcceptor, currentPkgId, valueSpace.stream().findFirst().get(),
                         template);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -191,7 +191,7 @@ public class Type {
                 case TypeTags
                         .FINITE:
                         if (type instanceof BFiniteType) {
-                            Set<BLangExpression> valueSpace = ((BFiniteType) type).valueSpace;
+                            Set<BLangExpression> valueSpace = ((BFiniteType) type).getValueSpace();
                             if (valueSpace.size() == 1 && valueSpace.toArray()[0] instanceof BLangLiteral) {
                                 BLangLiteral literal = (BLangLiteral) valueSpace.toArray()[0];
                                 if (literal.isConstant) {

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/proto/ServiceProtoUtils.java
@@ -547,7 +547,7 @@ public class ServiceProtoUtils {
                 int enumFieldIndex = 0;
                 EnumField.Builder enumFieldBuilder = EnumField.newBuilder();
                 EnumField enumField;
-                for (BLangExpression bLangExpression : finiteType.valueSpace) {
+                for (BLangExpression bLangExpression : finiteType.getValueSpace()) {
                     String enumValue = String.valueOf(bLangExpression);
                     enumField = enumFieldBuilder.setIndex(enumFieldIndex++).setName(enumValue).build();
                     enumBuilder.addFieldDefinition(enumField);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BRunUtil.java
@@ -724,7 +724,7 @@ public class BRunUtil {
                 org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType finiteType =
                         (org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType) type;
                 Set<Object> valueSpace = new HashSet<>();
-                for (BLangExpression expr : finiteType.valueSpace) {
+                for (BLangExpression expr : finiteType.getValueSpace()) {
                     if (!(expr instanceof BLangLiteral)) {
                         continue;
                     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -59,4 +59,9 @@ public class ListConstructorExprTest {
                 23, 34);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
+
+    @Test
+    public void testListConstructorAutoFillExpr() {
+        BRunUtil.invoke(result, "testListConstructorAutoFillExpr");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -188,6 +188,24 @@ public class ArrayFillTest {
     }
 
     @Test
+    public void testTupleSealedArrayFill() {
+        BValue[] args = new BValue[]{new BInteger(index)};
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testTupleSealedArrayFill", args);
+        BValueArray tupleArr = (BValueArray) returns[0];
+        assertEquals(tupleArr.size(), index + 1);
+
+        for (int i = 0; i < index; i++) {
+            BValueArray tuple = (BValueArray) tupleArr.getBValue(i);
+            assertEquals(tuple.getBValue(0).stringValue(), "");
+            assertEquals(((BInteger) tuple.getBValue(1)).intValue(), 0);
+        }
+
+        BValueArray tuple = (BValueArray) tupleArr.getBValue(index);
+        assertEquals(tuple.getBValue(0).stringValue(), "Hello World!");
+        assertEquals(((BInteger) tuple.getBValue(1)).intValue(), 100);
+    }
+
+    @Test
     public void testMapArrayFill() {
         BMap<String, BValue> emptyMap = new BMap<>(BTypes.typeMap);
         BMap<String, BValue> map = new BMap<>(BTypes.typeMap);
@@ -392,9 +410,37 @@ public class ArrayFillTest {
     }
 
     @Test
+    public void testAnySealedArrayFill() {
+        BValue[] args = new BValue[]{new BInteger(index)};
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testAnySealedArrayFill", args);
+        BValueArray unionArr = (BValueArray) returns[0];
+        assertEquals(unionArr.size(), index + 1);
+
+        for (int i = 0; i < index; i++) {
+            assertNull(unionArr.getBValue(i));
+        }
+
+        assertEquals(unionArr.getBValue(index).stringValue(), "{name:\"John\", age:25}");
+    }
+
+    @Test
     public void testAnydataArrayFill() {
         BValue[] args = new BValue[]{new BInteger(index)};
         BValue[] returns = BRunUtil.invokeFunction(compileResult, "testAnydataArrayFill", args);
+        BValueArray unionArr = (BValueArray) returns[0];
+        assertEquals(unionArr.size(), index + 1);
+
+        for (int i = 0; i < index; i++) {
+            assertNull(unionArr.getBValue(i));
+        }
+
+        assertEquals(unionArr.getBValue(index).stringValue(), "{name:\"John\", age:25}");
+    }
+
+    @Test
+    public void testAnydataSealedArrayFill() {
+        BValue[] args = new BValue[]{new BInteger(index)};
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testAnydataSealedArrayFill", args);
         BValueArray unionArr = (BValueArray) returns[0];
         assertEquals(unionArr.size(), index + 1);
 
@@ -458,6 +504,15 @@ public class ArrayFillTest {
     }
 
     @Test
+    public void testSingletonTypeArrayStaticFill() {
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testSingletonTypeArrayStaticFill");
+        BValueArray singletonArray = (BValueArray) returns[0];
+        assertEquals(singletonArray.size(), 2);
+        assertEquals(singletonArray.getRefValue(0).stringValue(), "true");
+        assertEquals(singletonArray.getRefValue(1).stringValue(), "true");
+    }
+
+    @Test
     public void testSequentialArrayInsertion() {
         BValue[] returns = BRunUtil.invokeFunction(compileResult, "testSequentialArrayInsertion");
         BValueArray resultArray = (BValueArray) returns[0];
@@ -485,15 +540,6 @@ public class ArrayFillTest {
         BValue[] returns = BRunUtil.invokeFunction(compileResult, "testFiniteTypeArrayFill");
         Assert.assertEquals(returns[0].getType().getTag(), TypeTags.ARRAY_TAG);
         Assert.assertEquals(((BValueArray) returns[0]).getValues()[5].value().toString(), "1.2");
-    }
-
-    @Test(enabled = false)
-    public void testRecordTypeWithOptionalFieldsArrayFill() {
-        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testRecordTypeWithOptionalFieldsArrayFill");
-        BValueArray resultArray = (BValueArray) returns[0];
-        assertEquals(resultArray.size(), 2);
-        assertEquals(resultArray.getBValue(0).stringValue(), "{j:0}");  // this fails
-        assertEquals(resultArray.getBValue(1).stringValue(), "{j:2, i:1}");
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -38,7 +38,7 @@ public class ArrayFillTestRuntime {
     }
 
     @Test
-    public void runtimeArrayFillTest(){
+    public void runtimeArrayFillTest() {
         BCompileUtil.runMain(compileResult, new String[]{});
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.statements.arrays;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for filling the elements of the array with its type's implicit initial value.
+ *
+ * @since 1.1.1
+ */
+public class ArrayFillTestRuntime {
+
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/statements/arrays/array_fill_runtime_test.bal");
+    }
+
+    @Test
+    public void runtimeArrayFillTest(){
+        BCompileUtil.runMain(compileResult, new String[]{});
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * Test cases for filling the elements of the array with its type's implicit initial value.
  *
- * @since 1.1.1
+ * @since 1.2.0
  */
 public class ArrayFillTestRuntime {
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -211,4 +211,9 @@ public class ArrayTest {
     public void createAbstractObjectEmptyArray() {
         BRunUtil.invokeFunction(compileResult, "createAbstractObjectEmptyArray");
     }
+
+    @Test
+    public void testObjectDynamicArrayFilling() {
+        BRunUtil.invokeFunction(compileResult, "testObjectDynamicArrayFilling");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -206,4 +206,9 @@ public class ArrayTest {
         BInteger value = (BInteger) retVals[0];
         Assert.assertEquals(value.intValue(), 4);
     }
+
+    @Test
+    public void createAbstractObjectEmptyArray() {
+        BRunUtil.invokeFunction(compileResult, "createAbstractObjectEmptyArray");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -36,177 +36,115 @@ import org.testng.annotations.Test;
  */
 public class SealedArrayTest {
 
-    private CompileResult compileResult, resultNegative, semanticsNegative;
+    private CompileResult compileResult, resultNegative, semanticsNegative, listExprNegative;
 
     @BeforeClass
     public void setup() {
         compileResult = BCompileUtil.compile("test-src/statements/arrays/sealed-array.bal");
         resultNegative = BCompileUtil.compile("test-src/statements/arrays/sealed-array-negative.bal");
+        listExprNegative = BCompileUtil.compile("test-src/statements/arrays/sealed_array_listexpr_negative.bal");
         semanticsNegative = BCompileUtil.compile("test-src/statements/arrays/sealed-array-semantics-negative" +
                 ".bal");
     }
 
     @Test
     public void testCreateIntegerSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createIntSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createIntSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createIntSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createIntAutoFilledSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createIntDefaultSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(returnValues[0].stringValue(), "[0, 0, 0, 0, 0]", "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createIntSealedArrayWithLabel");
+
+        BRunUtil.invoke(compileResult, "createIntDefaultSealedArray");
     }
 
     @Test
     public void testCreateBooleanSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createBoolSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createBoolSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createBoolSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createBoolAutoFilledSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createBoolDefaultSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(returnValues[0].stringValue(),
-                "[false, false, false, false, false]", "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createBoolSealedArrayWithLabel");
+
+        BRunUtil.invoke(compileResult, "createBoolDefaultSealedArray");
     }
 
     @Test
     public void testCreateFloatSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createFloatSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createFloatSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createFloatSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createFloatAutoFilledSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createFloatDefaultSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(returnValues[0].stringValue(), "[0.0, 0.0, 0.0, 0.0, 0.0]", "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createFloatSealedArrayWithLabel");
+
+        BRunUtil.invoke(compileResult, "createFloatDefaultSealedArray");
     }
 
     @Test
     public void testCreateStringSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createStringSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createStringSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createStringSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createStringAutoFilledSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createStringDefaultSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(returnValues[0].stringValue(), "[\"\", \"\", \"\", \"\", \"\"]", "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createStringSealedArrayWithLabel");
+
+        BRunUtil.invoke(compileResult, "createStringDefaultSealedArray");
     }
 
     @Test
     public void testCreateJSONSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createJSONSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createJSONSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createJSONSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createJSONSealedArrayWithLabel");
 
-        returnValues = BRunUtil.invoke(compileResult, "createJSONDefaultSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(returnValues[0].stringValue(), "[null, null, null, null, null]", "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createJSONDefaultSealedArray");
+
+        BRunUtil.invoke(compileResult, "createJSONAutoFilledSealedArray");
     }
 
     @Test
     public void testCreateAnySealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createAnySealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createAnySealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createAnySealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createAnyAutoFilledSealedArray");
+
+        BRunUtil.invoke(compileResult, "createAnySealedArrayWithLabel");
     }
 
     @Test
     public void testCreateRecordSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createRecordSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createRecordSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createRecordSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createRecordAutoFilledSealedArray");
+
+        BRunUtil.invoke(compileResult, "createRecordSealedArrayWithLabel");
     }
 
     @Test
     public void testCreateByteSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createByteSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createByteSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createByteSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createByteAutoFilledSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createByteDefaultSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(returnValues[0].stringValue(), "[0, 0, 0, 0, 0]", "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 5, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createByteSealedArrayWithLabel");
+
+        BRunUtil.invoke(compileResult, "createByteDefaultSealedArray");
     }
 
     @Test
     public void testCreateTupleSealedArray() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "createTupleSealedArray");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 3, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createTupleSealedArray");
 
-        returnValues = BRunUtil.invoke(compileResult, "createTupleSealedArrayWithLabel");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 3, "Length didn't match");
+        BRunUtil.invoke(compileResult, "createTupleAutoFilledSealedArray");
+
+        BRunUtil.invoke(compileResult, "createTupleSealedArrayWithLabel");
     }
 
     @Test
     public void testFunctionParametersAndReturnValues() {
-        BValue[] returnValues = BRunUtil.invoke(compileResult, "functionParametersAndReturns");
-        Assert.assertFalse(
-                returnValues == null || returnValues.length == 0 || returnValues[0] == null, "Invalid Return Values.");
-        Assert.assertEquals(((BInteger) returnValues[0]).intValue(), 3, "Length didn't match");
-        Assert.assertEquals(((BInteger) returnValues[1]).intValue(), 2, "Length didn't match");
+        BRunUtil.invoke(compileResult, "functionParametersAndReturns");
+
+        BRunUtil.invoke(compileResult, "functionParametersAndReturnsAutoFilling");
     }
 
     @Test
@@ -282,51 +220,67 @@ public class SealedArrayTest {
         BAssertUtil.validateError(resultNegative, 0, "variable 'sealedArray1' is not initialized", 19, 5);
     }
 
+    // TODO : uncomment
+    @Test()
+    public void testNegativeAutoFillSealedArray() {
+        Assert.assertEquals(listExprNegative.getErrorCount(), 7);
+        BAssertUtil.validateError(listExprNegative, 0, "invalid usage of list constructor with type 'Person[5]'", 24,
+                                  19);
+        BAssertUtil.validateError(listExprNegative, 1, "invalid usage of list constructor with type 'Person[5][]'", 31,
+                                  21);
+        BAssertUtil.validateError(listExprNegative, 2, "invalid usage of list constructor with type 'Person[5][1]'", 32,
+                                  22);
+        BAssertUtil.validateError(listExprNegative, 3, "invalid usage of list constructor with type 'Age[5][]'", 44,
+                                  18);
+        BAssertUtil.validateError(listExprNegative, 4, "invalid usage of list constructor with type 'Age[5][1]'", 45,
+                                  19);
+        BAssertUtil.validateError(listExprNegative, 5, "invalid usage of list constructor with type '1|2|3|4[3]'", 66,
+                                  18);
+        BAssertUtil.validateError(listExprNegative, 6, "invalid usage of list constructor with type '0|0.0f|[3]'", 72,
+                                  34);
+    }
+
     @Test()
     public void testSemanticsNegativeSealedArrays() {
-        Assert.assertEquals(semanticsNegative.getErrorCount(), 24);
+        Assert.assertEquals(semanticsNegative.getErrorCount(), 22);
         int i = 0;
         BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 19, 30);
         BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 25, 33);
-        BAssertUtil.validateError(semanticsNegative, i++, "size mismatch in sealed array. expected '4', but found '3'",
+        BAssertUtil.validateError(semanticsNegative, i++, "size mismatch in sealed array. expected '4', but found '5'",
                 30, 31);
-        BAssertUtil.validateError(semanticsNegative, i++, "size mismatch in sealed array. expected '4', but found '5'",
-                31, 31);
+        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 36, 18);
         BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 37, 18);
-        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 38, 18);
         BAssertUtil.validateError(semanticsNegative, i++, "invalid usage of sealed type: array not initialized",
-                39, 5);
+                38, 5);
         BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'int[3]', found 'int[]'",
-                46, 17);
+                45, 17);
         BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'string[2]', found 'string[]'",
-                52, 34);
+                51, 34);
         BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'boolean[4]', found " +
-                "'boolean[3]'", 52, 47);
-        BAssertUtil.validateError(semanticsNegative, i++, "ambiguous type '(int|int[]|int[4])'", 63, 30);
-        BAssertUtil.validateError(semanticsNegative, i++, "ambiguous type '(int|int[]|int[4]|int[5])'", 65, 40);
-        BAssertUtil.validateError(semanticsNegative, i++, "size mismatch in sealed array. expected '4', but found '2'",
-                79, 18);
+                "'boolean[3]'", 51, 47);
+        BAssertUtil.validateError(semanticsNegative, i++, "ambiguous type '(int|int[]|int[4])'", 62, 30);
+        BAssertUtil.validateError(semanticsNegative, i++, "ambiguous type '(int|int[]|int[4]|int[5])'", 64, 40);
         BAssertUtil.validateError(semanticsNegative, i++, "size mismatch in sealed array. expected '4', but found '5'",
-                80, 18);
-        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '4'", 83, 8);
-        BAssertUtil.validateError(semanticsNegative, i++, "invalid usage of sealed type: can not infer array size", 85,
+                78, 18);
+        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '4'", 81, 8);
+        BAssertUtil.validateError(semanticsNegative, i++, "invalid usage of sealed type: can not infer array size", 83,
                 18);
-        BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'json[3]', found 'json[]'", 87,
+        BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'json[3]', found 'json[]'", 85,
                 18);
         BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'int', found 'S1|S2'",
-                106, 20);
+                104, 20);
         BAssertUtil.validateError(semanticsNegative, i++, "invalid list index expression: value space '3|4|5' " +
-                "out of range", 107, 20);
+                "out of range", 105, 20);
         BAssertUtil.validateError(semanticsNegative, i++, "invalid list index expression: value space '3|4|5' " +
-                "out of range", 108, 23);
+                "out of range", 106, 23);
         BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'int', found " +
-                "'0|1|2|S1'", 109, 20);
+                "'0|1|2|S1'", 107, 20);
         BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'int', found " +
-                        "'(0|1|2|S1|S3)'", 110, 20);
+                        "'(0|1|2|S1|S3)'", 108, 20);
         BAssertUtil.validateError(semanticsNegative, i++, "invalid list index expression: value space " +
-                "'(3|4|5|7)' out of range", 111, 23);
+                "'(3|4|5|7)' out of range", 109, 23);
         BAssertUtil.validateError(semanticsNegative, i, "incompatible types: expected 'int[*]', found " +
-                        "'int[]'", 116, 22);
+                        "'int[]'", 114, 22);
     }
 
     @Test(description = "Test accessing invalid index of sealed array",
@@ -342,6 +296,28 @@ public class SealedArrayTest {
             expectedExceptionsMessageRegExp = ".*error:.*array index out of range: index: 4, size: 3.*")
     public void assignedArrayInvalidIndexAccess() {
         BRunUtil.invoke(compileResult, "assignedArrayInvalidIndexAccess");
+    }
+
+    @Test(description = "Test accessing invalid index of sealed auto filled array when assigned to unsealed array",
+          expectedExceptions = {BLangRuntimeException.class},
+          expectedExceptionsMessageRegExp = ".*error:.*array index out of range: index: 4, size: 3.*")
+    public void assignedAutoFilledArrayInvalidIndexAccess() {
+        BRunUtil.invoke(compileResult, "assignedAutoFilledArrayInvalidIndexAccess");
+    }
+
+    @Test(description = "Union array fill with an union which has default fill value as a member value.")
+    public void createUnionAutoFillArray() {
+        BRunUtil.invoke(compileResult, "createUnionAutoFillArray");
+    }
+
+    @Test(description = "Test union array fill with list-expr with an union with nil")
+    public void createNullableUnionAutoFillArray() {
+        BRunUtil.invoke(compileResult, "createNullableUnionAutoFillArray");
+    }
+
+    @Test(description = "Test non homogeneous union array fill with list-expr with an union with nil")
+    public void createNullableNonHomogeneousUnionAutoFillArray() {
+        BRunUtil.invoke(compileResult, "createNullableNonHomogeneousUnionAutoFillArray");
     }
 
     @Test(description = "Test accessing invalid index of sealed array matched union type",
@@ -414,5 +390,10 @@ public class SealedArrayTest {
         bIntArray.add(2, 5);
         BValue[] args = {bIntArray, new BInteger(3)};
         BRunUtil.invoke(compileResult, "testSealedArrayConstrainedMapInvalidIndex", args);
+    }
+
+    @Test
+    public void testCreateXMLSealedArray() {
+        BRunUtil.invoke(compileResult, "createXMLAutoFilledSealedArray");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -225,54 +225,47 @@ public class SealedArrayTest {
     // TODO : uncomment
     @Test()
     public void testNegativeAutoFillSealedArray() {
-        Assert.assertEquals(listExprNegative.getErrorCount(), 12);
+        Assert.assertEquals(listExprNegative.getErrorCount(), 10);
         BAssertUtil.validateError(listExprNegative, 0,
                                   "invalid usage of list constructor: type 'Person[5]' does not have a filler value",
                                   24,
                                   19);
         BAssertUtil.validateError(listExprNegative, 1,
-                                  "invalid usage of list constructor: type 'Person[5][]' does not have a filler value",
-                                  31,
-                                  21);
-        BAssertUtil.validateError(listExprNegative, 2,
                                   "invalid usage of list constructor: type 'Person[5][1]' does not have a filler value",
                                   32,
                                   22);
-        BAssertUtil.validateError(listExprNegative, 3,
-                                  "invalid usage of list constructor: type 'Age[5][]' does not have a filler value", 44,
-                                  18);
-        BAssertUtil.validateError(listExprNegative, 4,
+        BAssertUtil.validateError(listExprNegative, 2,
                                   "invalid usage of list constructor: type 'Age[5][1]' does not have a filler value",
                                   45,
                                   19);
-        BAssertUtil.validateError(listExprNegative, 5,
+        BAssertUtil.validateError(listExprNegative, 3,
                                   "invalid usage of list constructor: type '1|2|3|4[3]' does not have a filler value",
                                   66,
                                   18);
-        BAssertUtil.validateError(listExprNegative, 6,
+        BAssertUtil.validateError(listExprNegative, 4,
                                   "invalid usage of list constructor: type '0|0.0f|[3]' does not have a filler value",
                                   72,
                                   34);
-        BAssertUtil.validateError(listExprNegative, 7,
+        BAssertUtil.validateError(listExprNegative, 5,
                                   "invalid usage of list constructor: type 'Rec[2]' does not have a filler value",
                                   91,
                                   16);
-        BAssertUtil.validateError(listExprNegative, 8,
+        BAssertUtil.validateError(listExprNegative, 6,
                                   "invalid usage of list constructor: type 'RecWithManyOptional[2]' does not have a " +
                                           "filler value",
                                   95,
                                   32);
-        BAssertUtil.validateError(listExprNegative, 9,
+        BAssertUtil.validateError(listExprNegative, 7,
                                   "invalid usage of list constructor: type 'RecWithOptional[2]' does not have a " +
                                           "filler value",
                                   99,
                                   28);
-        BAssertUtil.validateError(listExprNegative, 10,
+        BAssertUtil.validateError(listExprNegative, 8,
                                   "invalid usage of list constructor: type 'ObjError[2]' does not have a " +
                                           "filler value",
                                   112,
                                   22);
-        BAssertUtil.validateError(listExprNegative, 11,
+        BAssertUtil.validateError(listExprNegative, 9,
                                   "invalid usage of list constructor: type '(HELLO|2)[2]' does not have a filler " +
                                           "value",
                                   121,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -225,7 +225,7 @@ public class SealedArrayTest {
     // TODO : uncomment
     @Test()
     public void testNegativeAutoFillSealedArray() {
-        Assert.assertEquals(listExprNegative.getErrorCount(), 11);
+        Assert.assertEquals(listExprNegative.getErrorCount(), 12);
         BAssertUtil.validateError(listExprNegative, 0,
                                   "invalid usage of list constructor: type 'Person[5]' does not have a filler value",
                                   24,
@@ -272,6 +272,11 @@ public class SealedArrayTest {
                                           "filler value",
                                   112,
                                   22);
+        BAssertUtil.validateError(listExprNegative, 11,
+                                  "invalid usage of list constructor: type '(HELLO|2)[2]' does not have a filler " +
+                                          "value",
+                                  121,
+                                  34);
     }
 
     @Test()

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -305,6 +305,11 @@ public class SealedArrayTest {
         BRunUtil.invoke(compileResult, "createUnionAutoFillArray");
     }
 
+    @Test(description = "Float Union array fill with an union which has default fill value as a member value.")
+    public void createUnionFloatAutoFillArray() {
+        BRunUtil.invoke(compileResult, "createUnionFloatAutoFillArray");
+    }
+
     @Test(description = "Test union array fill with list-expr with an union with nil")
     public void createNullableUnionAutoFillArray() {
         BRunUtil.invoke(compileResult, "createNullableUnionAutoFillArray");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -50,102 +50,76 @@ public class SealedArrayTest {
     @Test
     public void testCreateIntegerSealedArray() {
         BRunUtil.invoke(compileResult, "createIntSealedArray");
-
         BRunUtil.invoke(compileResult, "createIntAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createIntSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createIntDefaultSealedArray");
     }
 
     @Test
     public void testCreateBooleanSealedArray() {
         BRunUtil.invoke(compileResult, "createBoolSealedArray");
-
         BRunUtil.invoke(compileResult, "createBoolAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createBoolSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createBoolDefaultSealedArray");
     }
 
     @Test
     public void testCreateFloatSealedArray() {
         BRunUtil.invoke(compileResult, "createFloatSealedArray");
-
         BRunUtil.invoke(compileResult, "createFloatAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createFloatSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createFloatDefaultSealedArray");
     }
 
     @Test
     public void testCreateStringSealedArray() {
         BRunUtil.invoke(compileResult, "createStringSealedArray");
-
         BRunUtil.invoke(compileResult, "createStringAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createStringSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createStringDefaultSealedArray");
     }
 
     @Test
     public void testCreateJSONSealedArray() {
         BRunUtil.invoke(compileResult, "createJSONSealedArray");
-
         BRunUtil.invoke(compileResult, "createJSONSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createJSONDefaultSealedArray");
-
         BRunUtil.invoke(compileResult, "createJSONAutoFilledSealedArray");
     }
 
     @Test
     public void testCreateAnySealedArray() {
         BRunUtil.invoke(compileResult, "createAnySealedArray");
-
         BRunUtil.invoke(compileResult, "createAnyAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createAnySealedArrayWithLabel");
     }
 
     @Test
     public void testCreateRecordSealedArray() {
         BRunUtil.invoke(compileResult, "createRecordSealedArray");
-
         BRunUtil.invoke(compileResult, "createRecordAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createRecordSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createRecordSealedArrayAutoFill");
     }
 
     @Test
     public void testCreateByteSealedArray() {
         BRunUtil.invoke(compileResult, "createByteSealedArray");
-
         BRunUtil.invoke(compileResult, "createByteAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createByteSealedArrayWithLabel");
-
         BRunUtil.invoke(compileResult, "createByteDefaultSealedArray");
     }
 
     @Test
     public void testCreateTupleSealedArray() {
         BRunUtil.invoke(compileResult, "createTupleSealedArray");
-
         BRunUtil.invoke(compileResult, "createTupleAutoFilledSealedArray");
-
         BRunUtil.invoke(compileResult, "createTupleSealedArrayWithLabel");
     }
 
     @Test
     public void testFunctionParametersAndReturnValues() {
         BRunUtil.invoke(compileResult, "functionParametersAndReturns");
-
         BRunUtil.invoke(compileResult, "functionParametersAndReturnsAutoFilling");
     }
 
@@ -222,54 +196,43 @@ public class SealedArrayTest {
         BAssertUtil.validateError(resultNegative, 0, "variable 'sealedArray1' is not initialized", 19, 5);
     }
 
-    // TODO : uncomment
     @Test()
     public void testNegativeAutoFillSealedArray() {
         Assert.assertEquals(listExprNegative.getErrorCount(), 10);
         BAssertUtil.validateError(listExprNegative, 0,
                                   "invalid usage of list constructor: type 'Person[5]' does not have a filler value",
-                                  24,
-                                  19);
+                                  24, 19);
         BAssertUtil.validateError(listExprNegative, 1,
                                   "invalid usage of list constructor: type 'Person[5][1]' does not have a filler value",
-                                  32,
-                                  22);
+                                  31, 22);
         BAssertUtil.validateError(listExprNegative, 2,
                                   "invalid usage of list constructor: type 'Age[5][1]' does not have a filler value",
-                                  45,
-                                  19);
+                                  43, 19);
         BAssertUtil.validateError(listExprNegative, 3,
                                   "invalid usage of list constructor: type '1|2|3|4[3]' does not have a filler value",
-                                  66,
-                                  18);
+                                  63, 18);
         BAssertUtil.validateError(listExprNegative, 4,
                                   "invalid usage of list constructor: type '0|0.0f|[3]' does not have a filler value",
-                                  72,
-                                  34);
+                                  69, 34);
         BAssertUtil.validateError(listExprNegative, 5,
                                   "invalid usage of list constructor: type 'Rec[2]' does not have a filler value",
-                                  91,
-                                  16);
+                                  88, 16);
         BAssertUtil.validateError(listExprNegative, 6,
                                   "invalid usage of list constructor: type 'RecWithManyOptional[2]' does not have a " +
                                           "filler value",
-                                  95,
-                                  32);
+                                  92, 32);
         BAssertUtil.validateError(listExprNegative, 7,
                                   "invalid usage of list constructor: type 'RecWithOptional[2]' does not have a " +
                                           "filler value",
-                                  99,
-                                  28);
+                                  96, 28);
         BAssertUtil.validateError(listExprNegative, 8,
                                   "invalid usage of list constructor: type 'ObjError[2]' does not have a " +
                                           "filler value",
-                                  112,
-                                  22);
+                                  109, 22);
         BAssertUtil.validateError(listExprNegative, 9,
                                   "invalid usage of list constructor: type '(HELLO|2)[2]' does not have a filler " +
                                           "value",
-                                  121,
-                                  34);
+                                  118, 34);
     }
 
     @Test()

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -225,7 +225,7 @@ public class SealedArrayTest {
     // TODO : uncomment
     @Test()
     public void testNegativeAutoFillSealedArray() {
-        Assert.assertEquals(listExprNegative.getErrorCount(), 10);
+        Assert.assertEquals(listExprNegative.getErrorCount(), 11);
         BAssertUtil.validateError(listExprNegative, 0,
                                   "invalid usage of list constructor: type 'Person[5]' does not have a filler value",
                                   24,
@@ -267,6 +267,11 @@ public class SealedArrayTest {
                                           "filler value",
                                   99,
                                   28);
+        BAssertUtil.validateError(listExprNegative, 10,
+                                  "invalid usage of list constructor: type 'ObjError[2]' does not have a " +
+                                          "filler value",
+                                  112,
+                                  22);
     }
 
     @Test()

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -118,6 +118,8 @@ public class SealedArrayTest {
         BRunUtil.invoke(compileResult, "createRecordAutoFilledSealedArray");
 
         BRunUtil.invoke(compileResult, "createRecordSealedArrayWithLabel");
+
+        BRunUtil.invoke(compileResult, "createRecordSealedArrayAutoFill");
     }
 
     @Test
@@ -223,21 +225,48 @@ public class SealedArrayTest {
     // TODO : uncomment
     @Test()
     public void testNegativeAutoFillSealedArray() {
-        Assert.assertEquals(listExprNegative.getErrorCount(), 7);
-        BAssertUtil.validateError(listExprNegative, 0, "invalid usage of list constructor with type 'Person[5]'", 24,
+        Assert.assertEquals(listExprNegative.getErrorCount(), 10);
+        BAssertUtil.validateError(listExprNegative, 0,
+                                  "invalid usage of list constructor: type 'Person[5]' does not have a filler value",
+                                  24,
                                   19);
-        BAssertUtil.validateError(listExprNegative, 1, "invalid usage of list constructor with type 'Person[5][]'", 31,
+        BAssertUtil.validateError(listExprNegative, 1,
+                                  "invalid usage of list constructor: type 'Person[5][]' does not have a filler value",
+                                  31,
                                   21);
-        BAssertUtil.validateError(listExprNegative, 2, "invalid usage of list constructor with type 'Person[5][1]'", 32,
+        BAssertUtil.validateError(listExprNegative, 2,
+                                  "invalid usage of list constructor: type 'Person[5][1]' does not have a filler value",
+                                  32,
                                   22);
-        BAssertUtil.validateError(listExprNegative, 3, "invalid usage of list constructor with type 'Age[5][]'", 44,
+        BAssertUtil.validateError(listExprNegative, 3,
+                                  "invalid usage of list constructor: type 'Age[5][]' does not have a filler value", 44,
                                   18);
-        BAssertUtil.validateError(listExprNegative, 4, "invalid usage of list constructor with type 'Age[5][1]'", 45,
+        BAssertUtil.validateError(listExprNegative, 4,
+                                  "invalid usage of list constructor: type 'Age[5][1]' does not have a filler value",
+                                  45,
                                   19);
-        BAssertUtil.validateError(listExprNegative, 5, "invalid usage of list constructor with type '1|2|3|4[3]'", 66,
+        BAssertUtil.validateError(listExprNegative, 5,
+                                  "invalid usage of list constructor: type '1|2|3|4[3]' does not have a filler value",
+                                  66,
                                   18);
-        BAssertUtil.validateError(listExprNegative, 6, "invalid usage of list constructor with type '0|0.0f|[3]'", 72,
+        BAssertUtil.validateError(listExprNegative, 6,
+                                  "invalid usage of list constructor: type '0|0.0f|[3]' does not have a filler value",
+                                  72,
                                   34);
+        BAssertUtil.validateError(listExprNegative, 7,
+                                  "invalid usage of list constructor: type 'Rec[2]' does not have a filler value",
+                                  91,
+                                  16);
+        BAssertUtil.validateError(listExprNegative, 8,
+                                  "invalid usage of list constructor: type 'RecWithManyOptional[2]' does not have a " +
+                                          "filler value",
+                                  95,
+                                  32);
+        BAssertUtil.validateError(listExprNegative, 9,
+                                  "invalid usage of list constructor: type 'RecWithOptional[2]' does not have a " +
+                                          "filler value",
+                                  99,
+                                  28);
     }
 
     @Test()

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
@@ -37,8 +37,8 @@ function testListConstructorExpr() returns boolean {
 }
 
 function testListConstructorAutoFillExpr() {
-    int [8] arrOfEightInts = [1, 2, 3];
-    int  sum = 0;
+    int[8] arrOfEightInts = [1, 2, 3];
+    int sum = 0;
     int i = 0;
 
     while (i < 8) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
@@ -35,3 +35,18 @@ function testListConstructorExpr() returns boolean {
         && fooArr[0] == "DDD"
         && fooArr[1] == 444;
 }
+
+function testListConstructorAutoFillExpr() {
+    int [8] arrOfEightInts = [1, 2, 3];
+    int  sum = 0;
+    int i = 0;
+
+    while (i < 8) {
+        sum += arrOfEightInts[i];
+        i = i + 1;
+    }
+
+    if (sum != 6) {
+        panic error("Invalid sum of int array");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
@@ -70,6 +70,13 @@ function testTupleArrayFill(int index) returns [string, int][] {
     return ar;
 }
 
+function testTupleSealedArrayFill(int index) returns [string, int][] {
+    [string, int] tup = ["Hello World!", 100];
+    [string, int][251] ar = []; // 251 == index + 1
+    ar[index] = tup;
+    return ar;
+}
+
 function testMapArrayFill(int index, map<any> value) returns map<any>[] {
     map<any>[] ar = [];
     ar[index] = value;
@@ -150,10 +157,26 @@ function testAnyArrayFill(int index) returns any[] {
     return ar;
 }
 
+function testAnySealedArrayFill(int index) returns any[] {
+    Person p = {name:"John", age:25};
+    any value = p;
+    any[251] ar = []; // 251 == index + 1
+    ar[index] = value;
+    return ar;
+}
+
 function testAnydataArrayFill(int index) returns anydata[] {
     Person p = {name:"John", age:25};
     anydata value = p;
     anydata[] ar = [];
+    ar[index] = value;
+    return ar;
+}
+
+function testAnydataSealedArrayFill(int index) returns anydata[] {
+    Person p = {name:"John", age:25};
+    anydata value = p;
+    anydata[251] ar = []; // 251 == index + 1
     ar[index] = value;
     return ar;
 }
@@ -236,6 +259,12 @@ function testSingletonTypeArrayFill1() returns bTrue[] {
     return bTrueAr1;
 }
 
+function testSingletonTypeArrayStaticFill() returns bTrue[] {
+    bTrue[2] bTrueAr1 = [];
+    bTrueAr1[1] = true;
+    return bTrueAr1;
+}
+
 type Student object {
     public string name;
     public int age;
@@ -279,17 +308,6 @@ function testArrayFillWithObjs() returns Obj[][] {
     multiDimObjArray[0] = objArray;
     multiDimObjArray[2] = objArray;
     return multiDimObjArray;
-}
-
-type Rec record {
-    int i?;
-    int j = 10;
-};
-
-function testRecordTypeWithOptionalFieldsArrayFill() returns Rec[] {
-    Rec[] x = [];
-    x[1] = {i: 1, j: 2};
-    return x;
 }
 
 const decimal ZERO = 0.0;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
@@ -56,7 +56,7 @@ type Person record {
 };
 
 function testArrayOfArraysFill(int index) returns Person[][] {
-    Person p = {name:"John", age:25};
+    Person p = {name: "John", age: 25};
     Person[] personArr = [p, p];
     Person[][] ar = [];
     ar[index] = personArr;
@@ -126,7 +126,7 @@ function testUnionArrayFill2(int index) returns (string|string)[] {
 }
 
 function testUnionArrayFill3(int index) returns (Person|Person|())[] {
-    (Person|Person) value = {name:"John", age:25};
+    (Person|Person) value = {name: "John", age: 25};
     (Person|Person|())[] ar = [];
     ar[index] = value;
     return ar;
@@ -150,7 +150,7 @@ function testOptionalTypeArrayFill(int index) returns string?[] {
 }
 
 function testAnyArrayFill(int index) returns any[] {
-    Person p = {name:"John", age:25};
+    Person p = {name: "John", age: 25};
     any value = p;
     any[] ar = [];
     ar[index] = value;
@@ -158,7 +158,7 @@ function testAnyArrayFill(int index) returns any[] {
 }
 
 function testAnySealedArrayFill(int index) returns any[] {
-    Person p = {name:"John", age:25};
+    Person p = {name: "John", age: 25};
     any value = p;
     any[251] ar = []; // 251 == index + 1
     ar[index] = value;
@@ -166,7 +166,7 @@ function testAnySealedArrayFill(int index) returns any[] {
 }
 
 function testAnydataArrayFill(int index) returns anydata[] {
-    Person p = {name:"John", age:25};
+    Person p = {name: "John", age: 25};
     anydata value = p;
     anydata[] ar = [];
     ar[index] = value;
@@ -174,7 +174,7 @@ function testAnydataArrayFill(int index) returns anydata[] {
 }
 
 function testAnydataSealedArrayFill(int index) returns anydata[] {
-    Person p = {name:"John", age:25};
+    Person p = {name: "John", age: 25};
     anydata value = p;
     anydata[251] ar = []; // 251 == index + 1
     ar[index] = value;
@@ -188,7 +188,7 @@ function testByteArrayFill(int index, byte value) returns byte[] {
 }
 
 function testJSONArrayFill(int index) returns json[] {
-    json value = {name:"John", age:25};
+    json value = {name: "John", age: 25};
     json[] ar = [];
     ar[index] = value;
     return ar;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -153,3 +153,23 @@ function testGetFromFrozenArray() returns int {
 
     return -1;
 }
+
+type Age object {
+    public int age;
+    public function __init(int age) {
+    	 self.age = age;
+    }
+};
+
+function testObjectDynamicArrayFilling() {
+    Age[] y = [];
+    y[0] = new(5);
+    y[1] = new(5);
+}
+
+function assertArrayLengthPanic(int expected, any[] arr, string message = "Array length did not match") {
+    int actual = arr.length();
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -165,6 +165,7 @@ function testObjectDynamicArrayFilling() {
     Age[] y = [];
     y[0] = new(5);
     y[1] = new(5);
+    assertArrayLengthPanic(2, y);
 }
 
 type AbstractPersonObject abstract object {
@@ -199,8 +200,4 @@ function assertArrayLengthPanic(int expected, any[] arr, string message = "Array
     if (expected != actual) {
         panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
     }
-}
-
-public function main() {
-    createAbstractObjectEmptyArray();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -167,9 +167,40 @@ function testObjectDynamicArrayFilling() {
     y[1] = new(5);
 }
 
+type AbstractPersonObject abstract object {
+    public string fName;
+    public string lName;
+    function getFullName() returns string;
+};
+
+type Employee object {
+    *AbstractPersonObject;
+    function __init(string fname, string lname) {
+        self.fName = fname;
+        self.lName = lname;
+    }
+    function getFullName() returns string {
+        return self.fName + " " + self.lName;
+    }
+};
+
+function createAbstractObjectEmptyArray() {
+    AbstractPersonObject[5][] y = [];
+    AbstractPersonObject e1 = new Employee("John", "Doe");
+    y[0] = [e1];
+    AbstractPersonObject[][5] r = [];
+    r[0] = [e1, e1, e1, e1, e1];
+    assertArrayLengthPanic(5, r[0]);
+    assertArrayLengthPanic(1, y[0]);
+}
+
 function assertArrayLengthPanic(int expected, any[] arr, string message = "Array length did not match") {
     int actual = arr.length();
     if (expected != actual) {
         panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
     }
+}
+
+public function main() {
+    createAbstractObjectEmptyArray();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_fill_runtime_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_fill_runtime_test.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Rec record {
+    int i?;
+    int j = 10;
+};
+
+type Obj object {
+    int i;
+
+    function __init() {
+        self.i = 1;
+    }
+};
+
+type Age object {
+    public int age;
+    public function __init(int age = 5) {
+    	 self.age = age;
+    }
+};
+
+// TODO: fix me
+function testObjectDynamicArrayFilling() {
+    //Age[2] y = [];
+    //y[1] = new(10);
+    //
+    //assertEqualPanic(5, y[0].age);
+    //assertEqualPanic(10, y[1].age);
+}
+
+function testRecordTypeWithOptionalFieldsArrayFill() {
+    Rec[] x = [];
+    x[1] = {i: 1, j: 2};
+
+    assertEqualPanic(10, x[0].j);
+    assertEqualPanic(2, x[1].j);
+}
+
+function testRecordTypeWithOptionalFieldsSealedArrayFill() {
+    Rec[2] x = [];
+    x[1] = {i: 1, j: 2};
+
+    assertEqualPanic(10, x[0].j);
+    assertEqualPanic(2, x[1].j);
+}
+
+public function main() {
+    testObjectDynamicArrayFilling();
+    testRecordTypeWithOptionalFieldsArrayFill();
+    testRecordTypeWithOptionalFieldsSealedArrayFill();
+}
+
+function assertEqualPanic(anydata expected, anydata actual, string message = "Value mismatch") {
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_fill_runtime_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_fill_runtime_test.bal
@@ -27,6 +27,14 @@ type Obj object {
     }
 };
 
+type ObjInitNullable object {
+    int i;
+
+    function __init() returns () {
+        self.i = 1;
+    }
+};
+
 type Age object {
     public int age;
     public function __init(int age = 5) {
@@ -34,13 +42,29 @@ type Age object {
     }
 };
 
-// TODO: fix me
+// TODO: fix me https://github.com/ballerina-platform/ballerina-lang/issues/20983
 function testObjectDynamicArrayFilling() {
     //Age[2] y = [];
     //y[1] = new(10);
     //
     //assertEqualPanic(5, y[0].age);
     //assertEqualPanic(10, y[1].age);
+}
+
+function testObjectRetNullableDynamicArrayFilling() {
+    ObjInitNullable[2] y = [];
+    y[1] = new();
+
+    assertEqualPanic(1, y[0].i);
+    assertEqualPanic(1, y[1].i);
+}
+
+function testObjectNoRetDynamicArrayFilling() {
+    Obj[2] y = [];
+    y[1] = new();
+
+    assertEqualPanic(1, y[0].i);
+    assertEqualPanic(1, y[1].i);
 }
 
 function testRecordTypeWithOptionalFieldsArrayFill() {
@@ -63,6 +87,8 @@ public function main() {
     testObjectDynamicArrayFilling();
     testRecordTypeWithOptionalFieldsArrayFill();
     testRecordTypeWithOptionalFieldsSealedArrayFill();
+    testObjectRetNullableDynamicArrayFilling();
+    testObjectNoRetDynamicArrayFilling();
 }
 
 function assertEqualPanic(anydata expected, anydata actual, string message = "Value mismatch") {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array-semantics-negative.bal
@@ -27,7 +27,6 @@ function accessInvalidIndexOfSealedArrayUsingKeyword() returns string {
 }
 
 function initializeInvalidSizedSealedArray() {
-    boolean[4] sealedArray1 = [true, true, false];
     boolean[4] sealedArray2 = [true, true, false, false, true];
 }
 
@@ -76,7 +75,6 @@ function unionTestInvalidOrderedMatch(boolean | int[] | float[4] | float[] x) re
 }
 
 function invalidJSONArrays() {
-    json[4] x1 = [1, true];
     json[4] x2 = [1, 1.5, true, false, "abc"];
     json[4] x3 = [1, 1.5, true, false];
     x3[3] = 12;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array.bal
@@ -142,6 +142,21 @@ type Person record {
     int age = 0;
 };
 
+type PersonFillable record {
+    string name = "doe";
+    int age?;
+    boolean employee?;
+};
+
+function createRecordSealedArrayAutoFill() {
+    PersonFillable p = {name:"John", age:25, employee:false};
+    PersonFillable[5] sealedArray = [p];
+    sealedArray[3] = p;
+    assertEqualPanic("doe", sealedArray[2].name);
+    assertEqualPanic("John", sealedArray[3].name);
+    assertArrayLengthPanic(5, sealedArray);
+}
+
 function createRecordSealedArray() {
     Person[5] sealedArray = [{}, {}, {}, {}, {}];
     assertArrayLengthPanic(5, sealedArray);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array.bal
@@ -276,6 +276,24 @@ function createUnionAutoFillArray() {
     assertArrayLengthPanic(3, unionArray);
 }
 
+type myFloatUnion 1.2 | 3.5 | 0.0 | 3.4;
+function createUnionFloatAutoFillArray() {
+    myFloatUnion[2] unionArray = [];
+    unionArray[1] = 3.5;
+    assertArrayValuePanic(0.0, unionArray, 0);
+    assertArrayValuePanic(3.5, unionArray, 1);
+    assertArrayLengthPanic(2, unionArray);
+}
+
+type myBooleanUnion true | false;
+function createUnionBooleanAutoFillArray() {
+    myBooleanUnion[2] unionArray = [];
+    unionArray[1] = true;
+    assertArrayValuePanic(false, unionArray, 0);
+    assertArrayValuePanic(true, unionArray, 1);
+    assertArrayLengthPanic(2, unionArray);
+}
+
 type myNullableUnion 1 | 2 | 3 | 4 | ();
 function createNullableUnionAutoFillArray() {
     myNullableUnion[3] unionArray = [];
@@ -425,5 +443,11 @@ function isEqualPanic(string expected, any[] arr, string message = "Not equal") 
     string actual = arr.toString().trim();
     if (expected != actual) {
         panic error(message + " Expected : " + expected + " Actual : " + actual);
+    }
+}
+
+function assertTruePanic(boolean actual, string message = "Not equal") {
+    if (true != actual) {
+        panic error(message + " Expected : true" + " Actual : " + actual.toString());
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed-array.bal
@@ -16,82 +16,123 @@
 
 // Int Arrays
 
-function createIntSealedArray() returns int {
+function createIntSealedArray() {
     int[5] sealedArray = [2, 15, 200, 1500, 5000];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createIntSealedArrayWithLabel() returns int {
+function createIntAutoFilledSealedArray() {
+    int[5] sealedArray = [2];
+    sealedArray[4] = 2;
+    assertArrayValuePanic(2, sealedArray, 4);
+    assertArrayValuePanic(2, sealedArray, 0);
+    assertArrayValuePanic(0, sealedArray, 1);
+    assertArrayValuePanic(0, sealedArray, 2);
+    assertArrayValuePanic(0, sealedArray, 2);
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createIntSealedArrayWithLabel() {
     int[*] sealedArray = [2, 15, 200, 1500, 5000];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createIntDefaultSealedArray() returns [int[], int] {
+function createIntDefaultSealedArray() {
     int[5] sealedArray = [0, 0, 0, 0, 0];
-    return [sealedArray, sealedArray.length()];
+    assertArrayLengthPanic(5, sealedArray);
+    isEqualPanic("0 0 0 0 0", sealedArray);
 }
 
 // Boolean Arrays
 
-function createBoolSealedArray() returns int {
+function createBoolSealedArray() {
     boolean[5] sealedArray = [true, false, false, true, false];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createBoolSealedArrayWithLabel() returns int {
+function createBoolAutoFilledSealedArray() {
+    boolean[5] sealedArray = [true, false];
+    sealedArray[4] = false;
+    assertArrayValuePanic(false, sealedArray, 4);
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createBoolSealedArrayWithLabel() {
     boolean[*] sealedArray = [true, false, false, true, false];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createBoolDefaultSealedArray() returns [boolean[], int] {
+function createBoolDefaultSealedArray() {
     boolean[5] sealedArray = [false, false, false, false, false];
-    return [sealedArray, sealedArray.length()];
+    assertArrayLengthPanic(5, sealedArray);
+    isEqualPanic("false false false false false", sealedArray);
 }
 
 // Float Arrays
 
-function createFloatSealedArray() returns int {
+function createFloatSealedArray() {
     float[5] sealedArray = [0.0, 15.2, 1100.0, -25.8, -10.0];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createFloatSealedArrayWithLabel() returns int {
+function createFloatAutoFilledSealedArray() {
+    float[5] sealedArray = [0.0, 15.2];
+    sealedArray[4] = 2.5;
+    assertArrayValuePanic(2.5, sealedArray, 4);
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createFloatSealedArrayWithLabel() {
     float[*] sealedArray = [0.0, 15.2, 1100.0, -25.8, -10.0];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createFloatDefaultSealedArray() returns [float[], int] {
+function createFloatDefaultSealedArray() {
     float[5] sealedArray = [0.0, 0.0, 0.0, 0.0, 0.0];
-    return [sealedArray, sealedArray.length()];
+    assertArrayLengthPanic(5, sealedArray);
+    isEqualPanic("0.0 0.0 0.0 0.0 0.0", sealedArray);
 }
 
 // String Arrays
 
-function createStringSealedArray() returns int {
+function createStringSealedArray() {
     string[5] sealedArray = ["a", "abc", "12", "-12", "."];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createStringSealedArrayWithLabel() returns int {
+function createStringAutoFilledSealedArray() {
+    string[5] sealedArray = ["a"];
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createStringSealedArrayWithLabel() {
     string[*] sealedArray = ["a", "abc", "12", "-12", "."];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createStringDefaultSealedArray() returns [string[], int] {
+function createStringDefaultSealedArray() {
     string[5] sealedArray = ["", "", "", "", ""];
-    return [sealedArray, sealedArray.length()];
+    isEqualPanic("", sealedArray);
+    assertArrayLengthPanic(5, sealedArray);
 }
 
 // Any Type Arrays
 
-function createAnySealedArray() returns int {
+function createAnySealedArray() {
     any[5] sealedArray = ["a", true, 12, -12.5, "."];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createAnySealedArrayWithLabel() returns int {
+function createAnyAutoFilledSealedArray() {
+    any[5] sealedArray = ["a"];
+    sealedArray[4] = 23;
+    sealedArray[3] = -2.5;
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createAnySealedArrayWithLabel() {
     any[*] sealedArray = ["a", true, 12, -12.5, "."];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
 // Record Type Arrays
@@ -101,57 +142,87 @@ type Person record {
     int age = 0;
 };
 
-function createRecordSealedArray() returns int {
+function createRecordSealedArray() {
     Person[5] sealedArray = [{}, {}, {}, {}, {}];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createRecordSealedArrayWithLabel() returns int {
+function createRecordAutoFilledSealedArray() {
+    Person[5] sealedArray = [{}];
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createRecordSealedArrayWithLabel() {
     Person[*] sealedArray = [{}, {}, {}, {}, {}];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
 // Byte Arrays
 
-function createByteSealedArray() returns int {
+function createByteSealedArray() {
     byte a = 5;
     byte[5] sealedArray = [a, a, a, a, a];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createByteSealedArrayWithLabel() returns int {
+function createByteAutoFilledSealedArray() {
+    byte a = 5;
+    byte[5] sealedArray = [a];
+    sealedArray[4] = a;
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function createByteSealedArrayWithLabel() {
     byte a = 7;
     byte[*] sealedArray = [a, a, a, a, a];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createByteDefaultSealedArray() returns [byte[], int] {
+function createByteDefaultSealedArray() {
     byte[5] sealedArray = [0, 0, 0, 0, 0];
-    return [sealedArray, sealedArray.length()];
+    isEqualPanic("0 0 0 0 0", sealedArray);
+    assertArrayLengthPanic(5, sealedArray);
 }
 
 // Tuple Arrays
 
-function createTupleSealedArray() returns int {
+function createTupleSealedArray() {
     [int, boolean][3] sealedArray = [[2, true], [3, false], [6, true]];
     sealedArray[2] = [5, false];
-    return sealedArray.length();
+    assertArrayLengthPanic(3, sealedArray);
 }
 
-function createTupleSealedArrayWithLabel() returns int {
+function createTupleAutoFilledSealedArray() {
+    [int, boolean][3] sealedArray = [[2, true]];
+    sealedArray[2] = [5, false];
+    assertArrayLengthPanic(3, sealedArray);
+}
+
+function createTupleSealedArrayWithLabel() {
     [int, boolean][*] sealedArray = [[2, true], [3, false], [6, true]];
-    return sealedArray.length();
+    assertArrayLengthPanic(3, sealedArray);
 }
 
 // Function Params and Returns
 
-function functionParametersAndReturns() returns [int, int] {
+function functionParametersAndReturns() {
     boolean[3] sealedArray = [true, false, false];
     boolean[3] returnedBoolArray = [false, false, false];
     string[2] returnedStrArray = ["", ""];
     [returnedBoolArray, returnedStrArray] = mockFunction(sealedArray);
 
-    return [returnedBoolArray.length(), returnedStrArray.length()];
+    assertArrayLengthPanic(3, returnedBoolArray);
+    assertArrayLengthPanic(2, returnedStrArray);
+}
+
+function functionParametersAndReturnsAutoFilling() {
+    boolean[3] sealedArray = [];
+    boolean[3] returnedBoolArray = [];
+    string[2] returnedStrArray = [""];
+    [returnedBoolArray, returnedStrArray] = mockFunction(sealedArray);
+
+    assertArrayLengthPanic(3, returnedBoolArray);
+    assertArrayLengthPanic(2, returnedStrArray);
 }
 
 function mockFunction(boolean[3] sealedArray) returns [boolean[3], string[2]] {
@@ -170,6 +241,45 @@ function assignedArrayInvalidIndexAccess() {
     int[3] x1 = [1, 2, 3];
     int[] x2 = x1;
     x2[4] = 10;
+}
+
+function assignedAutoFilledArrayInvalidIndexAccess() {
+    int[3] x1 = [1, 2];
+    int[] x2 = x1;
+    x2[4] = 10;
+}
+
+// Union arrays
+
+type myUnion 1 | 2 | 3 | 4 | 0;
+function createUnionAutoFillArray() {
+    myUnion[3] unionArray = [];
+    unionArray[2] = 4;
+    assertArrayValuePanic(0, unionArray, 0);
+    assertArrayValuePanic(0, unionArray, 1);
+    assertArrayValuePanic(4, unionArray, 2);
+    assertArrayLengthPanic(3, unionArray);
+}
+
+type myNullableUnion 1 | 2 | 3 | 4 | ();
+function createNullableUnionAutoFillArray() {
+    myNullableUnion[3] unionArray = [];
+    unionArray[2] = 4;
+    assertArrayValuePanic((), unionArray, 0);
+    assertArrayValuePanic((), unionArray, 1);
+    assertArrayValuePanic(4, unionArray, 2);
+    assertArrayLengthPanic(3, unionArray);
+}
+
+// TODO: test code hit points
+type multiTypeUnion 1 | "hi" | 4.0 | ();
+function createNullableNonHomogeneousUnionAutoFillArray() {
+    multiTypeUnion[3] unionArray = [];
+    unionArray[2] = 4.0;
+    assertArrayValuePanic((), unionArray, 0);
+    assertArrayValuePanic((), unionArray, 1);
+    assertArrayValuePanic(4, unionArray, 2);
+    assertArrayLengthPanic(3, unionArray);
 }
 
 // Match Statments
@@ -218,14 +328,14 @@ function accessIndexOfMatchedSealedArray(int[] | int[3] x, int index) returns in
 
 // JSON Arrays
 
-function createJSONSealedArray() returns int {
+function createJSONSealedArray() {
     json[5] sealedArray = [false, "abc", "12", -12, "."];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function createJSONSealedArrayWithLabel() returns int {
+function createJSONSealedArrayWithLabel() {
     json[*] sealedArray = [false, "abc", "12", -12, "."];
-    return sealedArray.length();
+    assertArrayLengthPanic(5, sealedArray);
 }
 
 function invalidIndexJSONArray(int index) {
@@ -239,12 +349,18 @@ function invalidIndexReferenceJSONArray() {
     x2[3] = 1.0;
 }
 
-function createJSONDefaultSealedArray() returns [json[], int] {
+function createJSONDefaultSealedArray() {
     json[5] sealedArray = [(), (), (), (), ()];
-    return [sealedArray, sealedArray.length()];
+    assertArrayLengthPanic(5, sealedArray);
 }
 
-function testSealedArrayConstrainedMap (int[3] x1, int[] x2) returns int {
+function createJSONAutoFilledSealedArray() {
+    json[5] sealedArray = [(), ()];
+    assertEqualPanic("", sealedArray[4].toString());
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+function testSealedArrayConstrainedMap(int[3] x1, int[] x2) returns int {
     map<int[]> x = {};
     x["v1"] = x1;
     x["v2"] = x2;
@@ -252,8 +368,47 @@ function testSealedArrayConstrainedMap (int[3] x1, int[] x2) returns int {
     return arr[2];
 }
 
-function testSealedArrayConstrainedMapInvalidIndex (int[3] x1, int index) {
+function testSealedArrayConstrainedMapInvalidIndex(int[3] x1, int index) {
     map<int[]> x = {};
     x["v1"] = x1;
     x["v1"][index] = 4;
+}
+
+// xml arrays
+
+function createXMLAutoFilledSealedArray() {
+    xml a = xml `<name>Ballerina</name>`;
+    xml[5] sealedArray = [a, a];
+    sealedArray[3] = a;
+    assertEqualPanic("", sealedArray[4].toString());
+    assertArrayLengthPanic(5, sealedArray);
+}
+
+// helper methods
+
+function assertArrayLengthPanic(int expected, any[] arr, string message = "Array length did not match") {
+    int actual = arr.length();
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
+    }
+}
+
+function assertArrayValuePanic(anydata expected, anydata[] arr, int index, string message = "Array value mismatch") {
+    anydata actual = arr[index];
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
+    }
+}
+
+function assertEqualPanic(anydata expected, anydata actual, string message = "Value mismatch") {
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
+    }
+}
+
+function isEqualPanic(string expected, any[] arr, string message = "Not equal") {
+    string actual = arr.toString().trim();
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected + " Actual : " + actual);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
@@ -71,3 +71,30 @@ type myNonHomogeneousUnion 0 | 0.0 | "";
 function createInvalidNonHomogeneousUnionInitializedArray() {
     myNonHomogeneousUnion[3] z = [];
 }
+
+type Rec record {
+    int i;
+};
+
+type RecWithManyOptional record {|
+    int j?;
+    int k;
+    int a?;
+|};
+
+type RecWithOptional record {
+    int k;
+    int a?;
+};
+
+function testRecordTypeWithManyRequiredFieldsArrayAutoFill() {
+    Rec[2] x = [];
+}
+
+function testRecordTypeWithManyOptionalFieldsArrayAutoFill() {
+    RecWithManyOptional[2] x = [];
+}
+
+function testRecordTypeWithOptionalFieldsArrayAutoFill() {
+    RecWithOptional[2] x = [];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Person abstract object {
+    public int age;
+    function getFullName() returns string;
+};
+
+// [0] cannot initialize abstract objects
+function createAbstractObjectArray() {
+    Person[5] x = [];
+    Person p1 = x[2];
+    p1.age = 20;
+}
+
+// [1] cannot create multi dimensional arrays of abstract objects
+function createAbstractObjectEmptyArray() {
+    Person[5][] y = [];
+    Person[5][1] z = [[]];
+}
+
+type Age object {
+    public int age;
+    public function __init(int age) {
+    	 self.age = age;
+    }
+};
+
+// [2] cannot create object without properly initializing it
+function createDirtyObjectEmptyArray() {
+    Age[5][] y = [];
+    Age[5][1] z = [[]];
+    z[0][0].age = 30;
+}
+
+type AgeDefaulted object {
+    public int age;
+    public function __init(int age = 5) {
+    	 self.age = age;
+    }
+};
+
+// should not have a problem
+function createObjectDefaultedInitializedEmptyArray() {
+    AgeDefaulted[5][] y = [];
+    AgeDefaulted[5][1] z = [[]];
+    z[0][0].age = 30;
+}
+
+// [3] invalid union fill
+type myVar 1 | 2 | 3 | 4;
+function createInvalidUnionInitializedArray() {
+    myVar[3] z = [];
+}
+
+// [4] invalid union fill
+type myNonHomogeneousUnion 0 | 0.0 | "";
+function createInvalidNonHomogeneousUnionInitializedArray() {
+    myNonHomogeneousUnion[3] z = [];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
@@ -19,16 +19,16 @@ type Person abstract object {
     function getFullName() returns string;
 };
 
-// [0] cannot initialize abstract objects
+// cannot initialize abstract objects
 function createAbstractObjectArray() {
     Person[5] x = [];
     Person p1 = x[2];
     p1.age = 20;
 }
 
-// [1] cannot create multi dimensional arrays of abstract objects
+// cannot create multi dimensional arrays of abstract objects
 function createAbstractObjectEmptyArray() {
-    Person[5][] y = [];
+    Person[5][] y = []; Person[][5] r = [];// TODO: this should be allowed
     Person[5][1] z = [[]];
 }
 
@@ -39,9 +39,9 @@ type Age object {
     }
 };
 
-// [2] cannot create object without properly initializing it
+// cannot create object without properly initializing it
 function createDirtyObjectEmptyArray() {
-    Age[5][] y = [];
+    Age[5][] y = []; // TODO: this should be allowed
     Age[5][1] z = [[]];
     z[0][0].age = 30;
 }
@@ -110,4 +110,13 @@ type ObjError object {
 
 function testObjectRetErrorArrayFilling() {
     ObjError [2] y = [];
+}
+
+const MyConst = "HELLO";
+const MyIntConst = 2;
+
+type unionWithConst MyConst | MyIntConst ;
+
+function testUnionWithConstTypes() {
+    unionWithConst[2] unionArr = [];
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
@@ -27,8 +27,7 @@ function createAbstractObjectArray() {
 }
 
 // cannot create multi dimensional arrays of abstract objects
-function createAbstractObjectEmptyArray() {
-    Person[5][] y = []; Person[][5] r = [];// TODO: this should be allowed
+function createAbstractObjectMultidimentionalSealedArray() {
     Person[5][1] z = [[]];
 }
 
@@ -40,8 +39,7 @@ type Age object {
 };
 
 // cannot create object without properly initializing it
-function createDirtyObjectEmptyArray() {
-    Age[5][] y = []; // TODO: this should be allowed
+function createDirtyObjectMultidimentionalSealedArray() {
     Age[5][1] z = [[]];
     z[0][0].age = 30;
 }
@@ -54,21 +52,20 @@ type AgeDefaulted object {
 };
 
 // should not have a problem
-function createObjectDefaultedInitializedEmptyArray() {
-    AgeDefaulted[5][] y = [];
+function createObjectWithDefaultInitializerParametersSealedArray() {
     AgeDefaulted[5][1] z = [[]];
     z[0][0].age = 30;
 }
 
 // [3] invalid union fill
 type myVar 1 | 2 | 3 | 4;
-function createInvalidUnionInitializedArray() {
+function createInvalidUnionSealedArray() {
     myVar[3] z = [];
 }
 
 // [4] invalid union fill
 type myNonHomogeneousUnion 0 | 0.0 | "";
-function createInvalidNonHomogeneousUnionInitializedArray() {
+function createInvalidNonHomogeneousUnionSealedArray() {
     myNonHomogeneousUnion[3] z = [];
 }
 
@@ -87,15 +84,15 @@ type RecWithOptional record {
     int a?;
 };
 
-function testRecordTypeWithManyRequiredFieldsArrayAutoFill() {
+function createRecordTypeWithManyRequiredFieldsSealedArrayCreation() {
     Rec[2] x = [];
 }
 
-function testRecordTypeWithManyOptionalFieldsArrayAutoFill() {
+function createRecordTypeWithManyOptionalFieldsSealedArrayCreation() {
     RecWithManyOptional[2] x = [];
 }
 
-function testRecordTypeWithOptionalFieldsArrayAutoFill() {
+function createRecordTypeWithOptionalFieldsSealedArrayCreation() {
     RecWithOptional[2] x = [];
 }
 
@@ -108,7 +105,7 @@ type ObjError object {
     }
 };
 
-function testObjectRetErrorArrayFilling() {
+function createObjectWithErrorTypeReturningInitializerSealedArray() {
     ObjError [2] y = [];
 }
 
@@ -117,6 +114,6 @@ const MyIntConst = 2;
 
 type unionWithConst MyConst | MyIntConst ;
 
-function testUnionWithConstTypes() {
+function createUnionWithConstTypesSealedArray() {
     unionWithConst[2] unionArr = [];
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_listexpr_negative.bal
@@ -98,3 +98,16 @@ function testRecordTypeWithManyOptionalFieldsArrayAutoFill() {
 function testRecordTypeWithOptionalFieldsArrayAutoFill() {
     RecWithOptional[2] x = [];
 }
+
+
+type ObjError object {
+    int i;
+
+    function __init() returns error? {
+        self.i = 1;
+    }
+};
+
+function testObjectRetErrorArrayFilling() {
+    ObjError [2] y = [];
+}


### PR DESCRIPTION
## Purpose
Fixes #20721

## Approach

Changed explicit array size and list constructor size mismatch check by loosening it to only to error out scenarios where the list constructor is trying to create an array larger than given explicit array length.

Added fill value check to test if the array is created using a type which has a valid fill value

## Samples
Code Snippet
```ballerina
    int[4] arr = [3, 1];
    io:println("arr : ", arr);
    arr[3] = 30;
    io:println("arr : ", arr)
```
Output:
```
    arr : 3 1 0 0
    arr : 3 1 0 30
```
## Remarks
#### ToDo
- [x] boolean / int / float / decimal / string/ byte arrays
- [x] any
- [x] anydata
- [x] unions
- [x] tuples
- [x] records
- [x] Singleton array
- [ ] Object array  - Issue #20983 
- [x] json array
- [x] xml arrays

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [x] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
