### PR TITLE
Fix MetricsTestCase broken by jballerina migration

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -59,12 +59,15 @@ class JvmObservabilityGen {
     }
 
     private static String cleanUpServiceName(String serviceName) {
-
-        String finalString = serviceName;
-        if (serviceName.contains("$$service$")) {
-            finalString = serviceName.replace("$$service$", "_");
+        final String serviceIdentifier = "$$service$";
+        if (serviceName.contains(serviceIdentifier)) {
+            if (serviceName.contains("$anonService$")) {
+                return serviceName.replace(serviceIdentifier, "_");
+            } else {
+                return serviceName.substring(0, serviceName.lastIndexOf(serviceIdentifier));
+            }
         }
-        return finalString;
+        return serviceName;
     }
 
     static String getFullQualifiedRemoteFunctionName(String moduleOrg, String moduleName, String funcName) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
@@ -72,7 +72,7 @@ public class MetricsTestCase extends BaseTest {
         addMetrics();
     }
 
-    @Test (groups = "brokenOnJBallerina")
+    @Test
     public void testMetrics() throws Exception {
         // Test Service
         await().atMost(20, TimeUnit.SECONDS)

--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -294,11 +294,6 @@
 
     <test name="ballerina-observability-tests" parallel="false">
         <parameter name="enableJBallerinaTests" value="true"/>
-        <groups>
-            <run>
-                <exclude name="brokenOnJBallerina"/>
-            </run>
-        </groups>
         <classes>
             <class name="org.ballerinalang.test.observability.tracing.TracingTestCase"/>
             <class name="org.ballerinalang.test.observability.metrics.MetricsTestCase"/>


### PR DESCRIPTION
## Purpose
>The MetricsTestCase failed because of incorrect migration.

## Approach
> fix JvmObservabilityGen.cleanUpServiceName method

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
