### PR TITLE
Trim the scope string [master]

### DIFF
--- a/stdlib/oauth2/src/main/ballerina/src/oauth2/outbound_oauth2_provider.bal
+++ b/stdlib/oauth2/src/main/ballerina/src/oauth2/outbound_oauth2_provider.bal
@@ -572,7 +572,7 @@ function prepareRequest(RequestConfig config) returns http:Request|Error {
         }
     }
     if (scopeString != "") {
-        textPayload = textPayload + "&scope=" + scopeString;
+        textPayload = textPayload + "&scope=" + scopeString.trim();
     }
 
     string? clientId = config?.clientId;


### PR DESCRIPTION
## Purpose
Trim the value of the space-delimited scope string [1] starts which starts with white space as `...scope=<white_space>all...`

Fixes #20850 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
