### PR TITLE
Fix formatting issue for tuple variable

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/format/FormattingNodeTree.java
@@ -4977,9 +4977,13 @@ public class FormattingNodeTree {
                                     && node.get(FormattingConstants.IS_VAR_EXISTS).getAsBoolean())) {
                                 currentWS.addProperty(FormattingConstants.WS, FormattingConstants.SINGLE_SPACE);
                             } else {
-                                currentWS.addProperty(FormattingConstants.WS,
-                                        this.getWhiteSpaces(formatConfig
-                                                .get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                                if (formatConfig.get(FormattingConstants.SPACE_COUNT).getAsInt() > 0) {
+                                    currentWS.addProperty(FormattingConstants.WS,
+                                            this.getWhiteSpaces(formatConfig
+                                                    .get(FormattingConstants.SPACE_COUNT).getAsInt()));
+                                } else if (node.has(FormattingConstants.TYPE_NODE)) {
+                                    currentWS.addProperty(FormattingConstants.WS, FormattingConstants.SINGLE_SPACE);
+                                }
                             }
                         } else if (text.equals(Tokens.CLOSING_BRACKET) || text.equals(Tokens.COMMA)) {
                             currentWS.addProperty(FormattingConstants.WS, FormattingConstants.EMPTY_SPACE);
@@ -5020,6 +5024,13 @@ public class FormattingNodeTree {
                                         ? indentWithParentIndentation : indentation), true);
                     }
                     restVariable.add(FormattingConstants.FORMATTING_CONFIG, restParamFormatConfig);
+                }
+
+                if (node.has("initialExpression")) {
+                    JsonObject initialExpression = node.getAsJsonObject("initialExpression");
+                    initialExpression.add(FormattingConstants.FORMATTING_CONFIG,
+                            this.getFormattingConfig(0, 1, 0, false,
+                                    this.getWhiteSpaceCount(indentWithParentIndentation), true));
                 }
             } else if (node.has(FormattingConstants.TYPE_NODE)) {
                 node.getAsJsonObject(FormattingConstants.TYPE_NODE)

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleType.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedTupleType.bal
@@ -36,14 +36,38 @@ function searchPeople() returns ([string, int, float]) {
 
 function testArrayToTupleAssignment3() returns [string, string[]] {
     string[3] x = ["a", "b", "c"];
-    [string, string...][i, ...j] = x;
+    [string, string...] [i, ...j] = x;
     return [i, j];
 }
 
 function testArrayToTupleAssignment4() returns [string, string[]] {
     string[3] x = ["a", "b", "c"];
-    [string, string...][i,
+    [string, string...] [i,
     ...
     j] = x;
     return [i, j];
+}
+
+function tupleVariableTest1() {
+    [boolean, float] [a1, a2] = [true, 0.4];
+}
+
+function tupleVariableTest2() {
+    [
+    boolean
+    ,
+    float
+    ]
+    [
+    a1
+    ,
+    a2
+    ]
+    =
+    [
+        true
+        ,
+        0.4
+    ]
+    ;
 }

--- a/language-server/modules/langserver-core/src/test/resources/formatting/tupleType.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/tupleType.bal
@@ -38,3 +38,27 @@ function testArrayToTupleAssignment4() returns [string, string[]] {
 j] = x;
     return [i, j];
 }
+
+function tupleVariableTest1() {
+        [  boolean,float  ][   a1  ,   a2 ]  =  [ true ,  0.4 ] ;
+}
+
+function tupleVariableTest2() {
+       [
+  boolean
+       ,
+ float
+         ]
+  [
+        a1
+  ,
+        a2
+   ]
+        =
+   [
+ true
+ ,
+ 0.4
+]
+;
+}


### PR DESCRIPTION
## Purpose
This will fix the formatting issue of the tuple variable not adding a space between tuple types and tuple variable names.
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/21003

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
