### PR TITLE
Fix error building modules with periods in the module name

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 public class BTestRunner {
 
     public static final String MODULE_INIT_CLASS_NAME = "___init";
+    private static final String FILE_NAME_PERIOD_SEPARATOR = "$$$";
 
     private PrintStream errStream;
     private PrintStream outStream;
@@ -252,9 +253,8 @@ public class BTestRunner {
         boolean hasTestablePackage = !packageName.equals(TesterinaConstants.DOT);
         if (hasTestablePackage) {
             // Load test init class
-            String testClassName = TesterinaUtils.getQualifiedClassName(suite.getOrgName(),
-                                                                        suite.getPackageID(),
-                                                                        suite.getPackageID());
+            String testClassName = TesterinaUtils.getQualifiedClassName(suite.getOrgName(), suite.getPackageID(),
+                    suite.getPackageID().replace(".", FILE_NAME_PERIOD_SEPARATOR));
             try {
                 testInitClazz = classLoader.loadClass(testClassName);
             } catch (Throwable e) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingTestCase.java
@@ -253,6 +253,39 @@ public class PackagingTestCase extends BaseTest {
                 new LogLeecher[]{clientLeecher}, tempProjectDirectory.toString());
     }
 
+    @Test(description = "Test and run a module which has a module name contains period. eg: foo.bar")
+    public void testBuildAndRunModuleWithPeriod() throws BallerinaTestException {
+        // Test ballerina init
+        Path projectPath = tempProjectDirectory.resolve("buildAndRunModuleWithPeriodProject");
+
+        // Create project
+        balClient.runMain("new", new String[] { "buildAndRunModuleWithPeriodProject" }, envVariables, new String[] {},
+                new LogLeecher[] {}, projectPath.getParent().toString());
+
+        Assert.assertTrue(Files.exists(projectPath));
+        Assert.assertTrue(Files.isDirectory(projectPath));
+
+        // Create module named `foo.bar`
+        String moduleName = "foo.bar";
+        balClient.runMain("add", new String[] { moduleName }, envVariables, new String[] {}, new LogLeecher[] {},
+                projectPath.toString());
+
+        Assert.assertTrue(Files.exists(projectPath.resolve("src").resolve(moduleName)));
+        Assert.assertTrue(Files.isDirectory(projectPath.resolve("src").resolve(moduleName)));
+
+        // Build module
+        LogLeecher buildLeecher = new LogLeecher("[pass] testFunction");
+        balClient.runMain("build", new String[] { "-c", "-a" }, envVariables, new String[] {},
+                new LogLeecher[] { buildLeecher }, projectPath.toString());
+        buildLeecher.waitForText(60000);
+
+        // Run module
+        LogLeecher runLeecher = new LogLeecher("Hello World!");
+        balClient.runMain("run", new String[] { moduleName }, envVariables, new String[] {},
+                new LogLeecher[] { runLeecher }, projectPath.toString());
+        buildLeecher.waitForText(5000);
+    }
+
     /**
      * Get environment variables and add ballerina_home as a env variable the tmp directory.
      *


### PR DESCRIPTION
## Purpose
> Fixing the issue of building modules having periods ( . ) in the module name.
eg: foo.bar

Fixes #20868, #19482

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
