### PR TITLE
Provide the base64 encoded certificate with the request

### DIFF
--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -38,7 +38,7 @@ dependencies {
     dist 'org.wso2.carbon:org.wso2.carbon.core:5.1.0'
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'
     dist 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
-    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.5'
+    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.6'
     dist 'org.bouncycastle:bcprov-jdk15on:1.61'
     dist 'org.bouncycastle:bcpkix-jdk15on:1.61'
 

--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -21,8 +21,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.5"
-    path = "./lib/org.wso2.transport.http.netty-6.3.5.jar"
+    version = "6.3.6"
+    path = "./lib/org.wso2.transport.http.netty-6.3.6.jar"
     groupId = "org.wso2.transport.http"
     modules = ["grpc"]
 

--- a/stdlib/http/src/main/ballerina/Ballerina.toml
+++ b/stdlib/http/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.5"
-    path = "./lib/org.wso2.transport.http.netty-6.3.5.jar"
+    version = "6.3.6"
+    path = "./lib/org.wso2.transport.http.netty-6.3.6.jar"
     groupId = "org.wso2.transport.http"
     modules = ["http"]
 

--- a/stdlib/http/src/main/ballerina/src/http/http_request.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_request.bal
@@ -615,8 +615,10 @@ function externCheckReqEntityBodyAvailability(Request request) returns boolean =
 # A record for providing mutual SSL handshake results.
 #
 # + status - Status of the handshake.
+# + base64EncodedCert - Base64 encoded certificate.
 public type MutualSslHandshake record {|
     MutualSslStatus status = ();
+    string? base64EncodedCert = ();
 |};
 
 # Defines the possible values for the mutual ssl status.

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -233,6 +233,8 @@ public class HttpConstants {
     public static final String REQUEST_NO_ENTITY_BODY_FIELD = "noEntityBody";
     public static final String REQUEST_MUTUAL_SSL_HANDSHAKE_FIELD = "mutualSslHandshake";
     public static final String REQUEST_MUTUAL_SSL_HANDSHAKE_STATUS = "status";
+    public static final String MUTUAL_SSL_CERTIFICATE = "base64EncodedCert";
+    public static final String BASE_64_ENCODED_CERT = "BASE_64_ENCODED_CERT";
 
     //Response struct field names
     public static final String RESPONSE_STATUS_CODE_FIELD = "statusCode";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -149,6 +149,7 @@ import static org.ballerinalang.net.http.HttpConstants.HTTP_ERROR_MESSAGE;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_MODULE_VERSION;
 import static org.ballerinalang.net.http.HttpConstants.LISTENER_CONFIGURATION;
 import static org.ballerinalang.net.http.HttpConstants.MODULE;
+import static org.ballerinalang.net.http.HttpConstants.MUTUAL_SSL_CERTIFICATE;
 import static org.ballerinalang.net.http.HttpConstants.MUTUAL_SSL_HANDSHAKE_RECORD;
 import static org.ballerinalang.net.http.HttpConstants.NEVER;
 import static org.ballerinalang.net.http.HttpConstants.PACKAGE;
@@ -653,6 +654,7 @@ public class HttpUtil {
         MapValue mutualSslRecord = ValueCreatorUtils.createHTTPRecordValue(MUTUAL_SSL_HANDSHAKE_RECORD);
         mutualSslRecord.put(REQUEST_MUTUAL_SSL_HANDSHAKE_STATUS,
                 inboundRequestMsg.getProperty(HttpConstants.MUTUAL_SSL_RESULT));
+        mutualSslRecord.put(MUTUAL_SSL_CERTIFICATE, inboundRequestMsg.getProperty(HttpConstants.BASE_64_ENCODED_CERT));
         inboundRequest.set(REQUEST_MUTUAL_SSL_HANDSHAKE_FIELD, mutualSslRecord);
 
         enrichWithInboundRequestInfo(inboundRequest, inboundRequestMsg);

--- a/stdlib/mime/build.gradle
+++ b/stdlib/mime/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation project(':ballerina-file')
 
     interopImports project(':ballerina-io')
-    interopImports 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.4'
+    interopImports 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.6'
 
     implementation 'org.wso2.transport.http:org.wso2.transport.http.netty'
     implementation 'org.apache.ws.commons.axiom:axiom-dom'

--- a/stdlib/mime/src/main/ballerina/Ballerina.toml
+++ b/stdlib/mime/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.5"
-    path = "./lib/org.wso2.transport.http.netty-6.3.5.jar"
+    version = "6.3.6"
+    path = "./lib/org.wso2.transport.http.netty-6.3.6.jar"
     groupId = "org.wso2.transport.http"
     modules = ["mime"]
 

--- a/stdlib/websub/src/main/ballerina/Ballerina.toml
+++ b/stdlib/websub/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.5"
-    path = "./lib/org.wso2.transport.http.netty-6.3.5.jar"
+    version = "6.3.6"
+    path = "./lib/org.wso2.transport.http.netty-6.3.6.jar"
     groupId = "org.wso2.transport.http"
     modules = ["web-sub"]
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2BaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2BaseTest.java
@@ -38,7 +38,13 @@ public class Http2BaseTest extends BaseTest {
 
     @BeforeGroups(value = "http2-test", alwaysRun = true)
     public void start() throws BallerinaTestException {
-        int[] requiredPorts = new int[]{7090, 9090, 9092, 9093, 9094, 9095, 9096, 9097, 9098, 9099, 9107, 9108, 9109};
+        int[] requiredPorts = new int[]{7090, 9090, 9092, 9093, 9094, 9095, 9096, 9097, 9098, 9099, 9107, 9108, 9109,
+                                        9110};
+
+        String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                "private.key").toAbsolutePath().toString());
+        String publicCert = StringEscapeUtils.escapeJava(
+                Paths.get("src", "test", "resources", "certsAndKeys", "public.crt").toAbsolutePath().toString());
 
         String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "http2").getAbsolutePath();
@@ -48,7 +54,8 @@ public class Http2BaseTest extends BaseTest {
         String trustStore = StringEscapeUtils.escapeJava(
                 Paths.get("src", "test", "resources", "certsAndKeys", "ballerinaTruststore.p12").toAbsolutePath()
                         .toString());
-        String[] args = new String[] { "--keystore=" + keyStore, "--truststore=" + trustStore };
+        String[] args = new String[] { "--certificate.key=" + privateKey, "--public.cert=" + publicCert,
+                "--keystore=" + keyStore, "--truststore=" + trustStore };
         serverInstance = new BServerInstance(balServer);
         serverInstance.startServer(balFile, "http2services", null, args, requiredPorts);
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2MutualSslWithCerts.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http2/Http2MutualSslWithCerts.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.service.http2;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.LogLeecher;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+/**
+ * Testing Mutual SSL with certificates.
+ */
+@Test(groups = "http2-test")
+public class Http2MutualSslWithCerts extends Http2BaseTest {
+    @Test(description = "Test mutual ssl with http2 with certificates")
+    public void testMutualSslWithcerts() throws Exception {
+        String serverResponse = "Response received";
+
+        String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                "private.key").toAbsolutePath().toString());
+        String publicCert = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
+                "public.crt").toAbsolutePath().toString());
+
+        String balFile = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
+                "ssl" + File.separator + "http2_mutual_ssl_client_with_certs.bal").getAbsolutePath();
+        String[] flags = {"--certificate.key=" + privateKey, "--public.cert=" + publicCert};
+
+        BMainInstance ballerinaClient = new BMainInstance(balServer);
+        LogLeecher clientLeecher = new LogLeecher(serverResponse);
+        ballerinaClient.runMain(balFile, flags, null, new LogLeecher[]{clientLeecher});
+        clientLeecher.waitForText(20000);
+    }
+}

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/20_mutual_ssl_server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/20_mutual_ssl_server.bal
@@ -56,10 +56,31 @@ service helloWorld15 on echo15 {
         path: "/"
     }
     resource function sayHello(http:Caller caller, http:Request req) {
-
+        string expectedCert = "MIIDdzCCAl+gAwIBAgIEfP3e8zANBgkqhkiG9w0BAQsFADBkMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExF"
+                        + "jAUBgNVBAcTDU1vdW50YWluIFZpZXcxDTALBgNVBAoTBFdTTzIxDTALBgNVBAsTBFdTTzIxEjAQBgNVBAMTCWxvY2Fsa"
+                        + "G9zdDAeFw0xNzEwMjQwNTQ3NThaFw0zNzEwMTkwNTQ3NThaMGQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA"
+                        + "1UEBxMNTW91bnRhaW4gVmlldzENMAsGA1UEChMEV1NPMjENMAsGA1UECxMEV1NPMjESMBAGA1UEAxMJbG9jYWxob3N0M"
+                        + "IIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgVyi6fViVLiZKEnw59xzNi1lcYh6z9dZnug+F9gKqFIgmdcPe"
+                        + "+qtS7gZc1jYTjWMCbx13sFLkZqNHeDUadpmtKo3TDduOl1sqM6cz3yXb6L34k/leh50mzIPNmaaXxd3vOQoK4OpkgO1n"
+                        + "32mh6+tkp3sbHmfYqDQrkVK1tmYNtPJffSCLT+CuIhnJUJco7N0unax+ySZN67/AX++sJpqAhAIZJzrRi6ueN3RFCIxY"
+                        + "DXSMvxrEmOdn4gOC0o1Ar9u5Bp9N52sqqGbN1x6jNKi3bfUj122Hu5e+Y9KOmfbchhQil2P81cIi30VKgyDn5DeWEuDo"
+                        + "Yredk4+6qAZrxMw+wIDAQABozEwLzAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFNmtrQ36j6tUGhKrfW9qWWE7KFzMM"
+                        + "A0GCSqGSIb3DQEBCwUAA4IBAQAv3yOwgbtOu76eJMl1BCcgTFgaMUBZoUjK9Un6HGjKEgYz/YWSZFlY/qH5rT01DWQev"
+                        + "UZB626d5ZNdzSBZRlpsxbf9IE/ursNHwHx9ua6fB7yHUCzC1ZMp1lvBHABi7wcA+5nbV6zQ7HDmBXFhJfbgH1iVmA1Kc"
+                        + "vDeBPSJ/scRGasZ5q2W3IenDNrfPIUhD74tFiCiqNJO91qD/LO+++3XeZzfPh8NRKkiPX7dB8WJ3YNBuQAvgRWTISpSS"
+                        + "XLmqMb+7MPQVgecsepZdk8CwkRLxh3RKPJMjigmCgyvkSaoDMKAYC3iYjfUTiJ57UeqoSl0IaOFJ0wfZRFh+UytlDZa";
         http:Response res = new;
         if (req.mutualSslHandshake["status"] == "passed") {
-            res.setTextPayload("hello world");
+            string? cert = req.mutualSslHandshake["base64EncodedCert"];
+            if (cert is string) {
+                if (cert == expectedCert) {
+                    res.setTextPayload("hello world");
+                } else {
+                    res.setTextPayload("Expected cert not found");
+                }
+            } else {
+                res.setTextPayload("Cert not found");
+            }
         }
         checkpanic caller->respond(res);
         io:println("successful");

--- a/tests/jballerina-integration-test/src/test/resources/http2/src/http2services/09_http_2.0_mutual_ssl.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http2/src/http2services/09_http_2.0_mutual_ssl.bal
@@ -49,9 +49,31 @@ service http2Service on http2Listener {
         path: "/"
     }
     resource function sayHello(http:Caller caller, http:Request req) {
+        string expectedCert = "MIIDdzCCAl+gAwIBAgIEfP3e8zANBgkqhkiG9w0BAQsFADBkMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExF"
+                      + "jAUBgNVBAcTDU1vdW50YWluIFZpZXcxDTALBgNVBAoTBFdTTzIxDTALBgNVBAsTBFdTTzIxEjAQBgNVBAMTCWxvY2Fsa"
+                      + "G9zdDAeFw0xNzEwMjQwNTQ3NThaFw0zNzEwMTkwNTQ3NThaMGQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA"
+                      + "1UEBxMNTW91bnRhaW4gVmlldzENMAsGA1UEChMEV1NPMjENMAsGA1UECxMEV1NPMjESMBAGA1UEAxMJbG9jYWxob3N0M"
+                      + "IIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgVyi6fViVLiZKEnw59xzNi1lcYh6z9dZnug+F9gKqFIgmdcPe"
+                      + "+qtS7gZc1jYTjWMCbx13sFLkZqNHeDUadpmtKo3TDduOl1sqM6cz3yXb6L34k/leh50mzIPNmaaXxd3vOQoK4OpkgO1n"
+                      + "32mh6+tkp3sbHmfYqDQrkVK1tmYNtPJffSCLT+CuIhnJUJco7N0unax+ySZN67/AX++sJpqAhAIZJzrRi6ueN3RFCIxY"
+                      + "DXSMvxrEmOdn4gOC0o1Ar9u5Bp9N52sqqGbN1x6jNKi3bfUj122Hu5e+Y9KOmfbchhQil2P81cIi30VKgyDn5DeWEuDo"
+                      + "Yredk4+6qAZrxMw+wIDAQABozEwLzAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFNmtrQ36j6tUGhKrfW9qWWE7KFzMM"
+                      + "A0GCSqGSIb3DQEBCwUAA4IBAQAv3yOwgbtOu76eJMl1BCcgTFgaMUBZoUjK9Un6HGjKEgYz/YWSZFlY/qH5rT01DWQev"
+                      + "UZB626d5ZNdzSBZRlpsxbf9IE/ursNHwHx9ua6fB7yHUCzC1ZMp1lvBHABi7wcA+5nbV6zQ7HDmBXFhJfbgH1iVmA1Kc"
+                      + "vDeBPSJ/scRGasZ5q2W3IenDNrfPIUhD74tFiCiqNJO91qD/LO+++3XeZzfPh8NRKkiPX7dB8WJ3YNBuQAvgRWTISpSS"
+                      + "XLmqMb+7MPQVgecsepZdk8CwkRLxh3RKPJMjigmCgyvkSaoDMKAYC3iYjfUTiJ57UeqoSl0IaOFJ0wfZRFh+UytlDZa";
         http:Response res = new;
         if (req.mutualSslHandshake["status"] == "passed") {
-            res.setTextPayload("Passed");
+            string? cert = req.mutualSslHandshake["base64EncodedCert"];
+            if (cert is string) {
+                if (cert == expectedCert) {
+                    res.setTextPayload("Passed");
+                } else {
+                    res.setTextPayload("Expected cert not found");
+                }
+            } else {
+                res.setTextPayload("Cert not found");
+            }
         } else {
             res.setTextPayload("Failed");
         }

--- a/tests/jballerina-integration-test/src/test/resources/http2/src/http2services/13_http_2.0_mutual_ssl_with_certs.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http2/src/http2services/13_http_2.0_mutual_ssl_with_certs.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -17,16 +17,17 @@
 import ballerina/config;
 import ballerina/http;
 
-http:ListenerConfiguration mutualSslCertServiceConf = {
+http:ListenerConfiguration sslConf = {
     secureSocket: {
         keyFile: config:getAsString("certificate.key"),
         certFile: config:getAsString("public.cert"),
         trustedCertFile: config:getAsString("public.cert"),
         sslVerifyClient: "require"
-    }
+    },
+    httpVersion: "2.0"
 };
 
-listener http:Listener mutualSSLListener = new(9217, mutualSslCertServiceConf);
+listener http:Listener mutualSSLListener = new(9110, sslConf);
 
 @http:ServiceConfig {
     basePath:"/echo"
@@ -54,7 +55,7 @@ service mutualSSLService on mutualSSLListener {
                     + "D3WwdzAO8kZheemiZM5FZYhaXkBymNNe7qvL/aC6CuwyC3n+4GOtV+xabmH4T/p7HEcvq2SY0YGTpJ0OcUlvJ3UqzhTieK67"
                     + "dSFKmDN3hOBrxacFV9ybzub67erPkQpV4GpJUW9HShp0qXr6WuX1hg7WA6RgneWkq3y2h6sts/c5S/dAP8KlqghvEdv8lnAc"
                     + "SqjN3kSTim/JMMe4kChtjUE7C1Ag==";
-        if (req.mutualSslHandshake["status"] == "passed") {
+	    if (req.mutualSslHandshake["status"] == "passed") {
             string? cert = req.mutualSslHandshake["base64EncodedCert"];
             if (cert is string) {
                 if (cert == expectedCert) {
@@ -69,4 +70,3 @@ service mutualSSLService on mutualSSLListener {
         checkpanic caller->respond( res);
     }
 }
-

--- a/tests/jballerina-integration-test/src/test/resources/ssl/http2_mutual_ssl_client_with_certs.bal
+++ b/tests/jballerina-integration-test/src/test/resources/ssl/http2_mutual_ssl_client_with_certs.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/config;
+import ballerina/http;
+import ballerina/io;
+
+http:ClientConfiguration clientConf = {
+    secureSocket:{
+        keyFile: config:getAsString("certificate.key"),
+        certFile: config:getAsString("public.cert"),
+        trustedCertFile: config:getAsString("public.cert")
+    }
+};
+
+public function main() {
+    http:Client clientEP = new("https://localhost:9110", clientConf);
+    http:Request req = new;
+    var resp = clientEP->get("/echo/");
+    if (resp is http:Response) {
+        var payload = resp.getTextPayload();
+        if (payload is string) {
+            io:println(payload);
+        } else {
+            error err = payload;
+            io:println(<string> err.detail()["message"]);
+        }
+    } else {
+        error err = resp;
+        io:println(<string> err.detail()["message"]);
+    }
+}

--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -103,6 +103,7 @@
             <class name="org.ballerinalang.test.service.http2.ClientUpgradeWithLargePayload"/>
             <class name="org.ballerinalang.test.service.http2.HTTP2ClientActionsTestCase"/>
             <class name="org.ballerinalang.test.service.http2.Http2MutualSslTestCase"/>
+            <class name="org.ballerinalang.test.service.http2.Http2MutualSslWithCerts"/>
             <class name="org.ballerinalang.test.service.http2.Http2ForwardHeaderTest"/>
             <class name="org.ballerinalang.test.service.http2.Http2100ContinueTestCase"/>
             <class name="org.ballerinalang.test.service.http2.Http2TrailingHeadersTestCase"/>


### PR DESCRIPTION
## Purpose
Provide the certificate in the request.  This is provided as a base64 encoded string. 

Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/21314

## Samples
`string? cert = req.mutualSslHandshake["base64EncodedCert"];`

