### PR TITLE
Add support to pass tags to Observability start calls in Ballerina Old JVM Compiler Backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
           - nvm install 8
           - nvm use 8
           - npm install -g npm@'5.6.0'
-      install: 
+      install:
         - |
           if [ $TRAVIS_OS_NAME == "linux" ]; then
             export DISPLAY=':99.0'
@@ -114,7 +114,7 @@ before_cache:
   - rm -fr $HOME/.gradle/caches/*/scripts/
 cache:
   directories:
-    - $HOME/.gradle/caches/
+#    - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.m2
 
@@ -122,6 +122,7 @@ branches:
   only:
     - master
     - packerina-dev
+    - observability-improvements
     - next-release
     - release-stage
     - /^ballerina-\d*[.]\d*[.]x$/

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
@@ -69,17 +69,6 @@ public class ObserveUtils {
      * @param strand which holds the observer context being started.
      * @param serviceName name of the service to which the observer context belongs.
      * @param resourceName name of the resource being invoked.
-     */
-    public static void startResourceObservation(Strand strand, String serviceName, String resourceName) {
-        ObserveUtils.startResourceObservation(strand, serviceName, resourceName, Collections.emptyMap());
-    }
-
-    /**
-     * Start observation of a resource invocation.
-     *
-     * @param strand which holds the observer context being started.
-     * @param serviceName name of the service to which the observer context belongs.
-     * @param resourceName name of the resource being invoked.
      * @param tags tags to be used in the observation
      */
     public static void startResourceObservation(Strand strand, String serviceName, String resourceName,
@@ -144,17 +133,6 @@ public class ObserveUtils {
             observerContext.addProperty(ObservabilityConstants.PROPERTY_ERROR, Boolean.TRUE);
             observerContext.addProperty(ObservabilityConstants.PROPERTY_BSTRUCT_ERROR, errorValue);
         });
-    }
-
-    /**
-     * Start observability for the synchronous function/action invocations.
-     *
-     * @param strand which holds the observer context being started.
-     * @param connectorName name of the connector to which the observer context belongs.
-     * @param actionName name of the action/function being invoked.
-     */
-    public static void startCallableObservation(Strand strand, String connectorName, String actionName) {
-        ObserveUtils.startCallableObservation(strand, connectorName, actionName, Collections.emptyMap());
     }
 
     /**

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
@@ -32,12 +32,32 @@ function emitReportErrorInvocation(jvm:MethodVisitor mv, int strandIndex, int er
 }
 
 function emitStartObservationInvocation(jvm:MethodVisitor mv, int strandIndex, string serviceOrConnectorName,
-                                        string resourceOrActionName, string observationStartMethod) {
+                                        string resourceOrActionName, string observationStartMethod,
+                                        map<string> tags = {}) {
     mv.visitVarInsn(ALOAD, strandIndex);
     mv.visitLdcInsn(cleanUpServiceName(serviceOrConnectorName));
     mv.visitLdcInsn(resourceOrActionName);
+
+    if (tags.length() > 0) {
+        mv.visitTypeInsn(NEW, "java/util/HashMap");
+        mv.visitInsn(DUP);
+        mv.visitLdcInsn(tags.length());
+        mv.visitInsn(L2I);
+        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "(I)V", false);
+        foreach var [key, value] in tags.entries() {
+            mv.visitInsn(DUP);
+            mv.visitLdcInsn(key);
+            mv.visitLdcInsn(value);
+            mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put",
+                io:sprintf("(L%s;L%s;)L%s;", OBJECT, OBJECT, OBJECT), true);
+            mv.visitInsn(POP);
+        }
+    } else {
+        mv.visitMethodInsn(INVOKESTATIC, "java/util/Collections", "emptyMap",
+            io:sprintf("()L%s;", MAP), false);
+    }
     mv.visitMethodInsn(INVOKESTATIC, OBSERVE_UTILS, observationStartMethod,
-        io:sprintf("(L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE), false);
+        io:sprintf("(L%s;L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE, MAP), false);
 }
 
 function cleanUpServiceName(string serviceName) returns string {

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
@@ -52,12 +52,12 @@ function emitStartObservationInvocation(jvm:MethodVisitor mv, int strandIndex, s
                 io:sprintf("(L%s;L%s;)L%s;", OBJECT, OBJECT, OBJECT), true);
             mv.visitInsn(POP);
         }
-        mv.visitMethodInsn(INVOKESTATIC, OBSERVE_UTILS, observationStartMethod,
-            io:sprintf("(L%s;L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE, MAP), false);
     } else {
-        mv.visitMethodInsn(INVOKESTATIC, OBSERVE_UTILS, observationStartMethod,
-            io:sprintf("(L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE), false);
+        mv.visitMethodInsn(INVOKESTATIC, "java/util/Collections", "emptyMap",
+            io:sprintf("()L%s;", MAP), false);
     }
+    mv.visitMethodInsn(INVOKESTATIC, OBSERVE_UTILS, observationStartMethod,
+        io:sprintf("(L%s;L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE, MAP), false);
 }
 
 function cleanUpServiceName(string serviceName) returns string {


### PR DESCRIPTION
## Purpose
> Add support to pass tags to Observability start calls in Ballerina Old JVM Compiler Backend. This is done so that the stdlib projects will also be built with the required changes.

## Approach
> The same changes done to the new compiler had been done to the old compiler.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
