### PR TITLE
Fix issue of not showing errors of `Settings.toml`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/parser/SettingsProcessor.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/parser/SettingsProcessor.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.toml.parser;
 
 import com.moandjiezana.toml.Toml;
+import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.toml.model.Settings;
 
 import java.io.FileInputStream;
@@ -51,7 +52,12 @@ public class SettingsProcessor {
      * @return The Settings object
      */
     private static Settings getSettings(InputStream inputStream) {
-        Toml toml = new Toml().read(inputStream);
+        Toml toml;
+        try {
+            toml = new Toml().read(inputStream);
+        } catch (IllegalStateException e) {
+            throw new BLangCompilerException("invalid Settings.toml due to " + e.getMessage());
+        }
         return toml.to(Settings.class);
     }
 }

--- a/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/InvalidSettingsTomlTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/InvalidSettingsTomlTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.toml;
+
+import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.toml.parser.SettingsProcessor;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * Test class to test invalid `Settings.toml` file.
+ */
+public class InvalidSettingsTomlTest {
+
+    private final String expMsg =
+            ".*invalid Settings.toml due to Key is not followed by an equals sign on line 2: 2223,,,,.*";
+
+    @Test(description = "Test invalid Settings.toml", expectedExceptions = BLangCompilerException.class,
+            expectedExceptionsMessageRegExp = expMsg)
+    public void testParseTomlContentFromFile() throws IOException, URISyntaxException {
+        URI settingsTomlURI =
+                Objects.requireNonNull(getClass().getClassLoader().getResource("invalid-settings.toml")).toURI();
+        SettingsProcessor.parseTomlContentFromFile(Paths.get(settingsTomlURI));
+    }
+}

--- a/compiler/ballerina-lang/src/test/resources/invalid-settings.toml
+++ b/compiler/ballerina-lang/src/test/resources/invalid-settings.toml
@@ -1,0 +1,3 @@
+[central]
+2223,,,,
+accesstoken="273cc9f6-c333-36ab-aa2q-f08e9513ff5y"


### PR DESCRIPTION
## Purpose
> When there is a syntax error in `Settings.toml` file causes bad sad error without an indication of what caused it.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/20579

## Approach
> Throwing a `BLangCompilerException` with the message `invalid Settings.toml due to <REASON>` if `Settings.toml` file has any syntax error.

## Samples
Settings.toml
```toml
[central]
acesstoken="2833b8f6-c230-36db-a21e-f0"
2223,,,,
```

ballerina build -a
```
error: invalid Settings.toml due to Key is not followed by an equals sign on line 3: 2223,,,,
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
