### PR TITLE
Fix issue in defining anonymous record types in a tuple type desc

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -4147,6 +4147,7 @@ public class Desugar extends BLangNodeVisitor {
             result = rewriteExpr(conversionExpr.expr);
             return;
         }
+        conversionExpr.typeNode = rewrite(conversionExpr.typeNode, env);
         conversionExpr.expr = rewriteExpr(conversionExpr.expr);
         result = conversionExpr;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -872,6 +872,7 @@ public class Desugar extends BLangNodeVisitor {
         List<BLangType> rewrittenMembers = new ArrayList<>();
         tupleTypeNode.memberTypeNodes.forEach(member -> rewrittenMembers.add(rewrite(member, env)));
         tupleTypeNode.memberTypeNodes = rewrittenMembers;
+        tupleTypeNode.restParamType = rewrite(tupleTypeNode.restParamType, env);
         result = tupleTypeNode;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -701,4 +701,10 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns[2].stringValue(), "4.2");
         Assert.assertEquals(returns[3].stringValue(), "true");
     }
+
+    @Test
+    public void testAnonRecordInCast() {
+        BValue[] returns = BRunUtil.invoke(result, "testAnonRecordInCast");
+        Assert.assertEquals(returns[0].stringValue(), "{name:\"Pubudu\"}");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
@@ -167,6 +167,11 @@ public class BasicTupleTest {
         BRunUtil.invoke(result, "testUnionRestDescriptor");
     }
 
+    @Test
+    public void testAnonRecordsInTupleTypeDescriptor() {
+        BRunUtil.invoke(result, "testAnonRecordsInTupleTypeDescriptor");
+    }
+
     @Test(description = "Test negative scenarios of assigning tuple literals")
     public void testNegativeTupleLiteralAssignments() {
         Assert.assertEquals(resultNegative.getErrorCount(), 30);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -506,3 +506,8 @@ type Employee record {
     int id;
     string name;
 };
+
+
+function testAnonRecordInCast() returns record {| string name; |} {
+    return <record {| string name; |}>{ name: "Pubudu" };
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -241,6 +241,14 @@ function testUnionRestDescriptor() {
     assertEquality(true, x[6]);
 }
 
+function testAnonRecordsInTupleTypeDescriptor() {
+    [string, record {| string name; |}[]...] tup = ["foo", [{name: "Pubudu"}]];
+
+    assertEquality(2, tup.length());
+    assertEquality("foo", tup[0]);
+    assertEquality(<record {| string name; |}[]>[{name: "Pubudu"}], tup[1]);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
> The changes introduced to how locally defined anonymous record types are modeled seems to have broken the ability to define a locally defined record type as a rest member type. This PR fixes that.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
