### PR TITLE
Change LS Standard lib cache locking mechanism

### DIFF
--- a/language-server/modules/langserver-cli/src/main/java/org/ballerinalang/langserver/cmd/LangServerStartCmd.java
+++ b/language-server/modules/langserver-cli/src/main/java/org/ballerinalang/langserver/cmd/LangServerStartCmd.java
@@ -90,7 +90,7 @@ public class LangServerStartCmd implements BLauncherCmd {
             System.setProperty("experimental", Boolean.toString(experimental));
             System.setProperty("ballerina.debugLog", Boolean.toString(debugLog));
             System.setProperty("ballerina.traceLog", Boolean.toString(traceLog));
-            System.setProperty("ballerina.definition.enableStdlib", Boolean.toString(stdlibDefinition));
+            System.setProperty("ballerina.goToDefinition.enableStandardLibraries", Boolean.toString(stdlibDefinition));
             System.setProperty("ballerina.home", BALLERINA_HOME);
 
             // Start Language Server

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -91,7 +91,7 @@ public class BallerinaLanguageServer implements ExtendedLanguageServer, Extended
         lsGlobalContext.put(LSGlobalContextKeys.DOCUMENT_MANAGER_KEY, documentManager);
         lsGlobalContext.put(LSGlobalContextKeys.DIAGNOSTIC_HELPER_KEY, DiagnosticsHelper.getInstance());
         lsGlobalContext.put(LSGlobalContextKeys.ENABLE_STDLIB_DEFINITION,
-                Boolean.valueOf(System.getProperty("ballerina.definition.enableStdlib")));
+                Boolean.valueOf(System.getProperty("ballerina.goToDefinition.enableStandardLibraries")));
 
         this.textService = new BallerinaTextDocumentService(lsGlobalContext);
         this.workspaceService = new BallerinaWorkspaceService(lsGlobalContext);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/LSStdLibCacheUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/LSStdLibCacheUtil.java
@@ -74,7 +74,7 @@ public class LSStdLibCacheUtil {
         // Create the new extract root
         Path destinationPath;
         try {
-            destinationPath = Files.createDirectories(destinationRoot.resolve(getCacheEntryName(moduleName, version)));
+            destinationPath = Files.createDirectories(destinationRoot.resolve(getCacheableKey(moduleName, version)));
         } catch (IOException e) {
             throw new LSStdlibCacheException(e.getMessage(), e);
         }
@@ -131,13 +131,13 @@ public class LSStdLibCacheUtil {
      * @param module import module
      * @return {@link String} computed cache entry name
      */
-    protected static synchronized String getCacheEntryName(BLangImportPackage module) {
+    protected static synchronized String getCacheableKey(BLangImportPackage module) {
         String moduleName = module.getPackageName().stream()
                 .map(BLangIdentifier::getValue)
                 .collect(Collectors.joining("."));
         String version = module.getPackageVersion().getValue();
 
-        return getCacheEntryName(moduleName, version);
+        return getCacheableKey(moduleName, version);
     }
 
     /**
@@ -146,16 +146,16 @@ public class LSStdLibCacheUtil {
      * @param packageID Package ID instance to evaluate
      * @return {@link String} computed cache entry name
      */
-    protected static synchronized String getCacheEntryName(PackageID packageID) {
+    protected static synchronized String getCacheableKey(PackageID packageID) {
         String moduleName = packageID.getNameComps().stream()
                 .map(Name::getValue)
                 .collect(Collectors.joining("."));
         String version = packageID.getPackageVersion().getValue();
 
-        return getCacheEntryName(moduleName, version);
+        return getCacheableKey(moduleName, version);
     }
 
-    private static String getCacheEntryName(String moduleName, String version) {
+    private static String getCacheableKey(String moduleName, String version) {
         return moduleName + "_" + (version.isEmpty() ? ProjectDirConstants.BLANG_PKG_DEFAULT_VERSION : version);
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/StandardLibraryDefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/StandardLibraryDefinitionTest.java
@@ -48,7 +48,7 @@ public class StandardLibraryDefinitionTest extends DefinitionTest {
     public void init() {
         configRoot = FileUtils.RES_DIR.resolve("definition").resolve("expected");
         sourceRoot = FileUtils.RES_DIR.resolve("definition").resolve("sources");
-        System.setProperty("ballerina.definition.enableStdlib", String.valueOf(true));
+        System.setProperty("ballerina.goToDefinition.enableStandardLibraries", String.valueOf(true));
         this.serviceEndpoint = TestUtil.initializeLanguageSever();
     }
 
@@ -88,6 +88,6 @@ public class StandardLibraryDefinitionTest extends DefinitionTest {
     @Override
     public void shutDownLanguageServer() throws IOException {
         super.shutDownLanguageServer();
-        System.setProperty("ballerina.definition.enableStdlib", "");
+        System.setProperty("ballerina.goToDefinition.enableStandardLibraries", "");
     }
 }

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -81,10 +81,10 @@
                     "default": false,
                     "description": "If set to true debug msgs will be printed to Ballerina output channel"
                 },
-                "ballerina.definition.enableStdlib": {
+                "ballerina.goToDefinition.enableStandardLibraries": {
                     "type": "boolean",
                     "default": true,
-                    "description": "If set to false definitions for the standard library content will be disabled"
+                    "description": "If uncheck/set to false navigation for the standard library content will be disabled"
                 },
                 "ballerina.traceLog": {
                     "type": "boolean",

--- a/tool-plugins/vscode/src/core/preferences.ts
+++ b/tool-plugins/vscode/src/core/preferences.ts
@@ -3,4 +3,4 @@ export const OVERRIDE_BALLERINA_HOME = "ballerina.plugin.dev.mod";
 export const ALLOW_EXPERIMENTAL = "ballerina.allowExperimental";
 export const ENABLE_DEBUG_LOG = "ballerina.debugLog";
 export const ENABLE_TRACE_LOG = "ballerina.traceLog";
-export const ENABLE_STDLIB_DEFINITION = "ballerina.definition.enableStdlib";
+export const ENABLE_STDLIB_DEFINITION = "ballerina.goToDefinition.enableStandardLibraries";


### PR DESCRIPTION
## Purpose
> With this, change the standard library locking mechanism by introducing a volatile boolean flag instead of the earlier implementation's reentrant lock. Also, change the user setting's name to be more intuitive.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
