### PR TITLE
Send vscode client configuration during initialization

### DIFF
--- a/tool-plugins/vscode/src/diagram/activator.ts
+++ b/tool-plugins/vscode/src/diagram/activator.ts
@@ -16,14 +16,13 @@
  * under the License.
  *
  */
-import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent, Location } from 'vscode';
+import { workspace, commands, window, Uri, ViewColumn, ExtensionContext, TextEditor, WebviewPanel, TextDocumentChangeEvent } from 'vscode';
 import * as _ from 'lodash';
 import { render } from './renderer';
 import { ExtendedLangClient } from '../core/extended-language-client';
 import { BallerinaExtension } from '../core';
 import { WebViewRPCHandler, getCommonWebViewOptions } from '../utils';
 import { join } from "path";
-import { DidChangeConfigurationParams } from 'vscode-languageclient';
 import { TM_EVENT_OPEN_DIAGRAM, CMP_DIAGRAM_VIEW } from '../telemetry';
 
 const DEBOUNCE_WAIT = 500;
@@ -123,21 +122,5 @@ export function activate(ballerinaExtInstance: BallerinaExtension) {
 			reporter.sendTelemetryException(e, { component: CMP_DIAGRAM_VIEW });
 		});
 	});
-
-    ballerinaExtInstance.onReady().then(() => {
-		const args: DidChangeConfigurationParams = {
-            settings: workspace.getConfiguration('ballerina'),
-        };
-        langClient.sendNotification("workspace/didChangeConfiguration", args);
-        langClient.onNotification('window/showTextDocument', (location: Location) => {
-            if (location.uri !== undefined) {
-                window.showTextDocument(Uri.parse(location.uri.toString()), {selection: location.range});
-            }
-        });
-    	})
-        .catch((e) => {
-            window.showErrorMessage('Could not start openFile capability listener', e.message);
-        });
-
 	context.subscriptions.push(diagramRenderDisposable);
 }

--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -17,7 +17,7 @@
  * under the License.
  *
  */
-import { ExtensionContext, commands, window } from 'vscode';
+import { ExtensionContext, commands, window, workspace, Location, Uri } from 'vscode';
 import { ballerinaExtInstance } from './core';
 import { activate as activateAPIEditor } from './api-editor';
 // import { activate as activateDiagram } from './diagram'; 
@@ -29,7 +29,7 @@ import { activateDebugConfigProvider } from './debugger';
 import { activate as activateProjectFeatures } from './project';
 import { activate as activateOverview } from './overview';
 import { activate as activateSyntaxHighlighter } from './syntax-highlighter';
-import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities } from 'vscode-languageclient';
+import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities, DidChangeConfigurationParams } from 'vscode-languageclient';
 import { ExtendedLangClient } from './core/extended-language-client';
 import { log } from './utils';
 
@@ -91,6 +91,21 @@ export function activate(context: ExtensionContext): Promise<any> {
         activateTreeView(ballerinaExtInstance);
         // Enable Ballerina Syntax Highlighter
         activateSyntaxHighlighter(ballerinaExtInstance);
+
+        ballerinaExtInstance.onReady().then(() => {
+            const langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
+            // Send initial configuration 
+            const args: DidChangeConfigurationParams = {
+                settings: workspace.getConfiguration('ballerina'),
+            };
+            langClient.sendNotification("workspace/didChangeConfiguration", args);
+            // Register showTextDocument listener
+            langClient.onNotification('window/showTextDocument', (location: Location) => {
+                if (location.uri !== undefined) {
+                    window.showTextDocument(Uri.parse(location.uri.toString()), {selection: location.range});
+                }
+            });
+        });
     }).catch((e) => {
         log("Failed to activate Ballerina extension. " + (e.message ? e.message : e));
         // When plugins fails to start, provide a warning upon each command execution


### PR DESCRIPTION
## Purpose
> Send vscode client configuration during initialization. Expected behavior is soon after Language Server gets the initialization request, initial configurations need to be sync using workspace/didChangeConfiguration notification.

Fixes #21324

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
