### PR TITLE
[WIP] Add Fill-member support for list get

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -877,10 +877,13 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangStatementExpression statementExpression) {
         boolean variableStore = this.varAssignment;
+
+        // Bypass targetOperand to statementExpression.expr
         BIROperand prevTargetOperand = null;
         if (variableStore) {
             prevTargetOperand = this.env.targetOperand;
         }
+        // Stop varAssignment status propagation to statement block's code gen.
         this.varAssignment = false;
         statementExpression.stmt.accept(this);
         this.varAssignment = variableStore;
@@ -888,6 +891,7 @@ public class BIRGen extends BLangNodeVisitor {
         if (variableStore) {
             this.env.targetOperand = prevTargetOperand;
         }
+
         statementExpression.expr.accept(this);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -876,22 +876,21 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangStatementExpression statementExpression) {
+        // Stop varAssignment status propagation to statement block's code gen.
         boolean variableStore = this.varAssignment;
+        this.varAssignment = false;
 
-        // Bypass targetOperand to statementExpression.expr
+        // Bypass targetOperand till visit to statementExpression.expr
         BIROperand prevTargetOperand = null;
         if (variableStore) {
             prevTargetOperand = this.env.targetOperand;
         }
-        // Stop varAssignment status propagation to statement block's code gen.
-        this.varAssignment = false;
         statementExpression.stmt.accept(this);
-        this.varAssignment = variableStore;
 
+        this.varAssignment = variableStore;
         if (variableStore) {
             this.env.targetOperand = prevTargetOperand;
         }
-
         statementExpression.expr.accept(this);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -853,9 +853,10 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangAssignment astAssignStmt) {
         astAssignStmt.expr.accept(this);
 
+        boolean prevVarAssignmentStatus = this.varAssignment;
         this.varAssignment = true;
         astAssignStmt.varRef.accept(this);
-        this.varAssignment = false;
+        this.varAssignment = prevVarAssignmentStatus;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -876,7 +876,18 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangStatementExpression statementExpression) {
+        boolean variableStore = this.varAssignment;
+        BIROperand prevTargetOperand = null;
+        if (variableStore) {
+            prevTargetOperand = this.env.targetOperand;
+        }
+        this.varAssignment = false;
         statementExpression.stmt.accept(this);
+        this.varAssignment = variableStore;
+
+        if (variableStore) {
+            this.env.targetOperand = prevTargetOperand;
+        }
         statementExpression.expr.accept(this);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3381,10 +3381,8 @@ public class Desugar extends BLangNodeVisitor {
         // First get the type and then visit the expr. Order matters, since the desugar
         // can change the type of the expression, if it is type narrowed.
         BType varRefType = indexAccessExpr.expr.type;
-        if (indexAccessExpr.lhsVar
-                && varRefType.tag == TypeTags.ARRAY
-                && indexAccessExpr.expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR
-                && ((BLangIndexBasedAccess) indexAccessExpr.expr).indexExpr.type.tag == TypeTags.INT) {
+
+        if (isTwoDemensionalArrayLValueAccess(indexAccessExpr, varRefType)) {
             result = rewriteMultiDimensionalLValAccess(indexAccessExpr, varRefType);
             return;
         }
@@ -3414,6 +3412,13 @@ public class Desugar extends BLangNodeVisitor {
         targetVarRef.lhsVar = indexAccessExpr.lhsVar;
         targetVarRef.type = indexAccessExpr.type;
         result = targetVarRef;
+    }
+
+    private boolean isTwoDemensionalArrayLValueAccess(BLangIndexBasedAccess indexAccessExpr, BType varRefType) {
+        return indexAccessExpr.lhsVar
+                && varRefType.tag == TypeTags.ARRAY
+                && indexAccessExpr.expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR
+                && ((BLangIndexBasedAccess) indexAccessExpr.expr).expr.type.tag == TypeTags.ARRAY;
     }
 
     private BLangExpression rewriteMultiDimensionalLValAccess(BLangIndexBasedAccess indexAccessExpr, BType varRefType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3381,8 +3381,8 @@ public class Desugar extends BLangNodeVisitor {
         // First get the type and then visit the expr. Order matters, since the desugar
         // can change the type of the expression, if it is type narrowed.
         BType varRefType = indexAccessExpr.expr.type;
-        if (indexAccessExpr.lhsVar && varRefType.tag == TypeTags.ARRAY
-                && indexAccessExpr.indexExpr.type.tag == TypeTags.INT
+        if (indexAccessExpr.lhsVar
+                && varRefType.tag == TypeTags.ARRAY
                 && indexAccessExpr.expr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR
                 && ((BLangIndexBasedAccess) indexAccessExpr.expr).indexExpr.type.tag == TypeTags.INT) {
             result = rewriteMultiDimensionalLValAccess(indexAccessExpr, varRefType);
@@ -3417,7 +3417,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangExpression rewriteMultiDimensionalLValAccess(BLangIndexBasedAccess indexAccessExpr, BType varRefType) {
-        // ar[i][j] = n; -> int $t = i; if $t < ar.length() { ar[$t] = []; } ar[$t][j] = n;
+        // ar[i][j] = n; -> int $t = i; if ($t < ar.length() + 1) { ar[$t] = []; } ar[$t][j] = n;
 
         DiagnosticPos pos = indexAccessExpr.pos;
         BLangIndexBasedAccess expr = (BLangIndexBasedAccess) indexAccessExpr.expr;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3417,32 +3417,42 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangExpression rewriteMultiDimensionalLValAccess(BLangIndexBasedAccess indexAccessExpr, BType varRefType) {
-        // ar[i][j] = n; -> ar[i] = []; ar[i][j] = n;
+        // ar[i][j] = n; -> int $t = i; if $t < ar.length() { ar[$t] = []; } ar[$t][j] = n;
 
         DiagnosticPos pos = indexAccessExpr.pos;
         BLangIndexBasedAccess expr = (BLangIndexBasedAccess) indexAccessExpr.expr;
         BLangStatementExpression bLangStatementExpression = new BLangStatementExpression();
+
         BLangBlockStmt bLangBlockStmt = new BLangBlockStmt();
+        BLangSimpleVariableDef firstIndex =
+                createVarDef("$tempIndex$", expr.indexExpr.type, expr.indexExpr, expr.indexExpr.pos);
+        bLangBlockStmt.addStatement(firstIndex);
+
+        BLangInvocation invocationNode = createArrayLengthInvocation(expr);
+        BLangSimpleVariableDef lengthOfArray = createVarDef("$arrayLength$", symTable.intType, invocationNode, pos);
+        bLangBlockStmt.addStatement(lengthOfArray);
+
         BLangIf ifStmt = ASTBuilderUtil.createIfStmt(pos, bLangBlockStmt);
-
-        BLangInvocation invocationNode = createInvocationNode("length", new ArrayList<>(), symTable.intType);
-        invocationNode.expr = expr.expr;
-        invocationNode.symbol = symResolver.lookupLangLibMethod(symTable.arrayType, names.fromString("length"));
-        invocationNode.requiredArgs = Collections.singletonList(expr.expr);
-        invocationNode.type = symTable.intType;
-
+        // todo: extract index to a var, and then use that var here
+        BLangSimpleVarRef firstIndexVarRef = ASTBuilderUtil.createVariableRef(firstIndex.pos, firstIndex.var.symbol);
         BLangBinaryExpr addOneToIndex = ASTBuilderUtil.createBinaryExpr(pos,
-                expr.indexExpr,
+                firstIndexVarRef,
                 ASTBuilderUtil.createLiteral(pos, symTable.intType, Long.valueOf(1)),
                 symTable.intType,
                 OperatorKind.ADD, null);
-        ifStmt.expr = ASTBuilderUtil.createBinaryExpr(pos,
-                invocationNode,
+        BLangBinaryExpr condition = ASTBuilderUtil.createBinaryExpr(pos,
+                ASTBuilderUtil.createVariableRef(pos, lengthOfArray.var.symbol),
                 addOneToIndex,
                 symTable.booleanType, OperatorKind.LESS_THAN, null);
+        ifStmt.expr = rewriteExpr(condition);
 
-        BLangArrayAccessExpr arrayAccessExpr = new BLangArrayAccessExpr(pos, indexAccessExpr.expr,
-                indexAccessExpr.indexExpr);
+        BLangIndexBasedAccess arrayAccess = (BLangIndexBasedAccess) TreeBuilder.createIndexBasedAccessNode();
+        arrayAccess.pos = pos;
+        arrayAccess.expr = expr.expr;
+        arrayAccess.indexExpr = firstIndexVarRef;
+        arrayAccess.type = expr.type;
+
+        BLangArrayAccessExpr arrayAccessExpr = new BLangArrayAccessExpr(pos, arrayAccess, indexAccessExpr.indexExpr);
         arrayAccessExpr.lhsVar = true;
         arrayAccessExpr.type = varRefType;
         bLangStatementExpression.expr = arrayAccessExpr;
@@ -3450,9 +3460,8 @@ public class Desugar extends BLangNodeVisitor {
         BLangAssignment assignment = new BLangAssignment();
         ifStmt.body = ASTBuilderUtil.createBlockStmt(pos);
         ifStmt.body.addStatement(assignment);
-//        bLangBlockStmt.addStatement(assignment);
-        assignment.varRef = rewrite(expr, env);
 
+        assignment.varRef = rewrite(arrayAccess, env);
 
         BLangArrayLiteral arrayLiteral = new BLangArrayLiteral();
         arrayLiteral.pos = indexAccessExpr.expr.pos;
@@ -3462,6 +3471,23 @@ public class Desugar extends BLangNodeVisitor {
 
         bLangStatementExpression.type = indexAccessExpr.type;
         return rewriteExpr(bLangStatementExpression);
+    }
+
+    private BLangInvocation createArrayLengthInvocation(BLangIndexBasedAccess expr) {
+        BLangInvocation invocationNode = createInvocationNode("length", new ArrayList<>(), symTable.intType);
+        invocationNode.symbol = symResolver.lookupLangLibMethod(symTable.arrayType, names.fromString("length"));
+
+        BLangExpression arrayExpr = expr.expr;
+        // If the array ref is a simple variable ref, create a new variable ref as original one could be a LHS var ref.
+        if (expr.expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
+            BLangSimpleVarRef arrayRef = (BLangSimpleVarRef) arrayExpr;
+            BLangSimpleVarRef variableRef = ASTBuilderUtil.createVariableRef(arrayRef.pos, arrayRef.symbol);
+            arrayExpr = variableRef;
+        }
+        invocationNode.expr = arrayExpr;
+        invocationNode.requiredArgs = Collections.singletonList(expr.expr);
+        invocationNode.type = symTable.intType;
+        return invocationNode;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -90,6 +90,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
@@ -2287,6 +2288,11 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
 
         analyzeStmt(patternClause.body, blockEnv);
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess indexAccessExpr) {
+        super.visit(indexAccessExpr);
     }
 
     @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -118,11 +118,11 @@ public class ArrayAccessExprTest {
     }
 
     @Test
-    public void testFoo() {
+    public void testAssignToNonExistingFirstDimensionOfTwoDimensionArray() {
         BValue[] args = {};
-        BValue[] returns = BRunUtil.invoke(compileResult, "foo", args);
+        BValue[] returns = BRunUtil.invoke(compileResult, "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
 
-        Assert.assertEquals(returns[0], "");
+        Assert.assertEquals(returns[0].stringValue(), "[0, 2]");
     }
 
     @Test(description = "Test accessing an out of bound arrays-index",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -126,6 +126,15 @@ public class ArrayAccessExprTest {
         Assert.assertEquals(returns[0].stringValue(), "[0, 2]");
     }
 
+    @Test
+    public void testAssignToNonExistingFirstDimensionOfThreeDimensionalArray() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(compileResult,
+                "testAssignToNonExistingFirstDimensionOfThreeDimensionalArray", args);
+
+        Assert.assertEquals(returns[0].stringValue(), "[[0, 2]]");
+    }
+
     @Test(description = "Test accessing an out of bound arrays-index",
           expectedExceptions = { BLangRuntimeException.class },
           expectedExceptionsMessageRegExp = ".*array index out of range: index: 5, size: 2.*")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -117,6 +117,14 @@ public class ArrayAccessExprTest {
         Assert.assertEquals(actual, expected);
     }
 
+    @Test
+    public void testFoo() {
+        BValue[] args = {};
+        BValue[] returns = BRunUtil.invoke(compileResult, "foo", args);
+
+        Assert.assertEquals(returns[0], "");
+    }
+
     @Test(description = "Test accessing an out of bound arrays-index",
           expectedExceptions = { BLangRuntimeException.class },
           expectedExceptionsMessageRegExp = ".*array index out of range: index: 5, size: 2.*")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -120,7 +120,8 @@ public class ArrayAccessExprTest {
     @Test
     public void testAssignToNonExistingFirstDimensionOfTwoDimensionArray() {
         BValue[] args = {};
-        BValue[] returns = BRunUtil.invoke(compileResult, "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
+        BValue[] returns = BRunUtil.invoke(compileResult,
+                "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
 
         Assert.assertEquals(returns[0].stringValue(), "[0, 2]");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -118,21 +118,24 @@ public class ArrayAccessExprTest {
     }
 
     @Test
+    public void testAssignToExistingFirstDimensionOfTwoDimensionArray() {
+        BValue[] args = {};
+        BRunUtil.invoke(compileResult,
+                        "testAssignToExistingFirstDimensionOfTwoDimensionArray", args);
+    }
+
+    @Test
     public void testAssignToNonExistingFirstDimensionOfTwoDimensionArray() {
         BValue[] args = {};
-        BValue[] returns = BRunUtil.invoke(compileResult,
+        BRunUtil.invoke(compileResult,
                 "testAssignToNonExistingFirstDimensionOfTwoDimensionArray", args);
-
-        Assert.assertEquals(returns[0].stringValue(), "[0, 2]");
     }
 
     @Test
     public void testAssignToNonExistingFirstDimensionOfThreeDimensionalArray() {
         BValue[] args = {};
-        BValue[] returns = BRunUtil.invoke(compileResult,
+        BRunUtil.invoke(compileResult,
                 "testAssignToNonExistingFirstDimensionOfThreeDimensionalArray", args);
-
-        Assert.assertEquals(returns[0].stringValue(), "[[0, 2]]");
     }
 
     @Test(description = "Test accessing an out of bound arrays-index",

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
@@ -1,3 +1,10 @@
+function foo() returns int[][] {
+    int[][] x = [];
+    //x[0] = [];
+    x[0][1] = 2;
+    return x;
+}
+
 function testNonInitArrayAccess() returns (string){
     string[] fruits = [];
     return fruits[5];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
@@ -113,3 +113,9 @@ function testAssignToNonExistingFirstDimensionOfTwoDimensionArray() returns int[
     x[0][1] = 2;
     return x;
 }
+
+function testAssignToNonExistingFirstDimensionOfThreeDimensionalArray() returns int[][][] {
+    int[][][] x = [];
+    x[0][0][1] = 2;
+    return x;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
@@ -1,9 +1,3 @@
-function foo() returns int[][] {
-    int[][] x = [];
-    //x[0] = [];
-    x[0][1] = 2;
-    return x;
-}
 
 function testNonInitArrayAccess() returns (string){
     string[] fruits = [];
@@ -112,4 +106,10 @@ function testArrayIndexOutOfRangeErrorWithUnionWithFiniteTypesIndex() {
     animals = ["Lion", "Cat"];
     OneToFive ot = 4;
     name = animals[ot];
+}
+
+function testAssignToNonExistingFirstDimensionOfTwoDimensionArray() returns int[][] {
+    int[][] x = [];
+    x[0][1] = 2;
+    return x;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-access-expr.bal
@@ -108,14 +108,35 @@ function testArrayIndexOutOfRangeErrorWithUnionWithFiniteTypesIndex() {
     name = animals[ot];
 }
 
-function testAssignToNonExistingFirstDimensionOfTwoDimensionArray() returns int[][] {
-    int[][] x = [];
-    x[0][1] = 2;
-    return x;
+function testAssignToExistingFirstDimensionOfTwoDimensionArray() {
+    int[][] x = [[5], [5, 5]];
+    x[2][1] = 2;
+
+    assertEqualPanic(5, x[0][0]);
+    assertEqualPanic(5, x[1][0]);
+    assertEqualPanic(5, x[1][1]);
+    assertEqualPanic(0, x[2][0]);
+    assertEqualPanic(2, x[2][1]);
 }
 
-function testAssignToNonExistingFirstDimensionOfThreeDimensionalArray() returns int[][][] {
+function testAssignToNonExistingFirstDimensionOfTwoDimensionArray() {
+    int[][] x = [];
+    x[0][1] = 2;
+
+    assertEqualPanic(2, x[0][1]);
+    assertEqualPanic(0, x[0][0]);
+}
+
+function testAssignToNonExistingFirstDimensionOfThreeDimensionalArray() {
     int[][][] x = [];
     x[0][0][1] = 2;
-    return x;
+
+    assertEqualPanic(2, x[0][0][1]);
+    assertEqualPanic(0, x[0][0][0]);
+}
+
+function assertEqualPanic(anydata expected, anydata actual, string message = "Value mismatch") {
+    if (expected != actual) {
+        panic error(message + " Expected : " + expected.toString() + " Actual : " + actual.toString());
+    }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.


Fixes #20198 

## Approach
> Describe how you are implementing the solutions along with the design details.

- [x] 2d array already works by existing PR for the same issue
- [ ] Make sure 3d array works
        Current code should have a problem of creating variables by the same name and need to put statements in reverse order.
- [ ] Algorithms
    - [x] get array dimensions
    - [ ] refactor 3d array generation using a loop constructor
    - [ ] generation statements for 3d array (recursively for dimensions) and prbably need to reversly 
            dump them in desugar. 
    - [ ] test for higher dimensions

```
int[][][] x = [];
    x[0][0][1] = 2;
-------------
// only need to desugar below statements should be already supported
x[0] = []
x[0][0] = []
x[0][0][1] = 2
```

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
