### PR TITLE
[1.2.x] Add module level init for *ByteChannel objects

### DIFF
--- a/stdlib/io/src/main/ballerina/src/io/readable_byte_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/readable_byte_channel.bal
@@ -19,6 +19,9 @@ import ballerina/java;
 # ReadableByteChannel represents an input resource (i.e file). which could be used to source bytes.
 public type ReadableByteChannel object {
 
+    # Adding default __init function to prevent object getting initialized from the user code.
+    function __init() {}
+
     # Source bytes from a given input/output resource.
     #
     # Number of bytes returned will be < 0 if the file reached its end.
@@ -57,7 +60,7 @@ public type ReadableByteChannel object {
     }
 };
 
-function byteReadExtern(ReadableByteChannel byteChannel, @untainted int nBytes) returns @tainted byte[]|Error = @java:Method {
+function byteReadExtern(ReadableByteChannel byteChannel,@untainted int nBytes) returns @tainted byte[]|Error = @java:Method {
     name: "read",
     class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;

--- a/stdlib/io/src/main/ballerina/src/io/writable_byte_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/writable_byte_channel.bal
@@ -19,6 +19,9 @@ import ballerina/java;
 # WritableByteChannel represents an output resource (i.e file). which could be used to sink bytes.
 public type WritableByteChannel object {
 
+    # Adding default __init function to prevent object getting initialized from the user code.
+    function __init() {}
+
     # Sink bytes from a given input/output resource.
     #
     # This operation will be asynchronous, write might return without writing all the content.

--- a/stdlib/io/src/test/resources/test-src/io/bytes_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/bytes_io.bal
@@ -16,11 +16,10 @@
 
 import ballerina/io;
 
-io:ReadableByteChannel rch = new;
-io:WritableByteChannel wch = new;
+io:ReadableByteChannel? rch = ();
+io:WritableByteChannel? wch = ();
 
 function initReadableChannel(string filePath) returns @tainted io:Error? {
-
     var result = io:openReadableFile(filePath);
     if (result is io:ReadableByteChannel) {
         rch = <@untainted> result;
@@ -34,25 +33,43 @@ function initWritableChannel(string filePath) {
 }
 
 function readBytes(int numberOfBytes) returns @tainted byte[]|io:Error {
-    return rch.read(numberOfBytes);
+    io:ReadableByteChannel? rChannel = rch;
+    if (rChannel is io:ReadableByteChannel) {
+        return rChannel.read(numberOfBytes);
+    } else {
+        io:GenericError e = error(io:GENERIC_ERROR, message = "ReadableByteChannel not initialized");
+        return e;
+    }
 }
 
 function writeBytes(byte[] content, int startOffset) returns int|io:Error {
     int empty = -1;
-    var result = wch.write(content, startOffset);
-    if (result is int) {
-        return result;
+    io:WritableByteChannel? wChannel = wch;
+    if (wChannel is io:WritableByteChannel) {
+        var result = wChannel.write(content, startOffset);
+        if (result is int) {
+            return result;
+        } else {
+            return result;
+        }
     } else {
-        return result;
+       io:GenericError e = error(io:GENERIC_ERROR, message = "WritableByteChannel not initialized");
+       return e;
     }
 }
 
 function closeReadableChannel() {
-    var result = rch.close();
+    io:ReadableByteChannel? rChannel = rch;
+    if rChannel is io:ReadableByteChannel {
+        var result = rChannel.close();
+    }
 }
 
 function closeWritableChannel() {
-    var result = wch.close();
+    io:WritableByteChannel? wChannel = wch;
+    if wChannel is io:WritableByteChannel {
+        var result = wChannel.close();
+    }
 }
 
 function testBase64EncodeByteChannel(io:ReadableByteChannel contentToBeEncoded) returns io:ReadableByteChannel|io:Error {


### PR DESCRIPTION
## Purpose
Current io:ReadableByteChannel and io:WritableByteChannel objects can be initialized from the user code. This channels should not initialize from the user code since create of these should happen in the native level.

Add a module level __init to prevent the user code level channel initialization.

Fixes #22050

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
