### PR TITLE
Support object initialization for args with default values

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -192,7 +192,7 @@ import java.util.Set;
  *
  * @since 1.1
  */
-class NodeCloner extends BLangNodeVisitor {
+public class NodeCloner extends BLangNodeVisitor {
 
     private static final CompilerContext.Key<NodeCloner> NODE_CLONER_KEY = new CompilerContext.Key<>();
 
@@ -237,7 +237,7 @@ class NodeCloner extends BLangNodeVisitor {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Node> T clone(T source) {
+    public  <T extends Node> T clone(T source) {
 
         if (source == null) {
             return null;
@@ -1069,6 +1069,7 @@ class NodeCloner extends BLangNodeVisitor {
         clone.async = source.async;
         clone.flagSet = cloneSet(source.flagSet, Flag.class);
         clone.annAttachments = cloneList(source.annAttachments);
+        clone.requiredArgs = cloneList(source.requiredArgs);
 
         cloneBLangAccessExpression(source, clone);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2446,7 +2446,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         return analyzeNode(stmtNode, env);
     }
 
-    BType analyzeNode(BLangNode node, SymbolEnv env) {
+    public BType analyzeNode(BLangNode node, SymbolEnv env) {
         return analyzeNode(node, env, symTable.noType, null);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2993,7 +2993,8 @@ public class TypeChecker extends BLangNodeVisitor {
             return;
         }
 
-        if (iExpr.argExprs.isEmpty() && checkNoArgErrorCtorInvocation(expectedError, iExpr.name, iExpr.pos)) {
+        if (iExpr.argExprs.isEmpty() && iExpr.requiredArgs.isEmpty() && checkNoArgErrorCtorInvocation(expectedError,
+                iExpr.name, iExpr.pos)) {
             return;
         }
 
@@ -3137,8 +3138,10 @@ public class TypeChecker extends BLangNodeVisitor {
             iExpr.requiredArgs.add(reasonExpr);
             return;
         }
-        iExpr.requiredArgs.add(iExpr.argExprs.get(0));
-        iExpr.argExprs.remove(0);
+        if (!iExpr.argExprs.isEmpty()) {
+            iExpr.requiredArgs.add(iExpr.argExprs.get(0));
+            iExpr.argExprs.remove(0);
+        }
     }
 
     /**

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -238,4 +238,28 @@ public class ObjectInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithCheckAndRestParams2");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
     }
+
+    @Test(description = "Test invoking '__init' function with args with default values.")
+    public void testInitInvocationWithDefaultParams1() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultParams1");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
+
+    @Test(description = "Test invoking '__init' function with args with default values.")
+    public void testInitInvocationWithDefaultParams2() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultParams2");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
+
+    @Test(description = "Test invoking '__init' function with args with finite type.")
+    public void testInitInvocationWithFiniteType() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithFiniteType");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
+
+    @Test(description = "Test invoking '__init' function with args with error as a default value.")
+    public void testInitInvocationWithDefaultError() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultError");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -276,4 +276,10 @@ public class ObjectInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithReferenceToDefaultValue2");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
     }
+
+    @Test(description = "Test invoking '__init' function with args with default values and returns error.")
+    public void testErrorReturnWithInitialization() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testErrorReturnWithInitialization");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -262,4 +262,18 @@ public class ObjectInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithDefaultError");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
     }
+
+    @Test(description = "Test invoking '__init' function with args with default values and some of them are " +
+            "referenced by params.")
+    public void testInitInvocationWithReferenceToDefaultValue1() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithReferenceToDefaultValue1");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
+
+    @Test(description = "Test invoking '__init' function with args with default values and some of them are " +
+            "referenced by params.")
+    public void testInitInvocationWithReferenceToDefaultValue2() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testInitInvocationWithReferenceToDefaultValue2");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected booleans to be identified as equal");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -398,3 +398,81 @@ function testInitInvocationWithCheckAndRestParams2() returns (boolean) {
     var [s, marksBeforeChange, marksAfterChange] = testInitInvocationWithCheckAndRestParams(10, ...modules);
     return !(s is error) && marksBeforeChange == 90 && marksAfterChange == 95;
 }
+
+type Student6 object {
+    int id;
+
+    public function __init(int id = 1) {
+        self.id = id;
+    }
+
+    public function getId() returns int {
+        return self.id;
+    }
+};
+
+function testInitInvocationWithDefaultParams1() returns (boolean) {
+    Student6 student = new;
+    return student.getId() == 1;
+}
+
+type Student7 object {
+    int? id;
+
+    public function __init(int? id = 1) {
+        self.id = id;
+    }
+
+    public function getId() returns int {
+        if !(self.id is int) {
+            error err = error("ID should be an integer");
+            panic err;
+        }
+        return <int> self.id;
+    }
+};
+
+function testInitInvocationWithDefaultParams2() returns (boolean) {
+    Student7 student = new(4);
+    return student.getId() == 4;
+}
+
+public type ID int|string;
+
+type Student8 object {
+    int id;
+
+    public function __init(ID i=1) {
+        self.id = <int> i;
+    }
+
+    public function getId() returns int {
+        return self.id;
+    }
+};
+
+function testInitInvocationWithFiniteType() returns (boolean) {
+    Student8 student = new(4);
+    return student.getId() == 4;
+}
+
+type AddError object {
+    error er;
+    function __init(error simpleError = error("SimpleErrorType", message = "Simple error occurred")) {
+        self.er = simpleError;
+    }
+
+    public function getError() returns error|() {
+        return self.er;
+    }
+};
+
+function testInitInvocationWithDefaultError() returns (boolean) {
+    AddError newError = new;
+    var e = newError.getError();
+    if !(e is error) {
+        error err = error("Returned value should be an error");
+        panic err;
+    }
+    return e is error;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -494,7 +494,7 @@ function testInitInvocationWithReferenceToDefaultValue1() returns (boolean) {
     return student.getMarks() == 160;
 }
 
-type Calculate object {
+type Calculate1 object {
     int sum;
 
     public function __init(int a, int b, int c, int d = a + b + c*c) {
@@ -507,6 +507,29 @@ type Calculate object {
 };
 
 function testInitInvocationWithReferenceToDefaultValue2() returns (boolean) {
-    Calculate cal = new(2, 3, 4);
+    Calculate1 cal = new(2, 3, 4);
     return cal.getSum() == 21;
+}
+
+type Calculate2 object {
+    int sum;
+    string op;
+
+    public function __init(string operation, int a, int b, int c, int d = a + b + c*c) returns error? {
+        self.op = check checkOperation(operation);
+        self.sum = d;
+    }
+};
+
+function checkOperation(string operation) returns string|error {
+    if (operation == "SUB") {
+        error e = error("unsupported operation", op = operation);
+        return e;
+    }
+    return operation;
+}
+
+function testErrorReturnWithInitialization() returns (boolean) {
+    Calculate2|error cal = new("SUB", 2, 3, 4);
+    return cal is error;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectProject/src/init/object-initializer.bal
@@ -476,3 +476,37 @@ function testInitInvocationWithDefaultError() returns (boolean) {
     }
     return e is error;
 }
+
+type Student9 object {
+    int fullMarks;
+
+    public function __init(int firstMark = 80, int secondMark = firstMark) {
+        self.fullMarks = firstMark + secondMark;
+    }
+
+    public function getMarks() returns int {
+        return self.fullMarks;
+    }
+};
+
+function testInitInvocationWithReferenceToDefaultValue1() returns (boolean) {
+    Student9 student = new;
+    return student.getMarks() == 160;
+}
+
+type Calculate object {
+    int sum;
+
+    public function __init(int a, int b, int c, int d = a + b + c*c) {
+        self.sum = d;
+    }
+
+    public function getSum() returns int {
+        return self.sum;
+    }
+};
+
+function testInitInvocationWithReferenceToDefaultValue2() returns (boolean) {
+    Calculate cal = new(2, 3, 4);
+    return cal.getSum() == 21;
+}


### PR DESCRIPTION
## Purpose
Fixes #21186
Fixes #21258

## Approach
The error occurs because of an expression node referenced by two places. Therefore the expression node is cloned and assign to one place.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
