### PR TITLE
Enable the disabled lockinmaintest related testcases and add 'any' annotation to workers

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -92,7 +92,7 @@ public class LocksInMainTest {
     }
 
 //    TODO:https://github.com/ballerina-platform/ballerina-lang/issues/11305
-    @Test(description = "Tests throwing and error inside lock", enabled = false)
+    @Test(description = "Tests throwing and error inside lock")
     public void testThrowErrorInsideLock() {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/locks-in-functions.bal");
 
@@ -171,7 +171,7 @@ public class LocksInMainTest {
         assertEquals(returns[1].stringValue(), "worker 2 sets the string after try catch inside lock");
     }
 
-    @Test(description = "Tests lock within lock in workers for boolean and blob", enabled = false)
+    @Test(description = "Tests lock within lock in workers for boolean and blob")
     public void testLockWithinLockInWorkersForBlobAndBoolean() {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/locks-in-functions.bal");
 
@@ -196,7 +196,7 @@ public class LocksInMainTest {
         assertTrue("w1w1w1vw2w2w2v".equals(result) || "w2w2w2v".equals(result));
     }
 
-    @Test(description = "Tests returning inside lock statement", enabled = false)
+    @Test(description = "Tests returning inside lock statement")
     public void testReturnInsideLock() {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/locks-in-functions.bal");
 
@@ -224,7 +224,7 @@ public class LocksInMainTest {
 
     }
 
-    @Test(description = "Tests next inside lock statement", enabled = false)
+    @Test(description = "Tests next inside lock statement")
     public void testNextInsideLock() {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/locks-in-functions.bal");
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/locks-in-functions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/locks-in-functions.bal
@@ -34,6 +34,7 @@ function makeAsync() returns (int) {
 }
 
 function lockWithinLockInWorkers() returns [int, string] {
+    @strand{thread:"any"}
     worker w1 {
         lock {
             lockWithinLockInt1 = 90;
@@ -45,6 +46,8 @@ function lockWithinLockInWorkers() returns [int, string] {
             lockWithinLockInt1 = 45;
         }
     }
+
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(20);
         lock {
@@ -61,6 +64,7 @@ function lockWithinLockInWorkers() returns [int, string] {
 }
 
 function lockInsideWhileLoop() returns (int) {
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(10);
         lock {
@@ -95,6 +99,7 @@ function convertStringToInt() {
 }
 
 function throwErrorInsideLock() returns [int, string] {
+    @strand{thread:"any"}
     worker w1 {
         lock {
             convertStringToInt();
@@ -117,6 +122,7 @@ function errorPanicInsideLock() {
 }
 
 function throwErrorInsideLockInsideTryFinally() returns [int, string] {
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(10);
         lock {
@@ -139,7 +145,7 @@ function throwErrorInsideLockInsideTryFinally() returns [int, string] {
 }
 
 function throwErrorInsideTryCatchFinallyInsideLock() returns [int, string] {
-
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(10);
         lock {
@@ -165,6 +171,7 @@ function throwErrorInsideTryCatchFinallyInsideLock() returns [int, string] {
 }
 
 function throwErrorInsideTryFinallyInsideLock() returns [int, string] {
+    @strand{thread:"any"}
     worker w1 {
         lock {
             runtime:sleep(50);
@@ -193,6 +200,7 @@ function throwErrorInsideTryFinallyInsideLock() returns [int, string] {
 }
 
 function throwErrorInsideLockInsideTryCatch() returns [int, string] {
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(10);
         lock {
@@ -212,6 +220,7 @@ function throwErrorInsideLockInsideTryCatch() returns [int, string] {
 }
 
 function throwErrorInsideTryCatchInsideLock() returns [int, string] {
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(10);
         lock {
@@ -235,6 +244,7 @@ function throwErrorInsideTryCatchInsideLock() returns [int, string] {
 
 
 function lockWithinLockInWorkersForBlobAndBoolean() returns [boolean, byte[]] {
+    @strand{thread:"any"}
     worker w1 {
         lock {
             boolValue = true;
@@ -246,6 +256,8 @@ function lockWithinLockInWorkersForBlobAndBoolean() returns [boolean, byte[]] {
             runtime:sleep(100);
         }
     }
+
+    @strand{thread:"any"}
     worker w2 {
         runtime:sleep(20);
         lock {
@@ -263,6 +275,7 @@ function lockWithinLockInWorkersForBlobAndBoolean() returns [boolean, byte[]] {
 }
 
 function returnInsideLock() returns [int, string] {
+    @strand{thread:"any"}
     worker w1 {
         string value = returnInsideLockPart();
     }
@@ -289,6 +302,7 @@ function returnInsideLockPart() returns (string) {
 }
 
 function breakInsideLock() returns [int, string] {
+    @strand{thread:"any"}
     worker w1 {
         int i = 0;
         while (i < 3) {
@@ -316,6 +330,7 @@ function breakInsideLock() returns [int, string] {
 }
 
 function nextInsideLock() returns [int, string] {
+    @strand{thread:"any"}
     worker w1 {
         int i = 0;
         while (i < 1) {


### PR DESCRIPTION
## Purpose
> $title. Fix is done by adding the "any"annotation to the workers.

Fixes #21941

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
