### PR TITLE
Add support to pass tags to the Observability Runtime from Compiler

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
@@ -71,6 +71,19 @@ public class ObserveUtils {
      * @param resourceName name of the resource being invoked.
      */
     public static void startResourceObservation(Strand strand, String serviceName, String resourceName) {
+        ObserveUtils.startResourceObservation(strand, serviceName, resourceName, Collections.emptyMap());
+    }
+
+    /**
+     * Start observation of a resource invocation.
+     *
+     * @param strand which holds the observer context being started.
+     * @param serviceName name of the service to which the observer context belongs.
+     * @param resourceName name of the resource being invoked.
+     * @param tags tags to be used in the observation
+     */
+    public static void startResourceObservation(Strand strand, String serviceName, String resourceName,
+                                                Map<String, String> tags) {
         if (!enabled) {
             return;
         }
@@ -90,6 +103,9 @@ public class ObserveUtils {
         observerContext.setResourceName(resourceName);
         observerContext.setServer();
         observerContext.setStarted();
+        for (Map.Entry<String, String> tagEntry : tags.entrySet()) {
+            observerContext.addTag(tagEntry.getKey(), tagEntry.getValue());
+        }
         observers.forEach(observer -> observer.startServerObservation(strand.observerContext));
         strand.setProperty(ObservabilityConstants.SERVICE_NAME, serviceName);
     }
@@ -138,6 +154,19 @@ public class ObserveUtils {
      * @param actionName name of the action/function being invoked.
      */
     public static void startCallableObservation(Strand strand, String connectorName, String actionName) {
+        ObserveUtils.startCallableObservation(strand, connectorName, actionName, Collections.emptyMap());
+    }
+
+    /**
+     * Start observability for the synchronous function/action invocations.
+     *
+     * @param strand which holds the observer context being started.
+     * @param connectorName name of the connector to which the observer context belongs.
+     * @param actionName name of the action/function being invoked.
+     * @param tags tags to be used in the observation
+     */
+    public static void startCallableObservation(Strand strand, String connectorName, String actionName,
+                                                Map<String, String> tags) {
         if (!enabled) {
             return;
         }
@@ -150,6 +179,9 @@ public class ObserveUtils {
         newObContext.setServiceName(observerCtx == null ? UNKNOWN_SERVICE : observerCtx.getServiceName());
         newObContext.setConnectorName(connectorName);
         newObContext.setActionName(actionName);
+        for (Map.Entry<String, String> tagEntry : tags.entrySet()) {
+            newObContext.addTag(tagEntry.getKey(), tagEntry.getValue());
+        }
         strand.observerContext = newObContext;
         observers.forEach(observer -> observer.startClientObservation(newObContext));
     }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/metrics/Counter.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/metrics/Counter.java
@@ -136,4 +136,11 @@ public interface Counter extends Metric {
      */
     long getValue();
 
+    /**
+     * Returns the counter's current value and then resets.
+     *
+     * @return the counter's current value.
+     */
+    long getValueThenReset();
+
 }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/metrics/noop/NoOpCounter.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/metrics/noop/NoOpCounter.java
@@ -44,4 +44,9 @@ public class NoOpCounter extends AbstractMetric implements Counter {
     public long getValue() {
         return 0;
     }
+
+    @Override
+    public long getValueThenReset() {
+        return 0;
+    }
 }

--- a/misc/metrics-extensions/modules/ballerina-metrics-extension/src/main/java/org/ballerinalang/observe/metrics/extension/defaultimpl/DefaultCounter.java
+++ b/misc/metrics-extensions/modules/ballerina-metrics-extension/src/main/java/org/ballerinalang/observe/metrics/extension/defaultimpl/DefaultCounter.java
@@ -56,4 +56,9 @@ public class DefaultCounter extends AbstractMetric implements Counter {
     public long getValue() {
         return count.sum();
     }
+
+    @Override
+    public long getValueThenReset() {
+        return count.sumThenReset();
+    }
 }


### PR DESCRIPTION
## Purpose
> Add support to write byte code instructions to pass a set of known tags to the Observability Run-time at the byte code write level.

## Approach
> Update method (with a default value for tags) to support passing the tags

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
