### PR TITLE
Fix duplicate declarations in ballerina tests

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -155,7 +155,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return true;
         }
 
-        if (hasSameOwner(symbol, foundSym)) {
+        if (isRedeclaredSymbol(symbol, foundSym)) {
             dlog.error(pos, DiagnosticCode.REDECLARED_SYMBOL, symbol.name);
             return false;
         }
@@ -167,6 +167,10 @@ public class SymbolResolver extends BLangNodeVisitor {
 
         // if a symbol is found, then check whether it is unique
         return isDistinctSymbol(pos, symbol, foundSym);
+    }
+
+    private boolean isRedeclaredSymbol(BSymbol symbol, BSymbol foundSym) {
+        return hasSameOwner(symbol, foundSym) || isSymbolRedeclaredInTestPackage(symbol, foundSym);
     }
 
     public boolean checkForUniqueSymbol(SymbolEnv env, BSymbol symbol) {
@@ -256,6 +260,14 @@ public class SymbolResolver extends BLangNodeVisitor {
         // symbols are in the same block scope.
         return Symbols.isFlagOn(symbol.owner.flags, Flags.LAMBDA) &&
                 ((foundSym.owner.tag & SymTag.INVOKABLE) == SymTag.INVOKABLE);
+    }
+
+    private boolean isSymbolRedeclaredInTestPackage(BSymbol symbol, BSymbol foundSym) {
+        if (Symbols.isFlagOn(symbol.owner.flags, Flags.TESTABLE) &&
+                !Symbols.isFlagOn(foundSym.owner.flags, Flags.TESTABLE)) {
+            return true;
+        }
+        return false;
     }
 
     private boolean isSymbolDefinedInRootPkgLvl(BSymbol foundSym) {

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -130,7 +130,7 @@ public class BCompileUtil {
         String packageName = sourcePath.getFileName().toString();
         Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
         CompilerContext context = new CompilerContext();
-        return compileOnJBallerina(context, sourceRoot.toString(), packageName, false, true, true);
+        return compileOnJBallerina(context, sourceRoot.toString(), packageName, false, true, true, false);
     }
 
     /**
@@ -236,14 +236,29 @@ public class BCompileUtil {
      *
      * @param sourceRoot  root path of the modules
      * @param packageName name of the module to compile
+     * @return Semantic errors
+     */
+    public static CompileResult compileWithTests(String sourceRoot, String packageName) {
+        return compile(sourceRoot, packageName, true, true);
+    }
+
+    /**
+     * Compile and return the semantic errors.
+     *
+     * @param sourceRoot  root path of the modules
+     * @param packageName name of the module to compile
      * @param init init the module or not
      * @return Semantic errors
      */
     public static CompileResult compile(String sourceRoot, String packageName, boolean init) {
+        return compile(sourceRoot, packageName, init, false);
+    }
+
+    private static CompileResult compile(String sourceRoot, String packageName, boolean init, boolean withTests) {
         String filePath = concatFileName(sourceRoot, resourceDir);
         Path rootPath = Paths.get(filePath);
         Path packagePath = Paths.get(packageName);
-        return getCompileResult(packageName, rootPath, packagePath, init);
+        return getCompileResult(packageName, rootPath, packagePath, init, withTests);
     }
 
     /**
@@ -271,10 +286,11 @@ public class BCompileUtil {
         String filePath = concatFileName(sourceRoot, resourceDir);
         Path rootPath = Paths.get(filePath);
         Path packagePath = Paths.get(packageName);
-        return getCompileResult(packageName, rootPath, packagePath, init);
+        return getCompileResult(packageName, rootPath, packagePath, init, false);
     }
 
-    private static CompileResult getCompileResult(String packageName, Path rootPath, Path packagePath, boolean init) {
+    private static CompileResult getCompileResult(String packageName, Path rootPath, Path packagePath, boolean init,
+            boolean withTests) {
         String effectiveSource;
         if (Files.isDirectory(packagePath)) {
             String[] pkgParts = packageName.split("\\/");
@@ -291,12 +307,12 @@ public class BCompileUtil {
             // TODO: orgName is anon, fix it.
             PackageID pkgId = new PackageID(Names.ANON_ORG, pkgNameComps, Names.DEFAULT_VERSION);
             effectiveSource = pkgId.getName().getValue();
-            return compileOnJBallerina(rootPath.toString(), effectiveSource, false, init);
+            return compileOnJBallerina(rootPath.toString(), effectiveSource, false, init, withTests);
         }
 
         effectiveSource = packageName;
         return compileOnJBallerina(rootPath.toString(), effectiveSource, new FileSystemProjectDirectory(rootPath),
-                init);
+                init, withTests);
     }
 
     /**
@@ -515,32 +531,46 @@ public class BCompileUtil {
     }
 
     private static CompileResult compileOnJBallerina(String sourceRoot, String packageName,
-                                                     SourceDirectory sourceDirectory, boolean init) {
+                                                     SourceDirectory sourceDirectory, boolean init, boolean withTests) {
         CompilerContext context = new CompilerContext();
         context.put(SourceDirectory.class, sourceDirectory);
-        return compileOnJBallerina(context, sourceRoot, packageName, false, init);
+        return compileOnJBallerina(context, sourceRoot, packageName, false, init, withTests);
     }
 
     public static CompileResult compileOnJBallerina(String sourceRoot, String packageName, boolean temp, boolean init) {
+        return compileOnJBallerina(sourceRoot, packageName, temp, init, false);
+    }
+
+    private static CompileResult compileOnJBallerina(String sourceRoot, String packageName, boolean temp, boolean init,
+            boolean withTests) {
         CompilerContext context = new CompilerContext();
-        return compileOnJBallerina(context, sourceRoot, packageName, temp, init);
+        return compileOnJBallerina(context, sourceRoot, packageName, temp, init, withTests);
     }
 
     public static CompileResult compileOnJBallerina(CompilerContext context, String sourceRoot, String packageName,
                                                     boolean temp, boolean init) {
-        return compileOnJBallerina(context, sourceRoot, packageName, temp, init, false);
+        return compileOnJBallerina(context, sourceRoot, packageName, temp, init, false, false);
     }
 
     private static CompileResult compileOnJBallerina(CompilerContext context, String sourceRoot, String packageName,
-                                                     boolean temp, boolean init, boolean inProc) {
+                                                    boolean temp, boolean init, boolean withTests) {
+        return compileOnJBallerina(context, sourceRoot, packageName, temp, init, false, withTests);
+    }
+
+    private static CompileResult compileOnJBallerina(CompilerContext context, String sourceRoot, String packageName,
+                                                     boolean temp, boolean init, boolean inProc, boolean withTests) {
         CompilerOptions options = CompilerOptions.getInstance(context);
         options.put(PROJECT_DIR, sourceRoot);
         options.put(COMPILER_PHASE, CompilerPhase.BIR_GEN.toString());
         options.put(PRESERVE_WHITESPACE, "false");
         options.put(LOCK_ENABLED, Boolean.toString(true));
         options.put(CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED, Boolean.TRUE.toString());
+        if (withTests) {
+            options.put(CompilerOptionName.SKIP_TESTS, "false");
+            options.put(CompilerOptionName.TEST_ENABLED, "true");
+        }
 
-        CompileResult compileResult = compile(context, packageName, CompilerPhase.BIR_GEN, false);
+        CompileResult compileResult = compile(context, packageName, CompilerPhase.BIR_GEN, withTests);
         if (compileResult.getErrorCount() > 0) {
             return compileResult;
         }

--- a/tests/jballerina-integration-test/src/test/resources/packaging/balopath/case7/TestProject1/src/foo/tests/main_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/packaging/balopath/case7/TestProject1/src/foo/tests/main_test.bal
@@ -3,7 +3,7 @@ import ballerina/test;
 import wso2/utils;
 import ballerinax/java;
 
-function testAcceptNothingButReturnString() returns handle {
+function testAcceptNothingButReturnStringTest() returns handle {
     return utils:getString();
 }
 
@@ -27,7 +27,7 @@ function beforeFunc() {
     after: "afterFunc"
 }
 function testFunction() {
-    string result =  <string>java:toString(testAcceptNothingButReturnString());
+    string result =  <string>java:toString(testAcceptNothingButReturnStringTest());
     test:assertEquals(result, "This is a test string value !!!", msg = "Interop method call failed!");
     io:println("Tested utils getString method using interop and received: " + result);
 }

--- a/tests/jballerina-unit-test/build.gradle
+++ b/tests/jballerina-unit-test/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     baloImplementation project(path: ':ballerina-backend-jvm', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-jvm', configuration: 'baloImplementation')
     baloImplementation project(path: ':ballerina-bir', configuration: 'baloImplementation')
+    baloImplementation project(path: ':testerina:testerina-core', configuration: 'baloImplementation')
 }
 
 description = 'JBallerina - Unit Test Module'

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/testerina/TopLevelNodesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/testerina/TopLevelNodesTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.testerina;
+
+import org.ballerinalang.test.util.BAssertUtil;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for duplicate definitions in tests vs src.
+ */
+public class TopLevelNodesTest {
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compileWithTests("test-src/testerina/TopLevelNodesDupTest", "duptest");
+    }
+
+    @Test(description = "Test Toplevel nodes duplication")
+    public void testModule() {
+        Assert.assertEquals(compileResult.getErrorCount(), 4);
+
+        int index = 0;
+        BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'testDuplicate'", 4, 17);
+        BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'Person'", 8, 13);
+        BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'testString'", 13, 8);
+        BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'Company'", 15, 13);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/testerina/TopLevelNodesDupTest/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/testerina/TopLevelNodesDupTest/Ballerina.toml
@@ -1,0 +1,5 @@
+[project]
+org-name= "abc"
+version= "0.1.0"
+
+[dependencies]

--- a/tests/jballerina-unit-test/src/test/resources/test-src/testerina/TopLevelNodesDupTest/src/duptest/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/testerina/TopLevelNodesDupTest/src/duptest/main.bal
@@ -1,0 +1,26 @@
+import ballerina/io;
+
+public function main() {
+  testDuplicate();
+}
+
+public function testDuplicate() {
+  io:println("module");
+}
+
+string testString = "test";
+
+public type Company object {
+    string name;
+    string address;
+
+    public function __init() {
+    	 self.name = "test";
+    	 self.address = "test";
+    }
+};
+
+public type Person record {|
+    string name;
+    int age;
+|};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/testerina/TopLevelNodesDupTest/src/duptest/tests/main_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/testerina/TopLevelNodesDupTest/src/duptest/tests/main_test.bal
@@ -1,0 +1,38 @@
+import ballerina/io;
+import ballerina/test;
+
+public function testDuplicate() {
+  io:println("test");
+}
+
+public type Person record {|
+    string name;
+    int age;
+|};
+
+string testString = "test";
+
+public type Company object {
+    string name;
+    string address;
+
+    public function __init() {
+    	 self.name = "test";
+    	 self.address = "test";
+    }
+};
+
+@test:Config {
+    before: "beforeFunc",
+    after: "afterFunc"
+}
+function testFunction() {
+  testDuplicate();
+    main();
+}
+
+function beforeFunc() {
+}
+
+function afterFunc() {
+}

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -49,6 +49,7 @@
             <package name="org.ballerinalang.test.typedefs.*"/>
             <package name="org.ballerinalang.test.access.*"/>
             <package name="org.ballerinalang.test.structs.*"/>
+            <package name="org.ballerinalang.test.testerina.*"/>
             <package name="org.ballerinalang.test.jvm.*"/>
             <package name="org.ballerinalang.test.types.integer"/>
             <package name="org.ballerinalang.test.types.floattype"/>


### PR DESCRIPTION
## Purpose
>By applying this fix, the compiler will give a compiler error when there is a symbol duplication in the test files compared to the source files

Fixes #20963
Fixes #20694

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
