### PR TITLE
Disallow method invocation directly after xml navigation access expression.

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -313,6 +313,7 @@ public enum DiagnosticCode {
     CANNOT_UPDATE_XML_SEQUENCE("cannot.update.xml.sequence"),
     INVALID_XML_NS_INTERPOLATION("invalid.xml.ns.interpolation"),
     CANNOT_FIND_XML_NAMESPACE("cannot.find.xml.namespace.prefix"),
+    UNSUPPORTED_METHOD_INVOCATION_XML_NAV("method.invocation.in.xml.navigation.expressions.not.supported"),
 
     UNDEFINED_ANNOTATION("undefined.annotation"),
     ANNOTATION_NOT_ALLOWED("annotation.not.allowed"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -2295,9 +2295,9 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         boolean argsAvailable = invocation.invocationArgList() != null;
         BallerinaParser.AnyIdentifierNameContext identifierContext = invocation.anyIdentifierName();
         String invocationText = identifierContext.getText();
+        this.pkgBuilder.createGroupExpression(getCurrentPos(groupExpression), getWS(groupExpression));
         this.pkgBuilder.createInvocationNode(getCurrentPos(invocation), getWS(invocation),
                 invocationText, argsAvailable, getCurrentPos(identifierContext));
-        this.pkgBuilder.createGroupExpression(getCurrentPos(groupExpression), getWS(groupExpression));
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2107,7 +2107,14 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
     private void validateMethodInvocationsInXMLNavigationExpression(BLangXMLNavigationAccess expression) {
         if (!expression.methodInvocationAnalyzed && expression.parent.getKind() == NodeKind.INVOCATION) {
-            dlog.error(((BLangInvocation) expression.parent).pos, DiagnosticCode.UNSUPPORTED_METHOD_INVOCATION_XML_NAV);
+            BLangInvocation invocation = (BLangInvocation) expression.parent;
+            // avoid langlib invocations re-written to have the receiver as first argument.
+            if (invocation.argExprs.contains(expression)
+                    && ((invocation.symbol.flags & Flags.LANG_LIB) != Flags.LANG_LIB)) {
+                return;
+            }
+
+            dlog.error(invocation.pos, DiagnosticCode.UNSUPPORTED_METHOD_INVOCATION_XML_NAV);
         }
         expression.methodInvocationAnalyzed = true;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2107,8 +2107,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
     private void validateMethodInvocationsInXMLNavigationExpression(BLangXMLNavigationAccess expression) {
         if (!expression.methodInvocationAnalyzed && expression.parent.getKind() == NodeKind.INVOCATION) {
-            dlog.error(((BLangInvocation) expression.parent).name.pos,
-                    DiagnosticCode.UNSUPPORTED_METHOD_INVOCATION_XML_NAV);
+            dlog.error(((BLangInvocation) expression.parent).pos, DiagnosticCode.UNSUPPORTED_METHOD_INVOCATION_XML_NAV);
         }
         expression.methodInvocationAnalyzed = true;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2102,6 +2102,15 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         if (xmlNavigation.childIndex != null) {
             analyzeExpr(xmlNavigation.childIndex);
         }
+        validateMethodInvocationsInXMLNavigationExpression(xmlNavigation);
+    }
+
+    private void validateMethodInvocationsInXMLNavigationExpression(BLangXMLNavigationAccess expression) {
+        if (!expression.methodInvocationAnalyzed && expression.parent.getKind() == NodeKind.INVOCATION) {
+            dlog.error(((BLangInvocation) expression.parent).name.pos,
+                    DiagnosticCode.UNSUPPORTED_METHOD_INVOCATION_XML_NAV);
+        }
+        expression.methodInvocationAnalyzed = true;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangXMLNavigationAccess.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangXMLNavigationAccess.java
@@ -35,6 +35,10 @@ public class BLangXMLNavigationAccess extends BLangAccessExpression implements X
     public final NavAccessType navAccessType;
     public final List<BLangXMLElementFilter> filters;
     public BLangExpression childIndex;
+    // Hack to avoid duplicate error messages in CodeAnalyzer, the reason for this flag is since we are adding
+    // the 'receiver' of a method invocation as the first parameter to langlib invocations, XMLNavigationAccess
+    // could be checked multiple times when used with langlib functions producing multiple error messages.
+    public boolean methodInvocationAnalyzed;
 
     public BLangXMLNavigationAccess(DiagnosticPos pos, Set<Whitespace> ws, BLangExpression expr,
                                     List<BLangXMLElementFilter> filters,

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -488,6 +488,9 @@ error.invalid.xml.ns.interpolation=\
 error.cannot.find.xml.namespace.prefix=\
   cannot find xml namespace prefix ''{0}''
 
+error.method.invocation.in.xml.navigation.expressions.not.supported=\
+  method invocations are not supported in XML navigation expressions
+
 error.iterable.not.supported.collection=\
   incompatible types: ''{0}'' is not an iterable collection
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -489,7 +489,8 @@ error.cannot.find.xml.namespace.prefix=\
   cannot find xml namespace prefix ''{0}''
 
 error.method.invocation.in.xml.navigation.expressions.not.supported=\
-  method invocations are not supported in XML navigation expressions
+  method invocations are not supported within XML navigation expressions yet, use grouping expression (parenthesis) \
+  if you intent to invoke the method in the result of navigation expression.
 
 error.iterable.not.supported.collection=\
   incompatible types: ''{0}'' is not an iterable collection

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -489,7 +489,7 @@ error.cannot.find.xml.namespace.prefix=\
   cannot find xml namespace prefix ''{0}''
 
 error.method.invocation.in.xml.navigation.expressions.not.supported=\
-  method invocations are not yet supported within XML navigation expressions yet, use a grouping expression \
+  method invocations are not yet supported within XML navigation expressions, use a grouping expression \
   (parenthesis) if you intend to invoke the method on the result of the navigation expression.
 
 error.iterable.not.supported.collection=\

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -489,8 +489,8 @@ error.cannot.find.xml.namespace.prefix=\
   cannot find xml namespace prefix ''{0}''
 
 error.method.invocation.in.xml.navigation.expressions.not.supported=\
-  method invocations are not supported within XML navigation expressions yet, use grouping expression (parenthesis) \
-  if you intent to invoke the method in the result of navigation expression.
+  method invocations are not yet supported within XML navigation expressions yet, use a grouping expression \
+  (parenthesis) if you intend to invoke the method on the result of the navigation expression.
 
 error.iterable.not.supported.collection=\
   incompatible types: ''{0}'' is not an iterable collection

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-xml-typed-binding-patterns.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-xml-typed-binding-patterns.bal
@@ -47,7 +47,7 @@ function testXmlInnerElementsWithSimpleVariableWithoutType() returns string {
     output = "";
 
     int i = 0;
-    foreach var v in xdata/*.elements() {
+    foreach var v in (xdata/*).elements() {
         if v is xml {
             concatIntXml(i, v);
             i += 1;
@@ -60,7 +60,7 @@ function testXmlInnerElementsWithSimpleVariableWithType() returns string {
     output = "";
 
     int i = 0;
-    foreach xml|string v in xdata/*.elements() {
+    foreach xml|string v in (xdata/*).elements() {
         if v is xml {
             concatIntXml(i, v);
             i += 1;

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-xml.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-xml.bal
@@ -42,7 +42,7 @@ function testXMLWithArityTwo () returns (string) {
 function testXMLWithArityChildren () returns (string) {
     output = "";
     int i = 0;
-    foreach var x in xdata/*.elements() {
+    foreach var x in (xdata/*).elements() {
         if x is xml {
             concatIntString(i, x.toString());
             i += 1;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -273,13 +273,14 @@ public class XMLAccessTest {
 
     @Test
     public void testXMLNavExpressionMethodInvocationNegative() {
-        String message = "method invocations are not supported within XML navigation expressions yet, use grouping " +
-                "expression (parenthesis) if you intent to invoke the method in the result of navigation expression.";
+        String message = "method invocations are not yet supported within XML navigation expressions yet, " +
+                "use a grouping expression (parenthesis) " +
+                "if you intend to invoke the method on the result of the navigation expression.";
         Assert.assertEquals(navigationNegative.getErrorCount(), 5);
-        BAssertUtil.validateError(navigationNegative, 0, message, 3, 25);
-        BAssertUtil.validateError(navigationNegative, 1, message, 4, 19);
-        BAssertUtil.validateError(navigationNegative, 2, message, 5, 21);
-        BAssertUtil.validateError(navigationNegative, 3, message, 6, 28);
-        BAssertUtil.validateError(navigationNegative, 4, message, 7, 28);
+        BAssertUtil.validateError(navigationNegative, 0, message, 3, 14);
+        BAssertUtil.validateError(navigationNegative, 1, message, 4, 14);
+        BAssertUtil.validateError(navigationNegative, 2, message, 5, 14);
+        BAssertUtil.validateError(navigationNegative, 3, message, 6, 14);
+        BAssertUtil.validateError(navigationNegative, 4, message, 7, 14);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -273,7 +273,7 @@ public class XMLAccessTest {
 
     @Test
     public void testXMLNavExpressionMethodInvocationNegative() {
-        String message = "method invocations are not yet supported within XML navigation expressions yet, " +
+        String message = "method invocations are not yet supported within XML navigation expressions, " +
                 "use a grouping expression (parenthesis) " +
                 "if you intend to invoke the method on the result of the navigation expression.";
         Assert.assertEquals(navigationNegative.getErrorCount(), 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -40,6 +40,7 @@ public class XMLAccessTest {
     CompileResult elementAccess;
     CompileResult navigation;
     CompileResult negativeResult;
+    CompileResult navigationNegative;
 
     @BeforeClass
     public void setup() {
@@ -47,6 +48,7 @@ public class XMLAccessTest {
         elementAccess = BCompileUtil.compile("test-src/types/xml/xml-element-access.bal");
         navigation = BCompileUtil.compile("test-src/types/xml/xml-navigation-access.bal");
         negativeResult = BCompileUtil.compile("test-src/types/xml/xml-indexed-access-negative.bal");
+        navigationNegative = BCompileUtil.compile("test-src/types/xml/xml-nav-access-negative.bal");
     }
 
     @Test
@@ -267,5 +269,20 @@ public class XMLAccessTest {
         Assert.assertTrue(((BXML<?>) returns[2]).isEmpty().booleanValue());
         Assert.assertEquals(returns[3].stringValue(),
                 "<ns0:fname xmlns:ns0=\"http://test.com\" xmlns=\"http://test.com/default\">John</ns0:fname>");
+    }
+
+    @Test
+    public void testXMLNavExpressionMethodInvocationNegative() {
+        Assert.assertEquals(navigationNegative.getErrorCount(), 5);
+        BAssertUtil.validateError(navigationNegative, 0,
+                "method invocations are not supported in XML navigation expressions", 3, 25);
+        BAssertUtil.validateError(navigationNegative, 1,
+                "method invocations are not supported in XML navigation expressions", 4, 19);
+        BAssertUtil.validateError(navigationNegative, 2,
+                "method invocations are not supported in XML navigation expressions", 5, 21);
+        BAssertUtil.validateError(navigationNegative, 3,
+                "method invocations are not supported in XML navigation expressions", 6, 28);
+        BAssertUtil.validateError(navigationNegative, 4,
+                "method invocations are not supported in XML navigation expressions", 7, 28);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -273,16 +273,13 @@ public class XMLAccessTest {
 
     @Test
     public void testXMLNavExpressionMethodInvocationNegative() {
+        String message = "method invocations are not supported within XML navigation expressions yet, use grouping " +
+                "expression (parenthesis) if you intent to invoke the method in the result of navigation expression.";
         Assert.assertEquals(navigationNegative.getErrorCount(), 5);
-        BAssertUtil.validateError(navigationNegative, 0,
-                "method invocations are not supported in XML navigation expressions", 3, 25);
-        BAssertUtil.validateError(navigationNegative, 1,
-                "method invocations are not supported in XML navigation expressions", 4, 19);
-        BAssertUtil.validateError(navigationNegative, 2,
-                "method invocations are not supported in XML navigation expressions", 5, 21);
-        BAssertUtil.validateError(navigationNegative, 3,
-                "method invocations are not supported in XML navigation expressions", 6, 28);
-        BAssertUtil.validateError(navigationNegative, 4,
-                "method invocations are not supported in XML navigation expressions", 7, 28);
+        BAssertUtil.validateError(navigationNegative, 0, message, 3, 25);
+        BAssertUtil.validateError(navigationNegative, 1, message, 4, 19);
+        BAssertUtil.validateError(navigationNegative, 2, message, 5, 21);
+        BAssertUtil.validateError(navigationNegative, 3, message, 6, 28);
+        BAssertUtil.validateError(navigationNegative, 4, message, 7, 28);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable-with-variable-mutability.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable-with-variable-mutability.bal
@@ -124,7 +124,7 @@ function xmlTest() returns [string, xml] {
     </p:person>`;
 
     int index = 0;
-    xml m = xdata/*.elements()[1]/*.elements()
+    xml m = ((xdata/*).elements()[1]/*).elements()
                  .'map(function (xml|string x) returns (string| xml) {
                             index += 1;
                             if x is xml {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable.bal
@@ -137,8 +137,8 @@ function xmlTest() returns [int, int, xml] {
         </p:address>
         <q:ID>1131313</q:ID>
     </p:person>`;
-    int nodeCount = xdata/*.length();
-    int elementCount = xdata/*.elements().length();
+    int nodeCount = (xdata/*).length();
+    int elementCount = (xdata/*).elements().length();
 
     index = -1;
     xml m = xdata.getChildren().elements()[1].getChildren().elements()

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-native-functions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-native-functions.bal
@@ -743,7 +743,7 @@ function testRemoveComplexChildren() returns [xml, xml] {
 function testRemoveInnerChildren() returns [xml, xml] {
     xml x1 = xml `<person><name>John</name><address><street>Palm Grove</street><city>Colombo 03</city><country><name>Sri Lanka</name><code>LK</code></country></address><age>50</age></person>`;
     xml children = x1/*;
-    x1/<address>/<country>.removeChildren("code");
+    (x1/<address>/<country>).removeChildren("code");
     return [children, x1/*];
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-nav-access-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-nav-access-negative.bal
@@ -1,0 +1,10 @@
+function testXMLNavigationOnSingleElement() returns [xml, xml, xml, xml, xml] {
+    xml x1 = xml `<root><child attr="attr-val"></child></root>`;
+    xml x2 = x1/<child>.clone();
+    xml x3 = x1/*.clone();
+    xml x4 = x1/<*>.clone();
+    xml x5 = x1/**/<child>.clone();
+    xml x6 = x1/<child>[0].clone();
+
+    return [x2, x3, x4, x5, x6];
+}


### PR DESCRIPTION
## Purpose
This is because according to the spec, method invocations after XML navigation expression (xmlVal/<elem>.method()) should be associated with the navigation expression.

This means when we add the method invocation support to XML navigation expressions, method invocation directly after the nav-expression will change the semantic. Hence this PR is disallowing it. If the user want to invoke a method on the result of an XML navigation expression they can use grouping expressions to group the navigation expression and invoke the method on the group.

Also related to https://github.com/ballerina-platform/ballerina-lang/issues/21567

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
