### PR TITLE
Add auto completion support for variables as fields of mapping constructor

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/RecordTypeCompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/RecordTypeCompletionTest.java
@@ -50,6 +50,8 @@ public class RecordTypeCompletionTest extends CompletionTest {
                 {"recordTest12.json", "record"},
                 {"recordTest13.json", "record"},
                 {"recordTest14.json", "record"},
+                {"recordTest15.json", "record"},
+                {"recordTest16.json", "record"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
@@ -315,6 +315,7 @@ public class DefinitionTest {
                 {"defVarDefStmt6.json", "vardefstatement"},
                 {"defVarDefStmt7.json", "vardefstatement"},
                 {"defVarDefStmt8.json", "vardefstatement"},
+                {"defVarDefStmt26.json", "vardefstatement"},
                 // Covers Variable Definition Statement with Error Binding pattern
                 {"defVarDefStmt12.json", "vardefstatement"},
                 {"defVarDefStmt13.json", "vardefstatement"},

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest15.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 10,
+    "character": 9
+  },
+  "source": "record/source/recordTest15.bal",
+  "items": [
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "Field",
+      "sortText": "210",
+      "insertText": "name: \"${1}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "age",
+      "kind": "Field",
+      "detail": "Field",
+      "sortText": "210",
+      "insertText": "age: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "district",
+      "kind": "Field",
+      "detail": "Field",
+      "sortText": "210",
+      "insertText": "district: \"${1}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Add All Attributes",
+      "kind": "Property",
+      "detail": "none",
+      "sortText": "110",
+      "insertText": "name: \"\",\nage: 0,\ndistrict: \"\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "district",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "district",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "age",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "130",
+      "insertText": "age",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest16.json
@@ -1,0 +1,57 @@
+{
+  "position": {
+    "line": 10,
+    "character": 8
+  },
+  "source": "record/source/recordTest16.bal",
+  "items": [
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "Field",
+      "sortText": "210",
+      "insertText": "name: \"${1}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "age",
+      "kind": "Field",
+      "detail": "Field",
+      "sortText": "210",
+      "insertText": "age: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "district",
+      "kind": "Field",
+      "detail": "Field",
+      "sortText": "210",
+      "insertText": "district: \"${1}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Add All Attributes",
+      "kind": "Property",
+      "detail": "none",
+      "sortText": "110",
+      "insertText": "name: \"\",\nage: 0,\ndistrict: \"\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "district",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "district",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "age",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "130",
+      "insertText": "age",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest15.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest15.bal
@@ -1,0 +1,13 @@
+public const string district = "Galle";
+
+type Person record {
+    string name;
+    int age;
+    string district;
+};
+
+function testRecordFieldCompletion(int age) {
+    Person person = {
+        a
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest16.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/source/recordTest16.bal
@@ -1,0 +1,13 @@
+public const string district = "Galle";
+
+type Person record {
+    string name;
+    int age;
+    string district;
+};
+
+function testRecordFieldCompletion(int age) {
+    Person person = {
+        
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/expected/vardefstatement/defVarDefStmt26.json
+++ b/language-server/modules/langserver-core/src/test/resources/definition/expected/vardefstatement/defVarDefStmt26.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "file": "defFl29.bal"
+  },
+  "position": {
+    "line": 78,
+    "character": 11
+  },
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 75,
+          "character": 43
+        },
+        "end": {
+          "line": 75,
+          "character": 49
+        }
+      },
+      "uri": "defFl29.bal"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/sources/defFl29.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/sources/defFl29.bal
@@ -72,3 +72,15 @@ public function testFunction(string args) {
 public type ErrorTypeDesc1 error<REASON_CONST, TestDetail>;
 
 public const string REASON_CONST = "REASON_CONST_VAL";
+
+function testGotoDefVariableAsField(string field1) {
+    TestRecord1 testRec = {
+        field2: 0,
+        field1
+    };
+}
+
+type TestRecord1 record {
+     string field1;
+     int field2;
+};


### PR DESCRIPTION
## Purpose
> Add the auto-completion support within mapping constructors to support https://github.com/ballerina-platform/ballerina-spec/issues/400

Fixes #20979

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
