### PR TITLE
Fix Toml parser test cases in windows

### DIFF
--- a/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/ManifestProcessorTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/ManifestProcessorTest.java
@@ -132,8 +132,8 @@ public class ManifestProcessorTest {
         Path baloPath = tmpDir.resolve("string_utils.balo");
         Files.createFile(baloPath);
 
-        String tomlData = this.validProjectBlock + "[dependencies] \n " +
-                "string-utils = { path = \"" + baloPath.toString().replace("\\", "/") + "\", version = \"1.1.5\" } \n ";
+        String tomlData = this.validProjectBlock + "[dependencies] \n string-utils = { path = \""
+                + baloPath.toString().replace("\\", "/") + "\", version = \"1.1.5\" } \n ";
 
         Manifest manifest = ManifestProcessor.parseTomlContentFromString(tomlData);
         Assert.assertEquals(manifest.getDependencies().get(0).getModuleID(), "string-utils");
@@ -157,9 +157,9 @@ public class ManifestProcessorTest {
         Path baloPath = tmpDir.resolve("string_utils.balo");
         Files.createFile(baloPath);
 
-        String tomlData = this.validProjectBlock + "[dependencies] \n " +
-                "string-utils = { path = \"" + baloPath.toString().replace("\\", "/") + "\", version = \"1.0.5\" } \n " +
-                "jquery = { version = \"2.2.3\" } \n";
+        String tomlData = this.validProjectBlock + "[dependencies] \n string-utils = { path = \""
+                + baloPath.toString().replace("\\", "/") + "\", version = \"1.0.5\" } \n "
+                + "jquery = { version = \"2.2.3\" } \n";
 
         Manifest manifest = ManifestProcessor.parseTomlContentFromString(tomlData);
         Assert.assertEquals(manifest.getDependencies().get(0).getModuleID(), "string-utils");

--- a/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/ManifestProcessorTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/ballerinalang/toml/ManifestProcessorTest.java
@@ -131,9 +131,11 @@ public class ManifestProcessorTest {
         Path tmpDir = Files.createTempDirectory("manifest-test-");
         Path baloPath = tmpDir.resolve("string_utils.balo");
         Files.createFile(baloPath);
-        
-        Manifest manifest = ManifestProcessor.parseTomlContentFromString(this.validProjectBlock + "[dependencies] \n " +
-                "string-utils = {path = \"" + baloPath + "\", version = \"1.1.5\"} \n");
+
+        String tomlData = this.validProjectBlock + "[dependencies] \n " +
+                "string-utils = { path = \"" + baloPath.toString().replace("\\", "/") + "\", version = \"1.1.5\" } \n ";
+
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString(tomlData);
         Assert.assertEquals(manifest.getDependencies().get(0).getModuleID(), "string-utils");
         Assert.assertEquals(manifest.getDependencies().get(0).getMetadata().getVersion(), "1.1.5");
         Assert.assertEquals(manifest.getDependencies().get(0).getMetadata().getPath().toString(), baloPath.toString());
@@ -154,10 +156,12 @@ public class ManifestProcessorTest {
         Path tmpDir = Files.createTempDirectory("manifest-test-");
         Path baloPath = tmpDir.resolve("string_utils.balo");
         Files.createFile(baloPath);
-        
-        Manifest manifest = ManifestProcessor.parseTomlContentFromString(this.validProjectBlock + "[dependencies] \n " +
-                "string-utils = { path = \"" + baloPath + "\", version = \"1.0.5\" } \n " +
-                "jquery = { version = \"2.2.3\" } \n");
+
+        String tomlData = this.validProjectBlock + "[dependencies] \n " +
+                "string-utils = { path = \"" + baloPath.toString().replace("\\", "/") + "\", version = \"1.0.5\" } \n " +
+                "jquery = { version = \"2.2.3\" } \n";
+
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString(tomlData);
         Assert.assertEquals(manifest.getDependencies().get(0).getModuleID(), "string-utils");
         Assert.assertEquals(manifest.getDependencies().get(0).getMetadata().getVersion(), "1.0.5");
         Assert.assertEquals(manifest.getDependencies().get(1).getModuleID(), "jquery");


### PR DESCRIPTION
## Purpose
> $Title

Fixes #20044, #20933

## Approach
> This failure is because of the toml4j library, hence the path to Toml file is replaced so that it will be compatible with windows as well.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Suggested labels
Area/BuildTools

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
