### PR TITLE
Add alias support for module pull code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/OptimizeAllImportsCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/OptimizeAllImportsCodeAction.java
@@ -82,6 +82,10 @@ public class OptimizeAllImportsCodeAction extends AbstractCodeActionProvider {
                     String pkgName = matcher.group(1).trim();
                     String version = matcher.groupCount() > 1 && matcher.group(2) != null ? ":" + matcher.group(2) :
                             "";
+                    int aliasIndex = version.indexOf(" as ");
+                    if (aliasIndex > 0) {
+                        version = version.substring(0, aliasIndex);
+                    }
                     toBeRemovedImports.add(new ImmutablePair<>(pkgName, version));
                 }
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/PullModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/PullModuleCodeAction.java
@@ -101,6 +101,10 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
     private static String getVersion(LSContext context, String pkgName, Matcher matcher) {
         CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
         String version = matcher.groupCount() > 1 && matcher.group(2) != null ? ":" + matcher.group(2) : "";
+        int aliasIndex = version.indexOf(" as ");
+        if (aliasIndex > 0) {
+            version = version.substring(0, aliasIndex);
+        }
         if (compilerContext != null && version.isEmpty()) {
             // If no version in source, try reading Ballerina.toml dependencies
             ManifestProcessor manifestProcessor = ManifestProcessor.getInstance(compilerContext);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/PullModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/PullModuleCodeAction.java
@@ -22,10 +22,14 @@ import org.ballerinalang.langserver.commons.LSContext;
 import org.ballerinalang.langserver.commons.codeaction.CodeActionNodeType;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
+import org.ballerinalang.toml.model.Dependency;
+import org.ballerinalang.toml.model.Manifest;
+import org.ballerinalang.toml.parser.ManifestProcessor;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +84,7 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
         if (matcher.find() && matcher.groupCount() > 0) {
             List<Object> args = new ArrayList<>();
             String pkgName = matcher.group(1).trim();
-            String version = matcher.groupCount() > 1 && matcher.group(2) != null ? ":" + matcher.group(2) : "";
+            String version = getVersion(context, pkgName, matcher);
             args.add(new CommandArgument(CommandConstants.ARG_KEY_MODULE_NAME, pkgName + version));
             args.add(uriArg);
             String commandTitle = CommandConstants.PULL_MOD_TITLE;
@@ -92,5 +96,20 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
             return action;
         }
         return null;
+    }
+
+    private static String getVersion(LSContext context, String pkgName, Matcher matcher) {
+        CompilerContext compilerContext = context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY);
+        String version = matcher.groupCount() > 1 && matcher.group(2) != null ? ":" + matcher.group(2) : "";
+        if (compilerContext != null && version.isEmpty()) {
+            // If no version in source, try reading Ballerina.toml dependencies
+            ManifestProcessor manifestProcessor = ManifestProcessor.getInstance(compilerContext);
+            Manifest manifest = manifestProcessor.getManifest();
+            List<Dependency> dependencies = manifest.getDependencies();
+            version = dependencies.stream()
+                    .filter(d -> d.getModuleID().equals(pkgName))
+                    .findAny().map(d -> ":" + d.getMetadata().getVersion()).orElse(version);
+        }
+        return version;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -30,9 +30,9 @@ public class CommandConstants {
     public static final String NO_IMPL_FOUND_FOR_FUNCTION = "no implementation found for the function";
     public static final String FUNC_IMPL_FOUND_IN_ABSTRACT_OBJ = "cannot have a body";
     public static final Pattern UNUSED_IMPORT_MODULE_PATTERN = Pattern.compile(
-            "unused import module '([^a|^v|\\s]*)(\\W+(?:version)\\W+([^v|^a|^\\n|\\s]+))?.*'");
+            "unused import module '(\\S*)\\s*(?:version\\s(.*))?(.*)'");
     public static final Pattern UNRESOLVED_MODULE_PATTERN = Pattern.compile(
-            "cannot resolve module '([^a|^v|\\s]*)(\\W+(?:version)\\W+([^v|^a|^\\n|\\s]+))?.*'");
+            "cannot resolve module '(\\S*)\\s*(?:version\\s(.*))?(.*)'");
     public static final Pattern TAINTED_PARAM_PATTERN = Pattern.compile(
             "tainted value passed to untainted parameter '(.*)'");
     public static final Pattern UNDEFINED_FUNCTION_PATTERN = Pattern.compile("undefined function '(.*)'");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -30,9 +30,9 @@ public class CommandConstants {
     public static final String NO_IMPL_FOUND_FOR_FUNCTION = "no implementation found for the function";
     public static final String FUNC_IMPL_FOUND_IN_ABSTRACT_OBJ = "cannot have a body";
     public static final Pattern UNUSED_IMPORT_MODULE_PATTERN = Pattern.compile(
-            "unused import module '([^(v)]*)(?:version (.*))?'");
+            "unused import module '([^a|^v|\\s]*)(\\W+(?:version)\\W+([^v|^a|^\\n|\\s]+))?.*'");
     public static final Pattern UNRESOLVED_MODULE_PATTERN = Pattern.compile(
-            "cannot resolve module '([^(v)]*)(?:version (.*))?'");
+            "cannot resolve module '([^a|^v|\\s]*)(\\W+(?:version)\\W+([^v|^a|^\\n|\\s]+))?.*'");
     public static final Pattern TAINTED_PARAM_PATTERN = Pattern.compile(
             "tainted value passed to untainted parameter '(.*)'");
     public static final Pattern UNDEFINED_FUNCTION_PATTERN = Pattern.compile("undefined function '(.*)'");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CodeActionTest.java
@@ -294,6 +294,8 @@ public class CodeActionTest {
                 {"undefinedFunctionCodeAction2.json", "createUndefinedFunction2.bal"},
                 {"packagePull1.json", "packagePull.bal"},
                 {"packagePull2.json", "packagePull.bal"},
+                {"packagePull3.json", "packagePull2.bal"},
+                {"packagePull4.json", "packagePull2.bal"},
                 {"changeAbstractTypeObj1.json", "changeAbstractType.bal"},
                 {"changeAbstractTypeObj2.json", "changeAbstractType.bal"}
         };

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/packagePull3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/packagePull3.json
@@ -1,0 +1,22 @@
+{
+  "range": {
+    "start": {
+      "line": 1,
+      "character": 10
+    },
+    "end": {
+      "line": 1,
+      "character": 10
+    }
+  },
+  "expected": {
+    "title":"Pull from Ballerina Central",
+    "command":"PULL_MODULE",
+    "arguments":[
+      {
+        "argumentK": "module",
+        "argumentV": "org/unpulled_package:1.1.1"
+      }
+    ]
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/packagePull4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/packagePull4.json
@@ -1,0 +1,22 @@
+{
+  "range": {
+    "start": {
+      "line": 2,
+      "character": 10
+    },
+    "end": {
+      "line": 2,
+      "character": 10
+    }
+  },
+  "expected": {
+    "title":"Pull from Ballerina Central",
+    "command":"PULL_MODULE",
+    "arguments":[
+      {
+        "argumentK": "module",
+        "argumentV": "org/unpulled_package"
+      }
+    ]
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/source/packagePull2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/source/packagePull2.bal
@@ -1,0 +1,6 @@
+import org/unpulled_package version 1.1.1 as t;
+import org/unpulled_package as t;
+
+public function main(string... args) {
+
+}


### PR DESCRIPTION
## Purpose
> Add alias support for module pull code action

Fixes #21301

# Samples
Following imports will be supported;
```ballerina
import wso2/twitter as t
import wso2/twitter version 1.1.1 as t
import wso2/twitter version 1.1.1
import wso2/twitter
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
