### PR TITLE
Fix Compilation error when function has a function typed param with only rest params

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -574,6 +574,9 @@ public class BLangPackageBuilder {
         if (paramsAvail) {
             functionTypeNode.addWS(commaWsStack.pop());
             functionTypeNode.params.addAll(this.varListStack.pop());
+        } else if (restParamAvail) {
+            // VarListStack pops out the empty list added to the var list stack if no non-rest params are available
+            this.varListStack.pop();
         }
 
         if (restParamAvail) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureTest.java
@@ -444,4 +444,14 @@ public class FunctionSignatureTest {
         tuple.add(4, (Object) e);
         return tuple;
     }
+
+    @Test(description = "Test1: function signature which has a function typed param with only rest param")
+    public void testFunctionWithFunctionTypedParamWithOnlyRestParam1() {
+        BRunUtil.invoke(result, "testFunctionOfFunctionTypedParamWithRest1");
+    }
+
+    @Test(description = "Test2: function signature which has a function typed param with only rest param")
+    public void testFunctionWithFunctionTypedParamWithOnlyRestParam2() {
+        BRunUtil.invoke(result, "testFunctionOfFunctionTypedParamWithRest2");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures.bal
@@ -1,3 +1,5 @@
+const ASSERTION_ERROR_REASON = "AssertionError";
+
 //------------ Testing a function with all types of parameters ---------
 
 function functionWithAllTypesParams(int a, float b, string c = "John", int d = 5, string e = "Doe", int... z)
@@ -177,3 +179,44 @@ type Person object {
         return [intVal, val];
     }
 };
+
+// ------------------- Test function signature which has a function typed param with only rest param ------------------
+
+function functionOfFunctionTypedParamWithRest(int[] x, function (int...) returns int bar) returns [int, int] {
+    return [x[0], bar(x[0])] ;
+}
+
+function sampleFunctionTypedParam(int... a) returns int {
+    if (a.length() > 0) {
+        return a[0];
+    } else {
+        return 0;
+    }
+}
+
+function testFunctionOfFunctionTypedParamWithRest1() {
+    int[] x = [4];
+    int[] y = functionOfFunctionTypedParamWithRest(x, sampleFunctionTypedParam);
+    assertEquality(x[0], y[0]);
+    assertEquality(x[0], y[1]);
+}
+
+function testFunctionOfFunctionTypedParamWithRest2() {
+    int[] x = [10, 20, 30];
+    int[] y = functionOfFunctionTypedParamWithRest(x, sampleFunctionTypedParam);
+    assertEquality(x[0], y[0]);
+    assertEquality(x[0], y[1]);
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}


### PR DESCRIPTION
## Purpose
$title

Fixes #20919 

## Approach
Var list stack pops out the empty list added to the var list stack if function typed param has only rest param

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
