### PR TITLE
Add support to observe entry point main method

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -292,7 +292,8 @@ public class JvmMethodGen {
         @Nilable Label tryStart = null;
         boolean isObserved = false;
         boolean isWorker = (func.flags & Flags.WORKER) == Flags.WORKER;
-        if ((isService || isWorker) && !"__init".equals(funcName) && !"$__init$".equals(funcName)) {
+        if ((isService || isWorker || "main".equals(funcName))
+                && !"__init".equals(funcName) && !"$__init$".equals(funcName)) {
             // create try catch block to start and stop observability.
             isObserved = true;
             tryStart = labelGen.getLabel("observe-try-start");


### PR DESCRIPTION
## Purpose
> Add support to observe entry point main method

## Approach
> Since the entry point main method is not invoked from anywhere, it is observed at the callee side (inside method definition at the moment.