### PR TITLE
Enable VSCode configuration sync with LS

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -30,7 +30,7 @@ import {
 import * as path from 'path';
 import * as fs from 'fs';
 import { exec, execSync } from 'child_process';
-import { LanguageClientOptions, State as LS_STATE, RevealOutputChannelOn, DidChangeConfigurationParams, ServerOptions } from "vscode-languageclient";
+import { LanguageClientOptions, State as LS_STATE, RevealOutputChannelOn, ServerOptions } from "vscode-languageclient";
 import { getServerOptions, getOldServerOptions, getOldCliServerOptions } from '../server/server';
 import { ExtendedLangClient } from './extended-language-client';
 import { log, getOutputChannel } from '../utils/index';
@@ -72,6 +72,7 @@ export class BallerinaExtension {
         this.extension = extensions.getExtension(EXTENSION_ID)!;
         this.clientOptions = {
             documentSelector: [{ scheme: 'file', language: 'ballerina' }],
+            synchronize: {configurationSection: 'ballerina'},
             outputChannel: getOutputChannel(),
             revealOutputChannelOn: RevealOutputChannelOn.Never,
         };
@@ -203,12 +204,6 @@ export class BallerinaExtension {
             if (params.affectsConfiguration(BALLERINA_HOME) ||
                 params.affectsConfiguration(OVERRIDE_BALLERINA_HOME)) {
                 this.showMsgAndRestart(CONFIG_CHANGED);
-            }
-            if (params.affectsConfiguration('ballerina')) {
-                const args: DidChangeConfigurationParams = {
-                    settings: workspace.getConfiguration('ballerina'),
-                };
-                this.langClient!.sendNotification("workspace/didChangeConfiguration", args);
             }
         });
 

--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -17,7 +17,7 @@
  * under the License.
  *
  */
-import { ExtensionContext, commands, window, Location, Uri, workspace } from 'vscode';
+import { ExtensionContext, commands, window, Location, Uri } from 'vscode';
 import { ballerinaExtInstance } from './core';
 import { activate as activateAPIEditor } from './api-editor';
 // import { activate as activateDiagram } from './diagram'; 
@@ -29,7 +29,7 @@ import { activateDebugConfigProvider } from './debugger';
 import { activate as activateProjectFeatures } from './project';
 import { activate as activateOverview } from './overview';
 import { activate as activateSyntaxHighlighter } from './syntax-highlighter';
-import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities, DidChangeConfigurationParams } from 'vscode-languageclient';
+import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities } from 'vscode-languageclient';
 import { ExtendedLangClient } from './core/extended-language-client';
 import { log } from './utils';
 
@@ -94,11 +94,6 @@ export function activate(context: ExtensionContext): Promise<any> {
 
         ballerinaExtInstance.onReady().then(() => {
             const langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
-            // Send initial configuration
-            const args: DidChangeConfigurationParams = {
-                settings: workspace.getConfiguration('ballerina'),
-            };
-            langClient.sendNotification("workspace/didChangeConfiguration", args);
             // Register showTextDocument listener
             langClient.onNotification('window/showTextDocument', (location: Location) => {
                 if (location.uri !== undefined) {


### PR DESCRIPTION
## Purpose
> Enable VSCode configuration sync with LS. Manual config sync is removed.

Fixes #21450

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
