### PR TITLE
Remove extra spaces in BBE output

### DIFF
--- a/examples/table/table.bal
+++ b/examples/table/table.bal
@@ -56,13 +56,13 @@ public function main() {
     io:println("Table Information: ", tb);
 
     // Access the rows using the `foreach` loop.
-    io:println("Using foreach: ");
+    io:println("Using foreach:");
     foreach var x in tb {
         io:println("Name: ", x.name);
     }
 
     // Access rows using the `while` loop.
-    io:println("Using while loop: ");
+    io:println("Using while loop:");
     while (tb.hasNext()) {
         var ret = tb.getNext();
         io:println("Name: ", ret.name);


### PR DESCRIPTION
## Purpose
Remove extra spaces in BBE output. This will make the current reference output the same as actual output.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
