### PR TITLE
Resolve the redundant map name conflict

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Message.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Message.java
@@ -37,6 +37,7 @@ public class Message {
     private Map<String, List<Message>> oneofFieldMap;
     private List<EnumMessage> enumList;
     private List<Message> nestedMessageList;
+    private List<Message> mapList;
 
     private Message(String messageName, List<Field> fieldList) {
         this.messageName = messageName;
@@ -59,6 +60,14 @@ public class Message {
         this.enumList = enumList;
     }
 
+    public void setMapList(List<Message> mapList) {
+        this.mapList = mapList;
+    }
+
+    public List<Message> getMapList() {
+        return mapList;
+    }
+
     public static Message.Builder newBuilder(DescriptorProtos.DescriptorProto messageDescriptor) {
         return new Message.Builder(messageDescriptor);
     }
@@ -79,6 +88,10 @@ public class Message {
         return messageName;
     }
 
+    public void setMessageName(String messageName) {
+        this.messageName = messageName;
+    }
+
     /**
      * Message Definition.Builder.
      */
@@ -86,19 +99,41 @@ public class Message {
         private DescriptorProtos.DescriptorProto messageDescriptor;
 
         public Message build() {
+            List<Message> nestedMessageList = new ArrayList<>();
+            List<Message> mapList = new ArrayList<>();
+            List<String> mapNames = new ArrayList<>();
+            for (DescriptorProtos.DescriptorProto nestedDescriptorProto : messageDescriptor.getNestedTypeList()) {
+                Message nestedMessage = Message.newBuilder(nestedDescriptorProto).build();
+                if (nestedDescriptorProto.hasOptions() && nestedDescriptorProto.getOptions().hasMapEntry()) {
+                    mapNames.add(nestedMessage.getMessageName());
+
+                    // remove unnecessary "Entry" part appends to the message name by the proto library
+                    if (nestedMessage.getMessageName().length() > 5) {
+                        nestedMessage.setMessageName(
+                                nestedMessage.getMessageName().substring(
+                                        0, nestedMessage.getMessageName().length() - 5
+                                ).toLowerCase()
+                        );
+                    }
+                    mapList.add(nestedMessage);
+                } else {
+                    nestedMessageList.add(nestedMessage);
+                }
+            }
+
             List<Field> fieldList = new ArrayList<>();
             Map<String, List<Message>> oneofFieldMap = new HashMap<>();
             for (DescriptorProtos.FieldDescriptorProto fieldDescriptorProto : messageDescriptor.getFieldList()) {
+                Field field = Field.newBuilder(fieldDescriptorProto).build();
                 if (fieldDescriptorProto.hasOneofIndex()) {
                     List<Field> tempList = new ArrayList<>(1);
-                    tempList.add(Field.newBuilder(fieldDescriptorProto).build());
+                    tempList.add(field);
                     Message message = new Message(messageDescriptor.getName() + "_" + toCamelCase
                             (fieldDescriptorProto.getName()), tempList);
                     String oneofField = messageDescriptor.getOneofDecl(fieldDescriptorProto.getOneofIndex()).getName();
                     List<Message> oneofMessageList = oneofFieldMap.computeIfAbsent(oneofField, k -> new ArrayList<>());
                     oneofMessageList.add(message);
-                } else {
-                    Field field = Field.newBuilder(fieldDescriptorProto).build();
+                } else if (!mapNames.contains(field.getFieldType())) {
                     fieldList.add(field);
                 }
             }
@@ -108,11 +143,6 @@ public class Message {
                 enumList.add(enumMessage);
             }
 
-            List<Message> nestedMessageList = new ArrayList<>();
-            for (DescriptorProtos.DescriptorProto nestedDescriptorProto : messageDescriptor.getNestedTypeList()) {
-                Message nestedMessage = Message.newBuilder(nestedDescriptorProto).build();
-                nestedMessageList.add(nestedMessage);
-            }
             Message message = new Message(messageDescriptor.getName(), fieldList);
 
             if (!oneofFieldMap.isEmpty()) {
@@ -123,6 +153,9 @@ public class Message {
             }
             if (!nestedMessageList.isEmpty()) {
                 message.setNestedMessageList(nestedMessageList);
+            }
+            if (!mapList.isEmpty()) {
+                message.setMapList(mapList);
             }
             return message;
         }

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Message.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/components/Message.java
@@ -22,6 +22,7 @@ import com.google.protobuf.DescriptorProtos;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.ballerinalang.net.grpc.builder.utils.BalGenerationUtils.toCamelCase;
@@ -112,7 +113,7 @@ public class Message {
                         nestedMessage.setMessageName(
                                 nestedMessage.getMessageName().substring(
                                         0, nestedMessage.getMessageName().length() - 5
-                                ).toLowerCase()
+                                ).toLowerCase(Locale.getDefault())
                         );
                     }
                     mapList.add(nestedMessage);

--- a/stdlib/grpc/src/main/resources/templates/skeleton/message.mustache
+++ b/stdlib/grpc/src/main/resources/templates/skeleton/message.mustache
@@ -1,6 +1,8 @@
 public type {{messageName}} record {|
     {{#fieldList}}{{fieldType}}{{#isNull defaultValue}}?{{/isNull}}{{fieldLabel}} {{{fieldName}}}{{#isNull defaultValue}} = (){{/isNull}}{{#isNotNull defaultValue}} = {{#equals fieldType "string"}}{{#if fieldLabel}}{{defaultValue}}{{else}}"{{defaultValue}}"{{/if}}{{/equals}}{{#not_equal fieldType "string"}}{{defaultValue}}{{/not_equal}}{{/isNotNull}};
-    {{/fieldList}}{{#each oneofFieldMap as |value key|}}{{camelcase @key}} {{@key}};
+    {{/fieldList ~}}
+    {{#mapList}}record {| {{fieldList.0.fieldType}} key; {{fieldList.1.fieldType}} value; |}[] {{messageName}} = [];{{/mapList ~}}
+    {{#each oneofFieldMap as |value key|}}{{camelcase @key}} {{@key}};
     {{/each}}
 |};
 {{#each oneofFieldMap}}

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -134,6 +134,16 @@ public class StubGeneratorTestCase {
                 "Expected type definitions not found in compile results.");
     }
 
+    @Test(description = "Test stub generation for with nested maps with same name")
+    public void testUnaryHelloWorldWithMaps() throws IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        CompileResult compileResult = getStubCompileResult("helloWorldWithMap.proto",
+                "helloWorldWithMap_pb.bal");
+        assertEquals(compileResult.getDiagnostics().length, 0);
+        assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,
+                "Expected type definitions not found in compile results.");
+    }
+
     @Test(description = "Test service stub generation for service definition with reserved names")
     public void testUnaryHelloWorldWithReservedNames() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {

--- a/tests/jballerina-integration-test/src/test/resources/grpc/src/tool/helloWorldWithMap.proto
+++ b/tests/jballerina-integration-test/src/test/resources/grpc/src/tool/helloWorldWithMap.proto
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+syntax = "proto3";
+
+service helloWorld {
+    rpc hello(HelloRequest) returns (HelloResponse);
+}
+
+message HelloRequest {
+    string name = 1;
+    map<string, string> tags = 4;
+}
+
+message HelloResponse {
+    string message = 1;
+    map<string, string> tags = 4;
+}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/20842

## Approach
Filter out all the map fields and then create another list to hold those maps. Then pass that list to handlebar files to generate maps.

## Samples
#### Proto file
```proto
syntax = "proto3";

message Metric {
    map<string, string> tags = 4;
    message Result {
        string url = 1;
    }
    repeated Result results = 1;
}

message TraceSpan {
    map<string, string> tags = 5;
}
```

#### Generated Ballerina file

```ballerina
public type Metric record {|
    Result[] results = [];
    record {| string key; string value; |}[] tags = [];
|};


public type Result record {|
    string url = "";
    
|};


public type TraceSpan record {|
    record {| string key; string value; |}[] tags = [];
|};

...
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
