### PR TITLE
Fix formatting bug in check node

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/formatting/check.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/check.bal
@@ -80,3 +80,25 @@ public function test2() returns error? {
     string sd = check name();
     io:println("Response from organization count query from DB: " +check test1());
 }
+
+public function test3() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var    item  in      check      ItemArr {
+
+    }
+}
+
+public function test4() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var
+       item
+        in
+         check
+          ItemArr {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedCheck.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedCheck.bal
@@ -81,3 +81,25 @@ public function test2() returns error? {
     string sd = check name();
     io:println("Response from organization count query from DB: " + check test1());
 }
+
+public function test3() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var item in check ItemArr {
+
+    }
+}
+
+public function test4() {
+
+    json Items = [1, false, null, "foo", {first: "John", last: "Pala"}];
+    json[] | error ItemArr = trap <json[]>Items;
+    foreach var
+    item
+    in
+    check
+    ItemArr {
+
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix formatting bug in check node in following scenario

```java
json[] | error ItemArr = trap <json[]>Items;
foreach var item in check ItemArr {
     //some code goes inside here
}
```
Fixes #20780

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
