### PR TITLE
Migrate generateStringLoadIns to use StringValue

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/StringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/StringUtils.java
@@ -109,6 +109,16 @@ public class StringUtils {
         return String.valueOf(s.charAt((int) index));
     }
 
+    public static BString getStringAt(BString s, long index) {
+        if (index < 0 || index >= s.length()) {
+            throw BallerinaErrors.createError(getModulePrefixedReason(STRING_LANG_LIB,
+                                                                      INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER),
+                                              "string index out of range: index: " + index + ", size: " + s.length());
+        }
+
+        return StringUtils.fromString(String.valueOf(Character.toChars(s.getCodePoint((int) index))));
+    }
+
     public static BString fromString(String s) {
         List<Integer> highSurrogates = null;
         for (int i = 0; i < s.length(); i++) {

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_instruction_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_instruction_gen.bal
@@ -770,16 +770,17 @@ type InstructionGenerator object {
                 io:sprintf("(L%s;L%s;)V", useBString ? B_STRING_VALUE : STRING_VALUE, OBJECT), true);
     }
 
-    function generateStringLoadIns(bir:FieldAccess stringLoadIns) {
+    function generateStringLoadIns(bir:FieldAccess stringLoadIns, boolean useBString) {
         // visit the string
         self.loadVar(stringLoadIns.rhsOp.variableDcl);
 
         // visit the key expr
         self.loadVar(stringLoadIns.keyOp.variableDcl);
 
+        string consVal = useBString ? B_STRING_VALUE : STRING_VALUE;
         // invoke the `getStringAt()` method
         self.mv.visitMethodInsn(INVOKESTATIC, STRING_UTILS, "getStringAt",
-                                io:sprintf("(L%s;J)L%s;", STRING_VALUE, STRING_VALUE), false);
+                                io:sprintf("(L%s;J)L%s;", consVal, consVal), false);
 
         // store in the target reg
         self.storeToVar(stringLoadIns.lhsOp.variableDcl);

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -781,7 +781,7 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
                 } else if (insKind == bir:INS_KIND_FP_LOAD) {
                     instGen.generateFPLoadIns(<bir:FPLoad> inst);
                 } else if (insKind == bir:INS_KIND_STRING_LOAD) {
-                    instGen.generateStringLoadIns(<bir:FieldAccess> inst);
+                    instGen.generateStringLoadIns(<bir:FieldAccess> inst, useBString);
                 } else {
                     instGen.generateTableNewIns(<bir:NewTable> inst);
                 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueBasicsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueBasicsTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -74,6 +75,19 @@ public class StringValueBasicsTest {
         BValue[] returns = BRunUtil.invoke(result, "testArrayStore");
         Assert.assertEquals(returns[0].getClass(), BInteger.class);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
+    }
+
+    @Test
+    public void testStringIndexAccess() {
+        BValue[] returns = BRunUtil.invoke(result, "testStringIndexAccess");
+        Assert.assertEquals(returns[0].getClass(), BInteger.class);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*string index out of range: index: 6, size: 6.*")
+    public void testStringIndexAccessException() {
+        BRunUtil.invoke(result, "testStringIndexAccessException");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-value-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-value-test.bal
@@ -43,3 +43,15 @@ function testArrayStore() returns int {
     arr[0] = "h🤷llo";
     return arr[0].length() + arr2[0][1].length();
 }
+
+function testStringIndexAccess() returns int {
+    string hello = "hello👋";
+    string val = hello[5];
+    return val.length();
+}
+
+function testStringIndexAccessException() {
+    string hello = "hello👋";
+    string val = hello[6];
+}
+


### PR DESCRIPTION
## Purpose
> Migrate generateStringLoadIns to use StringValue

## Approach
> Migrate generateStringLoadIns without breaking other code with unit tests

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
