### PR TITLE
Fix dependency tree of gradle outputs

### DIFF
--- a/gradle/balNativeLibProject.gradle
+++ b/gradle/balNativeLibProject.gradle
@@ -125,6 +125,7 @@ task createBalo(type: CreateBaloTask) {
     inputs.dir(balFiles)
     inputs.files(configurations.baloImplementation)
     outputs.dir("$buildDir/generated-balo")
+    outputs.dir("$buildDir/generated-bir-jar")
     outputs.files(interopJars)
     outputs.cacheIf { true }
 }


### PR DESCRIPTION
should fix class not found issue during the build