### PR TITLE
Object initialization with implicit conversion

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -238,4 +238,16 @@ public class ObjectInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithCheckAndRestParams2");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
     }
+
+    @Test(description = "Test invoking '__init' function with args with default values.")
+    public void testInitInvocationWithDefaultParams1() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultParams1");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
+
+    @Test(description = "Test invoking '__init' function with args with default values.")
+    public void testInitInvocationWithDefaultParams2() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultParams2");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -250,4 +250,16 @@ public class ObjectInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultParams2");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
     }
+
+    @Test(description = "Test invoking '__init' function with args with finite type.")
+    public void testInitInvocationWithFiniteType() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithFiniteType");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
+
+    @Test(description = "Test invoking '__init' function with args with error as a default value.")
+    public void testInitInvocationWithDefaultError() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultError");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -436,3 +436,43 @@ function testInitInvocationWithDefaultParams2() returns (boolean) {
     Student7 student = new(4);
     return student.getId() == 4;
 }
+
+public type ID int|string;
+
+type Student8 object {
+    int id;
+
+    public function __init(ID i=1) {
+        self.id = <int> i;
+    }
+
+    public function getId() returns int {
+        return self.id;
+    }
+};
+
+function testInitInvocationWithFiniteType() returns (boolean) {
+    Student8 student = new(4);
+    return student.getId() == 4;
+}
+
+type AddError object {
+    error er;
+    function __init(error simpleError = error("SimpleErrorType", message = "Simple error occurred")) {
+        self.er = simpleError;
+    }
+
+    public function getError() returns error|() {
+        return self.er;
+    }
+};
+
+function testInitInvocationWithDefaultError() returns (boolean) {
+    AddError newError = new;
+    var e = newError.getError();
+    if !(e is error) {
+        error err = error("Returned value should be an error");
+        panic err;
+    }
+    return e is error;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -398,3 +398,41 @@ function testInitInvocationWithCheckAndRestParams2() returns (boolean) {
     var [s, marksBeforeChange, marksAfterChange] = testInitInvocationWithCheckAndRestParams(10, ...modules);
     return !(s is error) && marksBeforeChange == 90 && marksAfterChange == 95;
 }
+
+type Student6 object {
+    int id;
+
+    public function __init(int id = 1) {
+        self.id = id;
+    }
+
+    public function getId() returns int {
+        return self.id;
+    }
+};
+
+function testInitInvocationWithDefaultParams1() returns (boolean) {
+    Student6 student = new;
+    return student.getId() == 1;
+}
+
+type Student7 object {
+    int? id;
+
+    public function __init(int? id = 1) {
+        self.id = id;
+    }
+
+    public function getId() returns int {
+        if !(self.id is int) {
+            error err = error("ID should be an integer");
+            panic err;
+        }
+        return <int> self.id;
+    }
+};
+
+function testInitInvocationWithDefaultParams2() returns (boolean) {
+    Student7 student = new(4);
+    return student.getId() == 4;
+}


### PR DESCRIPTION
## Purpose
Fixes #21186

## Approach
The error occurs because of an expression tries to rewrite twice. So rewrite the expression once and assign the results to both places

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
