### PR TITLE
Optimize "ballerina run" command execution flow [master]

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
@@ -29,7 +29,6 @@ import org.ballerinalang.packerina.task.CopyNativeLibTask;
 import org.ballerinalang.packerina.task.CopyResourcesTask;
 import org.ballerinalang.packerina.task.CreateBaloTask;
 import org.ballerinalang.packerina.task.CreateBirTask;
-import org.ballerinalang.packerina.task.CreateExecutableTask;
 import org.ballerinalang.packerina.task.CreateJarTask;
 import org.ballerinalang.packerina.task.CreateTargetDirTask;
 import org.ballerinalang.packerina.task.PrintExecutablePathTask;
@@ -277,7 +276,6 @@ public class RunCommand implements BLauncherCmd {
                 .addTask(new CreateJarTask(this.dumpBIR, this.nativeBinary, this.dumpLLVMIR, this.noOptimizeLLVM))
                 .addTask(new CopyResourcesTask(), isSingleFileBuild)
                 .addTask(new CopyModuleJarTask())
-                .addTask(new CreateExecutableTask())  // create the executable .jar file
                 .addTask(new PrintExecutablePathTask(), isSingleFileBuild)   // print the location of the executable
                 .addTask(new PrintRunningExecutableTask(!isSingleFileBuild))   // print running executables
                 .addTask(new RunExecutableTask(programArgs, isInDebugMode))

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunExecutableTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunExecutableTask.java
@@ -91,7 +91,7 @@ public class RunExecutableTask implements Task {
             }
         }
 
-        // check if any entry points are found.
+        // If any entry point is not found.
         if (executableModule == null) {
             switch (buildContext.getSourceType()) {
                 case SINGLE_BAL_FILE:

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunExecutableTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunExecutableTask.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.packerina.task;
 
-import org.ballerinalang.packerina.OsUtils;
 import org.ballerinalang.packerina.buildcontext.BuildContext;
 import org.ballerinalang.packerina.buildcontext.BuildContextField;
 import org.ballerinalang.packerina.buildcontext.sourcecontext.SingleFileContext;
@@ -29,6 +28,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.ProjectDirConstants;
 import org.wso2.ballerinalang.util.Lists;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 import static org.ballerinalang.jvm.runtime.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
 import static org.ballerinalang.jvm.util.BLangConstants.MODULE_INIT_CLASS_NAME;
@@ -196,15 +197,12 @@ public class RunExecutableTask implements Task {
     }
 
     private String getAllClassPaths(BLangPackage executableModule, BuildContext buildContext) {
-        // Since classpath separator depends on the OS type
-        String separator = OsUtils.isWindows() ? ";" : ":";
-        StringBuilder cp = new StringBuilder();
+        StringJoiner cp = new StringJoiner(File.pathSeparator);
         // Adds executable thin jar path.
-        cp.append(this.executableJarPath.toString()).append(separator);
+        cp.add(this.executableJarPath.toString());
         // Adds all the dependency paths.
-        buildContext.moduleDependencyPathMap.get(executableModule.packageID).platformLibs.forEach(
-                path -> cp.append(path.toString()).append(separator));
-        // Returns the classpath string after removing last separator added.
-        return cp.toString().substring(0, cp.toString().length() - 1);
+        buildContext.moduleDependencyPathMap.get(executableModule.packageID).platformLibs.forEach(path ->
+                cp.add(path.toString()));
+        return cp.toString();
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/logging/LogAPITestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/logging/LogAPITestCase.java
@@ -58,12 +58,12 @@ public class LogAPITestCase extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", new String[]{"mainmod"}, new HashMap<>(),
                                                            projectDirPath, true);
         String[] logLines = output.split("\n");
-        assertEquals(logLines.length, 15);
+        assertEquals(logLines.length, 13);
 
-        validateLogLevel(logLines[11], "INFO", "[logorg/foo]", "Logging from inside `foo` module");
-        validateLogLevel(logLines[12], "INFO", "[logorg/bar]", "Logging from inside `bar` module");
-        validateLogLevel(logLines[13], "ERROR", "[logorg/baz]", "Logging at ERROR level inside `baz`");
-        validateLogLevel(logLines[14], "INFO", "[logorg/mainmod]", "Logging from inside `mainmod` module");
+        validateLogLevel(logLines[9], "INFO", "[logorg/foo]", "Logging from inside `foo` module");
+        validateLogLevel(logLines[10], "INFO", "[logorg/bar]", "Logging from inside `bar` module");
+        validateLogLevel(logLines[11], "ERROR", "[logorg/baz]", "Logging at ERROR level inside `baz`");
+        validateLogLevel(logLines[12], "INFO", "[logorg/mainmod]", "Logging from inside `mainmod` module");
     }
 
     @Test
@@ -72,8 +72,8 @@ public class LogAPITestCase extends BaseTest {
         String[] args = new String[]{testFileName, "--" + logLevelProperty + "=OFF"};
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
-    
-        assertEquals(logLines.length, 5);
+
+        assertEquals(logLines.length, 3);
     }
 
     @Test
@@ -83,13 +83,13 @@ public class LogAPITestCase extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
 
-        assertEquals(logLines.length, 8);
+        assertEquals(logLines.length, 6);
 
-        console.println(logLines[6]);
-        validateLogLevel(logLines[6], "ERROR", "[]", errLog);
+        console.println(logLines[4]);
+        validateLogLevel(logLines[4], "ERROR", "[]", errLog);
 
-        console.println(logLines[7]);
-        validateLogLevel(logLines[7], "ERROR", "[]", errLogWithErr);
+        console.println(logLines[5]);
+        validateLogLevel(logLines[5], "ERROR", "[]", errLogWithErr);
     }
 
     @Test
@@ -99,38 +99,38 @@ public class LogAPITestCase extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
 
-        assertEquals(logLines.length, 9);
+        assertEquals(logLines.length, 7);
+
+        console.println(logLines[4]);
+        validateLogLevel(logLines[4], "ERROR", "[]", errLog);
+
+        console.println(logLines[5]);
+        validateLogLevel(logLines[5], "ERROR", "[]", errLogWithErr);
 
         console.println(logLines[6]);
-        validateLogLevel(logLines[6], "ERROR", "[]", errLog);
-
-        console.println(logLines[7]);
-        validateLogLevel(logLines[7], "ERROR", "[]", errLogWithErr);
-
-        console.println(logLines[8]);
-        validateLogLevel(logLines[8], "WARN", "[]", warnLog);
+        validateLogLevel(logLines[6], "WARN", "[]", warnLog);
     }
 
     @Test
     public void testInfoLevel() throws BallerinaTestException {
         BMainInstance bMainInstance = new BMainInstance(balServer);
-        String[] args = new String[] { testFileName, "--" + logLevelProperty + "=INFO" };
+        String[] args = new String[]{testFileName, "--" + logLevelProperty + "=INFO"};
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
 
-        assertEquals(logLines.length, 10);
+        assertEquals(logLines.length, 8);
+
+        console.println(logLines[4]);
+        validateLogLevel(logLines[4], "ERROR", "[]", errLog);
+
+        console.println(logLines[5]);
+        validateLogLevel(logLines[5], "ERROR", "[]", errLogWithErr);
 
         console.println(logLines[6]);
-        validateLogLevel(logLines[6], "ERROR", "[]", errLog);
+        validateLogLevel(logLines[6], "WARN", "[]", warnLog);
 
         console.println(logLines[7]);
-        validateLogLevel(logLines[7], "ERROR", "[]", errLogWithErr);
-
-        console.println(logLines[8]);
-        validateLogLevel(logLines[8], "WARN", "[]", warnLog);
-
-        console.println(logLines[9]);
-        validateLogLevel(logLines[9], "INFO", "[]", infoLog);
+        validateLogLevel(logLines[7], "INFO", "[]", infoLog);
     }
 
     @Test
@@ -140,22 +140,22 @@ public class LogAPITestCase extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
 
-        assertEquals(logLines.length, 11);
+        assertEquals(logLines.length, 9);
+
+        console.println(logLines[4]);
+        validateLogLevel(logLines[4], "ERROR", "[]", errLog);
+
+        console.println(logLines[5]);
+        validateLogLevel(logLines[5], "ERROR", "[]", errLogWithErr);
 
         console.println(logLines[6]);
-        validateLogLevel(logLines[6], "ERROR", "[]", errLog);
+        validateLogLevel(logLines[6], "WARN", "[]", warnLog);
 
         console.println(logLines[7]);
-        validateLogLevel(logLines[7], "ERROR", "[]", errLogWithErr);
+        validateLogLevel(logLines[7], "INFO", "[]", infoLog);
 
         console.println(logLines[8]);
-        validateLogLevel(logLines[8], "WARN", "[]", warnLog);
-
-        console.println(logLines[9]);
-        validateLogLevel(logLines[9], "INFO", "[]", infoLog);
-
-        console.println(logLines[10]);
-        validateLogLevel(logLines[10], "DEBUG", "[]", debugLog);
+        validateLogLevel(logLines[8], "DEBUG", "[]", debugLog);
     }
 
     @Test
@@ -165,25 +165,25 @@ public class LogAPITestCase extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
 
-        assertEquals(logLines.length, 12);
+        assertEquals(logLines.length, 10);
+
+        console.println(logLines[4]);
+        validateLogLevel(logLines[4], "ERROR", "[]", errLog);
+
+        console.println(logLines[5]);
+        validateLogLevel(logLines[5], "ERROR", "[]", errLogWithErr);
 
         console.println(logLines[6]);
-        validateLogLevel(logLines[6], "ERROR", "[]", errLog);
+        validateLogLevel(logLines[6], "WARN", "[]", warnLog);
 
         console.println(logLines[7]);
-        validateLogLevel(logLines[7], "ERROR", "[]", errLogWithErr);
+        validateLogLevel(logLines[7], "INFO", "[]", infoLog);
 
         console.println(logLines[8]);
-        validateLogLevel(logLines[8], "WARN", "[]", warnLog);
+        validateLogLevel(logLines[8], "DEBUG", "[]", debugLog);
 
         console.println(logLines[9]);
-        validateLogLevel(logLines[9], "INFO", "[]", infoLog);
-
-        console.println(logLines[10]);
-        validateLogLevel(logLines[10], "DEBUG", "[]", debugLog);
-
-        console.println(logLines[11]);
-        validateLogLevel(logLines[11], "TRACE", "[]", traceLog);
+        validateLogLevel(logLines[9], "TRACE", "[]", traceLog);
     }
 
     @Test
@@ -193,25 +193,25 @@ public class LogAPITestCase extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), testFileLocation, true);
         String[] logLines = output.split("\n");
 
-        assertEquals(logLines.length, 12);
+        assertEquals(logLines.length, 10);
+
+        console.println(logLines[4]);
+        validateLogLevel(logLines[4], "ERROR", "[]", errLog);
+
+        console.println(logLines[5]);
+        validateLogLevel(logLines[5], "ERROR", "[]", errLogWithErr);
 
         console.println(logLines[6]);
-        validateLogLevel(logLines[6], "ERROR", "[]", errLog);
+        validateLogLevel(logLines[6], "WARN", "[]", warnLog);
 
         console.println(logLines[7]);
-        validateLogLevel(logLines[7], "ERROR", "[]", errLogWithErr);
+        validateLogLevel(logLines[7], "INFO", "[]", infoLog);
 
         console.println(logLines[8]);
-        validateLogLevel(logLines[8], "WARN", "[]", warnLog);
+        validateLogLevel(logLines[8], "DEBUG", "[]", debugLog);
 
         console.println(logLines[9]);
-        validateLogLevel(logLines[9], "INFO", "[]", infoLog);
-
-        console.println(logLines[10]);
-        validateLogLevel(logLines[10], "DEBUG", "[]", debugLog);
-
-        console.println(logLines[11]);
-        validateLogLevel(logLines[11], "TRACE", "[]", traceLog);
+        validateLogLevel(logLines[9], "TRACE", "[]", traceLog);
     }
 
     @Test
@@ -221,19 +221,19 @@ public class LogAPITestCase extends BaseTest {
                 "--logorg/mainmod.loglevel=OFF" };
         String output = bMainInstance.runMainAndReadStdOut("run", args, new HashMap<>(), projectDirPath, true);
         String[] logLines = output.split("\n");
-        assertEquals(logLines.length, 15, printLogLines(logLines));
+        assertEquals(logLines.length, 13, printLogLines(logLines));
+
+        console.println(logLines[9]);
+        validateLogLevel(logLines[9], "INFO", "[logorg/foo]", "Logging from inside `foo` module");
+
+        console.println(logLines[10]);
+        validateLogLevel(logLines[10], "DEBUG", "[logorg/foo]", "Logging at DEBUG level inside `foo`");
 
         console.println(logLines[11]);
-        validateLogLevel(logLines[11], "INFO", "[logorg/foo]", "Logging from inside `foo` module");
+        validateLogLevel(logLines[11], "INFO", "[logorg/bar]", "Logging from inside `bar` module");
 
         console.println(logLines[12]);
-        validateLogLevel(logLines[12], "DEBUG", "[logorg/foo]", "Logging at DEBUG level inside `foo`");
-
-        console.println(logLines[13]);
-        validateLogLevel(logLines[13], "INFO", "[logorg/bar]", "Logging from inside `bar` module");
-
-        console.println(logLines[14]);
-        validateLogLevel(logLines[14], "ERROR", "[logorg/baz]", "Logging at ERROR level inside `baz`");
+        validateLogLevel(logLines[12], "ERROR", "[logorg/baz]", "Logging at ERROR level inside `baz`");
     }
 
     private void validateLogLevel(String log, String logLevel, String logLocation, String logMsg) {


### PR DESCRIPTION
## Purpose
Fixes #20841.

## Approach
This PR excludes `CreateExecutableTask` phase (where the final uber jar is created) from the `ballerina run` execution flow. Therefore instead of creating a single executable uber jar and executing it, the executable thin jar will be running with all its dependency jars added to the classpath. Therefore this improves the ballerina program startup time. 

## Related PR
#20862.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
