### PR TITLE
Implement Function mocking

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageLoader.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageLoader.java
@@ -382,7 +382,7 @@ public class PackageLoader {
         return packageNode;
     }
 
-    private BLangPackage loadPackage(PackageID pkgId) {
+    public BLangPackage loadPackage(PackageID pkgId) {
         // TODO Remove this method()
         BLangPackage bLangPackage = packageCache.get(pkgId);
         if (bLangPackage != null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -251,7 +251,7 @@ public class BIRGen extends BLangNodeVisitor {
                 testPkg.symbol.bir = testBirPkg;
                 Map<String, String> mockFunctionMap = astPkg.getTestablePkg().getMockFunctionNamesMap();
                 if (!mockFunctionMap.isEmpty()) {
-                    visitMockFunctions(testBirPkg, mockFunctionMap);
+                    replaceMockedFunctions(testBirPkg, mockFunctionMap);
                 }
             });
         }
@@ -291,7 +291,7 @@ public class BIRGen extends BLangNodeVisitor {
         }
     }
 
-    private void visitMockFunctions(BIRPackage birPkg, Map<String, String> mockFunctionMap) {
+    private void replaceMockedFunctions(BIRPackage birPkg, Map<String, String> mockFunctionMap) {
         for (BIRFunction function : birPkg.functions) {
             List<BIRBasicBlock> functionBasicBlocks = function.basicBlocks;
             for (BIRBasicBlock functionBasicBlock : functionBasicBlocks) {
@@ -310,30 +310,6 @@ public class BIRGen extends BLangNodeVisitor {
                 }
             }
         }
-    }
-
-    // Checks if the name of the CALL terminator and the function name matches
-    private boolean checkName(BIRTerminator bbTerminator, String mockFunctionName) {
-        return ((BIRTerminator.Call) bbTerminator).name.getValue().equals(mockFunctionName);
-    }
-
-    // Checks if the Callee of the CALL terminator matches that of the function
-    private boolean checkCallee(BIRTerminator bbTerminator, String mockFunctionModule) {
-        if (mockFunctionModule.equals(".")) {
-            return true;
-        }
-        return ((BIRTerminator.Call) bbTerminator).calleePkg.toString().contains(mockFunctionModule);
-    }
-
-    //&& ((BIRTerminator.Call) bbTerminator).calleePkg.toString().contains(mockInfo[0])
-
-    private Name getMockFunctionName(String name, BIRPackage birPkg) {
-        for (BIRFunction function : birPkg.functions) {
-            if (function.name.value.equals(name)) {
-                return function.name;
-            }
-        }
-        return null;
     }
 
     // Nodes

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTestablePackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTestablePackage.java
@@ -17,8 +17,27 @@
  */
 package org.wso2.ballerinalang.compiler.tree;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @since 0.983.0
  */
 public class BLangTestablePackage extends BLangPackage {
+
+    //Map to maintain all the mock functions
+    private Map<String, String> mockFunctionNamesMap = new HashMap<>();
+
+    public Map<String, String> getMockFunctionNamesMap() {
+        return mockFunctionNamesMap;
+    }
+
+    public void setMockFunctionNamesMap(Map<String, String> mockFunctionNamesMap) {
+        this.mockFunctionNamesMap = mockFunctionNamesMap;
+    }
+
+    public void addMockFunction(String id, String function) {
+        this.mockFunctionNamesMap.put(id, function);
+    }
+
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTestablePackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTestablePackage.java
@@ -32,10 +32,6 @@ public class BLangTestablePackage extends BLangPackage {
         return mockFunctionNamesMap;
     }
 
-    public void setMockFunctionNamesMap(Map<String, String> mockFunctionNamesMap) {
-        this.mockFunctionNamesMap = mockFunctionNamesMap;
-    }
-
     public void addMockFunction(String id, String function) {
         this.mockFunctionNamesMap.put(id, function);
     }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -29,6 +29,7 @@ import org.ballerinalang.util.diagnostic.DiagnosticLog;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 
@@ -137,7 +138,11 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                             vals[1] = value;
                         }
                     });
-                    suite.addMockFunction(vals[0] + MOCK_ANNOTATION_DELIMITER + vals[1], functionName);
+
+                    //Creating a bLangTestablePackage to add a mock function
+                    BLangTestablePackage bLangTestablePackage = (BLangTestablePackage)((BLangFunction) functionNode).parent;
+                    bLangTestablePackage.addMockFunction(vals[0] + MOCK_ANNOTATION_DELIMITER + vals[1], functionName);
+
                 }
             } else if (TEST_ANNOTATION_NAME.equals(annotationName)) {
                 Test test = new Test();

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -174,15 +174,16 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                     
                     // Check if Function in annotation is empty
                     if (vals[1].isEmpty()) {
-                        diagnosticLog.logDiagnostic(Diagnostic.Kind.ERROR, ((BLangFunction) functionNode).pos,
-                                "Function name cannot be empty");
+                        diagnosticLog.logDiagnostic(Diagnostic.Kind.ERROR, attachmentNode.getPosition(),
+                                "function name cannot be empty");
+                        break;
                     }
 
                     // Find functionToMock in the packageID
                     PackageID functionToMockID = getPackageID(vals[0]);
                     if (functionToMockID == null) {
                         diagnosticLog.logDiagnostic(Diagnostic.Kind.ERROR, attachmentNode.getPosition(),
-                                "Could not find module specified ");
+                                "could not find module specified ");
                     }
 
                     BType functionToMockType = getFunctionType(packageEnvironmentMap, functionToMockID, vals[1]);
@@ -192,8 +193,8 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                     if (functionToMockType != null && mockFunctionType != null) {
                         if (!typeChecker.isAssignable(mockFunctionType, functionToMockType)) {
                             diagnosticLog.logDiagnostic(Diagnostic.Kind.ERROR, ((BLangFunction) functionNode).pos,
-                                    "incompatible types: expected " + mockFunctionType.toString()
-                                            + " but found " + functionToMockType.toString());
+                                    "incompatible types: expected " + functionToMockType.toString()
+                                            + " but found " + mockFunctionType.toString());
                         }
                     } else {
                         diagnosticLog.logDiagnostic(Diagnostic.Kind.ERROR, attachmentNode.getPosition(),

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -140,7 +140,8 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                     });
 
                     //Creating a bLangTestablePackage to add a mock function
-                    BLangTestablePackage bLangTestablePackage = (BLangTestablePackage)((BLangFunction) functionNode).parent;
+                    BLangTestablePackage bLangTestablePackage =
+                            (BLangTestablePackage) ((BLangFunction) functionNode).parent;
                     bLangTestablePackage.addMockFunction(vals[0] + MOCK_ANNOTATION_DELIMITER + vals[1], functionName);
 
                 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaReport.java
@@ -79,6 +79,7 @@ public class TesterinaReport {
         outStream.println("\t" + passed + " passing");
         outStream.println("\t" + failed + " failing");
         outStream.println("\t" + skipped + " skipped");
+        outStream.println();
     }
 
     public void addPackageReport(String packageName) {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
@@ -37,6 +37,7 @@ public class BaseTestCase {
     public static BalServer balServer;
     protected static Path singleFilesProjectPath;
     static Path multiModulesProjectPath;
+    static Path mockProjectPath;
 
     @BeforeSuite(alwaysRun = true)
     public void initialize() throws BallerinaTestException, IOException {
@@ -44,7 +45,8 @@ public class BaseTestCase {
         Path tempProjectDirectory = Files.createTempDirectory("bal-test-integration-testerina-project-");
 
         // copy TestProjects to a temp
-        Path originalSingleFilesProj = Paths.get("src", "test", "resources", "single-file-tests").toAbsolutePath();
+        Path originalSingleFilesProj = Paths.get("src", "test", "resources", "single-file-tests")
+                .toAbsolutePath();
         singleFilesProjectPath = tempProjectDirectory.resolve("single-file-tests");
         FileUtils.copyFolder(originalSingleFilesProj, singleFilesProjectPath);
 
@@ -52,6 +54,10 @@ public class BaseTestCase {
                 .toAbsolutePath();
         multiModulesProjectPath = tempProjectDirectory.resolve("tests-project");
         FileUtils.copyFolder(originalMultiModulesProj, multiModulesProjectPath);
+
+        Path originalMockProj = Paths.get("src", "test", "resources", "mock-tests").toAbsolutePath();
+        mockProjectPath = tempProjectDirectory.resolve("mock-tests");
+        FileUtils.copyFolder(originalMockProj, mockProjectPath);
     }
 
     @AfterSuite(alwaysRun = true)

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.testerina.test;
+
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test class to test positive scenarios of testerina using a ballerina project.
+ */
+public class MockTest extends BaseTestCase {
+
+    private BMainInstance balClient;
+    private String projectPath;
+
+    @BeforeClass
+    public void setup() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+        projectPath = mockProjectPath.toString();
+    }
+
+    @Test
+    public void testAssertTrue() throws BallerinaTestException {
+        String msg = "4 passing";
+        LogLeecher clientLeecher = new LogLeecher(msg);
+        balClient.runMain("test", new String[]{"--all"}, null,
+                new String[]{}, new LogLeecher[]{clientLeecher}, projectPath);
+        clientLeecher.waitForText(20000);
+    }
+
+}

--- a/tests/testerina-integration-test/src/test/resources/mock-tests/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/mock-tests/Ballerina.toml
@@ -1,0 +1,3 @@
+[project]
+org-name = "mock-tests"
+version = "0.0.0"

--- a/tests/testerina-integration-test/src/test/resources/mock-tests/src/Mock/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/mock-tests/src/Mock/main.bal
@@ -1,0 +1,18 @@
+public function main() {
+    int ans = intAdd(5, 3);
+}
+
+
+//
+// FUNCTIONS
+//
+
+// This should be mocked
+public function intAdd(int a, int b) returns (int) {
+    return a+b;
+}
+
+// This should NOT be mocked
+public function intSubtract(int a, int b) returns (int) {
+    return a-b;
+}

--- a/tests/testerina-integration-test/src/test/resources/mock-tests/src/Mock/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/mock-tests/src/Mock/tests/main_test.bal
@@ -1,0 +1,73 @@
+import ballerina/test;
+import SubtractModule;
+import ballerina/math;
+
+//
+// TEST CASES
+//
+
+// Test Function mocking in Same module
+@test:Config {}
+function test_AddFunction() {
+    int answer = 0;
+    answer = intAdd(5, 3);
+    test:assertEquals(answer, 2, "Mocking did not take place");
+}
+
+// Test Function mocking in Different module
+// Calling function directly
+@test:Config {}
+function test_SubtractFunction() {
+    int answer = 0;
+    answer = SubtractModule:intSubtract(5, 3);
+    test:assertEquals(answer, 8, "Mocking did not take place");
+}
+
+// Test Function mocking in Different module
+// Calling function directly
+@test:Config {}
+function test_SubtractFunctionInSameModule() {
+    int answer = 0;
+    answer = intSubtract(5, 3);
+    test:assertEquals(answer, 2, "Mocking did take place, but mocked the wrong function");
+}
+
+// Test Function mocking for native functions
+@test:Config {}
+function test_MockNativeFunction() {
+    float answer = 0;
+    answer = math:sqrt(5);
+
+    test:assertEquals(answer, 125.0, "Mocking did not take place");
+}
+
+
+//
+// FUNCTION MOCKS
+//
+
+@test:Mock {
+    moduleName : ".", //Remove module name
+    functionName : "intAdd"
+}
+function mockIntAdd(int a, int b) returns (int) {
+    return a-b;
+}
+
+@test:Mock {
+    moduleName : "SubtractModule",
+    functionName : "intSubtract"
+}
+function mockIntSubtract(int a, int b) returns (int) {
+    return a+b;
+}
+
+@test:Mock {
+    moduleName : "ballerina/math",
+    functionName : "sqrt"
+}
+function mocksqrt(float a) returns (float) {
+    return a*a*a;
+}
+
+

--- a/tests/testerina-integration-test/src/test/resources/mock-tests/src/SubtractModule/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/mock-tests/src/SubtractModule/main.bal
@@ -1,0 +1,4 @@
+
+public function intSubtract(int a, int b) returns (int) {
+    return a-b;
+}

--- a/tests/testerina-integration-test/src/test/resources/testng.xml
+++ b/tests/testerina-integration-test/src/test/resources/testng.xml
@@ -36,6 +36,7 @@ under the License.
             <class name="org.ballerinalang.testerina.test.negative.SkipTestsTestCase" />
             <class name="org.ballerinalang.testerina.test.negative.InvalidDataProviderTestCase" />
             <class name="org.ballerinalang.testerina.test.DisableTestsTestCase" />
+            <class name="org.ballerinalang.testerina.test.MockTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
To implement function mocking for Testerina. This allows us to use the mock annotation in a test case to mock other functions. 

Fixes #18780 

## Approach
`TestAnnotationProcessor` processes every function in the test suite that has a `@test:Mock` annotation. It checks if the mock function has the correct parameter types and return types as the function it is mocking. If the checks pass, the functions are added it to a `mockFunctionNamesMap` in the BLangTestablePackage. 

When generating the BIR in the `BIRGen` class, if the BLangPackage has a testable package defined AND the testable package has a `mockFunctionNamesMap`, then the `visitMockFunctions()` function is called. 

The `visitMockFunctions()` function deals with replacing the name and module of every function call with its equivalent mock provided it is defined in the `mockFunctionNamesMap`. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
