### PR TITLE
Improve Stream map constructor and function

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/StreamValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/StreamValue.java
@@ -20,6 +20,7 @@ package org.ballerinalang.jvm.values;
 
 import org.ballerinalang.jvm.IteratorUtils;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.types.BFunctionType;
 import org.ballerinalang.jvm.types.BStreamType;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.values.api.BFunctionPointer;
@@ -68,7 +69,6 @@ public class StreamValue implements RefValue, BStream {
     public StreamValue(BType type, BIterator iterator, BFunctionPointer<Object, Boolean> filterFunc,
                        BFunctionPointer<Object, Object> mapFunc) {
         this.constraintType = ((BStreamType) type).getConstrainedType();
-        this.type = new BStreamType(constraintType);
         this.streamId = UUID.randomUUID().toString();
         this.iterator = iterator;
 
@@ -79,10 +79,13 @@ public class StreamValue implements RefValue, BStream {
         }
 
         if (mapFunc != null) {
+            this.constraintType = ((BFunctionType) mapFunc.getType()).retType;
             this.mapper = new MapFunctionPointerWrapper(mapFunc);
         } else {
             this.mapper = new NoMapFunctionPointerWrapper();
         }
+
+        this.type = new BStreamType(constraintType);
     }
 
     public StreamValue(BStream sourceStream, BFunctionPointer<Object, Boolean> filterFunc,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1792,6 +1792,7 @@ public class BLangPackageBuilder {
         BLangFromClause fromClause = (BLangFromClause) TreeBuilder.createFromClauseNode();
         fromClause.addWS(ws);
         fromClause.pos = pos;
+        markVariableAsFinal((BLangVariable) variableDefinitionNode.getVariable());
         fromClause.setVariableDefinitionNode(variableDefinitionNode);
         fromClause.setCollection(this.exprNodeStack.pop());
         fromClause.isDeclaredWithVar = isDeclaredWithVar;

--- a/langlib/lang.stream/src/main/ballerina/src/lang.stream/internal.bal
+++ b/langlib/lang.stream/src/main/ballerina/src/lang.stream/internal.bal
@@ -21,7 +21,7 @@ type PureType3 anydata | error;
 # + td - A type description.
 # + func - A lambda function.
 # + return - New stream containing results of `func` invocation.
-function construct(typedesc<PureType3> td, function() returns PureType3 func) returns stream<PureType3> = external;
+function construct(typedesc<PureType3> td, function() returns record {|PureType3 value;|}? func) returns stream<PureType3> = external;
 
 # Represent the iterator type returned when `iterator` method is invoked.
 type StreamIterator object {

--- a/langlib/lang.stream/src/main/java/org/ballerinalang/langlib/stream/Construct.java
+++ b/langlib/lang.stream/src/main/java/org/ballerinalang/langlib/stream/Construct.java
@@ -52,7 +52,7 @@ public class Construct {
     public static StreamValue construct(Strand strand, TypedescValue td, FPValue<Object, Object> func) {
         BFunctionType functionType = (BFunctionType) func.getType();
         IteratorValue iterator = new Iterator(func);
-        return new StreamValue(new BStreamType(functionType.getReturnParameterType()), iterator, null, null);
+        return new StreamValue(new BStreamType(td.getDescribingType()), iterator, null, null);
     }
 
     static class Iterator implements IteratorValue {

--- a/langlib/lang.stream/src/main/java/org/ballerinalang/langlib/stream/Construct.java
+++ b/langlib/lang.stream/src/main/java/org/ballerinalang/langlib/stream/Construct.java
@@ -20,7 +20,6 @@ package org.ballerinalang.langlib.stream;
 
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.types.BFunctionType;
 import org.ballerinalang.jvm.types.BStreamType;
 import org.ballerinalang.jvm.values.FPValue;
 import org.ballerinalang.jvm.values.IteratorValue;
@@ -50,7 +49,6 @@ import org.ballerinalang.natives.annotations.ReturnType;
 public class Construct {
 
     public static StreamValue construct(Strand strand, TypedescValue td, FPValue<Object, Object> func) {
-        BFunctionType functionType = (BFunctionType) func.getType();
         IteratorValue iterator = new Iterator(func);
         return new StreamValue(new BStreamType(td.getDescribingType()), iterator, null, null);
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStreamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStreamTest.java
@@ -76,4 +76,10 @@ public class LangLibStreamTest {
         BValue[] values = BRunUtil.invoke(result, "testIterator", new BValue[]{});
         Assert.assertTrue(((BBoolean) values[0]).booleanValue());
     }
+
+    @Test
+    public void testMapFuncWithRecordType() {
+        BValue[] values = BRunUtil.invoke(result, "testMapFuncWithRecordType", new BValue[]{});
+        Assert.assertTrue(((BBoolean) values[0]).booleanValue());
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/streamlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/streamlib_test.bal
@@ -177,3 +177,26 @@ function testIterator() returns boolean {
 
     return testPassed;
 }
+
+function testMapFuncWithRecordType() returns boolean {
+     boolean testPassed = true;
+     Person[] personList = getPersonList();
+
+    stream<Person> personStream =  personList.toStream();
+
+    stream<Employee> mappedEmpStream = personStream.'map(function (Person person) returns Employee {
+        Employee e = {
+          name: person.name,
+          company: "WSO2"
+        };
+        return e;
+
+        });
+
+    record {| Employee value; |}? nextValue = mappedEmpStream.next();
+    Employee employee = <Employee>nextValue?.value;
+
+    testPassed = testPassed && employee.name == "Gima" && employee.company == "WSO2";
+    return  testPassed;
+}
+

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionTest.java
@@ -57,6 +57,36 @@ public class QueryActionTest {
         Assert.assertEquals(person3.get("lastName").stringValue(), "David");
     }
 
+    @Test(description = "Test simple query action - record variable definition")
+    public void testSimpleQueryActionWithRecordVariable() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testSimpleQueryActionWithRecordVariable");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues.length, 3, "Expected events are not received");
+
+        BMap<String, BValue> person1 = (BMap<String, BValue>) returnValues[0];
+        BMap<String, BValue> person2 = (BMap<String, BValue>) returnValues[1];
+        BMap<String, BValue> person3 = (BMap<String, BValue>) returnValues[2];
+
+        Assert.assertEquals(person1.get("firstName").stringValue(), "Alex");
+        Assert.assertEquals(person2.get("lastName").stringValue(), "Fonseka");
+        Assert.assertEquals(person3.get("lastName").stringValue(), "David");
+    }
+
+    @Test(description = "Test simple query action - record variable definition")
+    public void testSimpleSelectQueryWithRecordVariableV2() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV2");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues.length, 3, "Expected events are not received");
+
+        BMap<String, BValue> person1 = (BMap<String, BValue>) returnValues[0];
+        BMap<String, BValue> person2 = (BMap<String, BValue>) returnValues[1];
+        BMap<String, BValue> person3 = (BMap<String, BValue>) returnValues[2];
+
+        Assert.assertEquals(person1.get("firstName").stringValue(), "Alex");
+        Assert.assertEquals(person2.get("lastName").stringValue(), "Fonseka");
+        Assert.assertEquals(person3.get("lastName").stringValue(), "David");
+    }
+
     @Test(description = "Test simple query action statement v2")
     public void testSimpleQueryAction2() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleQueryAction2");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryNegativeTests.java
@@ -35,7 +35,7 @@ public class QueryNegativeTests {
     @Test
     public void testFromClauseWithInvalidType() {
         CompileResult compileResult = BCompileUtil.compile("test-src/query/query-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 8);
+        Assert.assertEquals(compileResult.getErrorCount(), 9);
         int index = 0;
 
         validateError(compileResult, index++, "incompatible types: expected 'Person', found 'Teacher'",
@@ -48,6 +48,7 @@ public class QueryNegativeTests {
         validateError(compileResult, index++, "undefined field 'lastName' in record 'Teacher'", 64, 20);
         validateError(compileResult, index++, "incompatible types: 'int' is not an iterable collection", 77, 32);
         validateError(compileResult, index++, "incompatible types: expected 'boolean', found 'int'", 78, 19);
-        validateError(compileResult, index, "incompatible types: expected 'Person', found 'int'", 79, 20);
+        validateError(compileResult, index++, "incompatible types: expected 'Person', found 'int'", 79, 20);
+        validateError(compileResult, index, "cannot assign a value to final 'person'", 94, 13);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -68,9 +68,10 @@ public class BStreamValueTest {
     @Test(description = "Test negative test scenarios of stream type")
     public void testStreamTypeNegative() {
         int i = 0;
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| int value; |}?', found" +
-                " 'int'", 26, 12);
-        BAssertUtil.validateError(negativeResult, i++, "undefined field 'val' in record 'record {| int value; |}'", 31, 14);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected "
+                +"'record {| int value; |}?', found 'int'", 26, 12);
+        BAssertUtil.validateError(negativeResult, i++, "undefined field 'val' in record "
+                +"'record {| int value; |}'", 31, 14);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 35, 21);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'boolean'", 39, 21);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -69,9 +69,9 @@ public class BStreamValueTest {
     public void testStreamTypeNegative() {
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected "
-                +"'record {| int value; |}?', found 'int'", 26, 12);
+                + "'record {| int value; |}?', found 'int'", 26, 12);
         BAssertUtil.validateError(negativeResult, i++, "undefined field 'val' in record "
-                +"'record {| int value; |}'", 31, 14);
+                + "'record {| int value; |}'", 31, 14);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 35, 21);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'boolean'", 39, 21);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -68,13 +68,11 @@ public class BStreamValueTest {
     @Test(description = "Test negative test scenarios of stream type")
     public void testStreamTypeNegative() {
         int i = 0;
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| int value; |}', found" +
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| int value; |}?', found" +
                 " 'int'", 26, 12);
-        BAssertUtil.validateError(negativeResult, i++, "undefined field 'val' in record '$anonType$2'", 31, 14);
+        BAssertUtil.validateError(negativeResult, i++, "undefined field 'val' in record 'record {| int value; |}'", 31, 14);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 35, 21);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'boolean'", 39, 21);
-        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'record {| int value; |}', found '" +
-                "()'", 43, 12);
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-action.bal
@@ -39,3 +39,39 @@ function testSimpleQueryAction2() returns int{
 
     return count;
 }
+
+function testSimpleQueryActionWithRecordVariable() returns FullName[]{
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName:"John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+    FullName[] nameList = [];
+
+    from var { firstName: nm1, lastName: nm2, age: a } in personList
+    do {
+        FullName fullName = {firstName: nm1, lastName: nm2};
+        nameList[nameList.length()] = fullName;
+    }
+
+    return  nameList;
+}
+
+function testSimpleSelectQueryWithRecordVariableV2() returns FullName[]{
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName:"John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+    FullName[] nameList = [];
+
+    from var { firstName, lastName, age } in personList
+    do {
+        FullName fullName = {firstName: firstName, lastName: lastName};
+        nameList[nameList.length()] = fullName;
+    }
+
+    return  nameList;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-negative.bal
@@ -80,3 +80,19 @@ function testQueryWithInvalidExpressions() returns Person[]{
 
     return  outputPersonList;
 }
+
+function testQueryActionWithMutableParams() returns Person[]{
+
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+
+    from var person in personList
+    do {
+            person = {firstName: "XYZ", lastName: "George", age: 30};
+    }
+
+    return personList;
+}


### PR DESCRIPTION
## Purpose
> Fixes type cast exception when casting the value of generated stream from Streams.map().
> Improve mapping constructor support in select clause
> Improve query tests

Fixes #20904 and #20812

## Approach
> n/a

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
