### PR TITLE
Terminate build when imports have errors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -173,7 +173,7 @@ public class Compiler {
         List<BLangPackage> compiledPackages = compilePackages(Lists.of(packageID));
         // TODO: this should check for dlog.errorCount > 0. But currently some errors are
         // not getting added to dlog, hence cannot check for error count. Issue #10454.
-        if (compiledPackages.isEmpty()) {
+        if (compiledPackages.isEmpty() || this.dlog.getErrorCount() > 0) {
             throw new BLangCompilerException("compilation contains errors");
         }
         return compiledPackages.get(0);


### PR DESCRIPTION
## Purpose
This will terminate build if import has errors 

Fixes #21913

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
