### PR TITLE
Make listener variables final

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -235,7 +235,6 @@ public enum DiagnosticCode {
     NO_NEW_VARIABLES_VAR_ASSIGNMENT("no.new.variables.var.assignment"),
     INVALID_VARIABLE_ASSIGNMENT("invalid.variable.assignment"),
     INVALID_VARIABLE_ASSIGNMENT_FINAL("invalid.variable.assignment.field.final"),
-    CANNOT_ASSIGN_VALUE_READONLY("cannot.assign.value.to.readonly.field"),
     CANNOT_ASSIGN_VALUE_FINAL("cannot.assign.value.to.final.field"),
     CANNOT_ASSIGN_VALUE_FUNCTION_ARGUMENT("cannot.assign.value.to.function.argument"),
     CANNOT_ASSIGN_VALUE_ENDPOINT("cannot.assign.value.to.endpoint"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -234,7 +234,7 @@ public enum DiagnosticCode {
 
     NO_NEW_VARIABLES_VAR_ASSIGNMENT("no.new.variables.var.assignment"),
     INVALID_VARIABLE_ASSIGNMENT("invalid.variable.assignment"),
-    INVALID_VARIABLE_ASSIGNMENT_FINAL("invalid.variable.assignment.field.final"),
+    INVALID_ASSIGNMENT_DECLARATION_FINAL("invalid.variable.assignment.declaration.final"),
     CANNOT_ASSIGN_VALUE_FINAL("cannot.assign.value.to.final.field"),
     CANNOT_ASSIGN_VALUE_FUNCTION_ARGUMENT("cannot.assign.value.to.function.argument"),
     CANNOT_ASSIGN_VALUE_ENDPOINT("cannot.assign.value.to.endpoint"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -234,6 +234,7 @@ public enum DiagnosticCode {
 
     NO_NEW_VARIABLES_VAR_ASSIGNMENT("no.new.variables.var.assignment"),
     INVALID_VARIABLE_ASSIGNMENT("invalid.variable.assignment"),
+    INVALID_VARIABLE_ASSIGNMENT_FINAL("invalid.variable.assignment.field.final"),
     CANNOT_ASSIGN_VALUE_READONLY("cannot.assign.value.to.readonly.field"),
     CANNOT_ASSIGN_VALUE_FINAL("cannot.assign.value.to.final.field"),
     CANNOT_ASSIGN_VALUE_FUNCTION_ARGUMENT("cannot.assign.value.to.function.argument"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -2088,6 +2088,7 @@ public class BLangPackageBuilder {
         }
         if (isListenerVar) {
             var.flagSet.add(Flag.LISTENER);
+            var.flagSet.add(Flag.FINAL);
             if (!isTypeNameProvided) {
                 var.isDeclaredWithVar = true;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2062,7 +2062,13 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         Name varName = names.fromIdNode(simpleVarRef.variableName);
         if (!Names.IGNORE.equals(varName) && env.enclInvokable != env.enclPkg.initFunction) {
             if ((simpleVarRef.symbol.flags & Flags.FINAL) == Flags.FINAL) {
-                dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_FINAL, varRef);
+                if ((simpleVarRef.symbol.flags & Flags.SERVICE) == Flags.SERVICE) {
+                    dlog.error(varRef.pos, DiagnosticCode.INVALID_VARIABLE_ASSIGNMENT_FINAL, "service", varRef);
+                } else if ((simpleVarRef.symbol.flags & Flags.LISTENER) == Flags.LISTENER) {
+                    dlog.error(varRef.pos, DiagnosticCode.INVALID_VARIABLE_ASSIGNMENT_FINAL, "listener", varRef);
+                } else {
+                    dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_FINAL, varRef);
+                }
             } else if ((simpleVarRef.symbol.flags & Flags.CONSTANT) == Flags.CONSTANT) {
                 dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_TO_CONSTANT);
             } else if ((simpleVarRef.symbol.flags & Flags.FUNCTION_FINAL) == Flags.FUNCTION_FINAL) {
@@ -2071,6 +2077,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
     }
 
+    // TODO : check if READONLY is used now
     private void checkReadonlyAssignment(BLangExpression varRef) {
         if (varRef.type == symTable.semanticError) {
             return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2077,21 +2077,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
     }
 
-    // TODO : check if READONLY is used now
-    private void checkReadonlyAssignment(BLangExpression varRef) {
-        if (varRef.type == symTable.semanticError) {
-            return;
-        }
-
-        BLangVariableReference varRefExpr = (BLangVariableReference) varRef;
-        if (varRefExpr.symbol != null) {
-            if (env.enclPkg.symbol.pkgID != varRefExpr.symbol.pkgID && varRefExpr.lhsVar
-                    && (varRefExpr.symbol.flags & Flags.READONLY) == Flags.READONLY) {
-                dlog.error(varRefExpr.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_READONLY, varRefExpr);
-            }
-        }
-    }
-
     @Override
     public void visit(BLangExpressionStmt exprStmtNode) {
         // Creates a new environment here.
@@ -2715,7 +2700,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         typeChecker.checkExpr(varRefExpr, env);
 
         // Check whether this is an readonly field.
-        checkReadonlyAssignment(varRefExpr);
         checkConstantAssignment(varRefExpr);
 
         // If this is an update of a type narrowed variable, the assignment should allow assigning

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2063,9 +2063,9 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         if (!Names.IGNORE.equals(varName) && env.enclInvokable != env.enclPkg.initFunction) {
             if ((simpleVarRef.symbol.flags & Flags.FINAL) == Flags.FINAL) {
                 if ((simpleVarRef.symbol.flags & Flags.SERVICE) == Flags.SERVICE) {
-                    dlog.error(varRef.pos, DiagnosticCode.INVALID_VARIABLE_ASSIGNMENT_FINAL, "service", varRef);
+                    dlog.error(varRef.pos, DiagnosticCode.INVALID_ASSIGNMENT_DECLARATION_FINAL, Names.SERVICE);
                 } else if ((simpleVarRef.symbol.flags & Flags.LISTENER) == Flags.LISTENER) {
-                    dlog.error(varRef.pos, DiagnosticCode.INVALID_VARIABLE_ASSIGNMENT_FINAL, "listener", varRef);
+                    dlog.error(varRef.pos, DiagnosticCode.INVALID_ASSIGNMENT_DECLARATION_FINAL, LISTENER_NAME);
                 } else {
                     dlog.error(varRef.pos, DiagnosticCode.CANNOT_ASSIGN_VALUE_FINAL, varRef);
                 }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -353,6 +353,9 @@ error.no.new.variables.var.assignment=\
 error.invalid.variable.assignment=\
   invalid assignment in variable ''{0}''
 
+error.invalid.variable.assignment.field.final =\
+  invalid assignment: ''{0}'' variable ''{1}'' is final
+
 error.cannot.assign.value.to.final.field=\
   cannot assign a value to final ''{0}''
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -353,8 +353,8 @@ error.no.new.variables.var.assignment=\
 error.invalid.variable.assignment=\
   invalid assignment in variable ''{0}''
 
-error.invalid.variable.assignment.field.final =\
-  invalid assignment: ''{0}'' variable ''{1}'' is final
+error.invalid.variable.assignment.declaration.final =\
+  invalid assignment: ''{0}'' declaration is final
 
 error.cannot.assign.value.to.final.field=\
   cannot assign a value to final ''{0}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -362,9 +362,6 @@ error.cannot.assign.value.to.final.field=\
 error.cannot.assign.value.to.function.argument=\
   cannot assign a value to function argument ''{0}''
 
-error.cannot.assign.value.to.readonly.field=\
-  cannot assign a value to readonly ''{0}''
-
 error.cannot.assign.value.to.endpoint=\
   cannot assign a value to endpoint ''{0}''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
@@ -131,7 +131,7 @@ public class InvalidSyntaxParserTest {
     @Test
     public void testListenerDeclarationWithDefinedDifferentType() {
         CompileResult result = BCompileUtil.compile("test-src/parser/listener_declaration_type_reuse_negative.bal");
-        BAssertUtil.validateError(result, 0, "invalid assignment: 'listener' variable 'x' is final", 22, 5);
+        BAssertUtil.validateError(result, 0, "invalid assignment: 'listener' declaration is final", 22, 5);
         BAssertUtil.validateError(result, 1, "incompatible types: expected 'ballerina/http:MockListener', found " +
                 "'int'", 22, 9);
         BAssertUtil.validateError(result, 2, "incompatible types: expected 'int', found " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
@@ -131,15 +131,16 @@ public class InvalidSyntaxParserTest {
     @Test
     public void testListenerDeclarationWithDefinedDifferentType() {
         CompileResult result = BCompileUtil.compile("test-src/parser/listener_declaration_type_reuse_negative.bal");
-        BAssertUtil.validateError(result, 0, "incompatible types: expected 'ballerina/http:MockListener', found " +
+        BAssertUtil.validateError(result, 0, "cannot assign a value to final 'x'", 22, 5);
+        BAssertUtil.validateError(result, 1, "incompatible types: expected 'ballerina/http:MockListener', found " +
                 "'int'", 22, 9);
-        BAssertUtil.validateError(result, 1, "incompatible types: expected 'int', found " +
+        BAssertUtil.validateError(result, 2, "incompatible types: expected 'int', found " +
                 "'ballerina/http:MockListener'", 23, 9);
-        BAssertUtil.validateError(result, 2, "incompatible types: expected 'lang.object:Listener', found 'int'", 26,
+        BAssertUtil.validateError(result, 3, "incompatible types: expected 'lang.object:Listener', found 'int'", 26,
                                   14);
-        BAssertUtil.validateError(result, 3, "incompatible types: expected 'lang.object:Listener', found 'Person'",
+        BAssertUtil.validateError(result, 4, "incompatible types: expected 'lang.object:Listener', found 'Person'",
                                   29, 24);
-        BAssertUtil.validateError(result, 4, "incompatible types: expected 'lang.object:Listener', found 'other'", 31
+        BAssertUtil.validateError(result, 5, "incompatible types: expected 'lang.object:Listener', found 'other'", 31
                 , 23);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/InvalidSyntaxParserTest.java
@@ -131,7 +131,7 @@ public class InvalidSyntaxParserTest {
     @Test
     public void testListenerDeclarationWithDefinedDifferentType() {
         CompileResult result = BCompileUtil.compile("test-src/parser/listener_declaration_type_reuse_negative.bal");
-        BAssertUtil.validateError(result, 0, "cannot assign a value to final 'x'", 22, 5);
+        BAssertUtil.validateError(result, 0, "invalid assignment: 'listener' variable 'x' is final", 22, 5);
         BAssertUtil.validateError(result, 1, "incompatible types: expected 'ballerina/http:MockListener', found " +
                 "'int'", 22, 9);
         BAssertUtil.validateError(result, 2, "incompatible types: expected 'int', found " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
@@ -45,7 +45,7 @@ public class FinalAccessTest {
     public void testFinalFailCase() {
         CompileResult compileResultNegative = BCompileUtil.compile(
                 "test-src/types/finaltypes/final-field-test-negative.bal");
-        Assert.assertEquals(compileResultNegative.getErrorCount(), 13);
+        Assert.assertEquals(compileResultNegative.getErrorCount(), 14);
         BAssertUtil.validateError(compileResultNegative, 0, "cannot assign a value to final 'globalFinalInt'", 8, 5);
         BAssertUtil.validateError(compileResultNegative, 1, "cannot assign a value to function argument 'a'", 19, 5);
         BAssertUtil.validateError(compileResultNegative, 2, "cannot assign a value to function argument 'a'", 25, 5);
@@ -58,7 +58,10 @@ public class FinalAccessTest {
         BAssertUtil.validateError(compileResultNegative, 9, "cannot assign a value to final 'name'", 58, 5);
         BAssertUtil.validateError(compileResultNegative, 10, "cannot assign a value to final 'name'", 63, 5);
         BAssertUtil.validateError(compileResultNegative, 11, "cannot assign a value to final 'name'", 68, 5);
-        BAssertUtil.validateError(compileResultNegative, 12, "cannot assign a value to final 'ml'", 78, 5);
+        BAssertUtil.validateError(compileResultNegative, 12, "invalid assignment: 'listener' variable 'ml' is final",
+                                  78, 5);
+        BAssertUtil.validateError(compileResultNegative, 13, "invalid assignment: 'service' variable 's' is final",
+                                  84, 5);
     }
 
     @Test(description = "Test final global variable")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
@@ -58,9 +58,9 @@ public class FinalAccessTest {
         BAssertUtil.validateError(compileResultNegative, 9, "cannot assign a value to final 'name'", 58, 5);
         BAssertUtil.validateError(compileResultNegative, 10, "cannot assign a value to final 'name'", 63, 5);
         BAssertUtil.validateError(compileResultNegative, 11, "cannot assign a value to final 'name'", 68, 5);
-        BAssertUtil.validateError(compileResultNegative, 12, "invalid assignment: 'listener' variable 'ml' is final",
+        BAssertUtil.validateError(compileResultNegative, 12, "invalid assignment: 'listener' declaration is final",
                                   78, 5);
-        BAssertUtil.validateError(compileResultNegative, 13, "invalid assignment: 'service' variable 's' is final",
+        BAssertUtil.validateError(compileResultNegative, 13, "invalid assignment: 'service' declaration is final",
                                   84, 5);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
@@ -45,7 +45,7 @@ public class FinalAccessTest {
     public void testFinalFailCase() {
         CompileResult compileResultNegative = BCompileUtil.compile(
                 "test-src/types/finaltypes/final-field-test-negative.bal");
-        Assert.assertEquals(compileResultNegative.getErrorCount(), 12);
+        Assert.assertEquals(compileResultNegative.getErrorCount(), 13);
         BAssertUtil.validateError(compileResultNegative, 0, "cannot assign a value to final 'globalFinalInt'", 8, 5);
         BAssertUtil.validateError(compileResultNegative, 1, "cannot assign a value to function argument 'a'", 19, 5);
         BAssertUtil.validateError(compileResultNegative, 2, "cannot assign a value to function argument 'a'", 25, 5);
@@ -58,6 +58,7 @@ public class FinalAccessTest {
         BAssertUtil.validateError(compileResultNegative, 9, "cannot assign a value to final 'name'", 58, 5);
         BAssertUtil.validateError(compileResultNegative, 10, "cannot assign a value to final 'name'", 63, 5);
         BAssertUtil.validateError(compileResultNegative, 11, "cannot assign a value to final 'name'", 68, 5);
+        BAssertUtil.validateError(compileResultNegative, 12, "cannot assign a value to final 'ml'", 78, 5);
     }
 
     @Test(description = "Test final global variable")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/final-field-test-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/final-field-test-negative.bal
@@ -71,3 +71,9 @@ function testLocalFinalValueWithoutTypeInitializedFromFunction() {
 function getName() returns string {
     return "Ballerina";
 }
+
+listener http:MockListener ml = new http:MockListener(8080);
+
+public function testListenerVariable() {
+    ml = new http:MockListener(8081);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/final-field-test-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/final-field-test-negative.bal
@@ -74,6 +74,12 @@ function getName() returns string {
 
 listener http:MockListener ml = new http:MockListener(8080);
 
-public function testListenerVariable() {
+public function testChangingListenerVariableAfterDefining() {
     ml = new http:MockListener(8081);
+}
+
+service s on ml {}
+
+public function testChangingServiceVariableAfterDefining() {
+    s = service {};
 }


### PR DESCRIPTION
## Purpose
Fixes #20892

## Approach
Flag listener variables as final

## Samples
#### Code
```Ballerina
import ballerina/http;
listener http:Listener l = new (8080);
public function main() {
    l = new (8181);
}
```

#### Output
```Logtalk
invalid assignment: 'listener' variable 'l' is final
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.
Maybe there is room for improvement for the error message.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [x] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
