### PR TITLE
Fix stringValue for errors when details is an empty map

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ErrorValue.java
@@ -88,7 +88,7 @@ public class ErrorValue extends BError implements RefValue {
     @Override
     @Deprecated
     public String stringValue() {
-        if (details == null) {
+        if (isEmptyDetail()) {
             return "error " + reason.getValue();
         }
         return "error " + reason.getValue() + " " + org.ballerinalang.jvm.values.utils.StringUtils.getStringValue(
@@ -97,7 +97,7 @@ public class ErrorValue extends BError implements RefValue {
 
     @Override
     public BString bStringValue() {
-        if (details == null) {
+        if (isEmptyDetail()) {
             return StringUtils.fromString("error ").concat(reason);
         }
         return StringUtils.fromString("error ").concat(reason).concat(StringUtils.fromString(" ")).concat(
@@ -252,6 +252,16 @@ public class ErrorValue extends BError implements RefValue {
             errorMsg = errorMsg + (reasonAdded ? " " : "") + details.toString();
         }
         return errorMsg;
+    }
+
+    private boolean isEmptyDetail() {
+        if (details == null) {
+            return true;
+        }
+        if ((details instanceof MapValue) && ((MapValue) details).isEmpty()) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HttpPayloadTestCase.java
@@ -53,7 +53,7 @@ public class HttpPayloadTestCase extends HttpBaseTest {
         Assert.assertEquals(response.getData(),
                             "Error occurred while extracting xml data from entity: " +
                                     "error failed to create xml: ParseError at [row,col]:[1,1]Message: " +
-                                    "Content is not allowed in prolog. ",
+                                    "Content is not allowed in prolog.",
                             "Message content mismatched");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/varargs/JavaVarargsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/varargs/JavaVarargsTest.java
@@ -138,7 +138,7 @@ public class JavaVarargsTest {
         BValue[] returns = BRunUtil.invoke(result, "testRefTypeVarArg");
         Assert.assertEquals(returns.length, 2);
         Assert.assertEquals(returns[0].stringValue(), "[7, 2, 8]");
-        Assert.assertEquals(returns[1].stringValue(), "[error error one , error error two ]");
+        Assert.assertEquals(returns[1].stringValue(), "[error error one, error error two]");
     }
 
     @Test
@@ -152,7 +152,7 @@ public class JavaVarargsTest {
     public void testRefArrayTypeVararg() {
         BValue[] returns = BRunUtil.invoke(result, "testRefArrayTypeVararg");
         Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(returns[0].stringValue(), "[[error error one ], [error error two ]]");
+        Assert.assertEquals(returns[0].stringValue(), "[[error error one], [error error two]]");
     }
 
     // Java methods for interop


### PR DESCRIPTION
## Purpose
Fix empty space print for error with empty details. With this change, we don't have to change union_type.bal BBE output to have extra spaces.
```
< error key '' not found
---
> error key '' not found<space>
```

BBE : https://ballerina.io/v1-1/learn/by-example/union-type.html'

## Approach
Check if details empty and generate string value accordingly

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
