### PR TITLE
[1.2.x] Fix compiler crashing issue when other fields are referenced in record field default values

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -1430,6 +1430,7 @@ public class NodeCloner extends BLangNodeVisitor {
         source.cloneRef = clone;
         clone.sealed = source.sealed;
         clone.restFieldType = clone(source.restFieldType);
+        clone.analyzed = source.analyzed;
         cloneBLangStructureTypeNode(source, clone);
         cloneBLangType(source, clone);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -146,6 +146,7 @@ import org.wso2.ballerinalang.util.Flags;
 import org.wso2.ballerinalang.util.Lists;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -473,6 +474,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         SymbolEnv recordEnv = SymbolEnv.createTypeEnv(recordTypeNode, recordTypeNode.symbol.scope, env);
         recordTypeNode.fields.forEach(field -> analyzeDef(field, recordEnv));
         validateDefaultable(recordTypeNode);
+        recordTypeNode.analyzed = true;
     }
 
     @Override
@@ -578,35 +580,14 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             // This is a variable declared in a function, let expression, an action or a resource
             // If the variable is parameter then the variable symbol is already defined
             if (varNode.symbol == null) {
-                symbolEnter.defineNode(varNode, env);
-
-                // When 'var' is used, the typeNode is null
-                if (varNode.typeNode != null && varNode.typeNode.getKind() == NodeKind.RECORD_TYPE) {
-                    analyzeDef(varNode.typeNode, env);
-                }
-
-                varNode.annAttachments.forEach(annotationAttachment -> {
-                    annotationAttachment.attachPoints.add(AttachPoint.Point.VAR);
-                    annotationAttachment.accept(this);
-                });
+                analyzeVarNode(varNode, env, AttachPoint.Point.VAR);
             } else {
-                varNode.annAttachments.forEach(annotationAttachment -> {
-                    annotationAttachment.attachPoints.add(AttachPoint.Point.PARAMETER);
-                    annotationAttachment.accept(this);
-                });
+                analyzeVarNode(varNode, env, AttachPoint.Point.PARAMETER);
             }
         } else if ((ownerSymTag & SymTag.OBJECT) == SymTag.OBJECT) {
-            for (BLangAnnotationAttachment annotationAttachment : varNode.annAttachments) {
-                annotationAttachment.attachPoints.add(AttachPoint.Point.OBJECT_FIELD);
-                annotationAttachment.attachPoints.add(AttachPoint.Point.FIELD);
-                annotationAttachment.accept(this);
-            }
+            analyzeVarNode(varNode, env, AttachPoint.Point.OBJECT_FIELD, AttachPoint.Point.FIELD);
         } else if ((ownerSymTag & SymTag.RECORD) == SymTag.RECORD) {
-            for (BLangAnnotationAttachment annotationAttachment : varNode.annAttachments) {
-                annotationAttachment.attachPoints.add(AttachPoint.Point.RECORD_FIELD);
-                annotationAttachment.attachPoints.add(AttachPoint.Point.FIELD);
-                annotationAttachment.accept(this);
-            }
+            analyzeVarNode(varNode, env, AttachPoint.Point.RECORD_FIELD, AttachPoint.Point.FIELD);
         } else {
             varNode.annAttachments.forEach(annotationAttachment -> {
                 if (Symbols.isFlagOn(varNode.symbol.flags, Flags.LISTENER)) {
@@ -652,6 +633,25 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
 
         transferForkFlag(varNode);
+    }
+
+    private void analyzeVarNode(BLangSimpleVariable varNode, SymbolEnv env, AttachPoint.Point... attachPoints) {
+        if (varNode.symbol == null) {
+            symbolEnter.defineNode(varNode, env);
+        }
+
+        // When 'var' is used, the typeNode is null. Need to analyze the record type node here if it's a locally
+        // defined record type.
+        if (varNode.typeNode != null && varNode.typeNode.getKind() == NodeKind.RECORD_TYPE &&
+                !((BLangRecordTypeNode) varNode.typeNode).analyzed) {
+            analyzeDef(varNode.typeNode, env);
+        }
+
+        List<AttachPoint.Point> attachPointsList = Arrays.asList(attachPoints);
+        for (BLangAnnotationAttachment annotationAttachment : varNode.annAttachments) {
+            annotationAttachment.attachPoints.addAll(attachPointsList);
+            annotationAttachment.accept(this);
+        }
     }
 
     private void transferForkFlag(BLangSimpleVariable varNode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangRecordTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangRecordTypeNode.java
@@ -32,6 +32,7 @@ public class BLangRecordTypeNode extends BLangStructureTypeNode implements Recor
 
     public boolean sealed;
     public BLangType restFieldType;
+    public boolean analyzed;
 
     public BLangRecordTypeNode() {
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
@@ -505,4 +505,9 @@ public class OpenRecordTest {
     public void removeIfHasKeyRest() {
         BRunUtil.invoke(compileResult, "removeIfHasKeyRest");
     }
+
+    @Test
+    public void testScopingRules() {
+        BRunUtil.invoke(compileResult, "testScopingRules");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDefNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDefNegativeTest.java
@@ -22,6 +22,8 @@ import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+
 /**
  * Test cases for user record definition negative test.
  */
@@ -45,5 +47,25 @@ public class RecordDefNegativeTest {
         BAssertUtil.validateError(compileResult, 0, "undefined symbol 'x'", 22, 19);
         BAssertUtil.validateError(compileResult, 1, "undefined symbol 'x'", 27, 19);
         BAssertUtil.validateError(compileResult, 2, "undefined symbol 'x'", 31, 57);
+    }
+
+    @Test
+    public void testFieldRefFromWithinARecordDef() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/record/negative/field_ref_in_own_record.bal");
+        int indx = 0;
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 19, 13);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 21, 17);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 25, 17);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'fname'", 33, 27);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'lname'", 33, 41);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 38, 17);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 41, 21);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 45, 21);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'x'", 52, 57);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'p'", 53, 17);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 59, 21);
+        BAssertUtil.validateError(compileResult, indx++, "undefined symbol 'a'", 61, 25);
+        BAssertUtil.validateError(compileResult, indx++, "incompatible types: expected 'string', found 'int'", 71, 16);
+        assertEquals(compileResult.getErrorCount(), indx);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/negative/field_ref_in_own_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/negative/field_ref_in_own_record.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo record {|
+    int a;
+    int b = a + 10;
+    record {
+        int x = a;
+    } c;
+
+    object {
+        int z = a;
+    } d;
+|};
+
+function fieldRefTest() {
+    record {|
+        string fname = "Pubudu";
+        string lname = "Fernando";
+        string fullName = fname + " " + lname;
+    |} person = {};
+
+    record {|
+        int a;
+        int b = a + 10;
+
+        record {
+            int x = a;
+        } c;
+
+        object {
+            int z = a;
+        } d;
+    |} rec;
+
+    int p = 25;
+    record {
+        int x = 10;
+        int marks = let int e = 3, int z = 5 in z * e + x;
+        int y = p;
+    } student = {};
+
+    object {
+        record {
+            int a;
+            int b = a;
+            record {
+                int d = a;
+            } nestd = {};
+        } f = {a: 10};
+    } obj;
+}
+
+int glbA = 100;
+
+type Bar record {
+    string glbA;
+    string z = glbA;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record.bal
@@ -574,3 +574,37 @@ function removeIfHasKeyRest() {
          panic error("Returned value should be nil.");
     }
 }
+
+int a = 10;
+
+type Foo2 record {
+    int a;
+    int b = a;
+};
+
+function testScopingRules() {
+    Foo2 f = {a: 20};
+    assert(<Foo2>{a: 20, b: 10}, f);
+
+    record {
+        int a;
+        int b = a;
+        record {
+            int p = a;
+        } c = {};
+    } f2 = {a: 20};
+
+    assert(<record {int a; int b; record {int p;} c;}>{a: 20, b: 10, c: {p: 10}}, f2);
+}
+
+// Util functions
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error(reason);
+    }
+}


### PR DESCRIPTION
## Purpose
> Currently when you refer to another field of the record in an expression for the default value of a field, the compiler crashes. This PR fixes this issue by giving a proper compile error message instead. 

Fixes #20825 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
