### PR TITLE
Update hello world parallel BBE with @strand annotation

### DIFF
--- a/examples/hello-world-parallel/hello_world_parallel.bal
+++ b/examples/hello-world-parallel/hello_world_parallel.bal
@@ -3,14 +3,17 @@ import ballerina/io;
 // Use one or more workers to define a function execution.
 // The function invocation starts all the workers.
 public function main() {
+    @strand {thread: "any"}
     worker w1 {
         io:println("Hello, World! #m");
     }
 
+    @strand {thread: "any"}
     worker w2 {
         io:println("Hello, World! #n");
     }
 
+    @strand {thread: "any"}
     worker w3 {
         io:println("Hello, World! #k");
     }


### PR DESCRIPTION
With recent changes to the Ballerina scheduler, the previous code
will not run in parallel. This PR fixes that by adding the @strand
annotation.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
