### PR TITLE
Add the Missing Descriptions of the IO Module in API Docs

### DIFF
--- a/stdlib/io/src/main/ballerina/src/io/constants.bal
+++ b/stdlib/io/src/main/ballerina/src/io/constants.bal
@@ -14,26 +14,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Format which will be used to represent the CSV.
+# The format, which will be used to represent the CSV.
 #
-# DEFAULT - Would default to the format specified by CSVChannel. Precedence will be given to field
+# DEFAULT - The default value is the format specified by the CSVChannel. Precedence will be given to the field
 #           separator and record separator.
 #
-# CSV - Field separator would be "," and the record separator would be new line.
+# CSV - Field separator would be "," and the record separator would be a new line.
 #
-# TDF - Field separator will be tab and record separator will be new line.
+# TDF - Field separator will be a tab and the record separator will be a new line.
 public type Format DEFAULT|CSV|TDF;
 
-#  Would default to the format specified by CSVChannel. Precedence will be given to field separator and record separator.
+#  Default value is the format specified by the CSVChannel. Precedence will be given to the field separator and record separator.
 public const DEFAULT = "default";
 
-# Field separator would be "," and the record separator would be new line.
+# Field separator would be "," and the record separator would be a new line.
 public const CSV = "csv";
 
-# Field separator will be tab and record separator will be new line.
+# Field separator will be a tab and record separator will be a new line.
 public const TDF = "tdf";
 
-# Field separators which are supported by DelimitedTextRecordChannel.
+# Field separators, which are supported by the DelimitedTextRecordChannel.
 #
 # COMMA - Delimited text records would be separated using a comma.
 #

--- a/stdlib/io/src/main/ballerina/src/io/readable_character_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/readable_character_channel.bal
@@ -16,7 +16,7 @@
 
 import ballerinax/java;
 
-#Represents a channel which could be used to read characters through a given ReadableByteChannel.
+#Represents a channel, which could be used to read characters through a given ReadableByteChannel.
 public type ReadableCharacterChannel object {
 
     private ReadableByteChannel byteChannel;
@@ -24,19 +24,19 @@ public type ReadableCharacterChannel object {
 
     # Constructs a ReadableCharacterChannel from a given ReadableByteChannel and Charset.
 
-    # + channel - ReadableByteChannel which would be used to read characters
-    # + charset - Character-Set which would be used to encode/decode given bytes to characters
+    # + byteChannel - ReadableByteChannel, which would be used to read the characters
+    # + charset - Character-Set, which would be used to encode/decode the given bytes to characters
     public function __init(ReadableByteChannel byteChannel, string charset) {
         self.byteChannel = byteChannel;
         self.charset = charset;
         initReadableCharacterChannel(self, byteChannel, java:fromString(charset));
     }
 
-    # Reads a given number of characters. This will attempt read up to `numberOfChars` characters from the channel.
-    # `io:EofError` will return once channel reach to it end.
+    # Reads a given number of characters. This will attempt to read up to `numberOfChars` characters of the channel.
+    # `io:EofError` will return once the channel reaches the end.
     #
-    # + numberOfChars - Number of characters which should be read
-    # + return - Content which is read or `EofError` once channel reach to it end. `Error` if any error occurred.
+    # + numberOfChars - Number of characters, which should be read
+    # + return - Content, which is read or `EofError` once the channel reaches the end. `Error` if any error occurred.
     public function read(@untainted int numberOfChars) returns @tainted string|Error {
         handle|Error result = readExtern(self, numberOfChars);
         if (result is handle) {
@@ -46,23 +46,23 @@ public type ReadableCharacterChannel object {
         }
     }
 
-    # Reads a json from the given channel.
+    # Reads a JSON from the given channel.
     #
-    # + return - Read json string or `Error` if any error occurred
+    # + return - the JSON string, which was read or `Error` if any error occurred
     public function readJson() returns @tainted json|Error {
         return readJsonExtern(self);
     }
 
-    # Reads a XML from the given channel.
+    # Reads an XML from the given channel.
     #
-    # + return - Read xml or `Error` if any error occurred
+    # + return - The XML, which was read or `Error` if any error occurred
     public function readXml() returns @tainted xml|Error {
         return readXmlExtern(self);
     }
 
     # Closes a given character channel.
     #
-    # + return - If an error occurred while writing
+    # + return - `Error` if an error occurred while writing
     public function close() returns Error? {
         return closeReadableCharacterChannel(self);
     }

--- a/stdlib/io/src/main/ballerina/src/io/writable_csv_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/writable_csv_channel.bal
@@ -15,26 +15,26 @@
 // under the License.
 
 
-# Represents record separator of the CSV file.
+# Represents the record separator of the CSV file.
 public const string CSV_RECORD_SEPARATOR = "\n";
 
 
-# Represents colon separator which should be used to identify colon separated files.
+# Represents the colon separator, which should be used to identify colon-separated files.
 public const string FS_COLON = ":";
 
 
-# Represents minimum number of headers which will be included in CSV.
+# Represents the minimum number of headers, which will be included in the CSV.
 public const int MINIMUM_HEADER_COUNT = 0;
 
 
-# Represents a WritableCSVChannel which could be used to write records from CSV file.
+# Represents a WritableCSVChannel, which could be used to write records from the CSV file.
 public type WritableCSVChannel object {
     private WritableTextRecordChannel? dc;
 
     # Constructs a CSV channel from a CharacterChannel to read/write CSV records.
 
-    # + channel - The CharacterChannel, which will represent the content in the CSV file
-    # + fs - Field separator which will separate between the records in the CSV
+    # + characterChannel - The CharacterChannel, which will represent the content in the CSV file
+    # + fs - Field separator, which will separate the records in the CSV
     public function __init(WritableCharacterChannel characterChannel, public Separator fs = ",") {
         if (fs == TAB) {
             self.dc = new WritableTextRecordChannel(characterChannel, fmt = "TDF");
@@ -47,7 +47,7 @@ public type WritableCSVChannel object {
         }
     }
 
-    # Writes record to a given CSV file.
+    # Writes the record to a given CSV file.
 
     # + csvRecord - A record to be written to the channel
     # + return - Returns an `Error` if the record could not be written properly

--- a/stdlib/io/src/main/ballerina/src/io/writable_record_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/writable_record_channel.bal
@@ -16,17 +16,21 @@
 
 import ballerinax/java;
 
-# Represents a channel which will allow to write records through a given WritableCharacterChannel.
+# Represents a channel, which will allow to write records through a given WritableCharacterChannel.
 public type WritableTextRecordChannel object {
     private WritableCharacterChannel characterChannel;
-    private string rs;
     private string fs;
+    private string rs;
 
     # Constructs a DelimitedTextRecordChannel from a given WritableCharacterChannel.
 
-    # + channel - WritableCharacterChannel which will point to the input/output resource
-    # + rs - Record separator (this could be a regex)
+    # + characterChannel - WritableCharacterChannel, which will point to the input/output resource
     # + fs - Field separator (this could be a regex)
+    # + rs - Record separator (this could be a regex)
+    # + fmt - The format, which will be used to represent the CSV (this could be "DEFAULT" (the format specified by the CSVChannel), 
+    # "CSV" (Field separator would be "," and record separator would be a new line), 
+    # or TDF (Field separator will be a tab and record separator will be a new line).
+    # 
     public function __init(WritableCharacterChannel characterChannel, public string fs = "", public string rs = "",
                            public string fmt = "default") {
         self.characterChannel = characterChannel;


### PR DESCRIPTION
## Purpose

We need to add the below missing descriptions of the IO Module in API Docs.
- https://ballerina.io/v1-1/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html(Constructor-byteChannel)
- https://ballerina.io/v1-1/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html(Constructor-characterChannel)
- https://ballerina.io/v1-1/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html(Constructor-characterChannel)

Fixes #21619 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
