### PR TITLE
Fix VSCode prints ""<--command--> failed"

### DIFF
--- a/tool-plugins/vscode/src/core/extension.ts
+++ b/tool-plugins/vscode/src/core/extension.ts
@@ -29,7 +29,7 @@ import {
 } from "./messages";
 import * as path from 'path';
 import * as fs from 'fs';
-import { exec, execSync } from 'child_process';
+import { exec, spawnSync } from 'child_process';
 import { LanguageClientOptions, State as LS_STATE, RevealOutputChannelOn, ServerOptions } from "vscode-languageclient";
 import { getServerOptions, getOldServerOptions, getOldCliServerOptions } from '../server/server';
 import { ExtendedLangClient } from './extended-language-client';
@@ -461,7 +461,7 @@ export class BallerinaExtension {
             isBallerinaNotFound = false,
             isOldBallerinaDist = false;
         try {
-            balHomeOutput = execSync(this.getBallerinaCmd() + ' home').toString().trim();
+            balHomeOutput = spawnSync(this.getBallerinaCmd(), ['home']).toString().trim();
             // specially handle unknown ballerina command scenario for windows
             if (balHomeOutput === "" && process.platform === "win32") {
                 isOldBallerinaDist = true;


### PR DESCRIPTION
## Purpose
> Fix VSCode prints ""<--command--> failed"

Fixes #21755

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
