### PR TITLE
Handle Ballereina reserved literal name when generating code from proto

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
@@ -85,7 +85,7 @@ public class Field {
                 fieldDefaultValue = fieldLabel;
             }
             String fieldName = fieldDescriptor.getName();
-            if (Arrays.stream(BallerinaLexer.ruleNames).anyMatch(fieldName::equalsIgnoreCase) || Names.ERROR.value
+            if (Arrays.stream(RESERVED_LITERAL_NAMES).anyMatch(fieldName::equalsIgnoreCase) || Names.ERROR.value
                     .equalsIgnoreCase(fieldName)) {
                 fieldName = "'" + fieldName;
             }
@@ -141,4 +141,17 @@ public class Field {
         FIELD_LABEL_MAP.put(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REQUIRED, null);
         FIELD_LABEL_MAP.put(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED, "[]");
     }
+
+    private static final String[] RESERVED_LITERAL_NAMES = {
+            "import", "as", "public", "private", "external", "final", "service", "resource", "function", "object",
+            "record", "annotation", "parameter", "transformer", "worker", "listener", "remote", "xmlns", "returns",
+            "version", "channel", "abstract", "client", "const", "typeof", "source", "from", "on", "group", "by",
+            "having", "order", "where", "followed", "for", "window","every", "within", "snapshot", "inner", "outer",
+            "right", "left", "full", "unidirectional", "forever", "limit", "ascending", "descending", "int", "byte",
+            "float", "decimal", "boolean", "string", "error", "map", "json", "xml", "table", "stream", "any",
+            "typedesc", "type", "future", "anydata", "handle", "var", "new", "__init", "if", "match", "else",
+            "foreach", "while", "continue", "break", "fork", "join", "some", "all", "try", "catch", "finally", "throw",
+            "panic", "trap", "return", "transaction", "abort", "retry", "onretry", "retries", "committed", "aborted",
+            "with", "in", "lock", "untaint", "start", "but", "check", "checkpanic", "primarykey", "is", "flush",
+            "wait", "default"};
 }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Field.java
@@ -18,7 +18,6 @@
 package org.ballerinalang.net.grpc.builder.components;
 
 import com.google.protobuf.DescriptorProtos;
-import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaLexer;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.Arrays;
@@ -146,7 +145,7 @@ public class Field {
             "import", "as", "public", "private", "external", "final", "service", "resource", "function", "object",
             "record", "annotation", "parameter", "transformer", "worker", "listener", "remote", "xmlns", "returns",
             "version", "channel", "abstract", "client", "const", "typeof", "source", "from", "on", "group", "by",
-            "having", "order", "where", "followed", "for", "window","every", "within", "snapshot", "inner", "outer",
+            "having", "order", "where", "followed", "for", "window", "every", "within", "snapshot", "inner", "outer",
             "right", "left", "full", "unidirectional", "forever", "limit", "ascending", "descending", "int", "byte",
             "float", "decimal", "boolean", "string", "error", "map", "json", "xml", "table", "stream", "any",
             "typedesc", "type", "future", "anydata", "handle", "var", "new", "__init", "if", "match", "else",

--- a/tests/jballerina-integration-test/src/test/resources/grpc/src/tool/helloWorldWithReservedNames.proto
+++ b/tests/jballerina-integration-test/src/test/resources/grpc/src/tool/helloWorldWithReservedNames.proto
@@ -27,6 +27,13 @@ message HelloRequest {
     string name = 1;
     string channel = 2;
     bool check = 3;
+    string json = 4;
+    string xml = 5;
+    string stream = 6;
+    string table = 7;
+    string break = 8;
+    string untaint = 9;
+    string future = 10;
 }
 message HelloResponse {
     string message = 1;


### PR DESCRIPTION
## Purpose
Fix the issue when generating the code from the proto definition which has ballerina reserved literal name as the field names.

Fixes #20837

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
