### PR TITLE
Avoid suggesting non-public object fields

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FilterUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FilterUtils.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.ballerinalang.langserver.common.utils;
 
 import com.google.common.collect.Lists;
@@ -70,11 +70,11 @@ public class FilterUtils {
     /**
      * Get the invocations and fields against an identifier (functions, actions and fields).
      *
-     * @param context Text Document Service context (Completion Context)
-     * @param varName Variable name to evaluate against (Can be package alias or defined variable)
-     * @param delimiter    delimiter type either dot or action invocation symbol
-     * @param defaultTokens         List of Default tokens
-     * @param delimIndex            Delimiter index
+     * @param context       Text Document Service context (Completion Context)
+     * @param varName       Variable name to evaluate against (Can be package alias or defined variable)
+     * @param delimiter     delimiter type either dot or action invocation symbol
+     * @param defaultTokens List of Default tokens
+     * @param delimIndex    Delimiter index
      * @return {@link ArrayList}    List of filtered symbol info
      */
     public static List<SymbolInfo> filterVariableEntriesOnDelimiter(LSContext context, String varName, int delimiter,
@@ -119,7 +119,8 @@ public class FilterUtils {
 
     /**
      * Get the actions defined over and endpoint.
-     * @param bObjectTypeSymbol    Endpoint variable symbol to evaluate
+     *
+     * @param bObjectTypeSymbol Endpoint variable symbol to evaluate
      * @return {@link List}         List of extracted actions as Symbol Info
      */
     public static List<SymbolInfo> getClientActions(BObjectTypeSymbol bObjectTypeSymbol) {
@@ -138,9 +139,9 @@ public class FilterUtils {
      * Get the invocations and fields for a dot separated chained statement
      * Eg: int x = var1.field1.testFunction()
      *
-     * @param context Language server operation context
+     * @param context       Language server operation context
      * @param defaultTokens List of default tokens removed (LHS Tokens)
-     * @param delimIndex Delimiter index
+     * @param delimIndex    Delimiter index
      * @return {@link List} List of extracted symbols
      */
     private static List<SymbolInfo> getInvocationsAndFields(LSContext context, List<CommonToken> defaultTokens,
@@ -223,11 +224,11 @@ public class FilterUtils {
     public static boolean isBTypeEntry(Scope.ScopeEntry entry) {
         return getBTypeEntry(entry).isPresent();
     }
-    
+
     ///////////////////////////
     ///// Private Methods /////
     ///////////////////////////
-    
+
     private static BType getBTypeForUnionType(BUnionType bType) {
         List<BType> memberTypeList = new ArrayList<>(bType.getMemberTypes());
         memberTypeList.removeIf(type -> type.tsymbol instanceof BErrorTypeSymbol || type instanceof BNilType);
@@ -235,7 +236,7 @@ public class FilterUtils {
         if (memberTypeList.size() == 1) {
             return memberTypeList.get(0);
         }
-        
+
         return bType;
     }
 
@@ -254,14 +255,14 @@ public class FilterUtils {
 
         return actionFunctionList;
     }
-    
+
     private static BType getModifiedBType(BSymbol bSymbol, LSContext context, InvocationFieldType fieldType) {
         Integer invocationType = context.get(CompletionKeys.INVOCATION_TOKEN_TYPE_KEY);
         BType actualType;
         if ((bSymbol.tag & SymTag.TYPE) == SymTag.TYPE) {
             actualType = new BTypedescType(bSymbol.type, null);
         } else if (bSymbol instanceof BInvokableSymbol) {
-             actualType = ((BInvokableSymbol) bSymbol).retType;
+            actualType = ((BInvokableSymbol) bSymbol).retType;
         } else if (bSymbol.type instanceof BArrayType && fieldType == InvocationFieldType.ARRAY_ACCESS) {
             return ((BArrayType) bSymbol.type).eType;
         } else {
@@ -346,7 +347,7 @@ public class FilterUtils {
      *
      * @param symbolName symbol name to evaluate
      * @param symbolType BType to evaluate
-     * @param context Language Server Operation Context
+     * @param context    Language Server Operation Context
      * @return {@link Map} Scope Entry Map
      */
     private static Map<Name, Scope.ScopeEntry> getInvocationsAndFieldsForSymbol(String symbolName, BType symbolType,
@@ -363,39 +364,21 @@ public class FilterUtils {
          */
         if (symbolType.tsymbol instanceof BObjectTypeSymbol) {
             BObjectTypeSymbol objectTypeSymbol = (BObjectTypeSymbol) symbolType.tsymbol;
-            Map<Name, Scope.ScopeEntry> methodEntries = objectTypeSymbol.methodScope.entries.entrySet().stream()
-                    .filter(entry -> {
-                        BSymbol entrySymbol = entry.getValue().symbol;
-                        boolean isPrivate = (entrySymbol.flags & Flags.PRIVATE) == Flags.PRIVATE;
-                        return !(entrySymbol.getName().getValue().contains(".__init")
-                            && !"self".equals(symbolName)) && !(isPrivate && !"self".equals(symbolName));
-                    })
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            Map<Name, Scope.ScopeEntry> fieldEntries = objectTypeSymbol.scope.entries.entrySet().stream()
-                    .filter(entry -> {
-                        BSymbol entrySymbol = entry.getValue().symbol;
-                        boolean isPrivate = (entrySymbol.flags & Flags.PRIVATE) == Flags.PRIVATE;
-                        return !(isPrivate && !"self".equals(symbolName));
-                    })
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            entries.putAll(methodEntries);
-            entries.putAll(fieldEntries);
+            entries.putAll(getObjectMethodsAndFields(context, objectTypeSymbol, symbolName));
             entries.putAll(getLangLibScopeEntries(symbolType, symbolTable, types));
             return entries.entrySet().stream().filter(entry -> (!(entry.getValue().symbol instanceof BInvokableSymbol))
                     || ((entry.getValue().symbol.flags & Flags.REMOTE) != Flags.REMOTE))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        } else if (symbolType instanceof BUnionType) {
+            entries.putAll(getInvocationsAndFieldsForUnionType((BUnionType) symbolType, context));
+        } else if (symbolType.tsymbol != null && symbolType.tsymbol.scope != null) {
+            entries.putAll(getLangLibScopeEntries(symbolType, symbolTable, types));
+            Map<Name, Scope.ScopeEntry> filteredEntries = symbolType.tsymbol.scope.entries.entrySet().stream()
+                    .filter(optionalFieldFilter(symbolType, invocationToken))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            entries.putAll(filteredEntries);
         } else {
-            if (symbolType instanceof BUnionType) {
-                entries.putAll(getInvocationsAndFieldsForUnionType((BUnionType) symbolType, context));
-            } else if (symbolType.tsymbol != null && symbolType.tsymbol.scope != null) {
-                entries.putAll(getLangLibScopeEntries(symbolType, symbolTable, types));
-                Map<Name, Scope.ScopeEntry> filteredEntries = symbolType.tsymbol.scope.entries.entrySet().stream()
-                        .filter(optionalFieldFilter(symbolType, invocationToken))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                entries.putAll(filteredEntries);
-            } else {
-                entries.putAll(getLangLibScopeEntries(symbolType, symbolTable, types));
-            }
+            entries.putAll(getLangLibScopeEntries(symbolType, symbolTable, types));
         }
         /*
         Here we add the BTypeSymbol check to skip the anyData and similar types suggested from lang lib scope entries
@@ -406,12 +389,48 @@ public class FilterUtils {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
+    private static Map<Name, Scope.ScopeEntry> getObjectMethodsAndFields(LSContext context,
+                                                                         BObjectTypeSymbol objectSymbol,
+                                                                         String symbolName) {
+        String currentModule = context.get(DocumentServiceKeys.CURRENT_PKG_NAME_KEY);
+        String objectOwnerModule = objectSymbol.pkgID.getName().getValue();
+        boolean symbolInCurrentModule = currentModule.equals(objectOwnerModule);
+
+        // Extract the method entries
+        Map<Name, Scope.ScopeEntry> entries = objectSymbol.methodScope.entries.entrySet().stream()
+                .filter(entry -> {
+                    BSymbol entrySymbol = entry.getValue().symbol;
+                    boolean isPrivate = (entrySymbol.flags & Flags.PRIVATE) == Flags.PRIVATE;
+                    boolean isPublic = (entrySymbol.flags & Flags.PUBLIC) == Flags.PUBLIC;
+
+                    return !((entrySymbol.getName().getValue().contains(".__init") && !"self".equals(symbolName))
+                            || (isPrivate && !"self".equals(symbolName))
+                            || (!isPrivate && !isPublic && !symbolInCurrentModule));
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // Extract Field Entries
+        Map<Name, Scope.ScopeEntry> fieldEntries = objectSymbol.scope.entries.entrySet().stream()
+                .filter(entry -> {
+                    BSymbol entrySymbol = entry.getValue().symbol;
+                    boolean isPrivate = (entrySymbol.flags & Flags.PRIVATE) == Flags.PRIVATE;
+                    boolean isPublic = (entrySymbol.flags & Flags.PUBLIC) == Flags.PUBLIC;
+                    return !((isPrivate && !"self".equals(symbolName))
+                            || (!isPrivate && !isPublic && !symbolInCurrentModule));
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        entries.putAll(fieldEntries);
+
+        return entries;
+    }
+
     /**
      * When given a union of record types, iterate over the member types to extract the fields with the same name.
      * If a certain field with the same name contains in all records we extract the field entries
-     * 
+     *
      * @param unionType union type to evaluate
-     * @param context Language server operation context
+     * @param context   Language server operation context
      * @return {@link Map} map of scope entries
      */
     private static Map<Name, Scope.ScopeEntry> getInvocationsAndFieldsForUnionType(BUnionType unionType,
@@ -493,10 +512,10 @@ public class FilterUtils {
     /**
      * Retrieve lang-lib scope entries for this typeTag.
      *
-     * @param bType   {@link BType}
-     * @param symTable  {@link SymbolTable}
-     * @param types {@link Types} analyzer
-     * @return  map of scope entries
+     * @param bType    {@link BType}
+     * @param symTable {@link SymbolTable}
+     * @param types    {@link Types} analyzer
+     * @return map of scope entries
      */
     public static Map<Name, Scope.ScopeEntry> getLangLibScopeEntries(BType bType, SymbolTable symTable, Types types) {
         Map<Name, Scope.ScopeEntry> entries = new HashMap<>(symTable.langValueModuleSymbol.scope.entries);
@@ -556,7 +575,7 @@ public class FilterUtils {
             return symbol.kind != null && symbol.kind != SymbolKind.OBJECT;
         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
-    
+
     private static Predicate<Map.Entry<Name, Scope.ScopeEntry>> optionalFieldFilter(BType symbolType,
                                                                                     Integer invocationTkn) {
         return entry -> {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion2.json
@@ -1,7 +1,7 @@
 {
   "position": {
-    "line": 13,
-    "character": 23
+    "line": 8,
+    "character": 16
   },
   "source": "function/source/chainCompletion2.bal",
   "items": [
@@ -94,14 +94,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "zone",
-      "kind": "Variable",
-      "detail": "time:TimeZone",
-      "sortText": "130",
-      "insertText": "zone",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "get(string k)((any|error))",
       "kind": "Function",
       "detail": "Function",
@@ -188,6 +180,14 @@
       }
     },
     {
+      "label": "recField1",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "130",
+      "insertText": "recField1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "forEach(function ((any|error)) returns () func)",
       "kind": "Function",
       "detail": "Function",
@@ -231,6 +231,14 @@
       },
       "sortText": "120",
       "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "recField2",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "recField2",
       "insertTextFormat": "Snippet"
     },
     {
@@ -309,14 +317,6 @@
       },
       "sortText": "120",
       "insertText": "toString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "time",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "130",
-      "insertText": "time",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion3.json
@@ -1,7 +1,7 @@
 {
   "position": {
-    "line": 5,
-    "character": 48
+    "line": 2,
+    "character": 37
   },
   "source": "function/source/chainCompletion3.bal",
   "items": [
@@ -94,14 +94,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "zone",
-      "kind": "Variable",
-      "detail": "time:TimeZone",
-      "sortText": "221",
-      "insertText": "zone",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "get(string k)((any|error))",
       "kind": "Function",
       "detail": "Function",
@@ -188,6 +180,14 @@
       }
     },
     {
+      "label": "recField1",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "221",
+      "insertText": "recField1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "forEach(function ((any|error)) returns () func)",
       "kind": "Function",
       "detail": "Function",
@@ -231,6 +231,14 @@
       },
       "sortText": "121",
       "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "recField2",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "221",
+      "insertText": "recField2",
       "insertTextFormat": "Snippet"
     },
     {
@@ -309,14 +317,6 @@
       },
       "sortText": "121",
       "insertText": "toString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "time",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "221",
-      "insertText": "time",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/errorLiftingSuggestions1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/errorLiftingSuggestions1.json
@@ -1,625 +1,581 @@
 {
-    "position": {
-        "line": 18,
-        "character": 27
-    },
-    "source": "function/source/errorLiftingSuggestions1.bal",
-    "items": [
-        {
-            "label": "setLastModified()",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setLastModified();",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "server",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "221",
-            "insertText": "server",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setTextPayload(string payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setTextPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getHeaderNames((leading|trailing) position)(string[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getHeaderNames(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setEntity(mime:Entity e)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setEntity(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setXmlPayload(xml payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setXmlPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getCookies()(http:Cookie[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the response.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the response  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getCookies()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getHeaders(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setBinaryPayload(byte[] payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setBinaryPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getBinaryPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setByteChannel(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "createNewEntity()(mime:Entity)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the response  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "createNewEntity()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setJsonPayload(json payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setJsonPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "hasHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getXmlPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "addHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`Response.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getByteChannel()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getEntity()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "removeAllHeaders((leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "removeAllHeaders(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "resolvedRequestedURI",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "221",
-            "insertText": "resolvedRequestedURI",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getContentType()(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getContentType()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setETag((json|xml|string|byte[]) payload)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setETag(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "removeCookiesFromRemoteStore(http:Cookie... cookiesToRemove)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nDeletes the cookies in the client\u0027s cookie store.\n  \n**Params**  \n- `http:Cookie[]` cookiesToRemove: Cookies to be deleted"
-                }
-            },
-            "sortText": "121",
-            "insertText": "removeCookiesFromRemoteStore(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "cacheControl",
-            "kind": "Variable",
-            "detail": "(http:ResponseCacheControl|())",
-            "sortText": "221",
-            "insertText": "cacheControl",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "requestTime",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "221",
-            "insertText": "requestTime",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the response  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getBodyParts()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setBodyParts(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getJsonPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setContentType(string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setContentType(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "addCookie(http:Cookie cookie)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nAdds the cookie to response.\n  \n**Params**  \n- `http:Cookie` cookie: The cookie, which is added to response"
-                }
-            },
-            "sortText": "121",
-            "insertText": "addCookie(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "reasonPhrase",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "221",
-            "insertText": "reasonPhrase",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "receivedTime",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "221",
-            "insertText": "receivedTime",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getHeader(string headerName, (leading|trailing) position)(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "removeHeader(string key, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "removeHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setFileAsPayload(string filePath, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
-                }
-            },
-            "sortText": "121",
-            "insertText": "setFileAsPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "toString()(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key\u003dvalue for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "toString()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getTextPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getEntityWithoutBody()(mime:Entity)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
-                }
-            },
-            "sortText": "121",
-            "insertText": "getEntityWithoutBody()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "statusCode",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "221",
-            "insertText": "statusCode",
-            "insertTextFormat": "Snippet"
+  "position": {
+    "line": 18,
+    "character": 27
+  },
+  "source": "function/source/errorLiftingSuggestions1.bal",
+  "items": [
+    {
+      "label": "setLastModified()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
         }
-    ]
+      },
+      "sortText": "121",
+      "insertText": "setLastModified();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "server",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "221",
+      "insertText": "server",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setTextPayload(string payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setTextPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeaderNames((leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getHeaderNames(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setEntity(mime:Entity e)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setEntity(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setXmlPayload(xml payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setXmlPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getCookies()(http:Cookie[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the response.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the response  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getCookies()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setBinaryPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getBinaryPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`Response.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders((leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "removeAllHeaders(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "resolvedRequestedURI",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "221",
+      "insertText": "resolvedRequestedURI",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setETag((json|xml|string|byte[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setETag(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeCookiesFromRemoteStore(http:Cookie... cookiesToRemove)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nDeletes the cookies in the client's cookie store.\n  \n**Params**  \n- `http:Cookie[]` cookiesToRemove: Cookies to be deleted"
+        }
+      },
+      "sortText": "121",
+      "insertText": "removeCookiesFromRemoteStore(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cacheControl",
+      "kind": "Variable",
+      "detail": "(http:ResponseCacheControl|())",
+      "sortText": "221",
+      "insertText": "cacheControl",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the response  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentType(string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setContentType(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "addCookie(http:Cookie cookie)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the cookie to response.\n  \n**Params**  \n- `http:Cookie` cookie: The cookie, which is added to response"
+        }
+      },
+      "sortText": "121",
+      "insertText": "addCookie(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "reasonPhrase",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "221",
+      "insertText": "reasonPhrase",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName, (leading|trailing) position)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "121",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "121",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "statusCode",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "221",
+      "insertText": "statusCode",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/chainCompletion2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/chainCompletion2.bal
@@ -1,16 +1,28 @@
-import ballerina/file;
-import ballerina/time;
-
+  
 function testFunction1() {
-	time:Time tm = {
-		time: 0,
-		zone: {
-			id: "",
-			offset: 0
-		}
-	};
-	
-	file:FileInfo fInfo = new("test", 12, tm, false);
-    fInfo.modifiedTime.
+    TestRecord testRec = {
+        recField1: 0,
+        recField2: ""
+    };
+
+    TestObject testObj = new("f1", 12, testRec);
+    testObj.rec.
     string testString = "Hello Ballerina!";
 }
+
+type TestObject object {
+    string field1;
+    int field2;
+    TestRecord rec;
+
+    public function __init(string f1, int f2, TestRecord recF) {
+         self.field1 = f1;
+         self.field2 = f2;
+         self.rec = recF;
+    }
+};
+
+public type TestRecord record {
+    int recField1;
+    string recField2;
+};

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/chainCompletion3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/chainCompletion3.bal
@@ -1,20 +1,32 @@
-import ballerina/file;
-import ballerina/time;
-
 function testFunction1() {
     string testString = "Hello Ballerina!";
-    var modifiedTime = getFileInfo.modifiedTime.
+    var result = getTestObject().rec.
 }
 
-function getFileInfo() returns file:FileInfo {
-	time:Time tm = {
-        time: 0,
-        zone: {
-            id: "",
-            offset: 0
-        }
-    };
-    	
-    file:FileInfo fInfo = new("test", 12, tm, false);
-    return fInfo;
+function getTestObject() returns TestObject {
+	TestRecord testRec = {
+            recField1: 0,
+            recField2: ""
+        };
+
+        TestObject testObj = new("f1", 12, testRec);
+
+        return testObj;
 }
+
+type TestObject object {
+    string field1;
+    int field2;
+    TestRecord rec;
+
+    public function __init(string f1, int f2, TestRecord recF) {
+         self.field1 = f1;
+         self.field2 = f2;
+         self.rec = recF;
+    }
+};
+
+public type TestRecord record {
+    int recField1;
+    string recField2;
+};

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions3.json
@@ -1,625 +1,581 @@
 {
-    "position": {
-        "line": 11,
-        "character": 18
-    },
-    "source": "function/source/typeGuardSuggestions3.bal",
-    "items": [
-        {
-            "label": "setLastModified()",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setLastModified();",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "server",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "130",
-            "insertText": "server",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setTextPayload(string payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setTextPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getHeaderNames((leading|trailing) position)(string[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getHeaderNames(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setEntity(mime:Entity e)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setEntity(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setXmlPayload(xml payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setXmlPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getCookies()(http:Cookie[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the response.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the response  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getCookies()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getHeaders(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setBinaryPayload(byte[] payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setBinaryPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getBinaryPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setByteChannel(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "createNewEntity()(mime:Entity)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the response  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "createNewEntity()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setJsonPayload(json payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setJsonPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "hasHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getXmlPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "addHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`Response.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getByteChannel()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getEntity()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "removeAllHeaders((leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "removeAllHeaders(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "resolvedRequestedURI",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "130",
-            "insertText": "resolvedRequestedURI",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getContentType()(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getContentType()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setETag((json|xml|string|byte[]) payload)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setETag(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "removeCookiesFromRemoteStore(http:Cookie... cookiesToRemove)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nDeletes the cookies in the client\u0027s cookie store.\n  \n**Params**  \n- `http:Cookie[]` cookiesToRemove: Cookies to be deleted"
-                }
-            },
-            "sortText": "120",
-            "insertText": "removeCookiesFromRemoteStore(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "cacheControl",
-            "kind": "Variable",
-            "detail": "(http:ResponseCacheControl|())",
-            "sortText": "130",
-            "insertText": "cacheControl",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "requestTime",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "130",
-            "insertText": "requestTime",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the response  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getBodyParts()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setBodyParts(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getJsonPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setContentType(string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setContentType(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "addCookie(http:Cookie cookie)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nAdds the cookie to response.\n  \n**Params**  \n- `http:Cookie` cookie: The cookie, which is added to response"
-                }
-            },
-            "sortText": "120",
-            "insertText": "addCookie(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "reasonPhrase",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "130",
-            "insertText": "reasonPhrase",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "receivedTime",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "130",
-            "insertText": "receivedTime",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getHeader(string headerName, (leading|trailing) position)(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "removeHeader(string key, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "removeHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setFileAsPayload(string filePath, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setFileAsPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "toString()(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key\u003dvalue for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "toString()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getTextPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getEntityWithoutBody()(mime:Entity)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getEntityWithoutBody()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "statusCode",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "130",
-            "insertText": "statusCode",
-            "insertTextFormat": "Snippet"
+  "position": {
+    "line": 11,
+    "character": 18
+  },
+  "source": "function/source/typeGuardSuggestions3.bal",
+  "items": [
+    {
+      "label": "setLastModified()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
         }
-    ]
+      },
+      "sortText": "120",
+      "insertText": "setLastModified();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "server",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "server",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setTextPayload(string payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setTextPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeaderNames((leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeaderNames(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setEntity(mime:Entity e)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setEntity(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setXmlPayload(xml payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setXmlPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getCookies()(http:Cookie[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the response.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the response  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getCookies()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setBinaryPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getBinaryPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`Response.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders((leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAllHeaders(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "resolvedRequestedURI",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "resolvedRequestedURI",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setETag((json|xml|string|byte[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setETag(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeCookiesFromRemoteStore(http:Cookie... cookiesToRemove)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nDeletes the cookies in the client's cookie store.\n  \n**Params**  \n- `http:Cookie[]` cookiesToRemove: Cookies to be deleted"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeCookiesFromRemoteStore(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cacheControl",
+      "kind": "Variable",
+      "detail": "(http:ResponseCacheControl|())",
+      "sortText": "130",
+      "insertText": "cacheControl",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the response  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentType(string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setContentType(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "addCookie(http:Cookie cookie)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the cookie to response.\n  \n**Params**  \n- `http:Cookie` cookie: The cookie, which is added to response"
+        }
+      },
+      "sortText": "120",
+      "insertText": "addCookie(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "reasonPhrase",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "reasonPhrase",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName, (leading|trailing) position)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "statusCode",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "130",
+      "insertText": "statusCode",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/variableBoundItemSuggestions3.json
@@ -1,625 +1,581 @@
 {
-    "position": {
-        "line": 6,
-        "character": 8
-    },
-    "source": "function/source/variableBoundItemSuggestions3.bal",
-    "items": [
-        {
-            "label": "setLastModified()",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setLastModified();",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "server",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "130",
-            "insertText": "server",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setTextPayload(string payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setTextPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getHeaderNames((leading|trailing) position)(string[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getHeaderNames(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setEntity(mime:Entity e)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setEntity(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setXmlPayload(xml payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setXmlPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getCookies()(http:Cookie[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the response.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the response  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getCookies()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getHeaders(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setBinaryPayload(byte[] payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setBinaryPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getBinaryPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setByteChannel(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "createNewEntity()(mime:Entity)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the response.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the response  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "createNewEntity()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setJsonPayload(json payload, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setJsonPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "hasHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getXmlPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "addHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`Response.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getByteChannel()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getEntity()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "removeAllHeaders((leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "removeAllHeaders(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "resolvedRequestedURI",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "130",
-            "insertText": "resolvedRequestedURI",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getContentType()(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getContentType()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setETag((json|xml|string|byte[]) payload)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setETag(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "removeCookiesFromRemoteStore(http:Cookie... cookiesToRemove)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nDeletes the cookies in the client\u0027s cookie store.\n  \n**Params**  \n- `http:Cookie[]` cookiesToRemove: Cookies to be deleted"
-                }
-            },
-            "sortText": "120",
-            "insertText": "removeCookiesFromRemoteStore(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "cacheControl",
-            "kind": "Variable",
-            "detail": "(http:ResponseCacheControl|())",
-            "sortText": "130",
-            "insertText": "cacheControl",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "requestTime",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "130",
-            "insertText": "requestTime",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the response  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getBodyParts()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setBodyParts(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getJsonPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "setContentType(string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setContentType(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "addCookie(http:Cookie cookie)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nAdds the cookie to response.\n  \n**Params**  \n- `http:Cookie` cookie: The cookie, which is added to response"
-                }
-            },
-            "sortText": "120",
-            "insertText": "addCookie(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "reasonPhrase",
-            "kind": "Variable",
-            "detail": "string",
-            "sortText": "130",
-            "insertText": "reasonPhrase",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "receivedTime",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "130",
-            "insertText": "receivedTime",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getHeader(string headerName, (leading|trailing) position)(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "removeHeader(string key, (leading|trailing) position)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "removeHeader(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "setFileAsPayload(string filePath, string contentType)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
-                }
-            },
-            "sortText": "120",
-            "insertText": "setFileAsPayload(${1});",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
-            }
-        },
-        {
-            "label": "toString()(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key\u003dvalue for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "toString()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getTextPayload()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "getEntityWithoutBody()(mime:Entity)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
-                }
-            },
-            "sortText": "120",
-            "insertText": "getEntityWithoutBody()",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "statusCode",
-            "kind": "Variable",
-            "detail": "int",
-            "sortText": "130",
-            "insertText": "statusCode",
-            "insertTextFormat": "Snippet"
+  "position": {
+    "line": 6,
+    "character": 8
+  },
+  "source": "function/source/variableBoundItemSuggestions3.bal",
+  "items": [
+    {
+      "label": "setLastModified()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the current time as the `last-modified` header.  \n"
         }
-    ]
+      },
+      "sortText": "120",
+      "insertText": "setLastModified();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "server",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "server",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setTextPayload(string payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setTextPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getHeaderNames((leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeaderNames(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setEntity(mime:Entity e)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the response.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the response"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setEntity(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setXmlPayload(xml payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setXmlPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getCookies()(http:Cookie[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the response.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the response  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getCookies()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setBinaryPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getBinaryPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the response.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the response. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the response payload as a `ByteChannel`, except in the case of multiparts. To retrieve multiparts, use\n`Response.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the response.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAllHeaders((leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the response.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAllHeaders(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "resolvedRequestedURI",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "resolvedRequestedURI",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the response (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setETag((json|xml|string|byte[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.\n  \n**Params**  \n- `(json|xml|string|byte[])` payload: The payload for which the ETag should be set"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setETag(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the response payload.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set\n            of body parts)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeCookiesFromRemoteStore(http:Cookie... cookiesToRemove)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nDeletes the cookies in the client's cookie store.\n  \n**Params**  \n- `http:Cookie[]` cookiesToRemove: Cookies to be deleted"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeCookiesFromRemoteStore(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cacheControl",
+      "kind": "Variable",
+      "detail": "(http:ResponseCacheControl|())",
+      "sortText": "130",
+      "insertText": "cacheControl",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the response. If the content type is not a composite media type, an error is returned.\n  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the response  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the response. If a mapping already exists for the specified header key, the\nexisting header value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setContentType(string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the response.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setContentType(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "addCookie(http:Cookie cookie)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the cookie to response.\n  \n**Params**  \n- `http:Cookie` cookie: The cookie, which is added to response"
+        }
+      },
+      "sortText": "120",
+      "insertText": "addCookie(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "reasonPhrase",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "reasonPhrase",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName, (leading|trailing) position)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Response.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeHeader(string key, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the response.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the response.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the response.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The string representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "statusCode",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "130",
+      "insertText": "statusCode",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/completionBeforeUnderscore2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/completionBeforeUnderscore2.json
@@ -5,703 +5,639 @@
   },
   "source": "resource/source/completionBeforeUnderscore2.bal",
   "items": [
-      {
-          "label": "extraPathInfo",
-          "kind": "Variable",
-          "detail": "string",
-          "sortText": "130",
-          "insertText": "extraPathInfo",
-          "insertTextFormat": "Snippet"
+    {
+      "label": "extraPathInfo",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "extraPathInfo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the request. If the content type is not XML, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
+        }
       },
-      {
-          "label": "getXmlPayload()((xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nExtracts `xml` payload from the request. If the content type is not XML, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(xml|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `xml` payload or `http:ClientError` in case of errors  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getXmlPayload()",
-          "insertTextFormat": "Snippet"
+      "sortText": "120",
+      "insertText": "getXmlPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "expects100Continue()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the client expects a `100-continue` response.\n  \n  \n  \n**Returns** `boolean`   \n- Returns true if the client expects a `100-continue` response  \n  \n"
+        }
       },
-      {
-          "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setByteChannel(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
+      "sortText": "120",
+      "insertText": "expects100Continue()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setByteChannel(io:ReadableByteChannel payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `ByteChannel` as the payload.\n  \n**Params**  \n- `io:ReadableByteChannel` payload: A `ByteChannel` through which the message payload can be read  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
       },
-      {
-          "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nExtracts `json` payload from the request. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getJsonPayload()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getBinaryPayload()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "parseCacheControlHeader()",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "parseCacheControlHeader();",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "createNewEntity()(mime:Entity)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nCreate a new `Entity` and link it with the request.\n  \n  \n  \n**Returns** `mime:Entity`   \n- Newly created `Entity` that has been set to the request  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "createNewEntity()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the request. If the content type is not of type text, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `text` payload or `http:ClientError` in case of errors  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getTextPayload()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getHeader(string headerName, (leading|trailing) position)(string)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Request.hasHeader()` beforehand to check the existence of header.  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getHeader(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `ByteChannel` except in the case of multiparts. To retrieve multiparts, use\n`Request.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getByteChannel()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "mutualSslHandshake",
-          "kind": "Variable",
-          "detail": "(http:MutualSslHandshake|())",
-          "sortText": "130",
-          "insertText": "mutualSslHandshake",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "setTextPayload(string payload, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setTextPayload(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "setContentType(string contentType)((()|error))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the request.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header  \n  \n**Returns** `(()|error)`   \n- Nil if successful, error in case of invalid content-type  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setContentType(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets the request payload. Note that any string value is set as `text/plain`. To send a JSON-compatible string,\nset the content-type header to `application/json` or use the `setJsonPayload` method instead.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel`, or `Entity[]` (i.e., a set\nof body parts)."
-              }
-          },
-          "sortText": "120",
-          "insertText": "setPayload(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "getQueryParamValues(string key)((string[]|()))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets all the query param values associated with the given key.\n  \n**Params**  \n- `string` key: Represents the query param key  \n  \n**Returns** `(string[]|())`   \n- Returns all the query param values associated with the given key as a `string[]`. Nil is returned if no key  \n           is found.  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getQueryParamValues(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "setFileAsPayload(string filePath, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the request.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setFileAsPayload(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "method",
-          "kind": "Variable",
-          "detail": "string",
-          "sortText": "130",
-          "insertText": "method",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the request. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "addHeader(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "noEntityBody",
-          "kind": "Variable",
-          "detail": "boolean",
-          "sortText": "130",
-          "insertText": "noEntityBody",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the request.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the request. An `http:ClientError` is returned, if entity construction fails  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getEntity()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "hasHeader(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "cacheControl",
-          "kind": "Variable",
-          "detail": "(http:RequestCacheControl|())",
-          "sortText": "130",
-          "insertText": "cacheControl",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "setJsonPayload(json payload, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setJsonPayload(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "checkEntityBodyAvailability()(boolean)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nCheck whether the entity body is present.\n  \n  \n  \n**Returns** `boolean`   \n- a boolean indicating entity body availability  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "checkEntityBodyAvailability()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getHeaderNames((leading|trailing) position)(string[])",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the request.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getHeaderNames(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the request. If the content type is not a composite media type, an error\nis returned.  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the request  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getBodyParts()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getFormParams()((map\u003cstring\u003e|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the form parameters from the HTTP request as a `map` when content type is application/x-www-form-urlencoded.\n  \n  \n  \n**Returns** `(map\u003cstring\u003e|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The map of form params or `http:ClientError` in case of errors  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getFormParams()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Request.hasHeader()` beforehand to check the existence of header.  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getHeaders(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "setBinaryPayload(byte[] payload, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setBinaryPayload(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "expects100Continue()(boolean)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nChecks whether the client expects a `100-continue` response.\n  \n  \n  \n**Returns** `boolean`   \n- Returns true if the client expects a `100-continue` response  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "expects100Continue()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getQueryParamValue(string key)((string|()))",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the query param value associated with the given key.\n  \n**Params**  \n- `string` key: Represents the query param key  \n  \n**Returns** `(string|())`   \n- Returns the query param value associated with the given key as a string. If multiple param values are  \n           present, then the first value is returned. Nil is returned if no key is found.  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getQueryParamValue(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "getEntityWithoutBody()(mime:Entity)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \n  \n  \n  \n**Returns** `mime:Entity`   \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getEntityWithoutBody()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "setEntity(mime:Entity e)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the request.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the request"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setEntity(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the request. If a mapping already exists for the specified header key, the existing\nheader value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setHeader(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "rawPath",
-          "kind": "Variable",
-          "detail": "string",
-          "sortText": "130",
-          "insertText": "rawPath",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "httpVersion",
-          "kind": "Variable",
-          "detail": "string",
-          "sortText": "130",
-          "insertText": "httpVersion",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getCookies()(http:Cookie[])",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the request.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the request  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getCookies()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "addCookies(http:Cookie[] cookiesToAdd)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nAdds cookies to the request.\n  \n**Params**  \n- `http:Cookie[]` cookiesToAdd: Represents the cookies to be added"
-              }
-          },
-          "sortText": "120",
-          "insertText": "addCookies(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "removeAllHeaders((leading|trailing) position)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the request.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "removeAllHeaders(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setBodyParts(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "userAgent",
-          "kind": "Variable",
-          "detail": "string",
-          "sortText": "130",
-          "insertText": "userAgent",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "setXmlPayload(xml payload, string contentType)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload.\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "setXmlPayload(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "removeHeader(string key, (leading|trailing) position)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the request.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
-              }
-          },
-          "sortText": "120",
-          "insertText": "removeHeader(${1});",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "getQueryParams()(map\u003cstring[]\u003e)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the query parameters of the request as a map consisting of a string array.\n  \n  \n  \n**Returns** `map\u003cstring[]\u003e`   \n- String array map of the query params  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getQueryParams()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "getMatrixParams(string path)(map\u003cany\u003e)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the matrix parameters of the request.\n  \n**Params**  \n- `string` path: Path to the location of matrix parameters  \n  \n**Returns** `map\u003cany\u003e`   \n- A map of matrix parameters which can be found for the given path  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getMatrixParams(${1})",
-          "insertTextFormat": "Snippet",
-          "command": {
-              "title": "editor.action.triggerParameterHints",
-              "command": "editor.action.triggerParameterHints"
-          }
-      },
-      {
-          "label": "getContentType()(string)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the request (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "getContentType()",
-          "insertTextFormat": "Snippet"
-      },
-      {
-          "label": "toString()(string)",
-          "kind": "Function",
-          "detail": "Function",
-          "documentation": {
-              "right": {
-                  "kind": "markdown",
-                  "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key\u003dvalue for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n"
-              }
-          },
-          "sortText": "120",
-          "insertText": "toString()",
-          "insertTextFormat": "Snippet"
+      "sortText": "120",
+      "insertText": "setByteChannel(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "getQueryParamValue(string key)((string|()))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the query param value associated with the given key.\n  \n**Params**  \n- `string` key: Represents the query param key  \n  \n**Returns** `(string|())`   \n- Returns the query param value associated with the given key as a string. If multiple param values are  \n           present, then the first value is returned. Nil is returned if no key is found.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getQueryParamValue(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getJsonPayload()((json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `json` payload from the request. If the content type is not JSON, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(json|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `json` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getJsonPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBinaryPayload()((byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `byte[]`.\n  \n  \n  \n**Returns** `(byte[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The byte[] representation of the message payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getBinaryPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getTextPayload()((string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts `text` payload from the request. If the content type is not of type text, an `http:ClientError` is returned.\n  \n  \n  \n**Returns** `(string|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `text` payload or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getTextPayload()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeader(string headerName, (leading|trailing) position)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nReturns the value of the specified header. If the specified header key maps to multiple values, the first of\nthese values is returned.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string`   \n- The first header value for the specified header name. An exception is thrown if no header is found. Use  \n           `Request.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setEntity(mime:Entity e)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the provided `Entity` to the request.\n  \n**Params**  \n- `mime:Entity` e: The `Entity` to be set to the request"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setEntity(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the specified header to the request. If a mapping already exists for the specified header key, the existing\nheader value is replaced with the specified header value.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getByteChannel()((io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the request payload as a `ByteChannel` except in the case of multiparts. To retrieve multiparts, use\n`Request.getBodyParts()`.\n  \n  \n  \n**Returns** `(io:ReadableByteChannel|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- A byte channel from which the message payload can be read or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getByteChannel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rawPath",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "rawPath",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "httpVersion",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "httpVersion",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getCookies()(http:Cookie[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets cookies from the request.\n  \n  \n  \n**Returns** `http:Cookie[]`   \n- An array of cookie objects, which are included in the request  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getCookies()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "addCookies(http:Cookie[] cookiesToAdd)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds cookies to the request.\n  \n**Params**  \n- `http:Cookie[]` cookiesToAdd: Represents the cookies to be added"
+        }
+      },
+      "sortText": "120",
+      "insertText": "addCookies(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "mutualSslHandshake",
+      "kind": "Variable",
+      "detail": "(http:MutualSslHandshake|())",
+      "sortText": "130",
+      "insertText": "mutualSslHandshake",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "setTextPayload(string payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `string` as the payload.\n  \n**Params**  \n- `string` payload: The `string` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `string`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setTextPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setContentType(string contentType)((()|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the `content-type` header to the request.\n  \n**Params**  \n- `string` contentType: Content type value to be set as the `content-type` header  \n  \n**Returns** `(()|error)`   \n- Nil if successful, error in case of invalid content-type  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setContentType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setPayload((string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]) payload)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the request payload. Note that any string value is set as `text/plain`. To send a JSON-compatible string,\nset the content-type header to `application/json` or use the `setJsonPayload` method instead.\n  \n**Params**  \n- `(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[])` payload: Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel`, or `Entity[]` (i.e., a set\nof body parts)."
+        }
+      },
+      "sortText": "120",
+      "insertText": "setPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getQueryParamValues(string key)((string[]|()))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the query param values associated with the given key.\n  \n**Params**  \n- `string` key: Represents the query param key  \n  \n**Returns** `(string[]|())`   \n- Returns all the query param values associated with the given key as a `string[]`. Nil is returned if no key  \n           is found.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getQueryParamValues(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setFileAsPayload(string filePath, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets the content of the specified file as the entity body of the request.\n  \n**Params**  \n- `string` filePath: Path to the file to be set as the payload  \n- `string` contentType: The content type of the specified file. Set this to override the default `content-type`\n                header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setFileAsPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeAllHeaders((leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves all the headers from the request.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAllHeaders(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "method",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "method",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "addHeader(string headerName, string headerValue, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nAdds the specified header to the request. Existing header values are not replaced.\n  \n**Params**  \n- `string` headerName: The header name  \n- `string` headerValue: The header value  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "addHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setBodyParts(mime:Entity[] bodyParts, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSet multiparts as the payload.\n  \n**Params**  \n- `mime:Entity[]` bodyParts: The entities which make up the message body  \n- `string` contentType: The content type of the top level message. Set this to override the default\n                `content-type` header value(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setBodyParts(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getEntity()((mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the `Entity` associated with the request.\n  \n  \n  \n**Returns** `(mime:Entity|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The `Entity` of the request. An `http:ClientError` is returned, if entity construction fails  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getEntity()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "userAgent",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "userAgent",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "hasHeader(string headerName, (leading|trailing) position)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nChecks whether the requested header key exists in the header map.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `boolean`   \n- Returns true if the specified header key exists  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasHeader(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setXmlPayload(xml payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets an `xml` as the payload.\n  \n**Params**  \n- `xml` payload: The `xml` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `xml`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setXmlPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cacheControl",
+      "kind": "Variable",
+      "detail": "(http:RequestCacheControl|())",
+      "sortText": "130",
+      "insertText": "cacheControl",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeHeader(string key, (leading|trailing) position)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nRemoves the specified header from the request.\n  \n**Params**  \n- `string` key: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeHeader(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setJsonPayload(json payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `json` as the payload.\n  \n**Params**  \n- `json` payload: The `json` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `json`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setJsonPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getQueryParams()(map<string[]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the query parameters of the request as a map consisting of a string array.\n  \n  \n  \n**Returns** `map<string[]>`   \n- String array map of the query params  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getQueryParams()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeaderNames((leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the names of the headers of the request.\n  \n**Params**  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- An array of all the header names  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeaderNames(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getMatrixParams(string path)(map<any>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the matrix parameters of the request.\n  \n**Params**  \n- `string` path: Path to the location of matrix parameters  \n  \n**Returns** `map<any>`   \n- A map of matrix parameters which can be found for the given path  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getMatrixParams(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getContentType()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the type of the payload of the request (i.e: the `content-type` header value).\n  \n  \n  \n**Returns** `string`   \n- Returns the `content-type` header value as a string  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getContentType()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getBodyParts()((mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nExtracts body parts from the request. If the content type is not a composite media type, an error\nis returned.  \n  \n  \n**Returns** `(mime:Entity[]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- Returns the body parts as an array of entities or an `http:ClientError` if there were any errors in  \n           constructing the body parts from the request  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getBodyParts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getFormParams()((map<string>|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the form parameters from the HTTP request as a `map` when content type is application/x-www-form-urlencoded.\n  \n  \n  \n**Returns** `(map<string>|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError)`   \n- The map of form params or `http:ClientError` in case of errors  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getFormParams()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getHeaders(string headerName, (leading|trailing) position)(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets all the header values to which the specified header key maps to.\n  \n**Params**  \n- `string` headerName: The header name  \n- `(leading|trailing)` position: Represents the position of the header as an optional parameter(Defaultable)  \n  \n**Returns** `string[]`   \n- The header values the specified header key maps to. An exception is thrown if no header is found. Use  \n           `Request.hasHeader()` beforehand to check the existence of header.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getHeaders(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "setBinaryPayload(byte[] payload, string contentType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nSets a `byte[]` as the payload.\n  \n**Params**  \n- `byte[]` payload: The `byte[]` payload  \n- `string` contentType: The content type of the payload. Set this to override the default `content-type` header value\n                for `byte[]`(Defaultable)"
+        }
+      },
+      "sortText": "120",
+      "insertText": "setBinaryPayload(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
   ]
 }


### PR DESCRIPTION
## Purpose
> With this, avoid suggesting non-public fields and methods in objects over Dot operator.

Fixes #20315

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/20840

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
