### PR TITLE
Improve the grpc command to only create essentials in client and service modes

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/BallerinaFileBuilder.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/BallerinaFileBuilder.java
@@ -150,7 +150,7 @@ public class BallerinaFileBuilder {
                     if (MethodDescriptor.MethodType.UNARY.equals(method.getMethodType())) {
                         isUnaryContains = true;
                     }
-                    if (method.containsEmptyType() && !(stubFileObject.messageExists(EMPTY_DATA_TYPE))) {
+                    if (method.containsEmptyType() && !(stubFileObject.isMessageExists(EMPTY_DATA_TYPE))) {
                         Message message = Message.newBuilder(EmptyMessage.newBuilder().getDescriptor().toProto())
                                 .build();
                         messageList.add(message);

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/BallerinaFileBuilder.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/BallerinaFileBuilder.java
@@ -73,6 +73,7 @@ import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.SAMPLE_CL
 import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.SAMPLE_FILE_PREFIX;
 import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.SAMPLE_SERVICE_FILE_PREFIX;
 import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.SAMPLE_SERVICE_TEMPLATE_NAME;
+import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.SERVICE_SKELETON_TEMPLATE_NAME;
 import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.SKELETON_TEMPLATE_NAME;
 import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.STUB_FILE_PREFIX;
 import static org.ballerinalang.net.grpc.builder.utils.BalGenConstants.TEMPLATES_DIR_PATH_KEY;
@@ -225,7 +226,7 @@ public class BallerinaFileBuilder {
                 }
             }
 
-            if (!GRPC_SERVICE.equals(mode) || needStubFile) {
+            if (!GRPC_SERVICE.equals(mode)) {
                 stubFileObject.setMessageList(messageList);
                 stubFileObject.setEnumList(enumList);
                 stubFileObject.setDescriptors(descriptors);
@@ -234,6 +235,15 @@ public class BallerinaFileBuilder {
                 }
                 String stubFilePath = generateOutputFile(this.balOutPath, filename + STUB_FILE_PREFIX);
                 writeOutputFile(stubFileObject, DEFAULT_SKELETON_DIR, SKELETON_TEMPLATE_NAME, stubFilePath);
+            } else if (needStubFile) {
+                stubFileObject.setMessageList(messageList);
+                stubFileObject.setEnumList(enumList);
+                stubFileObject.setDescriptors(descriptors);
+                if (!stubRootDescriptor.isEmpty()) {
+                    stubFileObject.setRootDescriptor(stubRootDescriptor);
+                }
+                String stubFilePath = generateOutputFile(this.balOutPath, filename + STUB_FILE_PREFIX);
+                writeOutputFile(stubFileObject, DEFAULT_SKELETON_DIR, SERVICE_SKELETON_TEMPLATE_NAME, stubFilePath);
             }
         } catch (GrpcServerException e) {
             throw new CodeBuilderException("Message descriptor error. " + e.getMessage());

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/AbstractStub.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/AbstractStub.java
@@ -77,11 +77,19 @@ public abstract class AbstractStub {
         descriptors.add(descriptor);
     }
 
+    public void setDescriptors(Set<Descriptor> descriptors) {
+        this.descriptors = descriptors;
+    }
+
     public Set<Descriptor> getDescriptors() {
         return descriptors;
     }
 
     public void setMessageList(List<Message> messageList) {
         this.messageList = messageList;
+    }
+
+    public void setEnumList(List<EnumMessage> enumList) {
+        this.enumList = enumList;
     }
 }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/AbstractStub.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/AbstractStub.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.grpc.builder.components;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Holds the abstract features of the stubs which are common to service and client stubs.
+ */
+public abstract class AbstractStub {
+    private List<Message> messageList = new ArrayList<>();
+    private List<EnumMessage> enumList = new ArrayList<>();
+    private String rootDescriptor;
+    private Set<Descriptor> descriptors = new TreeSet<>((descriptor1, descriptor2) -> {
+        if (descriptor1.getKey().equalsIgnoreCase(descriptor2.getKey())) {
+            return 0;
+        }
+        return 1;
+    });
+    public void addMessage(Message message) {
+        messageList.add(message);
+    }
+
+    public boolean messageExists(String messageName) {
+        if (messageName == null) {
+            return false;
+        }
+        for (Message message : messageList) {
+            if (messageName.equals(message.getMessageName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<Message> getMessageList() {
+        return messageList;
+    }
+
+    public void addEnumMessage(EnumMessage message) {
+        enumList.add(message);
+    }
+
+    public List<EnumMessage> getEnumList() {
+        return enumList;
+    }
+
+    public String getRootDescriptor() {
+        return rootDescriptor;
+    }
+
+    public void setRootDescriptor(String rootDescriptor) {
+        this.rootDescriptor = rootDescriptor;
+    }
+
+    public void addDescriptor(Descriptor descriptor) {
+        descriptors.add(descriptor);
+    }
+
+    public Set<Descriptor> getDescriptors() {
+        return descriptors;
+    }
+
+    public void setMessageList(List<Message> messageList) {
+        this.messageList = messageList;
+    }
+}

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/AbstractStub.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/AbstractStub.java
@@ -36,11 +36,12 @@ public abstract class AbstractStub {
         }
         return 1;
     });
+
     public void addMessage(Message message) {
         messageList.add(message);
     }
 
-    public boolean messageExists(String messageName) {
+    public boolean isMessageExists(String messageName) {
         if (messageName == null) {
             return false;
         }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/ServiceFile.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/ServiceFile.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * Service file definition bean class.
  */
-public class ServiceFile {
+public class ServiceFile extends AbstractStub {
     private boolean bidiStreaming;
     private boolean clientStreaming;
     private boolean unary;

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/StubFile.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/StubFile.java
@@ -19,24 +19,13 @@ package org.ballerinalang.net.grpc.builder.components;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Client Stub File definition bean class.
  *
  * @since 0.982.0
  */
-public class StubFile {
-    private String rootDescriptor;
-    private Set<Descriptor> descriptors = new TreeSet<>((descriptor1, descriptor2) -> {
-        if (descriptor1.getKey().equalsIgnoreCase(descriptor2.getKey())) {
-            return 0;
-        }
-        return 1;
-    });
-    private List<Message> messageList = new ArrayList<>();
-    private List<EnumMessage> enumList = new ArrayList<>();
+public class StubFile extends AbstractStub {
     private List<ServiceStub> stubList = new ArrayList<>();
     private String fileName;
     
@@ -46,49 +35,6 @@ public class StubFile {
 
     public String getFileName() {
         return fileName;
-    }
-
-    public String getRootDescriptor() {
-        return rootDescriptor;
-    }
-
-    public void setRootDescriptor(String rootDescriptor) {
-        this.rootDescriptor = rootDescriptor;
-    }
-
-    public void addDescriptor(Descriptor descriptor) {
-        descriptors.add(descriptor);
-    }
-    public Set<Descriptor> getDescriptors() {
-        return descriptors;
-    }
-
-    public void addMessage(Message message) {
-        messageList.add(message);
-    }
-
-    public boolean messageExists(String messageName) {
-        if (messageName == null) {
-            return false;
-        }
-        for (Message message : messageList) {
-            if (messageName.equals(message.getMessageName())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public List<Message> getMessageList() {
-        return messageList;
-    }
-
-    public void addEnumMessage(EnumMessage message) {
-        enumList.add(message);
-    }
-
-    public List<EnumMessage> getEnumList() {
-        return enumList;
     }
 
     public void addServiceStub(ServiceStub serviceStub) {

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/utils/BalGenConstants.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/utils/BalGenConstants.java
@@ -66,8 +66,10 @@ public class BalGenConstants {
     public static final String DEFAULT_SKELETON_DIR = DEFAULT_TEMPLATE_DIR + RESOURCE_SEPARATOR + "skeleton";
     
     public static final String DEFAULT_SAMPLE_DIR = DEFAULT_TEMPLATE_DIR + RESOURCE_SEPARATOR + "skeleton";
-    
+
     public static final String SKELETON_TEMPLATE_NAME = "stub_file";
+
+    public static final String SERVICE_SKELETON_TEMPLATE_NAME = "service_stub_file";
 
     public static final String GRPC_CLIENT = "client";
 

--- a/stdlib/grpc/src/main/resources/templates/skeleton/service_sample.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/service_sample.mustache
@@ -40,7 +40,8 @@ service {{serviceName}} on ep {
 }
 
 {{#each messageList}}{{> message}}{{/each}}
-{{#enumList}}{{> enum}}{{/enumList}}{{#if rootDescriptor}}const string ROOT_DESCRIPTOR = "{{rootDescriptor}}";
+{{#enumList}}{{> enum}}{{/enumList}}{{#if rootDescriptor}}
+const string ROOT_DESCRIPTOR = "{{rootDescriptor}}";
 function getDescriptorMap() returns map<string> {
     return {
         {{#each descriptors}}"{{descriptorKey}}":"{{descriptorData}}"{{#unless @last}},{{/unless}}

--- a/stdlib/grpc/src/main/resources/templates/skeleton/service_sample.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/service_sample.mustache
@@ -38,3 +38,12 @@ service {{serviceName}} on ep {
         // You should return a {{outputType}}
     }{{/unaryFunctions}}
 }
+
+{{#each messageList}}{{> message}}{{/each}}
+{{#enumList}}{{> enum}}{{/enumList}}{{#if rootDescriptor}}const string ROOT_DESCRIPTOR = "{{rootDescriptor}}";
+function getDescriptorMap() returns map<string> {
+    return {
+        {{#each descriptors}}"{{descriptorKey}}":"{{descriptorData}}"{{#unless @last}},{{/unless}}
+        {{/each}}
+    };
+}{{/if}}

--- a/stdlib/grpc/src/main/resources/templates/skeleton/service_stub_file.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/service_stub_file.mustache
@@ -1,0 +1,11 @@
+{{#each messageList}}
+{{> message}}{{/each}}
+{{#enumList}}
+{{> enum}}{{/enumList}}{{#if rootDescriptor}}
+const string ROOT_DESCRIPTOR = "{{rootDescriptor}}";
+function getDescriptorMap() returns map<string> {
+    return {
+        {{#each descriptors}}"{{descriptorKey}}":"{{descriptorData}}"{{#unless @last}},{{/unless}}
+        {{/each}}
+    };
+}{{/if}}

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -41,6 +41,7 @@ import java.nio.file.Paths;
 
 import static org.ballerinalang.net.grpc.proto.ServiceProtoConstants.TMP_DIRECTORY_PATH;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -331,6 +332,27 @@ public class StubGeneratorTestCase {
                 "Expected constants not found in compile results.");
         assertEquals(((BLangPackage) compileResult.getAST()).imports.size(), 1,
                 "Expected imports not found in compile results.");
+    }
+
+    @Test(description = "Test case checks creation of only the service file, in the service mode, with single service")
+    public void testServiceFileGenWithoutStub() throws IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        Class<?> grpcCmd = Class.forName("org.ballerinalang.protobuf.cmd.GrpcCmd");
+        GrpcCmd grpcCommand = (GrpcCmd) grpcCmd.newInstance();
+        Path tempDirPath = outputDirPath.resolve("service");
+        Path protoPath = Paths.get("helloWorld.proto");
+        Path protoRoot = resourceDir.resolve(protoPath);
+        grpcCommand.setBalOutPath(tempDirPath.toAbsolutePath().toString());
+        grpcCommand.setProtoPath(protoRoot.toAbsolutePath().toString());
+        grpcCommand.setMode("service");
+        grpcCommand.execute();
+        Path sampleServiceFile = Paths.get(TMP_DIRECTORY_PATH, "grpc", "service", "helloWorld_sample_service.bal");
+
+        // This file should not be created when --mode service enabled with one service
+        Path sampleStubFile = Paths.get(TMP_DIRECTORY_PATH, "grpc", "service", "helloWorld_pb.bal");
+
+        assertTrue(Files.exists(sampleServiceFile));
+        assertFalse(Files.exists(sampleStubFile));
     }
 
     private void validatePublicAttachedFunctions(CompileResult compileResult) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -354,7 +354,7 @@ public class StubGeneratorTestCase {
         assertTrue(Files.exists(sampleServiceFile));
         assertFalse(Files.exists(sampleStubFile));
 
-        CompileResult compileResult = BCompileUtil.compile(sampleServiceFile.toString());
+        CompileResult compileResult = BCompileUtil.compileOnly(sampleServiceFile.toString());
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).constants.size(), 1,
                 "Expected constants count not found." +
@@ -362,11 +362,11 @@ public class StubGeneratorTestCase {
         );
         assertEquals(((BLangPackage) compileResult.getAST()).services.size(), 1,
                 "Expected services count not found. " +
-                        ((BLangPackage) compileResult.getAST()).constants.size()
+                        ((BLangPackage) compileResult.getAST()).services.size()
         );
         assertEquals(((BLangPackage) compileResult.getAST()).getTypeDefinitions().size(), 6,
                 "Expected type definitions count not found." +
-                        ((BLangPackage) compileResult.getAST()).constants.size()
+                        ((BLangPackage) compileResult.getAST()).getTypeDefinitions().size()
         );
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -353,6 +353,21 @@ public class StubGeneratorTestCase {
 
         assertTrue(Files.exists(sampleServiceFile));
         assertFalse(Files.exists(sampleStubFile));
+
+        CompileResult compileResult = BCompileUtil.compile(sampleServiceFile.toString());
+        assertEquals(compileResult.getDiagnostics().length, 0);
+        assertEquals(((BLangPackage) compileResult.getAST()).constants.size(), 1,
+                "Expected constants count not found." +
+                        ((BLangPackage) compileResult.getAST()).constants.size()
+        );
+        assertEquals(((BLangPackage) compileResult.getAST()).services.size(), 1,
+                "Expected services count not found. " +
+                        ((BLangPackage) compileResult.getAST()).constants.size()
+        );
+        assertEquals(((BLangPackage) compileResult.getAST()).getTypeDefinitions().size(), 6,
+                "Expected type definitions count not found." +
+                        ((BLangPackage) compileResult.getAST()).constants.size()
+        );
     }
 
     private void validatePublicAttachedFunctions(CompileResult compileResult) {


### PR DESCRIPTION
## Purpose 
Fixes #20960

## Approach
- Only create messages, enums, and descriptors when the user configures mode as `--mode service`.
- In the client mode or in stub mode, ti will generate the `*.pb.bal` file which contains the entire stub definition.

## Samples
[Bi-direction stream sample](https://ballerina.io/v1-1/learn/by-example/grpc-bidirectional-streaming.html)

The service generation will be as follows. 

**Command**

```sh
$ ballerina grpc --input grpc_bidirectional_streaming.proto --mode service --output .
```

**Generated file**

```ballerina
import ballerina/grpc;

listener grpc:Listener ep = new (9090);

@grpc:ServiceConfig { 
    name: "chat",
    clientStreaming: true,
    serverStreaming: true
}
service Chat on ep {

    resource function onOpen(grpc:Caller caller) {
        // Implementation goes here.
    }

    resource function onMessage(grpc:Caller caller, ChatMessage value) {
        // Implementation goes here.
    }

    resource function onError(grpc:Caller caller, error err) {
        // Implementation goes here.
    }

    resource function onComplete(grpc:Caller caller) {
            // Implementation goes here.
            // You should return a string
    }

}

public type ChatMessage record {|
    string name = "";
    string message = "";
    
|};


const string ROOT_DESCRIPTOR = "0A22677270635F6269646972656374696F6E616C5F73747265616D696E672E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F223B0A0B436861744D65737361676512120A046E616D6518012001280952046E616D6512180A076D65737361676518022001280952076D657373616765323E0A044368617412360A0463686174120C2E436861744D6573736167651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C756528013001620670726F746F33";
function getDescriptorMap() returns map<string> {
    return {
        "grpc_bidirectional_streaming.proto":"0A22677270635F6269646972656374696F6E616C5F73747265616D696E672E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F223B0A0B436861744D65737361676512120A046E616D6518012001280952046E616D6512180A076D65737361676518022001280952076D657373616765323E0A044368617412360A0463686174120C2E436861744D6573736167651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C756528013001620670726F746F33",
        "google/protobuf/wrappers.proto":"0A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F120F676F6F676C652E70726F746F62756622230A0B446F75626C6556616C756512140A0576616C7565180120012801520576616C756522220A0A466C6F617456616C756512140A0576616C7565180120012802520576616C756522220A0A496E74363456616C756512140A0576616C7565180120012803520576616C756522230A0B55496E74363456616C756512140A0576616C7565180120012804520576616C756522220A0A496E74333256616C756512140A0576616C7565180120012805520576616C756522230A0B55496E74333256616C756512140A0576616C756518012001280D520576616C756522210A09426F6F6C56616C756512140A0576616C7565180120012808520576616C756522230A0B537472696E6756616C756512140A0576616C7565180120012809520576616C756522220A0A427974657356616C756512140A0576616C756518012001280C520576616C756542570A13636F6D2E676F6F676C652E70726F746F627566420D577261707065727350726F746F50015A057479706573F80101A20203475042AA021E476F6F676C652E50726F746F6275662E57656C6C4B6E6F776E5479706573620670726F746F33"
        
    };
}


```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
