### PR TITLE
Fix lang-server breaks for --std-libs param for old SDKs

### DIFF
--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/config/LSClientConfig.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/config/LSClientConfig.java
@@ -35,11 +35,11 @@ public class LSClientConfig {
         String balExperimental = System.getenv("BAL_EXPERIMENTAL");
         String balDefStdLibs = System.getenv("BAL_DEF_STD_LIBS");
 
-        this.allowExperimental = (balExperimental != null) && Boolean.getBoolean(balExperimental);
-        this.debugLog = (balDebugLog != null) && Boolean.getBoolean(balDebugLog);
-        this.traceLog = (balTraceLog != null) && Boolean.getBoolean(balTraceLog);
+        this.allowExperimental = Boolean.parseBoolean(balExperimental);
+        this.debugLog = Boolean.parseBoolean(balDebugLog);
+        this.traceLog = Boolean.parseBoolean(balTraceLog);
         this.codeLens = new CodeLensConfig();
-        this.goToDefinition = (balDefStdLibs != null) ? new GoToDefinitionConfig(Boolean.getBoolean(balDefStdLibs)) :
+        this.goToDefinition = (balDefStdLibs != null) ? new GoToDefinitionConfig(Boolean.parseBoolean(balDefStdLibs)) :
                 new GoToDefinitionConfig(true);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -131,8 +131,13 @@ public class BallerinaWorkspaceService implements WorkspaceService {
         if (!(params.getSettings() instanceof JsonObject)) {
             return;
         }
-        configHolder.updateConfig(GSON.fromJson(((JsonObject) params.getSettings()).get("ballerina"),
-                                                LSClientConfig.class));
+        if (((JsonObject) params.getSettings()).get("ballerina") != null) {
+            configHolder.updateConfig(GSON.fromJson(((JsonObject) params.getSettings()).get("ballerina"),
+                                                    LSClientConfig.class));
+        } else {
+            // To support old plugins versions
+            configHolder.updateConfig(GSON.fromJson(((JsonObject) params.getSettings()), LSClientConfig.class));
+        }
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -131,12 +131,12 @@ public class BallerinaWorkspaceService implements WorkspaceService {
         if (!(params.getSettings() instanceof JsonObject)) {
             return;
         }
-        if (((JsonObject) params.getSettings()).get("ballerina") != null) {
-            configHolder.updateConfig(GSON.fromJson(((JsonObject) params.getSettings()).get("ballerina"),
-                                                    LSClientConfig.class));
+        JsonObject settings = (JsonObject) params.getSettings();
+        if (settings.get("ballerina") != null) {
+            configHolder.updateConfig(GSON.fromJson(settings.get("ballerina"), LSClientConfig.class));
         } else {
             // To support old plugins versions
-            configHolder.updateConfig(GSON.fromJson(((JsonObject) params.getSettings()), LSClientConfig.class));
+            configHolder.updateConfig(GSON.fromJson(settings, LSClientConfig.class));
         }
     }
 

--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -205,6 +205,11 @@ export class BallerinaExtension {
                 params.affectsConfiguration(OVERRIDE_BALLERINA_HOME)) {
                 this.showMsgAndRestart(CONFIG_CHANGED);
             }
+            // If it is older SDK less than 1.2.0, needs a server restart
+            if ((!ballerinaExtInstance.isNewConfigChangeSupported) && (params.affectsConfiguration(ALLOW_EXPERIMENTAL) 
+                || params.affectsConfiguration(ENABLE_DEBUG_LOG) || params.affectsConfiguration(ENABLE_TRACE_LOG))) {
+                this.showMsgAndRestart(CONFIG_CHANGED);
+            }
         });
 
         languages.setLanguageConfiguration('ballerina', {

--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -17,7 +17,7 @@
  * under the License.
  *
  */
-import { ExtensionContext, commands, window, Location, Uri } from 'vscode';
+import { ExtensionContext, commands, window, Location, Uri, workspace } from 'vscode';
 import { ballerinaExtInstance } from './core';
 import { activate as activateAPIEditor } from './api-editor';
 // import { activate as activateDiagram } from './diagram'; 
@@ -29,7 +29,7 @@ import { activateDebugConfigProvider } from './debugger';
 import { activate as activateProjectFeatures } from './project';
 import { activate as activateOverview } from './overview';
 import { activate as activateSyntaxHighlighter } from './syntax-highlighter';
-import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities } from 'vscode-languageclient';
+import { StaticFeature, ClientCapabilities, DocumentSelector, ServerCapabilities, DidChangeConfigurationParams } from 'vscode-languageclient';
 import { ExtendedLangClient } from './core/extended-language-client';
 import { log } from './utils';
 
@@ -94,6 +94,13 @@ export function activate(context: ExtensionContext): Promise<any> {
 
         ballerinaExtInstance.onReady().then(() => {
             const langClient = <ExtendedLangClient>ballerinaExtInstance.langClient;
+            // Send initial configuration without 'ballerina' field to support older SDK versions below 1.2.0
+            if (!ballerinaExtInstance.isNewConfigChangeSupported) {
+                const args: DidChangeConfigurationParams = {
+                    settings: workspace.getConfiguration('ballerina'),
+                };
+                langClient.sendNotification("workspace/didChangeConfiguration", args);
+            }
             // Register showTextDocument listener
             langClient.onNotification('window/showTextDocument', (location: Location) => {
                 if (location.uri !== undefined) {

--- a/tool-plugins/vscode/src/server/server.ts
+++ b/tool-plugins/vscode/src/server/server.ts
@@ -87,9 +87,6 @@ export function getOldCliServerOptions(ballerinaCmd: string, experimental: boole
     if (experimental) {
         args.push('--experimental');
     }
-    if (enableStdlibDefinition) {
-        args.push('--stdlib-definition');
-    }
 
     return {
         command: cmd,


### PR DESCRIPTION
## Purpose
> Fix lang-server breaks for --std-libs param  for old SDKs

Fixes #21705

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
