### PR TITLE
[master] Fix several type-checking issues for langlib functions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -960,31 +960,12 @@ public class ArrayValueImpl extends AbstractArrayValue {
     protected void unshift(long index, ArrayValue vals) {
         handleFrozenArrayValue();
         unshiftArray(index, vals.size(), getCurrentArrayLength());
-        switch (this.elementType.getTag()) {
-            case TypeTags.INT_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
-            case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
-            case TypeTags.UNSIGNED8_INT_TAG:
-                addToIntArray(vals, (int) index);
-                break;
-            case TypeTags.BOOLEAN_TAG:
-                addToBooleanArray(vals, (int) index);
-                break;
-            case TypeTags.BYTE_TAG:
-                addToByteArray(vals, (int) index);
-                break;
-            case TypeTags.FLOAT_TAG:
-                addToFloatArray(vals, (int) index);
-                break;
-            case TypeTags.STRING_TAG:
-            case TypeTags.CHAR_STRING_TAG:
-                addToStringArray(vals, (int) index);
-                break;
-            default:
-                addToRefArray(vals, (int) index);
+
+        int startIndex = (int) index;
+        int endIndex = startIndex + vals.size();
+
+        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
+            add(i, vals.get(j));
         }
     }
 
@@ -1043,48 +1024,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private void resetSize(int index) {
         if (index >= size) {
             size = index + 1;
-        }
-    }
-
-    private void addToIntArray(ArrayValue vals, int startIndex) {
-        int endIndex = startIndex + vals.size();
-        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            add(i, vals.getInt(j));
-        }
-    }
-
-    private void addToFloatArray(ArrayValue vals, int startIndex) {
-        int endIndex = startIndex + vals.size();
-        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            add(i, vals.getFloat(j));
-        }
-    }
-
-    private void addToStringArray(ArrayValue vals, int startIndex) {
-        int endIndex = startIndex + vals.size();
-        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            add(i, vals.getString(j));
-        }
-    }
-
-    private void addToByteArray(ArrayValue vals, int startIndex) {
-        int endIndex = startIndex + vals.size();
-        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            add(i, vals.getByte(j));
-        }
-    }
-
-    private void addToBooleanArray(ArrayValue vals, int startIndex) {
-        int endIndex = startIndex + vals.size();
-        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            add(i, vals.getBoolean(j));
-        }
-    }
-
-    private void addToRefArray(ArrayValue vals, int startIndex) {
-        int endIndex = startIndex + vals.size();
-        for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            add(i, vals.getRefValue(j));
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/ArrayValueImpl.java
@@ -300,7 +300,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (byteValues != null) {
             return byteValues[(int) index];
         }
-        return (Byte) refValues[(int) index];
+        return ((Integer) refValues[(int) index]).byteValue();
     }
 
     /**
@@ -1069,9 +1069,8 @@ public class ArrayValueImpl extends AbstractArrayValue {
 
     private void addToByteArray(ArrayValue vals, int startIndex) {
         int endIndex = startIndex + vals.size();
-        byte[] bytes = vals.getBytes();
         for (int i = startIndex, j = 0; i < endIndex; i++, j++) {
-            this.byteValues[i] = bytes[j];
+            add(i, vals.getByte(j));
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/utils/ArrayUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/utils/ArrayUtils.java
@@ -36,6 +36,7 @@ import static org.ballerinalang.jvm.util.exceptions.BallerinaErrorReasons.getMod
  */
 public class ArrayUtils {
 
+    @Deprecated
     public static void add(ArrayValue arr, int elemTypeTag, long index, Object value) {
         switch (elemTypeTag) {
             case TypeTags.INT_TAG:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3731,7 +3731,9 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         if (vararg != null) {
-            checkTypeParamExpr(vararg, this.env, restParam.type, langlibInvocation);
+            checkTypeParamExpr(vararg.getKind() == NodeKind.REST_ARGS_EXPR ?
+                                       ((BLangRestArgsExpression) vararg).expr.pos : vararg.pos,
+                               vararg, this.env, restParam.type, langlibInvocation);
             restArgExprs.add(vararg);
             return;
         }
@@ -3748,6 +3750,11 @@ public class TypeChecker extends BLangNodeVisitor {
 
     private void checkTypeParamExpr(BLangExpression arg, SymbolEnv env, BType expectedType,
                                     boolean inferTypeForNumericLiteral) {
+        checkTypeParamExpr(arg.pos, arg, env, expectedType, inferTypeForNumericLiteral);
+    }
+
+    private void checkTypeParamExpr(DiagnosticPos pos, BLangExpression arg, SymbolEnv env, BType expectedType,
+                                    boolean inferTypeForNumericLiteral) {
 
         if (typeParamAnalyzer.notRequireTypeParams(env)) {
             checkExpr(arg, env, expectedType);
@@ -3757,11 +3764,11 @@ public class TypeChecker extends BLangNodeVisitor {
             // Need to infer the type. Calculate matching bound type, with no type.
             BType expType = typeParamAnalyzer.getMatchingBoundType(expectedType, env);
             BType inferredType = checkExpr(arg, env, expType);
-            typeParamAnalyzer.checkForTypeParamsInArg(inferredType, this.env, expectedType);
+            typeParamAnalyzer.checkForTypeParamsInArg(pos, inferredType, this.env, expectedType);
             return;
         }
         checkExpr(arg, env, expectedType);
-        typeParamAnalyzer.checkForTypeParamsInArg(arg.type, this.env, expectedType);
+        typeParamAnalyzer.checkForTypeParamsInArg(pos, arg.type, this.env, expectedType);
     }
 
     private boolean requireTypeInference(BLangExpression expr, boolean inferTypeForNumericLiteral) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3742,17 +3742,18 @@ public class TypeChecker extends BLangNodeVisitor {
 
         BType restType = ((BArrayType) restParam.type).eType;
         for (BLangExpression arg : restArgExprs) {
-            checkTypeParamExpr(arg, this.env, restType, langlibInvocation);
+            checkTypeParamExpr(arg, this.env, restType, true);
         }
     }
 
-    private void checkTypeParamExpr(BLangExpression arg, SymbolEnv env, BType expectedType, boolean langlibInvocation) {
+    private void checkTypeParamExpr(BLangExpression arg, SymbolEnv env, BType expectedType,
+                                    boolean inferTypeForNumericLiteral) {
 
         if (typeParamAnalyzer.notRequireTypeParams(env)) {
             checkExpr(arg, env, expectedType);
             return;
         }
-        if (requireTypeInference(arg, langlibInvocation)) {
+        if (requireTypeInference(arg, inferTypeForNumericLiteral)) {
             // Need to infer the type. Calculate matching bound type, with no type.
             BType expType = typeParamAnalyzer.getMatchingBoundType(expectedType, env);
             BType inferredType = checkExpr(arg, env, expType);
@@ -3763,17 +3764,17 @@ public class TypeChecker extends BLangNodeVisitor {
         typeParamAnalyzer.checkForTypeParamsInArg(arg.type, this.env, expectedType);
     }
 
-    private boolean requireTypeInference(BLangExpression expr, boolean langlibInvocation) {
+    private boolean requireTypeInference(BLangExpression expr, boolean inferTypeForNumericLiteral) {
 
         switch (expr.getKind()) {
             case GROUP_EXPR:
-                return requireTypeInference(((BLangGroupExpr) expr).expression, langlibInvocation);
+                return requireTypeInference(((BLangGroupExpr) expr).expression, inferTypeForNumericLiteral);
             case ARROW_EXPR:
             case LIST_CONSTRUCTOR_EXPR:
             case RECORD_LITERAL_EXPR:
                 return true;
             case NUMERIC_LITERAL:
-                return langlibInvocation;
+                return inferTypeForNumericLiteral;
             default:
                 return false;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -50,6 +50,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLogHelper;
+import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -115,7 +116,7 @@ public class TypeParamAnalyzer {
         return containsTypeParam(type, new HashSet<>());
     }
 
-    void checkForTypeParamsInArg(BType actualType, SymbolEnv env, BType expType) {
+    void checkForTypeParamsInArg(DiagnosticPos pos, BType actualType, SymbolEnv env, BType expType) {
 
         // Not a langlib module invocation
         if (notRequireTypeParams(env)) {
@@ -123,7 +124,7 @@ public class TypeParamAnalyzer {
         }
 
         FindTypeParamResult findTypeParamResult = new FindTypeParamResult();
-        findTypeParam(expType, actualType, env, new HashSet<>(), findTypeParamResult);
+        findTypeParam(pos, expType, actualType, env, new HashSet<>(), findTypeParamResult);
     }
 
     boolean notRequireTypeParams(SymbolEnv env) {
@@ -260,13 +261,13 @@ public class TypeParamAnalyzer {
         return type;
     }
 
-    private void findTypeParam(BType expType, BType actualType, SymbolEnv env, HashSet<BType> resolvedTypes,
-                               FindTypeParamResult result) {
-        findTypeParam(expType, actualType, env, resolvedTypes, result, false);
+    private void findTypeParam(DiagnosticPos pos, BType expType, BType actualType, SymbolEnv env,
+                               HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+        findTypeParam(pos, expType, actualType, env, resolvedTypes, result, false);
     }
 
-    private void findTypeParam(BType expType, BType actualType, SymbolEnv env, HashSet<BType> resolvedTypes,
-                               FindTypeParamResult result, boolean checkContravariance) {
+    private void findTypeParam(DiagnosticPos pos, BType expType, BType actualType, SymbolEnv env,
+                               HashSet<BType> resolvedTypes, FindTypeParamResult result, boolean checkContravariance) {
 
         if (resolvedTypes.contains(expType)) {
             return;
@@ -274,15 +275,15 @@ public class TypeParamAnalyzer {
         resolvedTypes.add(expType);
         // Finding TypePram and its bound type require, both has to be same structure.
         if (isTypeParam(expType)) {
-            updateTypeParamAndBoundType(env, expType, actualType, result);
+            updateTypeParamAndBoundType(pos, env, expType, actualType);
 
             // If type param discovered before, now type check with actual type. It has to be matched.
 
             if (checkContravariance) {
-                types.checkType(env.node.pos, getMatchingBoundType(expType, env, new HashSet<>()), actualType,
+                types.checkType(pos, getMatchingBoundType(expType, env, new HashSet<>()), actualType,
                                 DiagnosticCode.INCOMPATIBLE_TYPES);
             } else {
-                types.checkType(env.node.pos, actualType, getMatchingBoundType(expType, env, new HashSet<>()),
+                types.checkType(pos, actualType, getMatchingBoundType(expType, env, new HashSet<>()),
                                 DiagnosticCode.INCOMPATIBLE_TYPES);
             }
             return;
@@ -291,119 +292,122 @@ public class TypeParamAnalyzer {
         switch (expType.tag) {
             case TypeTags.ARRAY:
                 if (actualType.tag == TypeTags.ARRAY) {
-                    findTypeParam(((BArrayType) expType).eType, ((BArrayType) actualType).eType, env,
-                            resolvedTypes, result);
+                    findTypeParam(pos, ((BArrayType) expType).eType, ((BArrayType) actualType).eType, env,
+                                  resolvedTypes, result);
                 }
                 if (actualType.tag == TypeTags.TUPLE) {
-                    findTypeParamInTupleForArray((BArrayType) expType, (BTupleType) actualType, env, resolvedTypes,
+                    findTypeParamInTupleForArray(pos, (BArrayType) expType, (BTupleType) actualType, env, resolvedTypes,
                                                  result);
                 }
                 return;
             case TypeTags.TABLE:
                 if (actualType.tag == TypeTags.TABLE) {
-                    findTypeParam(((BTableType) expType).constraint, ((BTableType) actualType).constraint, env,
-                            resolvedTypes, result);
+                    findTypeParam(pos, ((BTableType) expType).constraint, ((BTableType) actualType).constraint, env,
+                                  resolvedTypes, result);
                 }
                 return;
             case TypeTags.MAP:
                 if (actualType.tag == TypeTags.MAP) {
-                    findTypeParam(((BMapType) expType).constraint, ((BMapType) actualType).constraint, env,
-                            resolvedTypes, result);
+                    findTypeParam(pos, ((BMapType) expType).constraint, ((BMapType) actualType).constraint, env,
+                                  resolvedTypes, result);
                 }
                 if (actualType.tag == TypeTags.RECORD) {
-                    findTypeParamInMapForRecord((BMapType) expType, (BRecordType) actualType, env, resolvedTypes,
+                    findTypeParamInMapForRecord(pos, (BMapType) expType, (BRecordType) actualType, env, resolvedTypes,
                                                 result);
                 }
                 return;
             case TypeTags.STREAM:
                 if (actualType.tag == TypeTags.STREAM) {
-                    findTypeParamInStream(((BStreamType) expType), ((BStreamType) actualType), env, resolvedTypes,
-                            result);
+                    findTypeParamInStream(pos, ((BStreamType) expType), ((BStreamType) actualType), env, resolvedTypes,
+                                          result);
                 }
                 return;
             case TypeTags.TUPLE:
                 if (actualType.tag == TypeTags.TUPLE) {
-                    findTypeParamInTuple((BTupleType) expType, (BTupleType) actualType, env, resolvedTypes, result);
+                    findTypeParamInTuple(pos, (BTupleType) expType, (BTupleType) actualType, env, resolvedTypes,
+                                         result);
                 }
                 return;
             case TypeTags.RECORD:
                 if (actualType.tag == TypeTags.RECORD) {
-                    findTypeParamInRecord((BRecordType) expType, (BRecordType) actualType, env, resolvedTypes, result);
+                    findTypeParamInRecord(pos, (BRecordType) expType, (BRecordType) actualType, env, resolvedTypes,
+                                          result);
                 }
                 return;
             case TypeTags.INVOKABLE:
                 if (actualType.tag == TypeTags.INVOKABLE) {
-                    findTypeParamInInvokableType((BInvokableType) expType, (BInvokableType) actualType, env,
-                            resolvedTypes, result);
+                    findTypeParamInInvokableType(pos, (BInvokableType) expType, (BInvokableType) actualType, env,
+                                                 resolvedTypes, result);
                 }
                 return;
             case TypeTags.OBJECT:
                 if (actualType.tag == TypeTags.OBJECT && !(actualType instanceof BServiceType)) {
-                    findTypeParamInObject((BObjectType) expType, (BObjectType) actualType, env, resolvedTypes, result);
+                    findTypeParamInObject(pos, (BObjectType) expType, (BObjectType) actualType, env, resolvedTypes,
+                                          result);
                 }
                 return;
             case TypeTags.UNION:
                 if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnion((BUnionType) expType, (BUnionType) actualType, env, resolvedTypes, result);
+                    findTypeParamInUnion(pos, (BUnionType) expType, (BUnionType) actualType, env, resolvedTypes,
+                                         result);
                 }
                 return;
             case TypeTags.ERROR:
                 if (actualType.tag == TypeTags.ERROR) {
-                    findTypeParamInError((BErrorType) expType, (BErrorType) actualType, env, resolvedTypes, result);
+                    findTypeParamInError(pos, (BErrorType) expType, (BErrorType) actualType, env, resolvedTypes,
+                                         result);
                 }
                 if (actualType.tag == TypeTags.UNION && types.isSubTypeOfBaseType(actualType, TypeTags.ERROR)) {
-                    findTypeParamInError((BErrorType) expType, symTable.errorType, env, resolvedTypes, result);
+                    findTypeParamInError(pos, (BErrorType) expType, symTable.errorType, env, resolvedTypes, result);
                 }
                 return;
             case TypeTags.TYPEDESC:
                 if (actualType.tag == TypeTags.TYPEDESC) {
-                    findTypeParam(((BTypedescType) expType).constraint, ((BTypedescType) actualType).constraint, env,
-                            resolvedTypes, result);
+                    findTypeParam(pos, ((BTypedescType) expType).constraint, ((BTypedescType) actualType).constraint,
+                                  env, resolvedTypes, result);
                 }
-                return;
         }
     }
 
-    private void updateTypeParamAndBoundType(SymbolEnv env, BType typeParamType, BType boundType,
-                                             FindTypeParamResult result) {
+    private void updateTypeParamAndBoundType(DiagnosticPos pos, SymbolEnv env, BType typeParamType, BType boundType) {
 
         if (env.typeParamsEntries.stream()
                 .noneMatch(entry -> entry.typeParam.tsymbol.pkgID.equals(typeParamType.tsymbol.pkgID)
                         && entry.typeParam.tsymbol.name.equals(typeParamType.tsymbol.name))) {
             if (boundType == symTable.noType) {
-                dlog.error(env.node.pos, DiagnosticCode.CANNOT_INFER_TYPE);
+                dlog.error(pos, DiagnosticCode.CANNOT_INFER_TYPE);
                 return;
             }
             env.typeParamsEntries.add(new SymbolEnv.TypeParamEntry(typeParamType, boundType));
         }
     }
 
-    private void findTypeParamInTuple(BTupleType expType, BTupleType actualType, SymbolEnv env,
+    private void findTypeParamInTuple(DiagnosticPos pos, BTupleType expType, BTupleType actualType, SymbolEnv env,
                                       HashSet<BType> resolvedTypes, FindTypeParamResult result) {
 
         for (int i = 0; i < expType.tupleTypes.size() && i < actualType.tupleTypes.size(); i++) {
-            findTypeParam(expType.tupleTypes.get(i), actualType.tupleTypes.get(i), env, resolvedTypes, result);
+            findTypeParam(pos, expType.tupleTypes.get(i), actualType.tupleTypes.get(i), env, resolvedTypes, result);
         }
     }
 
-    private void findTypeParamInStream(BStreamType expType, BStreamType actualType, SymbolEnv env,
+    private void findTypeParamInStream(DiagnosticPos pos, BStreamType expType, BStreamType actualType, SymbolEnv env,
                                        HashSet<BType> resolvedTypes, FindTypeParamResult result) {
-        findTypeParam(expType.constraint, actualType.constraint, env, resolvedTypes, result);
-        findTypeParam(expType.error, (actualType.error != null) ? actualType.error : symTable.nilType,
-                env, resolvedTypes, result);
+        findTypeParam(pos, expType.constraint, actualType.constraint, env, resolvedTypes, result);
+        findTypeParam(pos, expType.error, (actualType.error != null) ? actualType.error : symTable.nilType, env,
+                      resolvedTypes, result);
     }
 
-    private void findTypeParamInTupleForArray(BArrayType expType, BTupleType actualType, SymbolEnv env,
-                                              HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+    private void findTypeParamInTupleForArray(DiagnosticPos pos, BArrayType expType, BTupleType actualType,
+                                              SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
         LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>(actualType.tupleTypes);
         if (actualType.restType != null) {
             tupleTypes.add(actualType.restType);
         }
         BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
-        findTypeParam(expType.eType, tupleElementType, env, resolvedTypes, result);
+        findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
     }
 
-    private void findTypeParamInRecord(BRecordType expType, BRecordType actualType, SymbolEnv env,
+    private void findTypeParamInRecord(DiagnosticPos pos, BRecordType expType, BRecordType actualType, SymbolEnv env,
                                        HashSet<BType> resolvedTypes, FindTypeParamResult result) {
 
         for (BField exField : expType.fields) {
@@ -415,11 +419,11 @@ public class TypeParamAnalyzer {
                 // This is an error, which is logged already.
                 continue;
             }
-            findTypeParam(exField.type, actualFieldType, env, resolvedTypes, result);
+            findTypeParam(pos, exField.type, actualFieldType, env, resolvedTypes, result);
         }
     }
 
-    private void findTypeParamInMapForRecord(BMapType expType, BRecordType actualType, SymbolEnv env,
+    private void findTypeParamInMapForRecord(DiagnosticPos pos, BMapType expType, BRecordType actualType, SymbolEnv env,
                                              HashSet<BType> resolvedTypes, FindTypeParamResult result) {
         LinkedHashSet<BType> fields = actualType.fields.stream().map(f -> f.type)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -446,19 +450,20 @@ public class TypeParamAnalyzer {
             commonFieldType = BUnionType.create(null, reducedTypeSet);
         }
 
-        findTypeParam(expType.constraint, commonFieldType, env, resolvedTypes, result);
+        findTypeParam(pos, expType.constraint, commonFieldType, env, resolvedTypes, result);
     }
 
-    private void findTypeParamInInvokableType(BInvokableType expType, BInvokableType actualType, SymbolEnv env,
-                                              HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+    private void findTypeParamInInvokableType(DiagnosticPos pos, BInvokableType expType, BInvokableType actualType,
+                                              SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
 
         for (int i = 0; i < expType.paramTypes.size() && i < actualType.paramTypes.size(); i++) {
-            findTypeParam(expType.paramTypes.get(i), actualType.paramTypes.get(i), env, resolvedTypes, result, true);
+            findTypeParam(pos, expType.paramTypes.get(i), actualType.paramTypes.get(i), env, resolvedTypes, result,
+                          true);
         }
-        findTypeParam(expType.retType, actualType.retType, env, resolvedTypes, result);
+        findTypeParam(pos, expType.retType, actualType.retType, env, resolvedTypes, result);
     }
 
-    private void findTypeParamInObject(BObjectType expType, BObjectType actualType, SymbolEnv env,
+    private void findTypeParamInObject(DiagnosticPos pos, BObjectType expType, BObjectType actualType, SymbolEnv env,
                                        HashSet<BType> resolvedTypes, FindTypeParamResult result) {
 
         // Not needed now.
@@ -471,7 +476,7 @@ public class TypeParamAnalyzer {
                 // This is an error, which is logged already.
                 continue;
             }
-            findTypeParam(exField.type, actualFieldType, env, resolvedTypes, result);
+            findTypeParam(pos, exField.type, actualFieldType, env, resolvedTypes, result);
         }
         List<BAttachedFunction> expAttFunctions = ((BObjectTypeSymbol) expType.tsymbol).attachedFuncs;
         List<BAttachedFunction> actualAttFunctions = ((BObjectTypeSymbol) actualType.tsymbol).attachedFuncs;
@@ -484,11 +489,11 @@ public class TypeParamAnalyzer {
             if (actFuncType == null) {
                 continue;
             }
-            findTypeParamInInvokableType(expFunc.type, actFuncType, env, resolvedTypes, result);
+            findTypeParamInInvokableType(pos, expFunc.type, actFuncType, env, resolvedTypes, result);
         }
     }
 
-    private void findTypeParamInUnion(BUnionType expType, BUnionType actualType, SymbolEnv env,
+    private void findTypeParamInUnion(DiagnosticPos pos, BUnionType expType, BUnionType actualType, SymbolEnv env,
                                       HashSet<BType> resolvedTypes, FindTypeParamResult result) {
         // Limitation : supports only optional types and depends to given order.
         if ((expType.getMemberTypes().size() != 2) || !expType.isNullable()
@@ -499,17 +504,17 @@ public class TypeParamAnalyzer {
                 .filter(type -> type != symTable.nilType).findFirst().orElse(symTable.nilType);
         BType act = actualType.getMemberTypes().stream()
                 .filter(type -> type != symTable.nilType).findFirst().orElse(symTable.nilType);
-        findTypeParam(exp, act, env, resolvedTypes, result);
+        findTypeParam(pos, exp, act, env, resolvedTypes, result);
     }
 
-    private void findTypeParamInError(BErrorType expType, BErrorType actualType, SymbolEnv env,
+    private void findTypeParamInError(DiagnosticPos pos, BErrorType expType, BErrorType actualType, SymbolEnv env,
                                       HashSet<BType> resolvedTypes, FindTypeParamResult result) {
 
         if (expType == symTable.errorType) {
             return;
         }
-        findTypeParam(expType.detailType, actualType.detailType, env, resolvedTypes, result);
-        findTypeParam(expType.reasonType, actualType.reasonType, env, resolvedTypes, result);
+        findTypeParam(pos, expType.detailType, actualType.detailType, env, resolvedTypes, result);
+        findTypeParam(pos, expType.reasonType, actualType.reasonType, env, resolvedTypes, result);
     }
 
     private BType getMatchingBoundType(BType expType, SymbolEnv env, HashSet<BType> resolvedTypes) {

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
@@ -28,8 +28,6 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 
-import static org.ballerinalang.jvm.values.utils.ArrayUtils.add;
-
 /**
  * Native implementation of lang.array:filter(Type[], function).
  *
@@ -52,7 +50,7 @@ public class Filter {
         for (int i = 0, j = 0; i < size; i++) {
             val = arr.get(i);
             if (func.apply(new Object[]{strand, arr.get(i), true})) {
-                add(newArr, elemTypeTag, j++, val);
+                newArr.add(j++, val);
             }
         }
 

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
@@ -32,7 +32,6 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 
-import static org.ballerinalang.jvm.values.utils.ArrayUtils.add;
 import static org.ballerinalang.jvm.values.utils.ArrayUtils.createOpNotSupportedError;
 
 /**
@@ -54,17 +53,14 @@ public class Map {
         ArrayValue retArr = new ArrayValueImpl((BArrayType) retArrType);
         int size = arr.size();
         GetFunction getFn;
-        int elemTypeTag;
 
         BType arrType = arr.getType();
         switch (arrType.getTag()) {
             case TypeTags.ARRAY_TAG:
                 getFn = ArrayValue::get;
-                elemTypeTag = elemType.getTag();
                 break;
             case TypeTags.TUPLE_TAG:
                 getFn = ArrayValue::getRefValue;
-                elemTypeTag = elemType.getTag();
                 break;
             default:
                 throw createOpNotSupportedError(arrType, "map()");
@@ -72,7 +68,7 @@ public class Map {
 
         for (int i = 0; i < size; i++) {
             Object newVal = func.getFunction().apply(new Object[]{strand, getFn.get(arr, i), true});
-            add(retArr, elemTypeTag, i, newVal);
+            retArr.add(i, newVal);
         }
 
         return retArr;

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Push.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Push.java
@@ -27,7 +27,6 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 
-import static org.ballerinalang.jvm.values.utils.ArrayUtils.add;
 import static org.ballerinalang.jvm.values.utils.ArrayUtils.createOpNotSupportedError;
 
 /**
@@ -48,14 +47,9 @@ public class Push {
         int nVals = vals.size();
         switch (arrType.getTag()) {
             case TypeTags.ARRAY_TAG:
-                int elemTypeTag = arr.getElementType().getTag();
-                for (int i = arr.size(), j = 0; j < nVals; i++, j++) {
-                    add(arr, elemTypeTag, i, vals.get(j));
-                }
-                break;
             case TypeTags.TUPLE_TAG:
                 for (int i = arr.size(), j = 0; j < nVals; i++, j++) {
-                    add(arr, TypeTags.ANY_TAG, i, vals.get(j));
+                    arr.add(i, vals.get(j));
                 }
                 break;
             default:

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reverse.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reverse.java
@@ -27,8 +27,6 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 
-import static org.ballerinalang.jvm.values.utils.ArrayUtils.add;
-
 /**
  * Native implementation of lang.array:reverse((any|error)[]).
  *
@@ -48,7 +46,7 @@ public class Reverse {
         int size = arr.size();
 
         for (int i = size - 1, j = 0; i >= 0; i--, j++) {
-            add(reversedArr, elemTypeTag, j, arr.get(i));
+            reversedArr.add(j, arr.get(i));
         }
 
         return reversedArr;

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
@@ -33,7 +33,6 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 
-import static org.ballerinalang.jvm.values.utils.ArrayUtils.add;
 import static org.ballerinalang.jvm.values.utils.ArrayUtils.createOpNotSupportedError;
 
 /**
@@ -85,7 +84,7 @@ public class Slice {
                 elemTypeTag = -1; // To ensure additions go to ref value array in ArrayValue
 
                 for (long i = startIndex, j = 0; i < endIndex; i++, j++) {
-                    add(slicedArr, elemTypeTag, j, arr.getRefValue(i));
+                    slicedArr.add(j, arr.getRefValue(i));
                 }
                 break;
             default:

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Sort.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Sort.java
@@ -28,7 +28,6 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
 
-import static org.ballerinalang.jvm.values.utils.ArrayUtils.add;
 import static org.ballerinalang.jvm.values.utils.ArrayUtils.checkIsArrayOnlyOperation;
 
 /**
@@ -71,18 +70,18 @@ public class Sort {
         int elemTypeTag = input.getElementType().getTag();
 
         for (int i = lo; i <= hi; i++) {
-            add(aux, elemTypeTag, i, input.get(i));
+            aux.add(i, input.get(i));
         }
 
         for (int i = lo, j = mid + 1, k = lo; k <= hi; k++) {
             if (i > mid) {
-                add(input, elemTypeTag, k, aux.get(j++));
+                input.add(k, aux.get(j++));
             } else if (j > hi) {
-                add(input, elemTypeTag, k, aux.get(i++));
+                input.add(k, aux.get(i++));
             } else if (comparator.apply(new Object[]{strand, aux.get(j), true, aux.get(i), true}) < 0) {
-                add(input, elemTypeTag, k, aux.get(j++));
+                input.add(k, aux.get(j++));
             } else {
-                add(input, elemTypeTag, k, aux.get(i++));
+                input.add(k, aux.get(i++));
             }
         }
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -330,9 +330,8 @@ public class LangLibArrayTest {
     }
 
     @Test
-    public void testBytePush() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "testBytePush");
-        Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    public void testPush() {
+        BRunUtil.invoke(compileResult, "testPush");
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -67,6 +67,13 @@ public class TypeParamTest {
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'int', found 'float'", 119, 21);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 122, 31);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 125, 26);
+
+        // Disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/22137
+        // BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'int'", 130,
+        // 14);
+        // BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'float'", 131,
+        //                           24);
+
         Assert.assertEquals(result.getErrorCount(), err);
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -39,21 +39,34 @@ public class TypeParamTest {
 
         CompileResult result = BCompileUtil.compile("test-src/type-param/type_param_test_negative.bal");
         int err = 0;
-        BAssertUtil.validateError(result, err++, "incompatible types: expected 'boolean[]', found 'int[]'", 20, 20);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'boolean[]', found 'int[]'", 21, 20);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'anydata', found 'function (string) " +
-                "returns ()[]'", 24, 18);
+                "returns ()[]'", 25, 18);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'float[]', found 'function (string) " +
-                "returns ()[]'", 24, 18);
-        BAssertUtil.validateError(result, err++, "incompatible types: expected 'float', found 'string'", 30, 16);
+                "returns ()[]'", 25, 18);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'float', found 'string'", 31, 16);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'object { public function next () " +
                 "returns (record {| string value; |}?); }', found 'object { public function next () returns " +
-                "(record {| record {| string x; anydata...; |} value; |}?); }'", 37, 12);
-        BAssertUtil.validateError(result, err++, "incompatible types: expected 'boolean', found 'Foo'", 47, 18);
-        BAssertUtil.validateError(result, err++, "incompatible types: expected 'Bar', found 'Foo'", 50, 14);
-        BAssertUtil.validateError(result, err++, "incompatible types: expected 'boolean', found 'BarDetail'", 64, 18);
-        BAssertUtil.validateError(result, err++, "incompatible types: expected 'string', found 'int'", 69, 16);
+                "(record {| record {| string x; anydata...; |} value; |}?); }'", 38, 12);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'boolean', found 'Foo'", 48, 18);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'Bar', found 'Foo'", 51, 14);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'boolean', found 'BarDetail'", 65, 18);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'string', found 'int'", 72, 15);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'string', found '(Person|error)'",
-                88, 16);
+                89, 16);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 94, 15);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 95, 22);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 97, 25);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 99, 18);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 100, 18);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 100, 22);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 101, 28);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 110, 22);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'int', found 'float'", 113, 21);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 116, 21);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'int', found 'float'", 119, 21);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 122, 31);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 125, 26);
         Assert.assertEquals(result.getErrorCount(), err);
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -66,6 +66,17 @@ public class TypeParamTest {
         BRunUtil.invoke(result, "testMapFunctionInfer");
     }
 
+    @Test(description = "Tests for the bound type as the contextually expected type for arguments")
+    public void testBoundTypeAsCET() {
+
+        CompileResult result = BCompileUtil.compile("test-src/type-param/type_param_bound_type_as_cet.bal");
+        Assert.assertEquals(result.getErrorCount(), 0);
+        BRunUtil.invoke(result, "testBoundRestParamAsCET");
+        BRunUtil.invoke(result, "testIntLiteralAsByte");
+        BRunUtil.invoke(result, "testIntAndFloatLiteralAsDecimal");
+        BRunUtil.invoke(result, "testBroadTypeAsCET");
+    }
+
     @Test
     public void testLangLibImports() {
 

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -301,13 +301,6 @@ function testRemoveAllFixedLengthArray() returns int[] {
     return ar;
 }
 
-function testBytePush() returns boolean {
-    byte[] arr = [1, 2];
-    byte b = 255;
-    arr.push(b);
-    return arr.length() == 3 && arr[2] == <byte> 255;
-}
-
 function testTupleResize() returns [int, string] {
     [int, string] t = [1, "hello"];
     t.setLength(3);
@@ -365,4 +358,186 @@ function testSort2() returns int[] {
     });
 
     return sorted;
+}
+
+function testPush() {
+    testBooleanPush();
+    testBytePush();
+    testUnionArrayPush();
+    testPushOnUnionOfSameBasicType();
+    testInvalidPushOnUnionOfSameBasicType();
+}
+
+function testBooleanPush() {
+    boolean[] arr = [false, true];
+    boolean b = false;
+
+    boolean[] moreBooleans = [true, true];
+
+    arr.push(b);
+    arr.push(false, false);
+    arr.push(...moreBooleans);
+
+    array:push(arr, true);
+    array:push(arr, true, false);
+    array:push(arr, ...moreBooleans);
+
+    assertValueEquality(12, arr.length());
+
+    assertFalse(arr[0]);
+    assertTrue(arr[1]);
+    assertFalse(arr[2]);
+    assertFalse(arr[3]);
+    assertFalse(arr[4]);
+    assertTrue(arr[5]);
+    assertTrue(arr[6]);
+    assertTrue(arr[7]);
+    assertTrue(arr[8]);
+    assertFalse(arr[9]);
+    assertTrue(arr[10]);
+    assertTrue(arr[11]);
+}
+
+function testBytePush() {
+    byte[] arr = [1, 2];
+    byte b = 3;
+
+    byte[] moreBytes = [0, 3, 254];
+
+    arr.push(b);
+    arr.push(255, 254);
+    arr.push(...moreBytes);
+
+    array:push(arr, 65);
+    array:push(arr, 66, 67);
+    array:push(arr, ...moreBytes);
+
+    assertValueEquality(14, arr.length());
+
+    assertValueEquality(1, arr[0]);
+    assertValueEquality(2, arr[1]);
+    assertValueEquality(3, arr[2]);
+    assertValueEquality(<byte> 255, arr[3]);
+    assertValueEquality(254, arr[4]);
+    assertValueEquality(0, arr[5]);
+    assertValueEquality(3, arr[6]);
+    assertValueEquality(254, arr[7]);
+    assertValueEquality(65, arr[8]);
+    assertValueEquality(66, arr[9]);
+    assertValueEquality(67, arr[10]);
+    assertValueEquality(0, arr[11]);
+    assertValueEquality(3, arr[12]);
+    assertValueEquality(254, arr[13]);
+}
+
+function testUnionArrayPush() {
+    (Foo|Bar)[] arr = [{s: "a"}];
+
+    arr.push({s: "b"}, {i: 1});
+
+    (Foo|Bar)[] more = [{i: 2}, {s: "c"}];
+    array:push(arr, ...more);
+
+    assertValueEquality(5, arr.length());
+
+    Foo|Bar val = arr[0];
+    assertTrue(val is Foo && val.s == "a");
+
+    val = arr[1];
+    assertTrue(val is Foo && val.s == "b");
+
+    val = arr[2];
+    assertTrue(val is Bar && val.i == 1);
+
+    val = arr[3];
+    assertTrue(val is Bar && val.i == 2);
+
+    val = arr[4];
+    assertTrue(val is Foo && val.s == "c");
+}
+
+type Foo record {
+    string s;
+};
+
+type Bar record{
+    int i;
+};
+
+function testPushOnUnionOfSameBasicType() {
+    int[2]|int[] arr = [1, 7, 3];
+    arr.push(99);
+    'array:push(arr, 100, 101);
+
+    int[] moreInts = [999, 998];
+    arr.push(...moreInts);
+    'array:push(arr, ...moreInts);
+
+    assertValueEquality(10, arr.length());
+
+    assertValueEquality(1, arr[0]);
+    assertValueEquality(7, arr[1]);
+    assertValueEquality(3, arr[2]);
+    assertValueEquality(99, arr[3]);
+    assertValueEquality(100, arr[4]);
+    assertValueEquality(101, arr[5]);
+    assertValueEquality(999, arr[6]);
+    assertValueEquality(998, arr[7]);
+    assertValueEquality(999, arr[8]);
+    assertValueEquality(998, arr[9]);
+}
+
+function testInvalidPushOnUnionOfSameBasicType() {
+    int[]|string[] arr = [1, 2];
+
+    var fn = function () {
+        arr.push("foo");
+    };
+
+    error? res = trap fn();
+    assertTrue(res is error);
+
+    error err = <error> res;
+    assertValueEquality("{ballerina/lang.array}InherentTypeViolation", err.reason());
+    assertValueEquality("incompatible types: expected 'int', found 'string'", err.detail()?.message);
+
+    fn = function () {
+        arr.unshift("foo");
+    };
+
+    res = trap fn();
+    assertTrue(res is error);
+
+    err = <error> res;
+    assertValueEquality("{ballerina/lang.array}InherentTypeViolation", err.reason());
+    assertValueEquality("incompatible types: expected 'int', found 'string'", err.detail()?.message);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertTrue(any|error actual) {
+    if actual is boolean && actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected 'true', found '" + actual.toString () + "'");
+}
+
+function assertFalse(any|error actual) {
+    if actual is boolean && !actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected 'false', found '" + actual.toString () + "'");
+}
+
+function assertValueEquality(anydata|error expected, anydata|error actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
@@ -1,0 +1,186 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.array;
+
+function testBoundRestParamAsCET() {
+    testNumericTypeAsBoundRestParam();
+    testStructedTypeAsBoundRestParam();
+}
+
+function testNumericTypeAsBoundRestParam() {
+    byte[] bytes = [];
+    bytes.push(0);
+    bytes.push(1, 2);
+
+    byte[] arr = [3, 4];
+    bytes.push(...arr);
+
+    array:unshift(bytes, 255);
+    array:unshift(bytes, 254, 253);
+
+    byte[] arr2 = [252, 251];
+    array:unshift(bytes, ...arr2);
+
+    assertValueEquality(10, bytes.length());
+
+    assertValueEquality(252, bytes[0]);
+    assertValueEquality(251, bytes[1]);
+    assertValueEquality(254, bytes[2]);
+    assertValueEquality(253, bytes[3]);
+    assertValueEquality(255, bytes[4]);
+    assertValueEquality(0, bytes[5]);
+    assertValueEquality(1, bytes[6]);
+    assertValueEquality(2, bytes[7]);
+    assertValueEquality(3, bytes[8]);
+    assertValueEquality(4, bytes[9]);
+}
+
+function testStructedTypeAsBoundRestParam() {
+    [function() returns int, string][] funcs = [];
+    funcs.push([function () returns int => 1, "a"]);
+    funcs.push([function () returns int => 2, "b"], [function () returns int => 3, "c"]);
+
+    [function() returns int, string][] arr = [[function () returns int => 4, "d"], [function () returns int => 5, "e"]];
+    funcs.push(...arr);
+
+    array:push(funcs, [function () returns int => 6, "f"]);
+    array:push(funcs, [function () returns int => 7, "g"], [function () returns int => 8, "h"]);
+
+    [function() returns int, string][] arr2 = [[function () returns int => 9, "i"], 
+                                               [function () returns int => 10, "j"]];
+    array:push(funcs, ...arr2);
+
+    assertValueEquality(10, funcs.length());
+
+    int sum = 0;
+    string concat = "";
+
+    foreach [function() returns int, string] [func, str] in funcs {
+        sum += func();
+        concat += str;
+    }
+
+    assertValueEquality(55, sum);
+    assertValueEquality("abcdefghij", concat);
+}
+
+function testIntLiteralAsByte() {
+    byte[] b = [0, 1, 2, 100, 101, 255];
+    b.push(4);
+
+    assertValueEquality(0, b.indexOf(0));
+    assertValueEquality(5, b.indexOf(255));
+    assertValueEquality(3, b.indexOf(100));
+    assertValueEquality(6, b.indexOf(4));
+    assertValueEquality((), b.indexOf(102));
+
+    map<byte> m = {
+        a: 3,
+        b: 5,
+        c: 1
+    };
+
+    int f = m.reduce(function (byte x, byte y) returns byte {
+                         int res = x * y;
+                         return <byte> res;
+                     }, 2);
+    assertValueEquality(30, f);
+}
+
+function testIntAndFloatLiteralAsDecimal() {
+    decimal[] d = [0, 1.0, 2, 10.01, 101, 2550.1d];
+    d.push(4);
+    d.push(23.2);
+
+    assertValueEquality(0, d.indexOf(0));
+    assertValueEquality(1, d.indexOf(1));
+    assertValueEquality(5, d.indexOf(2550.1));
+    assertValueEquality(7, d.indexOf(23.2));
+    assertValueEquality((), d.indexOf(10.2));
+
+    map<decimal> m = {
+        a: 30,
+        b: 500.1,
+        c: 1.01d
+    };
+
+    float f = m.reduce(function (float x, decimal y) returns float {
+                           int xi = <int> x;
+                           int yi = <int> y;
+                           return <float> (xi + yi);
+                       }, 2);
+    assertValueEquality(533.0, f);
+}
+
+function testBroadTypeAsCET() {
+    any[] arr = [];
+
+    arr.push("foo");
+    arr.push([1, "bar", 2.0]);
+    arr.push({a: "abc", b: 1, c: true});
+
+    assertValueEquality(3, arr.length());
+
+    assertTrue(arr[0] is string);
+    assertValueEquality("foo", <string> arr[0]);
+
+    assertTrue(arr[1] is any[]);
+
+    any[] anyArr = <any[]> arr[1];
+
+    any val = anyArr[0];
+    assertTrue(val is int && val == 1);
+
+    val = anyArr[1];
+    assertTrue(val is string && val == "bar");
+
+    val = anyArr[2];
+    assertTrue(val is float && val == 2.0);
+
+    assertTrue(arr[2] is map<any>);
+
+    map<any> anyMap = <map<any>> arr[2];
+
+    val = anyMap["a"];
+    assertTrue(val is string && val == "abc");
+
+    val = anyMap["b"];
+    assertTrue(val is int && val == 1);
+
+    val = anyMap["c"];
+    assertTrue(val is boolean && val);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertTrue(any|error actual) {
+    if actual is boolean && actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected 'true', found '" + actual.toString () + "'");
+}
+
+function assertValueEquality(anydata|error expected, anydata|error actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
@@ -13,9 +13,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/lang.array;
+import ballerina/lang.'map;
 
 function testAnyData() {
-
     int[] x = [];
     boolean[] x1 = x.clone();  // incompatible types: expected 'boolean[]', found 'int[]'
     int[] x2 = x.clone();  // No error;
@@ -86,4 +87,40 @@ function testTypedescFunctions() {
     Student p = { name : "Michel"};
     Person|error q = Person.constructFrom(p); // No error;
     string r = Person.constructFrom(p); // Error
+}
+
+function testInvalidArgForBoundRestParam() {
+    byte[] barr = [0, 1];
+    barr.push(-1);
+    array:push(barr, 256);
+    int[] x = [-10, 257];
+    array:push(barr, ...x);
+
+    barr.unshift(-3);
+    barr.unshift(-3, 257);
+    array:unshift(barr, ...x);
+}
+
+function testInvalidArgForBoundRequiredParam() {
+    map<int> m = {
+        a: 1,
+        b: 2
+    };
+
+    int s = m.reduce(function (int i, byte b) returns int {
+                        return i;
+                    },
+                    1.0);
+
+    s = 'map:reduce(m,
+                    function (int i, byte b) returns int {
+                        return i;
+                    },
+                    1.0);
+
+    byte[] barr = [0, 1];
+    int? index = barr.indexOf(257);
+
+    int i = -1;
+    index = barr.indexOf(i);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
@@ -124,3 +124,9 @@ function testInvalidArgForBoundRequiredParam() {
     int i = -1;
     index = barr.indexOf(i);
 }
+
+function testInvalidArgOnUnionTypedValue() {
+    int[]|string[] arr = [1, 2];
+    arr.push(true);
+    array:unshift(arr, 13.2);
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
@@ -60,8 +60,8 @@ public class IterableOperationsTests {
                 " (boolean)', found 'function (int,string) returns (boolean)'", 16, 14);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'map<string>', found " +
                 "'map<[string,string]>'", 31, 21);
-        BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'any'", 35, 18);
-        BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'any'", 38, 13);
+        BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'any'", 35, 27);
+        BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'any'", 38, 22);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'int', found '()'", 46, 9);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected '[other,other]', found 'string[]'",
                 48, 18);
@@ -76,7 +76,7 @@ public class IterableOperationsTests {
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'function ((any|error)) " +
                 "returns ()', found 'int'", 58, 15);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected '[string,string,string]', found " +
-                "'string'", 63, 5);
+                "'string'", 63, 15);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'function ((any|error))" +
                 " returns ()', found 'function () returns ()'", 64, 15);
         BAssertUtil.validateError(negative, index++, "variable assignment is required", 65, 5);
@@ -95,7 +95,7 @@ public class IterableOperationsTests {
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'int[]', found 'any[]'", 73, 15);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'int[]', found 'string[]'", 80, 15);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'int[]', found 'string[]'", 89, 15);
-        BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'any'", 99, 18);
+        BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'any'", 99, 27);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'string', found 'map'", 103, 16);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'boolean', found 'int'", 111, 20);
         BAssertUtil.validateError(negative, index++, "incompatible types: expected 'float', found 'int'", 120, 39);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordIterationTest.java
@@ -59,29 +59,29 @@ public class ClosedRecordIterationTest {
         // Test invalid foreach iterable operation
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'",
-                47, 5);
+                47, 15);
 
         // Test invalid map iterable operation
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'",
-                52, 21);
+                52, 28);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'",
-                56, 12);
+                56, 19);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'",
-                60, 12);
+                60, 19);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected 'ClosedPerson', found 'map<[string,any]>'",
                 64, 27);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'",
-                64, 27);
+                64, 34);
 
         // Test invalid filter iterable operation
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'",
-                70, 21);
+                70, 30);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected 'function ((any|error)) returns (boolean)', found " +
                         "'function ([string,any]) returns (string)'", 74, 21);
@@ -90,21 +90,21 @@ public class ClosedRecordIterationTest {
                         "found 'map<(string|int|ClosedAddress)>'", 78, 27);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,any]', found '(string|int|ClosedAddress)'", 78,
-                27);
+                36);
 
         // Test mismatching chained iterable op return values
-        BAssertUtil.validateError(closedRecNegatives, index++,
-                "incompatible types: expected '[string,int]', found 'int'",
-                86, 18);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected 'map<int>', found 'map<[string,float]>'",
                 86, 18);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected '[string,int]', found 'int'",
-                116, 16);
+                86, 25);
         BAssertUtil.validateError(closedRecNegatives, index++,
                 "incompatible types: expected 'int[]', found 'map<float>'",
                 116, 16);
+        BAssertUtil.validateError(closedRecNegatives, index++,
+                "incompatible types: expected '[string,int]', found 'int'",
+                116, 23);
 
         Assert.assertEquals(closedRecNegatives.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordIterationTest.java
@@ -60,15 +60,15 @@ public class OpenRecordIterationTest {
 
         // Test invalid foreach iterable operation
         BAssertUtil.validateError(openRecNegatives, index++,
-                                  "incompatible types: expected '[string,any]', found 'anydata'", 41, 5);
+                                  "incompatible types: expected '[string,any]', found 'anydata'", 41, 15);
         BAssertUtil.validateError(openRecNegatives, index++,
                                   "incompatible types: expected '(string|int|Address)', found 'anydata'",
-                                  44, 5);
+                                  44, 15);
 
         // Test invalid map iterable operation
         BAssertUtil.validateError(openRecNegatives, index++,
                                   "incompatible types: expected '[string,any]', found 'anydata'",
-                                  52, 21);
+                                  52, 28);
         BAssertUtil.validateError(openRecNegatives, index++,
                                   "incompatible types: expected 'map', found 'map<(any|error)>'", 60, 12);
         BAssertUtil.validateError(openRecNegatives, index++,
@@ -78,7 +78,7 @@ public class OpenRecordIterationTest {
         // Test invalid filter iterable operation
         BAssertUtil.validateError(openRecNegatives, index++,
                                   "incompatible types: expected '[string,any]', found 'anydata'",
-                                  74, 21);
+                                  74, 30);
         BAssertUtil.validateError(openRecNegatives, index++,
                                   "incompatible types: expected 'function ((any|error)) returns (boolean)', found " +
                                           "'function (anydata) returns (string)'",


### PR DESCRIPTION
## Purpose
$title.

Fixes #19486 Compilation error when using int literals with byte[] langlib methods
Fixes #20439 Type checking issue with push() method for tuple arrays
Fixes #22120 Incorrect type-checking for vararg in langlib invocation
Fixes #22129 Invalid `push` on a union-typed array results in a bad, sad error at runtime
Fixes #22117 Bad, sad error with array:unshift for byte[]
Fixes #20192 No tests for lang.array:push()

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
