### PR TITLE
Fix the Broken How To Guides Links in API Docs

### DIFF
--- a/observelib/observe/src/main/ballerina/src/observe/Module.md
+++ b/observelib/observe/src/main/ballerina/src/observe/Module.md
@@ -5,7 +5,7 @@ Ballerina supports Observability out of the box. This module provides user api's
 
 To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service. 
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit [How to Observe Ballerina Services](https://v1-0.ballerina.io/learn/how-to-observe-ballerina-code/).
+For more information on Ballerina Observability visit [How to Observe Ballerina Services](https://ballerina.io/v1-2/learn/how-to-observe-ballerina-code/).
 
 ## Tracing
 

--- a/stdlib/websub/src/main/ballerina/src/websub/Module.md
+++ b/stdlib/websub/src/main/ballerina/src/websub/Module.md
@@ -508,4 +508,4 @@ service specificSubscriber on new WebhookListener(8080) {
 }
 ```
 
-For a step-by-step guide on introducing custom subscriber services, see the ["Create Webhook Callback Services"](https://ballerina.io/learn/how-to-extend-ballerina/#create-webhook-callback-services) section of "How to Extend Ballerina". 
+For a step-by-step guide on introducing custom subscriber services, see the ["Create Webhook Callback Services"](https://ballerina.io/v1-2/learn/how-to-extend-ballerina/#create-webhook-callback-services) section of "How to Extend Ballerina". 


### PR DESCRIPTION
## Purpose
This is to fix the 2 broken links of the How-To Guides linked from API Docs in [1] and [2].

<img width="1680" alt="Screenshot 2020-03-24 at 10 53 55" src="https://user-images.githubusercontent.com/11707273/77391133-f7b06300-6dbd-11ea-8c08-38d6431aa301.png">

<img width="1679" alt="Screenshot 2020-03-23 at 18 09 48" src="https://user-images.githubusercontent.com/11707273/77391153-0565e880-6dbe-11ea-9b42-6e852e092ba2.png">


[1] https://ballerina.io/v1-2/learn/api-docs/ballerina/websub/index.html
[2] https://ballerina.io/v1-2/learn/api-docs/ballerina/observe/index.html

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
