### PR TITLE
Fix OpenApi validator plugin issue with not been able to give relative path for contract

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectoryManager.java
@@ -117,6 +117,10 @@ public class SourceDirectoryManager {
         return null;
     }
 
+    public SourceDirectory getSourceDirectory() {
+        return sourceDirectory;
+    }
+
     // private methods
 
     private SourceDirectory initializeAndGetSourceDirectory(CompilerContext context) {

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/cmd/OpenApiGenServiceCmd.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/cmd/OpenApiGenServiceCmd.java
@@ -129,6 +129,7 @@ public class OpenApiGenServiceCmd implements BLauncherCmd {
         final File openApiFile = new File(argList.get(0));
         final String openApiFilePath = openApiFile.getPath();
         Path resourcePath = Paths.get(resourcesDirectory + "/" + openApiFile.getName());
+        Path relativeResourcePath = Paths.get("resources", openApiFile.getName());
 
         //Check provided OpenApi file is a valid and existing one
         if (Files.notExists(Paths.get(openApiFilePath))) {
@@ -215,7 +216,7 @@ public class OpenApiGenServiceCmd implements BLauncherCmd {
         //Path pathRelative = basePath.relativize(absPath);
 
         try {
-            generator.generateService(executionPath, resourcePath.toString(), resourcePath.toString(),
+            generator.generateService(executionPath, resourcePath.toString(), relativeResourcePath.toString(),
                     moduleArgs.get(1), output);
         } catch (IOException | BallerinaOpenApiException e) {
             throw LauncherUtils.createLauncherException("Error occurred when generating service for openapi " +


### PR DESCRIPTION
## Purpose
Fixes the following issue.

- Cannot give relative paths to the OpenAPI file in the openapi:ServiceInfo attribute

Fixes #17834

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
