### PR TITLE
Improve usability of the bindgen tool

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindgenCommand.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindgenCommand.java
@@ -64,6 +64,7 @@ public class BindgenCommand implements BLauncherCmd {
     @Override
     public void execute() {
 
+        outStream.println("\nNote: This is an experimental tool.\n");
         //Help flag check
         if (helpFlag) {
             String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(getName());
@@ -74,6 +75,7 @@ public class BindgenCommand implements BLauncherCmd {
         if (classNames == null) {
             outError.println("One or more class names for bindings generation should be specified.");
             outStream.println(BINDGEN_CMD);
+            outStream.println("\nUse 'ballerina bindgen --help' for more information on the command.");
             return;
         }
 

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/components/JClass.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/components/JClass.java
@@ -103,7 +103,7 @@ public class JClass {
         Method[] declaredMethods = classObject.getDeclaredMethods();
         List<Method> classMethods = new ArrayList<>();
         for (Method m : declaredMethods) {
-            if (!m.isSynthetic()) {
+            if (!m.isSynthetic() && (!m.getName().equals("toString"))) {
                 classMethods.add(m);
             }
         }

--- a/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
@@ -17,6 +17,11 @@ public type {{shortClassName}} object {
     {{/each}}
     public function __init(handle obj) {
         self.jObj = obj;
+    }
+
+    public function toString() returns string {
+
+        return jObjToString(self.jObj);
     }{{#methodList}}{{#isInstance}}
 
     public function {{#reservedWord}}{{#controlChars methodName ""}}{{/controlChars}}{{/reservedWord}}{{#noReservedWord}}{{methodName}}{{/noReservedWord}}({{#parameters}}{{#if isPrimitiveArray}}{{#getType type ""}}{{/getType}}{{else}}{{shortTypeName}}{{/if}} {{fieldName}}{{#notLast}}, {{/notLast}}{{/parameters}}) {{#hasReturn}}returns {{returnType}}{{#if isStringReturn}}?{{/if}}{{#if exceptionTypes}}|error{{/if}} {{/hasReturn}}{{#noReturn}}{{#if exceptionTypes}}returns error? {{else if hasPrimitiveParam}}returns error? {{/if}}{{/noReturn}}{

--- a/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
@@ -34,7 +34,7 @@ public type {{shortClassName}} object {
     }{{/isInstance}}{{/methodList}}
 };
 {{#initFunctionList}}
-public function {{shortClassName}}{{constructorName}}({{#parameters}}{{shortTypeName}} {{fieldName}}{{#notLast}}, {{/notLast}}{{/parameters}}) returns {{shortClassName}}{{#exceptionTypes}}|error{{/exceptionTypes}} {
+public function new{{shortClassName}}{{constructorName}}({{#parameters}}{{shortTypeName}} {{fieldName}}{{#notLast}}, {{/notLast}}{{/parameters}}) returns {{shortClassName}}{{#exceptionTypes}}|error{{/exceptionTypes}} {
     handle{{#exceptionTypes}}|error{{/exceptionTypes}} obj = {{prefix}}_{{externalFunctionName}}({{#parameters}}{{#if isPrimitiveArray}}check getHandleFromArray({{fieldName}}, "{{componentType}}"){{#notLast}}, {{/notLast}}{{else if isString}}java:fromString({{fieldName}}){{#notLast}}, {{/notLast}}{{else}}{{fieldName}}{{#isObj}}.jObj{{/isObj}}{{#notLast}}, {{/notLast}}{{/if}}{{/parameters}});
     {{#exceptionTypes}}if (obj is handle) {
         {{/exceptionTypes}}{{shortClassName}} {{initObjectName}} = new(obj);

--- a/misc/ballerina-bindgen/src/main/resources/templates/jobject.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/jobject.mustache
@@ -1,4 +1,4 @@
 public type JObject abstract object {
 
-    handle jObj;
+    public handle jObj;
 };

--- a/misc/ballerina-bindgen/src/main/resources/templates/jobject.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/jobject.mustache
@@ -1,4 +1,16 @@
+import ballerina/java;
+
 public type JObject abstract object {
 
     public handle jObj;
 };
+
+function jObjToString(handle jObj) returns string {
+    handle jStringValue = toStringInternal(jObj);
+    return java:toString(jStringValue) ?: "null";
+}
+
+function toStringInternal(handle jObj) returns handle = @java:Method {
+    name: "toString",
+    class: "java.lang.Object"
+} external;


### PR DESCRIPTION
## Purpose
* Add the access modifier of the `JObject` as public.
* Add a note during command execution to specify that this tool is at an experimental stage.
* Add the `new` prefix to the constructor name.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
