### PR TITLE
Add support for iterator errors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -1282,6 +1282,7 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.isDeclaredWithVar = source.isDeclaredWithVar;
         clone.varType = source.varType;
         clone.resultType = source.resultType;
+        clone.errorType = source.errorType;
         clone.nillableResultType = source.nillableResultType;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangFromClause.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangFromClause.java
@@ -36,8 +36,9 @@ public class BLangFromClause extends BLangNode implements FromClauseNode {
     public BLangExpression collection;
 
     public VariableDefinitionNode variableDefinitionNode;
-    public BType varType; // T
+    public BType varType; // T || T|E
     public BType resultType; // map<T>
+    public BType errorType; // E
     public BType nillableResultType; // map<T>?
     public boolean isDeclaredWithVar;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangForeach.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangForeach.java
@@ -37,8 +37,9 @@ public class BLangForeach extends BLangStatement implements ForeachNode {
     public BLangBlockStmt body;
 
     public VariableDefinitionNode variableDefinitionNode;
-    public BType varType; // T
+    public BType varType; // T || T|E
     public BType resultType; // map<T>
+    public BType errorType; // E
     public BType nillableResultType; // map<T>?
     public boolean isDeclaredWithVar;
 


### PR DESCRIPTION
## Purpose
$title

Fixes #20720

## Approach
n/a

## Samples
```ballerina
type Iterable object {
    public function __iterator() returns abstract object {public function next() returns record {|int value;|}|error?;
    } {
        object {
            int[] integers = [12, 34, 56, 34, 78, 21, 90];
            int cursorIndex = 0;
            public function next() returns
            record {|
                int value;
            |}|error? {
                self.cursorIndex += 1;
                if (self.cursorIndex <= 7) {
                    return {
                        value: self.integers[self.cursorIndex - 1]
                    };
                } else {
                    return ();
                }
            }
        } sample = new;
        return sample;
    }
};

public function main() {
    Iterable p = new Iterable();
    int[] integers = [];
    foreach int|error item in p {
        integers.push(<int>item);
    }
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
