### PR TITLE
Fix formatting bug in check node

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
@@ -606,8 +606,7 @@ public class FormattingNodeTree {
         if (node.has(FormattingConstants.FORMATTING_CONFIG) && node.has(FormattingConstants.WS)) {
             JsonArray ws = node.getAsJsonArray(FormattingConstants.WS);
             JsonObject formatConfig = node.getAsJsonObject(FormattingConstants.FORMATTING_CONFIG);
-            boolean isExpression = node.has(FormattingConstants.IS_EXPRESSION)
-                    && node.get(FormattingConstants.IS_EXPRESSION).getAsBoolean();
+            boolean useParentIndentation = formatConfig.get(FormattingConstants.USE_PARENT_INDENTATION).getAsBoolean();
 
             // Get the indentation for the node.
             String indentation = this.getIndentation(formatConfig, false);
@@ -615,11 +614,10 @@ public class FormattingNodeTree {
             // Get the indentation for the node.
             String indentationWithParent = this.getParentIndentation(formatConfig);
 
-            if (isExpression) {
-                this.preserveHeight(ws, indentationWithParent);
-            } else {
-                this.preserveHeight(ws, indentation);
-            }
+            this.preserveHeight(ws, useParentIndentation ? indentationWithParent : indentation);
+
+            int indentationSpaceCount = formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt();
+            int indentationNewLineCount = formatConfig.get(FormattingConstants.NEW_LINE_COUNT).getAsInt();
 
             // Update whitespaces for check.
             for (JsonElement wsItem : ws) {
@@ -627,10 +625,10 @@ public class FormattingNodeTree {
                 if (this.noHeightAvailable(currentWS.get(FormattingConstants.WS).getAsString())) {
                     String text = currentWS.get(FormattingConstants.TEXT).getAsString();
                     if (text.equals(Tokens.CHECK)) {
-                        if (isExpression) {
+                        if (indentationSpaceCount > 0) {
                             currentWS.addProperty(FormattingConstants.WS,
                                     this.getWhiteSpaces(formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt()));
-                        } else {
+                        } else if (indentationNewLineCount > 0) {
                             currentWS.addProperty(FormattingConstants.WS, this.getNewLines(formatConfig
                                     .get(FormattingConstants.NEW_LINE_COUNT).getAsInt()) + indentation);
                         }
@@ -644,8 +642,8 @@ public class FormattingNodeTree {
             if (node.has(FormattingConstants.EXPRESSION)) {
                 node.getAsJsonObject(FormattingConstants.EXPRESSION).add(FormattingConstants.FORMATTING_CONFIG,
                         this.getFormattingConfig(0, 1, 0, false,
-                                this.getWhiteSpaceCount(isExpression ? indentationWithParent : indentation),
-                                false));
+                                this.getWhiteSpaceCount((indentationSpaceCount > 0) ?
+                                                                indentationWithParent : indentation), true));
             }
         }
     }
@@ -1654,7 +1652,7 @@ public class FormattingNodeTree {
             if (node.has("collection")) {
                 JsonObject collection = node.getAsJsonObject("collection");
                 JsonObject collectionFormatConfig = this.getFormattingConfig(0, 1, 0, false,
-                        this.getWhiteSpaceCount(indentWithParentIndentation), false);
+                        this.getWhiteSpaceCount(indentWithParentIndentation), true);
                 collection.add(FormattingConstants.FORMATTING_CONFIG, collectionFormatConfig);
             }
 

--- a/language-server/modules/langserver-core/src/test/resources/formatting/check.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/check.bal
@@ -80,3 +80,25 @@ public function test2() returns error? {
     string sd = check name();
     io:println("Response from organization count query from DB: " +check test1());
 }
+
+public function test3() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var    item  in      check      ItemArr {
+
+    }
+}
+
+public function test4() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var
+       item
+        in
+         check
+          ItemArr {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedCheck.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedCheck.bal
@@ -81,3 +81,25 @@ public function test2() returns error? {
     string sd = check name();
     io:println("Response from organization count query from DB: " + check test1());
 }
+
+public function test3() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var item in check ItemArr {
+
+    }
+}
+
+public function test4() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var
+    item
+    in
+    check
+    ItemArr {
+
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix formatting bug in check node in following scenario
```java
json[] | error ItemArr = trap <json[]>Items;
foreach var item in check ItemArr {
     //some code goes inside here
}
```

Fixes #20780 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
