### PR TITLE
Link the Security Policy in Bio from the SECURITY.md File

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,5 +6,9 @@ permalink: /security/
 
 # Security Policy
 
-For the Security Policy of Ballerina, go to the [Security Policy](https://ballerina.io/security-policy/).
+Ballerina project maintainers take security issues very seriously and all the vulnerability reports are treated with the highest priority and confidentiality.
+
+>**IMPORTANT:** Please use the **[security@ballerina.io](mailto:security@ballerina.io)** mailing list to report all security-related issues.
+
+For more information on the Security Policy of Ballerina, go to the [Security Policy](https://ballerina.io/security/).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,39 +6,5 @@ permalink: /security/
 
 # Security Policy
 
-Ballerina project maintainers take security issues very seriously and all the vulnerability reports are treated with the highest priority and confidentiality.
-
-- [Reporting a vulnerability](#reporting-a-vulnerability)
-- [Handling a vulnerability](#handling-a-vulnerability)
-
-## Reporting a vulnerability
-
-Ensure you are using the latest Ballerina version before you run an automated security scan or perform a penetration test against it.
-
-Based on the ethics of responsible disclosure, you must only use the **[security@ballerina.io](mailto:security@ballerina.io)** mailing list to report security vulnerabilities and any other concerns regarding the security aspects of the source code or any other resource in this repo.
-
-**WARNING:** To protect the end-user security, please do not use any other medium to report security vulnerabilities. Also, kindly refrain from disclosing the vulnerability details you come across with other individuals, in any forums, sites, or other groups - public or private before it’s mitigation actions and disclosure process are completed.
-
-Use the following key to send secure messages to security@ballerina.io:
-
-> security@ballerina.io: 0168 DA26 2989 0DB9 4ACD 8367 E683 061E 2F85 C381 [pgp.mit.edu](https://pgp.surfnet.nl/pks/lookup?op=vindex&fingerprint=on&search=0xE683061E2F85C381)
-
-Also, use the following template when reporting vulnerabilities so that it contains all the required information and helps expedite the analysis and mitigation process.
-
-- Vulnerable Ballerina artifact(s) and version(s)
-- Overview: High-level overview of the issue and self-assessed severity
-- Description: Include the steps to reproduce
-- Impact: Self-assessed impact
-- Solution: Any proposed solution
-
-We will keep you informed of the progress towards a fix and disclosure of the vulnerability if the reported issue is identified as a true positive. 
-
-## Handling a vulnerability
-
-The below is an overview of the vulnerability handling process.
-
-1. The vulnerability will be reported privately to security@ballerina.io. (The initial response time will be less than 24 hours).
-2. The reported vulnerability gets fixed and the solution gets verified by the relevant teams at WSO2.
-3. The fix gets applied to the master branch and a new version of the distribution gets released if required.
-4. The reported user is kept updated on the progress of the process. 
+For the Security Policy of Ballerina, go to the [Security Policy](https://ballerina.io/security-policy/).
 


### PR DESCRIPTION
## Purpose
Since now we have the Security Policy added to Bio in [1] it will be better to have a link to it from the SECURITY.md file in this ballerina-lang repo for easier maintainability.

[1] https://ballerina.io/security/

Fixes #21020

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
