### PR TITLE
Add toArray() method to map lang library

### DIFF
--- a/langlib/lang.map/src/main/ballerina/src/lang.map/map.bal
+++ b/langlib/lang.map/src/main/ballerina/src/lang.map/map.bal
@@ -124,3 +124,9 @@ public function hasKey(map<Type> m, string k) returns boolean = external;
 # + m - the map
 # + return - a new list of all keys
 public function keys(map<any|error> m) returns string[] = external;
+
+# Returns a list of all the members of a map.
+#
+# + m - the map
+# + return - an array whose members are the members of `m`
+public function toArray(map<Type> m) returns Type[] = external;

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langlib.map;
+
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.types.BArrayType;
+import org.ballerinalang.jvm.types.BMapType;
+import org.ballerinalang.jvm.types.BRecordType;
+import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.types.TypeTags;
+import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.ArrayValueImpl;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.langlib.map.util.MapLibUtils;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+import java.util.Collection;
+
+import static org.ballerinalang.jvm.MapUtils.createOpNotSupportedError;
+
+/**
+ * Function for returning the values of the map as an array. T[] vals = m.toArray();
+ *
+ * @since 1.2.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.map",
+        functionName = "toArray",
+        args = {@Argument(name = "m", type = TypeKind.MAP)},
+        returnType = {@ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.ANY)},
+        isPublic = true
+)
+public class ToArray {
+
+    public static ArrayValue toArray(Strand strand, MapValue<?, ?> m) {
+        BType mapType = m.getType();
+        BType arrElemType;
+        switch (mapType.getTag()) {
+            case TypeTags.MAP_TAG:
+                arrElemType = ((BMapType) mapType).getConstrainedType();
+                break;
+            case TypeTags.RECORD_TYPE_TAG:
+                arrElemType = MapLibUtils.getCommonTypeForRecordField((BRecordType) mapType);
+                break;
+            default:
+                throw createOpNotSupportedError(mapType, "toArray()");
+        }
+
+        Collection values = m.values();
+        int size = values.size();
+        int i = 0;
+        switch (arrElemType.getTag()) {
+            case TypeTags.INT_TAG:
+                long[] intArr = new long[size];
+                for (Object val : values) {
+                    intArr[i++] = (Long) val;
+                }
+                return new ArrayValueImpl(intArr);
+            case TypeTags.FLOAT_TAG:
+                double[] floatArr = new double[size];
+                for (Object val : values) {
+                    floatArr[i++] = (Double) val;
+                }
+                return new ArrayValueImpl(floatArr);
+            case TypeTags.BYTE_TAG:
+                byte[] byteArr = new byte[size];
+                for (Object val : values) {
+                    byteArr[i++] = (Byte) val;
+                }
+                return new ArrayValueImpl(byteArr);
+            case TypeTags.BOOLEAN_TAG:
+                boolean[] booleanArr = new boolean[size];
+                for (Object val : values) {
+                    booleanArr[i++] = (Boolean) val;
+                }
+                return new ArrayValueImpl(booleanArr);
+            case TypeTags.STRING_TAG:
+                String[] stringArr = new String[size];
+                for (Object val : values) {
+                    stringArr[i++] = (String) val;
+                }
+                return new ArrayValueImpl(stringArr);
+            default:
+                return new ArrayValueImpl(values.toArray(), new BArrayType(arrElemType));
+
+        }
+    }
+}

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ToArray.java
@@ -84,7 +84,7 @@ public class ToArray {
             case TypeTags.BYTE_TAG:
                 byte[] byteArr = new byte[size];
                 for (Object val : values) {
-                    byteArr[i++] = (Byte) val;
+                    byteArr[i++] = ((Integer) val).byteValue();
                 }
                 return new ArrayValueImpl(byteArr);
             case TypeTags.BOOLEAN_TAG:

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibMapTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibMapTest.java
@@ -200,6 +200,11 @@ public class LangLibMapTest {
         BRunUtil.invoke(compileResult, "testMapOfUnionToArray");
     }
 
+    @Test
+    public void testRecordWithSameTypeFieldsToArray() {
+        BRunUtil.invoke(compileResult, "testRecordWithSameTypeFieldsToArray");
+    }
+
     @DataProvider(name = "mapKeyProvider")
     public Object[][] getMapKeys() {
         return new Object[][]{

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibMapTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibMapTest.java
@@ -175,6 +175,31 @@ public class LangLibMapTest {
         assertEquals(((BFloat) returns[0]).floatValue(), 80.5);
     }
 
+    @Test
+    public void testBasicToArray() {
+        BRunUtil.invoke(compileResult, "testBasicToArray");
+    }
+
+    @Test
+    public void testLargeMapToArray() {
+        BRunUtil.invoke(compileResult, "testLargeMapToArray");
+    }
+
+    @Test
+    public void testRecordToArray() {
+        BRunUtil.invoke(compileResult, "testRecordToArray");
+    }
+
+    @Test
+    public void testOpenRecordToArray() {
+        BRunUtil.invoke(compileResult, "testOpenRecordToArray");
+    }
+
+    @Test
+    public void testMapOfUnionToArray() {
+        BRunUtil.invoke(compileResult, "testMapOfUnionToArray");
+    }
+
     @DataProvider(name = "mapKeyProvider")
     public Object[][] getMapKeys() {
         return new Object[][]{

--- a/langlib/langlib-test/src/test/resources/test-src/maplib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/maplib_test.bal
@@ -73,3 +73,140 @@ function testReduce() returns float {
     }, 0.0);
     return avg;
 }
+
+function testBasicToArray() {
+    map<int> ints = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5};
+    int[] intArr = ints.toArray();
+
+    map<float> floats = {"one": 1.1, "two": 2.2, "three": 3.3, "four": 4.4, "five": 5.5};
+    float[] floatArr = floats.toArray();
+
+    map<decimal> decimals = {"one": 1.1, "two": 2.2, "three": 3.3, "four": 4.4, "five": 5.5};
+    decimal[] decimalArr = decimals.toArray();
+
+    map<string> strings = {"a": "A", "b": "B", "c": "C"};
+    string[] stringArr = strings.toArray();
+
+    map<boolean> booleans = {"a": true, "b": false, "c": true};
+    boolean[] booleanArr = booleans.toArray();
+
+    map<map<int>> maps = {"a": {"one": 1, "two": 2}, "b": {"three": 3, "four": 4}};
+    map<int>[] mapArr = maps.toArray();
+
+    assert(<int[]>[1, 2, 3, 4, 5], intArr);
+    assert(<float[]>[1.1, 2.2, 3.3, 4.4, 5.5], floatArr);
+    assert(<decimal[]>[1.1, 2.2, 3.3, 4.4, 5.5], decimalArr);
+    assert(<string[]>["A", "B", "C"], stringArr);
+    assert(<boolean[]>[true, false, true], booleanArr);
+    assert(<map<int>[]>[{"one": 1, "two": 2}, {"three": 3, "four": 4}], mapArr);
+}
+
+function testLargeMapToArray() {
+    var fn = function () returns int[] {
+        int[] arr = [];
+        foreach var i in 0...999 {
+            arr[i] = i + 1;
+        }
+        return arr;
+    };
+
+    assert(fn(), getLargeMap().toArray());
+}
+
+function getLargeMap() returns map<int> {
+    map<int> m = {};
+    foreach var i in 1...1000 {
+        m[i.toString()] = i;
+    }
+    return m;
+}
+
+type Person object {
+    string name;
+
+    function __init(string n) {
+        self.name = n;
+    }
+
+    function getName() returns string => self.name;
+};
+
+function testMapOfUnionToArray() {
+    map<int|string|Person> m = {"i": 10, "s": "foo", "p": new Person("Pubudu")};
+    (int|string|Person)[] arr = m.toArray();
+
+    assert(10, <anydata>arr[0]);
+    assert("foo", <anydata>arr[1]);
+    assertSameRef(m["p"], arr[2]);
+}
+
+type Foo record {|
+    string name;
+    int age;
+    float weight;
+    decimal height;
+    boolean isStudent;
+|};
+
+function testRecordToArray() {
+    Foo foo = {
+        name: "John Doe",
+        age: 25,
+        weight: 65.5,
+        height: 172.3,
+        isStudent: true
+    };
+
+    var arr = foo.toArray();
+
+    assert(<(string|int|float|decimal|boolean)[]>["John Doe", 25, 65.5, 172.3d, true], arr);
+}
+
+type OpenFoo record {
+    string name;
+    int age;
+    float weight;
+    decimal height;
+    boolean isStudent;
+};
+
+function testOpenRecordToArray() {
+    OpenFoo foo = {
+        name: "John Doe",
+        age: 25,
+        weight: 65.5,
+        height: 172.3,
+        isStudent: true,
+        "location": "Sri Lanka",
+        "postalCode": 12500
+    };
+
+    var arr = foo.toArray();
+
+    assert(<(string|int|float|decimal|boolean)[]>["John Doe", 25, 65.5, 172.3d, true, "Sri Lanka", 12500], arr);
+}
+
+
+// Util functions
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}
+
+function assertSameRef(any expected, any actual) {
+    if (expected !== actual) {
+        typedesc<any> expT = typeof expected;
+        typedesc<any> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}

--- a/langlib/langlib-test/src/test/resources/test-src/maplib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/maplib_test.bal
@@ -186,27 +186,40 @@ function testOpenRecordToArray() {
     assert(<(string|int|float|decimal|boolean)[]>["John Doe", 25, 65.5, 172.3d, true, "Sri Lanka", 12500], arr);
 }
 
+type Bar record {|
+    byte a;
+    byte b;
+    byte...;
+|};
+
+function testRecordWithSameTypeFieldsToArray() {
+    Bar bar = {a: 10, b: 20, "c": 30, "d": 40};
+    byte[] arr = bar.toArray();
+    byte[] exp = [10, 20, 30, 40];
+    assert(exp, arr);
+}
+
 
 // Util functions
 
 function assert(anydata expected, anydata actual) {
-    if (expected != actual) {
-        typedesc<anydata> expT = typeof expected;
-        typedesc<anydata> actT = typeof actual;
-        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
-                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
-        error e = error(reason);
-        panic e;
+    if (expected == actual) {
+        return;
     }
+    typedesc<anydata> expT = typeof expected;
+    typedesc<anydata> actT = typeof actual;
+    string msg = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                        + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+    panic error("{AssertionError}", message = msg);
 }
 
 function assertSameRef(any expected, any actual) {
-    if (expected !== actual) {
-        typedesc<any> expT = typeof expected;
-        typedesc<any> actT = typeof actual;
-        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
-                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
-        error e = error(reason);
-        panic e;
+    if (expected === actual) {
+        return;
     }
+    typedesc<any> expT = typeof expected;
+    typedesc<any> actT = typeof actual;
+    string msg = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                        + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+    panic error("{AssertionError}", message = msg);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/maplib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/maplib_test.bal
@@ -99,6 +99,30 @@ function testBasicToArray() {
     assert(<string[]>["A", "B", "C"], stringArr);
     assert(<boolean[]>[true, false, true], booleanArr);
     assert(<map<int>[]>[{"one": 1, "two": 2}, {"three": 3, "four": 4}], mapArr);
+
+    // Test modifying the resultant array
+    intArr[1] = 22;
+    intArr[9] = 10;
+    assert(<int[]>[1, 22, 3, 4, 5, 0, 0, 0, 0, 10], intArr);
+
+    floatArr[1] = 22.2;
+    floatArr[7] = 7.7;
+    assert(<float[]>[1.1, 22.2, 3.3, 4.4, 5.5, 0.0, 0.0, 7.7], floatArr);
+
+    decimalArr[2] = 33.3;
+    decimalArr[6] = 6.6;
+    assert(<decimal[]>[1.1, 2.2, 33.3, 4.4, 5.5, 0.0, 6.6], decimalArr);
+
+    stringArr[0] = "Z";
+    _ = stringArr.remove(1);
+    assert(<string[]>["Z", "C"], stringArr);
+
+    booleanArr[1] = !booleanArr[1];
+    booleanArr.push(true);
+    assert(<boolean[]>[true, true, true, true], booleanArr);
+
+    mapArr[0]["one"] = 10;
+    assert(<map<int>[]>[{"one": 10, "two": 2}, {"three": 3, "four": 4}], mapArr);
 }
 
 function testLargeMapToArray() {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion2.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/chainCompletion3.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/groupedExpressionSuggestion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/groupedExpressionSuggestion1.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/iterableOperation4.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions4.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest14.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest2.json
@@ -112,6 +112,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "employer",
       "kind": "Variable",
       "detail": "Person",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest3.json
@@ -1,1 +1,337 @@
-{"position":{"line":9,"character":9},"source":"record/source/recordTest3.bal","items":[{"label":"fromJsonString()((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"}},"sortText":"120","insertText":"fromJsonString()","insertTextFormat":"Snippet"},{"label":"keys()(string[])","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"}},"sortText":"120","insertText":"keys()","insertTextFormat":"Snippet"},{"label":"remove(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"}},"sortText":"120","insertText":"remove(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"removeAll()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"}},"sortText":"120","insertText":"removeAll();","insertTextFormat":"Snippet"},{"label":"iterator()()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"}},"sortText":"120","insertText":"iterator()","insertTextFormat":"Snippet"},{"label":"isReadOnly()(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"}},"sortText":"120","insertText":"isReadOnly()","insertTextFormat":"Snippet"},{"label":"get(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"}},"sortText":"120","insertText":"get(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"employer","kind":"Variable","detail":"Person","sortText":"130","insertText":"employer","insertTextFormat":"Snippet"},{"label":"map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"}},"sortText":"120","insertText":"map(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"toJsonString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"}},"sortText":"120","insertText":"toJsonString()","insertTextFormat":"Snippet"},{"label":"reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"}},"sortText":"120","insertText":"reduce(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"hasKey(string k)(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"}},"sortText":"120","insertText":"hasKey(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"forEach(function ((any|error)) returns () func)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"}},"sortText":"120","insertText":"forEach(${1});","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"length()(int)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"}},"sortText":"120","insertText":"length()","insertTextFormat":"Snippet"},{"label":"cloneReadOnly()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"120","insertText":"cloneReadOnly()","insertTextFormat":"Snippet"},{"label":"filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"}},"sortText":"120","insertText":"filter(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"entries()(map<[string,(any|error)]>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"}},"sortText":"120","insertText":"entries()","insertTextFormat":"Snippet"},{"label":"mergeJson(json j2)((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"}},"sortText":"120","insertText":"mergeJson(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"name","kind":"Variable","detail":"string","sortText":"130","insertText":"name","insertTextFormat":"Snippet"},{"label":"clone()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"120","insertText":"clone()","insertTextFormat":"Snippet"},{"label":"toString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"}},"sortText":"120","insertText":"toString()","insertTextFormat":"Snippet"}]}
+{
+  "position": {
+    "line": 9,
+    "character": 9
+  },
+  "source": "record/source/recordTest3.bal",
+  "items": [
+    {
+      "label": "fromJsonString()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "iterator()()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "employer",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "130",
+      "insertText": "employer",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function ((any|error)) returns () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
+        }
+      },
+      "sortText": "120",
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "entries()(map<[string,(any|error)]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "mergeJson(json j2)((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "mergeJson(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "name",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "name",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest4.json
@@ -1,1 +1,337 @@
-{"position":{"line":12,"character":29},"source":"record/source/recordTest4.bal","items":[{"label":"fromJsonString()((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"}},"sortText":"121","insertText":"fromJsonString()","insertTextFormat":"Snippet"},{"label":"keys()(string[])","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"}},"sortText":"121","insertText":"keys()","insertTextFormat":"Snippet"},{"label":"remove(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"}},"sortText":"121","insertText":"remove(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"removeAll()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"}},"sortText":"121","insertText":"removeAll();","insertTextFormat":"Snippet"},{"label":"iterator()()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"}},"sortText":"121","insertText":"iterator()","insertTextFormat":"Snippet"},{"label":"isReadOnly()(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"}},"sortText":"121","insertText":"isReadOnly()","insertTextFormat":"Snippet"},{"label":"get(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"}},"sortText":"121","insertText":"get(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"}},"sortText":"121","insertText":"map(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"toJsonString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"}},"sortText":"121","insertText":"toJsonString()","insertTextFormat":"Snippet"},{"label":"reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"}},"sortText":"121","insertText":"reduce(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"hasKey(string k)(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"}},"sortText":"121","insertText":"hasKey(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"forEach(function ((any|error)) returns () func)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"}},"sortText":"121","insertText":"forEach(${1});","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"length()(int)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"}},"sortText":"121","insertText":"length()","insertTextFormat":"Snippet"},{"label":"cloneReadOnly()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"121","insertText":"cloneReadOnly()","insertTextFormat":"Snippet"},{"label":"filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"}},"sortText":"121","insertText":"filter(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"field1","kind":"Variable","detail":"string","sortText":"221","insertText":"field1","insertTextFormat":"Snippet"},{"label":"entries()(map<[string,(any|error)]>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"}},"sortText":"121","insertText":"entries()","insertTextFormat":"Snippet"},{"label":"mergeJson(json j2)((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"}},"sortText":"121","insertText":"mergeJson(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"clone()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"121","insertText":"clone()","insertTextFormat":"Snippet"},{"label":"toString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"}},"sortText":"121","insertText":"toString()","insertTextFormat":"Snippet"},{"label":"field2","kind":"Variable","detail":"boolean","sortText":"221","insertText":"field2","insertTextFormat":"Snippet"}]}
+{
+  "position": {
+    "line": 12,
+    "character": 29
+  },
+  "source": "record/source/recordTest4.bal",
+  "items": [
+    {
+      "label": "fromJsonString()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "iterator()()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function ((any|error)) returns () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
+        }
+      },
+      "sortText": "120",
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "field1",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "field1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,(any|error)]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "mergeJson(json j2)((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "mergeJson(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field2",
+      "kind": "Variable",
+      "detail": "boolean",
+      "sortText": "130",
+      "insertText": "field2",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest8.json
@@ -1,1 +1,337 @@
-{"position":{"line":15,"character":8},"source":"record/source/recordTest8.bal","items":[{"label":"fromJsonString()((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"}},"sortText":"120","insertText":"fromJsonString()","insertTextFormat":"Snippet"},{"label":"keys()(string[])","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"}},"sortText":"120","insertText":"keys()","insertTextFormat":"Snippet"},{"label":"remove(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"}},"sortText":"120","insertText":"remove(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"removeAll()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"}},"sortText":"120","insertText":"removeAll();","insertTextFormat":"Snippet"},{"label":"iterator()()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"}},"sortText":"120","insertText":"iterator()","insertTextFormat":"Snippet"},{"label":"isReadOnly()(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"}},"sortText":"120","insertText":"isReadOnly()","insertTextFormat":"Snippet"},{"label":"get(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"}},"sortText":"120","insertText":"get(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"}},"sortText":"120","insertText":"map(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"toJsonString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"}},"sortText":"120","insertText":"toJsonString()","insertTextFormat":"Snippet"},{"label":"reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"}},"sortText":"120","insertText":"reduce(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"hasKey(string k)(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"}},"sortText":"120","insertText":"hasKey(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"forEach(function ((any|error)) returns () func)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"}},"sortText":"120","insertText":"forEach(${1});","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"length()(int)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"}},"sortText":"120","insertText":"length()","insertTextFormat":"Snippet"},{"label":"cloneReadOnly()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"120","insertText":"cloneReadOnly()","insertTextFormat":"Snippet"},{"label":"i","kind":"Variable","detail":"int","sortText":"130","insertText":"i","insertTextFormat":"Snippet"},{"label":"filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"}},"sortText":"120","insertText":"filter(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"entries()(map<[string,(any|error)]>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"}},"sortText":"120","insertText":"entries()","insertTextFormat":"Snippet"},{"label":"s","kind":"Variable","detail":"string","sortText":"130","insertText":"s","insertTextFormat":"Snippet"},{"label":"mergeJson(json j2)((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"}},"sortText":"120","insertText":"mergeJson(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"clone()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"120","insertText":"clone()","insertTextFormat":"Snippet"},{"label":"toString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"}},"sortText":"120","insertText":"toString()","insertTextFormat":"Snippet"}]}
+{
+  "position": {
+    "line": 15,
+    "character": 8
+  },
+  "source": "record/source/recordTest8.bal",
+  "items": [
+    {
+      "label": "fromJsonString()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "iterator()()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function ((any|error)) returns () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
+        }
+      },
+      "sortText": "120",
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "i",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "130",
+      "insertText": "i",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "entries()(map<[string,(any|error)]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "s",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "s",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "mergeJson(json j2)((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "mergeJson(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record/recordTest9.json
@@ -1,1 +1,329 @@
-{"position":{"line":15,"character":7},"source":"record/source/recordTest9.bal","items":[{"label":"fromJsonString()((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"}},"sortText":"120","insertText":"fromJsonString()","insertTextFormat":"Snippet"},{"label":"keys()(string[])","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"}},"sortText":"120","insertText":"keys()","insertTextFormat":"Snippet"},{"label":"remove(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"}},"sortText":"120","insertText":"remove(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"removeAll()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"}},"sortText":"120","insertText":"removeAll();","insertTextFormat":"Snippet"},{"label":"iterator()()","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"}},"sortText":"120","insertText":"iterator()","insertTextFormat":"Snippet"},{"label":"isReadOnly()(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"}},"sortText":"120","insertText":"isReadOnly()","insertTextFormat":"Snippet"},{"label":"get(string k)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"}},"sortText":"120","insertText":"get(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"}},"sortText":"120","insertText":"map(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"toJsonString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"}},"sortText":"120","insertText":"toJsonString()","insertTextFormat":"Snippet"},{"label":"reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"}},"sortText":"120","insertText":"reduce(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"hasKey(string k)(boolean)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"}},"sortText":"120","insertText":"hasKey(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"forEach(function ((any|error)) returns () func)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"}},"sortText":"120","insertText":"forEach(${1});","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"length()(int)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"}},"sortText":"120","insertText":"length()","insertTextFormat":"Snippet"},{"label":"cloneReadOnly()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"120","insertText":"cloneReadOnly()","insertTextFormat":"Snippet"},{"label":"filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"}},"sortText":"120","insertText":"filter(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"entries()(map<[string,(any|error)]>)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"}},"sortText":"120","insertText":"entries()","insertTextFormat":"Snippet"},{"label":"s","kind":"Variable","detail":"string","sortText":"130","insertText":"s","insertTextFormat":"Snippet"},{"label":"mergeJson(json j2)((json|error))","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"}},"sortText":"120","insertText":"mergeJson(${1})","insertTextFormat":"Snippet","command":{"title":"editor.action.triggerParameterHints","command":"editor.action.triggerParameterHints"}},{"label":"clone()(anydata)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"}},"sortText":"120","insertText":"clone()","insertTextFormat":"Snippet"},{"label":"toString()(string)","kind":"Function","detail":"Function","documentation":{"right":{"kind":"markdown","value":"**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"}},"sortText":"120","insertText":"toString()","insertTextFormat":"Snippet"}]}
+{
+  "position": {
+    "line": 15,
+    "character": 7
+  },
+  "source": "record/source/recordTest9.bal",
+  "items": [
+    {
+      "label": "fromJsonString()((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nParses a string in JSON format and returns the the value that it represents.\nAll numbers in the JSON will be represented as float values.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `(json|error)`   \n- `str` parsed to json or error  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "iterator()()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ``   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `(any|error)`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ((any|error)) returns ((any|error))` func: a function to apply to each member  \n  \n**Returns** `map<(any|error)>`   \n- new map containing result of applying function 'func' to each member  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns the string that represents `v` in JSON format.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function ((any|error),(any|error)) returns ((any|error)) func, (any|error) initial)((any|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ((any|error),(any|error)) returns ((any|error))` func: combining function  \n- `(any|error)` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `(any|error)`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function ((any|error)) returns () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nApplies a function to each member of a map.\nThe function 'func' is applied to each member of `m`.\n  \n**Params**  \n- `function ((any|error)) returns ()` func: a function to apply to each member"
+        }
+      },
+      "sortText": "120",
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "filter(function ((any|error)) returns (boolean) func)(map<(any|error)>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ((any|error)) returns (boolean)` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<(any|error)>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "entries()(map<[string,(any|error)]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,(any|error)]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "s",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "130",
+      "insertText": "s",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "mergeJson(json j2)((json|error))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `(json|error)`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \n  set `j1[k]` to the merge of `j1[k]` with `j`  \n    - if `j1[k]` is undefined, then set `j1[k]` to `j`  \n    - if any merge fails, then the merge of `j1` with `j2` fails  \n    - otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "mergeJson(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/exprFunctionBodyCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/exprFunctionBodyCompletion3.json
@@ -120,6 +120,20 @@
       }
     },
     {
+      "label": "toArray()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "map(function ((any|error)) returns ((any|error)) func)(map<(any|error)>)",
       "kind": "Function",
       "detail": "Function",


### PR DESCRIPTION
## Purpose
> This PR adds a new method to the `map` lang library to get an array of values from maps/records. If it's a record, the element type will be the union of all the fields in the record type descriptor (including the rest field type).

## Samples
```ballerina
// Getting the values as an array
map<int> ints = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5};
int[] intArr = ints.toArray();

// Getting record field values as an array
type Foo record {|
    string name;
    int age;
    float weight;
    decimal height;
    boolean isStudent;
|};

Foo foo = {
        name: "John Doe",
        age: 25,
        weight: 65.5,
        height: 172.3,
        isStudent: true
    };

(string|int|float|decimal|boolean)[] arr = foo.toArray();
```
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
