### PR TITLE
Fix OpenAPI client generation doesn't generate the specify module directory

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/CodeGenerator.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/CodeGenerator.java
@@ -103,8 +103,6 @@ public class CodeGenerator {
         Path implPath = CodegenUtils.getImplPath(srcPackage, srcPath);
 
         if (type.equals(GEN_CLIENT)) {
-            srcPath = srcPath.resolve("client");
-            implPath = implPath.resolve("client");
 
             if (Files.notExists(srcPath)) {
                 Files.createDirectory(srcPath);

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/cmd/OpenApiGenClientCmd.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/cmd/OpenApiGenClientCmd.java
@@ -86,8 +86,10 @@ public class OpenApiGenClientCmd implements BLauncherCmd {
             throw LauncherUtils.createLauncherException(OpenApiMesseges.OPENAPI_FILE_MANDATORY);
         }
 
-        if (moduleArgs.size() > 2) {
+        if (moduleArgs.size() > 1) {
             generator.setSrcPackage(moduleArgs.get(0));
+        } else {
+            generator.setSrcPackage("client");
         }
 
         try {


### PR DESCRIPTION
## Purpose
> Fix client generation doesn't generate the specify module dir for names like "module-one"

Fixes  #20346

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
