### PR TITLE
Improve final executable jar creation task

### DIFF
--- a/cli/ballerina-packerina/build.gradle
+++ b/cli/ballerina-packerina/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation project(':docerina')
     implementation 'com.moandjiezana.toml:toml4j'
     implementation 'info.picocli:picocli'
+    implementation 'org.apache.commons:commons-compress:1.18'
+
     testCompile 'org.testng:testng'
     testCompile 'com.moandjiezana.toml:toml4j'
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateExecutableTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateExecutableTask.java
@@ -18,6 +18,10 @@
 
 package org.ballerinalang.packerina.task;
 
+import org.apache.commons.compress.archivers.jar.JarArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntryPredicate;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.ballerinalang.packerina.buildcontext.BuildContext;
 import org.ballerinalang.packerina.buildcontext.BuildContextField;
 import org.ballerinalang.packerina.buildcontext.sourcecontext.SingleFileContext;
@@ -25,21 +29,16 @@ import org.ballerinalang.packerina.buildcontext.sourcecontext.SingleModuleContex
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.util.Lists;
 
-import java.io.FileInputStream;
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
 
 import static org.ballerinalang.tool.LauncherUtils.createLauncherException;
 
@@ -47,29 +46,15 @@ import static org.ballerinalang.tool.LauncherUtils.createLauncherException;
  * Task for creating the executable jar file.
  */
 public class CreateExecutableTask implements Task {
-    
-    private static HashSet<String> excludeExtensions =  new HashSet<>(Lists.of("DSA", "SF"));
-    private static Field namesField;
 
-    static {
-        try {
-            // We need to access the already inserted names set to override the default behavior of throwing exception.
-            namesField = ZipOutputStream.class.getDeclaredField("names");
-            AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-                namesField.setAccessible(true);
-                return null;
-            });
-        } catch (NoSuchFieldException e) {
-            throw createLauncherException("unable to retrive the entry names field :" + e.getMessage());
-        }
-    }
+    private static HashSet<String> excludeExtensions = new HashSet<>(Lists.of("DSA", "SF"));
 
     @Override
     public void execute(BuildContext buildContext) {
         Optional<BLangPackage> modulesWithEntryPoints = buildContext.getModules().stream()
                 .filter(m -> m.symbol.entryPointExists)
                 .findAny();
-        
+
         if (modulesWithEntryPoints.isPresent()) {
             buildContext.out().println();
             buildContext.out().println("Generating executables");
@@ -77,16 +62,10 @@ public class CreateExecutableTask implements Task {
                 if (module.symbol.entryPointExists) {
                     Path executablePath = buildContext.getExecutablePathFromTarget(module.packageID);
                     Path jarFromCachePath = buildContext.getJarPathFromTargetCache(module.packageID);
-                    /*
-                    TODO: We earlier used ZipFileSystem but we cannot explicitly set the compression method in
-                     java8 with ZipFileSystem. Once we moved to java11 we can revert back to ZipFileSystem then we can
-                      get rid of with accessing names field as well.
-                      */
-                    try (ZipOutputStream outStream =
-                                 new ZipOutputStream(new FileOutputStream(String.valueOf(executablePath)))) {
+                    try (ZipArchiveOutputStream outStream = new ZipArchiveOutputStream(new BufferedOutputStream(
+                            new FileOutputStream(String.valueOf(executablePath))))) {
                         assembleExecutable(jarFromCachePath,
-                                           buildContext.moduleDependencyPathMap.get(module.packageID).platformLibs,
-                                           outStream);
+                                buildContext.moduleDependencyPathMap.get(module.packageID).platformLibs, outStream);
                     } catch (IOException e) {
                         throw createLauncherException("unable to extract the uber jar :" + e.getMessage());
                     }
@@ -100,7 +79,7 @@ public class CreateExecutableTask implements Task {
                 case SINGLE_MODULE:
                     SingleModuleContext singleModuleContext = buildContext.get(BuildContextField.SOURCE_CONTEXT);
                     throw createLauncherException("no entry points found in '" + singleModuleContext.getModuleName() +
-                                                  "'.\n" +
+                            "'.\n" +
                             "Use `ballerina build -c` to compile the module without building executables.");
                 case ALL_MODULES:
                     throw createLauncherException("no entry points found in any of the modules.\n" +
@@ -111,55 +90,51 @@ public class CreateExecutableTask implements Task {
         }
     }
 
-    private void assembleExecutable(Path jarFromCachePath, HashSet<Path> dependencySet, ZipOutputStream outStream) {
+    private void assembleExecutable(Path jarFromCachePath, HashSet<Path> dependencySet,
+                                    ZipArchiveOutputStream outStream) {
         try {
-            HashSet<String> entries = (HashSet<String>) namesField.get(outStream);
-            HashMap<String, StringBuilder> services = new HashMap<>();
-            copyJarToJar(outStream, jarFromCachePath.toString(), entries, services);
+            // Used to prevent adding duplicated entries during the final jar creation.
+            HashSet<String> entries = new HashSet<>();
+            // Used to process SPI related metadata entries separately. The reason is unlike the other entry types,
+            // service loader related information should be merged together in the final executable jar creation.
+            HashMap<String, StringBuilder> serviceEntries = new HashMap<>();
+            // Copy executable thin jar and the dependency jars.
+            // Executable is created at given location.
+            // If no entry point is found, we do nothing.
+            copyJarToJar(outStream, jarFromCachePath.toString(), entries, serviceEntries);
             for (Path path : dependencySet) {
-                copyJarToJar(outStream, path.toString(), entries, services);
+                copyJarToJar(outStream, path.toString(), entries, serviceEntries);
             }
-            // Copy merged spi services
-            for (Map.Entry<String, StringBuilder> entry : services.entrySet()) {
+            // Copy merged spi services.
+            for (Map.Entry<String, StringBuilder> entry : serviceEntries.entrySet()) {
                 String s = entry.getKey();
                 StringBuilder service = entry.getValue();
-                ZipEntry e = new ZipEntry(s);
-                outStream.putNextEntry(e);
+                JarArchiveEntry e = new JarArchiveEntry(s);
+                outStream.putArchiveEntry(e);
                 outStream.write(service.toString().getBytes(StandardCharsets.UTF_8));
-                outStream.closeEntry();
+                outStream.closeArchiveEntry();
             }
-            // Copy dependency jar
-            // Copy dependency libraries
-            // Executable is created at give location.
-            // If no entry point is found we do nothing.
-        } catch (IOException | NullPointerException | IllegalAccessException e) {
+        } catch (IOException | NullPointerException e) {
             throw createLauncherException("unable to create the executable: " + e.getMessage());
         }
     }
 
     /**
-     * Copy jar file to executable fat jar.
+     * Copies a given jar file into the executable fat jar.
      *
-     * @param outStream     Executable jar out stream
-     * @param sourceJarFile Source file
-     * @param entries       Entries set wiil be used ignore duplicate files
+     * @param outStream     Output stream of the final uber jar.
+     * @param sourceJarFile Path of the source jar file.
+     * @param entries       Entries set will be used to ignore duplicate files.
      * @param services      Services will be used to temporary hold merged spi files.
-     * @throws IOException If file copy failed ioexception will be thrown
+     * @throws IOException If jar file copying is failed.
      */
-    private void copyJarToJar(ZipOutputStream outStream, String sourceJarFile, HashSet<String> entries,
+    private void copyJarToJar(ZipArchiveOutputStream outStream, String sourceJarFile, HashSet<String> entries,
                               HashMap<String, StringBuilder> services) throws IOException {
 
-        byte[] buffer = new byte[1024];
-        int len;
-        try (ZipInputStream inStream = new ZipInputStream(new FileInputStream(sourceJarFile))) {
-            for (ZipEntry e; (e = inStream.getNextEntry()) != null; ) {
-                String entryName = e.getName();
-                // Skip already copied files or excluded extensions.
-                if (e.isDirectory() || entries.contains(entryName) ||
-                        excludeExtensions.contains(entryName.substring(entryName.lastIndexOf(".") + 1))) {
-                    continue;
-                }
-                // SPIs will be merged first and then put into jar separately.
+        ZipFile zipFile = new ZipFile(sourceJarFile);
+        ZipArchiveEntryPredicate predicate = entry -> {
+            try {
+                String entryName = entry.getName();
                 if (entryName.startsWith("META-INF/services")) {
                     StringBuilder s = services.get(entryName);
                     if (s == null) {
@@ -167,6 +142,8 @@ public class CreateExecutableTask implements Task {
                         services.put(entryName, s);
                     }
                     char c = '\n';
+                    InputStream inStream = zipFile.getInputStream(entry);
+                    int len;
                     while ((len = inStream.read()) != -1) {
                         c = (char) len;
                         s.append(c);
@@ -174,14 +151,27 @@ public class CreateExecutableTask implements Task {
                     if (c != '\n') {
                         s.append('\n');
                     }
-                    continue;
+                    // Its not required to copy SPI entries in here as we'll be adding merged SPI related entries
+                    // separately. Therefore the predicate should be set as false.
+                    return false;
                 }
-                outStream.putNextEntry(e);
-                while ((len = inStream.read(buffer)) > 0) {
-                    outStream.write(buffer, 0, len);
+                // Skip already copied files or excluded extensions.
+                if (entries.contains(entryName) ||
+                        excludeExtensions.contains(entryName.substring(entryName.lastIndexOf(".") + 1))) {
+                    return false;
                 }
-                outStream.closeEntry();
+                // SPIs will be merged first and then put into jar separately.
+                entries.add(entryName);
+            } catch (IOException e) {
+                throw createLauncherException(e.getMessage());
             }
-        }
+
+            return true;
+        };
+
+        // Transfers selected entries from this zip file to the output stream, while preserving its compression and
+        // all the other original attributes.
+        zipFile.copyRawEntries(outStream, predicate);
+        zipFile.close();
     }
 }

--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     // dist 'org.ow2.asm:asm:6.2.1'
     dist 'org.codehaus.woodstox:woodstox-core-asl:4.2.0'
     dist 'org.codehaus.woodstox:stax2-api:3.1.1'
+    dist 'org.apache.commons:commons-compress:1.18'
 
     // Following dependencies are required for kraal library
     dist 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'


### PR DESCRIPTION
## Purpose
This PR adds improvements related to executable jar creation process, which reduces the final uber jar creation time by more than ~80% in average. 

Possibly fixes #20438.

## Approach
This PR uses `apache.commons.compress.archivers.zip` library APIs which is capable of copying the compressed data as it is, when constructing final executable uber jar by merging the thin jar with all the dependency jars.

## Remarks
Average uber jar creation execution time for time for few known samples are listed below.

| Sample Scenario | before (ms) | after (ms) |
| --------- |:---------:|:------------:|
| Hello World | ~1600 | ~350 |
| Hello World Service | ~4600 | ~650 |

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
