### PR TITLE
Improve XML freeze support and reference equality

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -462,7 +462,10 @@ public class TypeChecker {
                 return false;
             }
         }
-        return !(lhsIter.hasNext() || rhsIter.hasNext());
+        // lhs hasNext = false & rhs hasNext = false -> empty sequences, hence ref equal
+        // lhs hasNext = true & rhs hasNext = true would never reach here
+        // only one hasNext method returns true means requences are of different sizes, hence not ref equal
+        return lhsIter.hasNext() == rhsIter.hasNext();
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/XMLItem.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/XMLItem.java
@@ -657,6 +657,7 @@ public final class XMLItem extends XMLValue {
         if (FreezeUtils.isOpenForFreeze(this.freezeStatus, freezeStatus)) {
             this.freezeStatus = freezeStatus;
         }
+        this.children.attemptFreeze(freezeStatus);
         this.attributes.attemptFreeze(freezeStatus);
     }
 
@@ -666,6 +667,7 @@ public final class XMLItem extends XMLValue {
     @Override
     public void freezeDirect() {
         this.freezeStatus.setFrozen();
+        this.children.freezeDirect();
         this.attributes.freezeDirect();
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/RefEqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/RefEqualAndNotEqualOperationsTest.java
@@ -397,6 +397,12 @@ public class RefEqualAndNotEqualOperationsTest {
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
     }
 
+    @Test
+    public void testEmptyXMLSequencesRefEquality() {
+        BValue[] returns = BRunUtil.invoke(result, "testEmptyXMLSequencesRefEquality");
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
     @Test(description = "Test reference equal with errors")
     public void testRefEqualNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 22);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinfunctions/FreezeAndIsFrozenTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinfunctions/FreezeAndIsFrozenTest.java
@@ -267,6 +267,14 @@ public class FreezeAndIsFrozenTest {
         BRunUtil.invoke(result, "testFrozenXmlSetChildren", new BValue[0]);
     }
 
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.xml\\}XMLOperationError message=Failed to set" +
+                    " children to xml element: modification not allowed on readonly value.*")
+    public void testFrozenXmlSetChildrenDeep() {
+        BRunUtil.invoke(result, "testFrozenXmlSetChildrenDeep", new BValue[0]);
+    }
+
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate message=Invalid map " +
                     "insertion: modification not allowed on readonly value.*")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
@@ -438,3 +438,11 @@ function testXMLSequenceRefEqualityIncludingDifferentString() returns boolean {
 
     return x2 === x3;
 }
+
+function testEmptyXMLSequencesRefEquality() returns boolean {
+    xml x = xml `<elem></elem>`;
+    xml y = xml `<elem></elem>`;
+    xml z = x/*;
+    xml q = y/*;
+    return z === q;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/builtinoperations/freeze-and-isfrozen.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/builtinoperations/freeze-and-isfrozen.bal
@@ -267,6 +267,15 @@ function testFrozenXmlSetChildren() {
     x3.setChildren(x2);
 }
 
+function testFrozenXmlSetChildrenDeep() {
+    xml x1 = xml `<book><name>The Lost World</name><authors></authors></book>`;
+    xml x2 = xml `<author>Doyle</author>`;
+
+    xml x3 = x1.cloneReadOnly();
+    xml x4 = x3/<authors>;
+    x4.setChildren(x2);
+}
+
 function testFrozenMapUpdate() {
     map<anydata> m1 = { one: "1", two: 2 };
     map<anydata> m2 = { one: "21", two: 22, mapVal: m1 };


### PR DESCRIPTION
## Purpose
Fix cloneReadonly operation not propagating read-only-ness to child elements of an xml element. And fix reference equality of empty XML sequences so that all empty xml sequences are equal to each other.

```ballerina
    xml x1 = xml `<book><name>The Lost World</name><authors></authors></book>`;
    xml x2 = xml `<author>Doyle</author>`;

    xml x3 = x1.cloneReadOnly();
    xml x4 = x3/<authors>;
    x4.setChildren(x2); // panic
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/21534 and https://github.com/ballerina-platform/ballerina-lang/issues/21533

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
