### PR TITLE
Fix empty space print for error with empty details

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ErrorValue.java
@@ -88,31 +88,20 @@ public class ErrorValue extends BError implements RefValue {
     @Override
     @Deprecated
     public String stringValue() {
-        String detailsString;
         if (details == null) {
-            detailsString = "";
-        } else {
-            detailsString = org.ballerinalang.jvm.values.utils.StringUtils.getStringValue(details);
-        }
-        if (detailsString.trim().isEmpty()) {
             return "error " + reason.getValue();
         }
-        return "error " + reason.getValue() + " " + detailsString;
+        return "error " + reason.getValue() + " " + org.ballerinalang.jvm.values.utils.StringUtils.getStringValue(
+                details);
     }
 
     @Override
     public BString bStringValue() {
-        BString detailsString;
         if (details == null) {
-            detailsString = StringUtils.fromString("");
-        } else {
-            detailsString = org.ballerinalang.jvm.values.utils.StringUtils.getBStringValue(details);
-        }
-        if (detailsString.toString().trim().isEmpty()) {
             return StringUtils.fromString("error ").concat(reason);
         }
         return StringUtils.fromString("error ").concat(reason).concat(StringUtils.fromString(" ")).concat(
-                detailsString);
+                org.ballerinalang.jvm.values.utils.StringUtils.getBStringValue(details));
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ErrorValue.java
@@ -88,16 +88,31 @@ public class ErrorValue extends BError implements RefValue {
     @Override
     @Deprecated
     public String stringValue() {
-        return "error " + reason.getValue() +
-                Optional.ofNullable(details).map(
-                        details -> " " + org.ballerinalang.jvm.values.utils.StringUtils.getStringValue(details)).orElse(
-                        "");
+        String detailsString;
+        if (details == null) {
+            detailsString = "";
+        } else {
+            detailsString = org.ballerinalang.jvm.values.utils.StringUtils.getStringValue(details);
+        }
+        if (detailsString.trim().isEmpty()) {
+            return "error " + reason.getValue();
+        }
+        return "error " + reason.getValue() + " " + detailsString;
     }
 
     @Override
     public BString bStringValue() {
+        BString detailsString;
+        if (details == null) {
+            detailsString = StringUtils.fromString("");
+        } else {
+            detailsString = org.ballerinalang.jvm.values.utils.StringUtils.getBStringValue(details);
+        }
+        if (detailsString.toString().trim().isEmpty()) {
+            return StringUtils.fromString("error ").concat(reason);
+        }
         return StringUtils.fromString("error ").concat(reason).concat(StringUtils.fromString(" ")).concat(
-                org.ballerinalang.jvm.values.utils.StringUtils.getBStringValue(details));
+                detailsString);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Fix empty space print for error with empty details. With this change, we don't have to change union_type.bal BBE output to have extra spaces.

```
< error key '' not found
---
> error key '' not found<space>
```
BBE : https://ballerina.io/v1-1/learn/by-example/union-type.html

## Approach
> Describe how you are implementing the solutions along with the design details.
Trim the string and check if it is empty.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
