### PR TITLE
Fix ignore code action breaks for inline records

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateVariableCodeAction.java
@@ -79,7 +79,7 @@ import static org.ballerinalang.langserver.util.references.ReferencesUtil.getRef
  * @since 1.1.1
  */
 @JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
-public class VariableAssignmentCodeAction extends AbstractCodeActionProvider {
+public class CreateVariableCodeAction extends AbstractCodeActionProvider {
 
     /**
      * {@inheritDoc}
@@ -183,7 +183,7 @@ public class VariableAssignmentCodeAction extends AbstractCodeActionProvider {
                 }
                 // Add ignore return value code action
                 if (!hasError) {
-                    List<TextEdit> iEdits = getIgnoreCodeActionEdits(refAtCursor);
+                    List<TextEdit> iEdits = getIgnoreCodeActionEdits(position);
                     commandTitle = CommandConstants.IGNORE_RETURN_TITLE;
                     action = new CodeAction(commandTitle);
                     action.setKind(CodeActionKind.QuickFix);
@@ -333,10 +333,8 @@ public class VariableAssignmentCodeAction extends AbstractCodeActionProvider {
         return edits;
     }
 
-    private static List<TextEdit> getIgnoreCodeActionEdits(SymbolReferencesModel.Reference referenceAtCursor) {
+    private static List<TextEdit> getIgnoreCodeActionEdits(Position position) {
         String editText = "_ = ";
-        BLangNode bLangNode = referenceAtCursor.getbLangNode();
-        Position position = new Position(bLangNode.pos.sLine - 1, bLangNode.pos.sCol - 1);
         List<TextEdit> edits = new ArrayList<>();
         edits.add(new TextEdit(new Range(position, position), editText));
         return edits;


### PR DESCRIPTION
## Purpose
>IgnoreReturnValue code action breaks the code for inline record definitions.

Fixes #21562

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
