### PR TITLE
Remove unwanted unknown parent creation in callable observation start

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
@@ -33,11 +33,8 @@ import java.util.function.Supplier;
 
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.CONFIG_METRICS_ENABLED;
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
-import static org.ballerinalang.jvm.observability.ObservabilityConstants.UNKNOWN_CONNECTOR;
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.UNKNOWN_SERVICE;
 import static org.ballerinalang.jvm.observability.tracer.TraceConstants.KEY_SPAN;
-import static org.ballerinalang.jvm.observability.tracer.TraceConstants.TAG_KEY_SPAN_KIND;
-import static org.ballerinalang.jvm.observability.tracer.TraceConstants.TAG_SPAN_KIND_SERVER;
 
 /**
  * Util class used for observability.
@@ -146,25 +143,11 @@ public class ObserveUtils {
         }
 
         ObserverContext observerCtx = strand.observerContext;
-        // If parent context is null, create a new context and start it as a server.
-        if (observerCtx == null) {
-            observerCtx = new ObserverContext();
-            observerCtx.addTag(TAG_KEY_SPAN_KIND, TAG_SPAN_KIND_SERVER);
-            observerCtx.setServiceName(UNKNOWN_SERVICE);
-            observerCtx.setConnectorName(UNKNOWN_CONNECTOR);
-            observerCtx.setResourceName(UNKNOWN_CONNECTOR);
-            observerCtx.setServer();
-            observerCtx.setStarted();
-            for (BallerinaObserver observer : observers) {
-                observer.startServerObservation(observerCtx);
-            }
-        }
 
         ObserverContext newObContext = new ObserverContext();
         newObContext.setParent(observerCtx);
         newObContext.setStarted();
-
-        newObContext.setServiceName(observerCtx.getServiceName());
+        newObContext.setServiceName(observerCtx == null ? UNKNOWN_SERVICE : observerCtx.getServiceName());
         newObContext.setConnectorName(connectorName);
         newObContext.setActionName(actionName);
         strand.observerContext = newObContext;


### PR DESCRIPTION
## Purpose
> Due to the parent observe context created in callable observation start, the main function always comes as a span with no root (the root is the additional observe context which was created but not stopped). This causes never ending spans to be present in the ballerina span as well as the traces to be incomplete.

> This was initially added to avoid an issue in the Zipkin Tracing Extension. However, the issue can be solved by adding a missing dependency. This was added in ballerina-platform/ballerina-observability#34

## Approach
> The additional parent context which was created was removed

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
