### PR TITLE
Mark deprecated APIs in api-docs

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -470,14 +470,13 @@ public class Generator {
      * @return @deprecated annotation contains
      */
     private static boolean isDeprecated(List<BLangAnnotationAttachment> annotationAttachments) {
-        boolean isDeprecated = false;
         if (annotationAttachments != null) {
             for (BLangAnnotationAttachment attachment : annotationAttachments) {
                 if (attachment.getAnnotationName().getValue().equals("deprecated")) {
-                    isDeprecated = true;
+                    return true;
                 }
             }
         }
-        return isDeprecated;
+        return false;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -22,7 +22,7 @@ import org.ballerinalang.docgen.docs.utils.BallerinaDocUtils;
 import org.ballerinalang.docgen.generator.model.Annotation;
 import org.ballerinalang.docgen.generator.model.Client;
 import org.ballerinalang.docgen.generator.model.Constant;
-import org.ballerinalang.docgen.generator.model.DefaultableVarible;
+import org.ballerinalang.docgen.generator.model.DefaultableVariable;
 import org.ballerinalang.docgen.generator.model.Error;
 import org.ballerinalang.docgen.generator.model.FiniteType;
 import org.ballerinalang.docgen.generator.model.Function;
@@ -114,6 +114,7 @@ public class Generator {
      */
     public static void createTypeDefModels(BLangTypeDefinition typeDefinition, Module module) {
         String typeName = typeDefinition.getName().getValue();
+        boolean isDeprecated = isDeprecated(typeDefinition.getAnnotationAttachments());
         BLangType typeNode = typeDefinition.typeNode;
         NodeKind kind = typeNode.getKind();
         boolean added = false;
@@ -126,7 +127,7 @@ public class Generator {
             List<String> values = enumNode.getValueSet().stream()
                     .map(java.lang.Object::toString)
                     .collect(Collectors.toList());
-            module.finiteTypes.add(new FiniteType(typeName, description(typeDefinition), values));
+            module.finiteTypes.add(new FiniteType(typeName, description(typeDefinition), isDeprecated, values));
             added = true;
         } else if (kind == NodeKind.RECORD_TYPE) {
             BLangRecordTypeNode recordNode = (BLangRecordTypeNode) typeNode;
@@ -140,11 +141,11 @@ public class Generator {
             List<Type> memberTypes = memberTypeNodes.stream()
                     .map(type -> Type.fromTypeNode(type, module.id))
                     .collect(Collectors.toList());
-            module.unionTypes.add(new UnionType(typeName, description(typeDefinition), memberTypes));
+            module.unionTypes.add(new UnionType(typeName, description(typeDefinition), isDeprecated, memberTypes));
             added = true;
         } else if (kind == NodeKind.USER_DEFINED_TYPE) {
             BLangUserDefinedType userDefinedType = (BLangUserDefinedType) typeNode;
-            module.unionTypes.add(new UnionType(typeName, description(typeDefinition),
+            module.unionTypes.add(new UnionType(typeName, description(typeDefinition), isDeprecated,
                     Collections.singletonList(Type.fromTypeNode(userDefinedType, module.id))));
             added = true;
         } else if (kind == NodeKind.VALUE_TYPE) {
@@ -156,7 +157,8 @@ public class Generator {
         } else if (kind == NodeKind.ERROR_TYPE) {
             BLangErrorType errorType = (BLangErrorType) typeNode;
             Type detailType = errorType.detailType != null ? Type.fromTypeNode(errorType.detailType, module.id) : null;
-            module.errors.add(new Error(errorType.type.tsymbol.name.value, description(typeDefinition), detailType));
+            module.errors.add(new Error(errorType.type.tsymbol.name.value, description(typeDefinition), isDeprecated,
+                    detailType));
             added = true;
         } else if (kind == NodeKind.FUNCTION_TYPE) {
             // TODO: handle function type nodes
@@ -183,7 +185,8 @@ public class Generator {
                 .map(attachPoint -> attachPoint.point.getValue())
                 .collect(Collectors.joining(", "));
         Type dataType = annotationNode.typeNode != null ? Type.fromTypeNode(annotationNode.typeNode, module.id) : null;
-        return new Annotation(annotationName, description(annotationNode), dataType, attachments);
+        return new Annotation(annotationName, description(annotationNode),
+                isDeprecated(annotationNode.getAnnotationAttachments()), dataType, attachments);
     }
 
     public static Constant createDocForConstant(BLangConstant constant, Module module) {
@@ -192,18 +195,8 @@ public class Generator {
         String desc = description(constant);
         BLangType typeNode = constant.typeNode != null ? constant.typeNode : constant.associatedTypeDefinition.typeNode;
 
-        // deprecated annotation
-        boolean isDeprecated = false;
-        if (constant.getAnnotationAttachments() != null) {
-            List<BLangAnnotationAttachment> annotationAttachments = constant.getAnnotationAttachments();
-            for (BLangAnnotationAttachment attachment:annotationAttachments) {
-                if (attachment.getAnnotationName().getValue().equals("deprecated")) {
-                    isDeprecated = true;
-                }
-            }
-        }
-
-        return new Constant(constantName, desc, isDeprecated, Type.fromTypeNode(typeNode, module.id), value.toString());
+        return new Constant(constantName, desc, isDeprecated(constant.getAnnotationAttachments()),
+                Type.fromTypeNode(typeNode, module.id), value.toString());
     }
 
     /**
@@ -215,12 +208,12 @@ public class Generator {
      */
     public static Function createDocForFunction(BLangFunction functionNode, Module module) {
         String functionName = functionNode.getName().value;
-        List<DefaultableVarible> parameters = new ArrayList<>();
+        List<DefaultableVariable> parameters = new ArrayList<>();
         List<Variable> returnParams = new ArrayList<>();
         // Iterate through the parameters
         if (functionNode.getParameters().size() > 0) {
             for (BLangSimpleVariable param : functionNode.getParameters()) {
-                DefaultableVarible variable = getVariable(functionNode, param, module);
+                DefaultableVariable variable = getVariable(functionNode, param, module);
                 parameters.add(variable);
             }
         }
@@ -229,7 +222,7 @@ public class Generator {
             SimpleVariableNode restParameter = functionNode.getRestParameters();
             if (restParameter instanceof BLangSimpleVariable) {
                 BLangSimpleVariable param = (BLangSimpleVariable) restParameter;
-                DefaultableVarible variable = getVariable(functionNode, param, module);
+                DefaultableVariable variable = getVariable(functionNode, param, module);
                 parameters.add(variable);
             }
         }
@@ -240,36 +233,26 @@ public class Generator {
             String dataType = getTypeName(returnType);
             if (!dataType.equals("null")) {
                 String desc = returnParamAnnotation(functionNode);
-                Variable variable = new Variable(EMPTY_STRING, desc, Type.fromTypeNode(returnType, module.id));
+                Variable variable = new Variable(EMPTY_STRING, desc, false, Type.fromTypeNode(returnType, module.id));
                 returnParams.add(variable);
             }
 
         }
 
-        // deprecated annotation
-        boolean isDeprecated = false;
-        if (functionNode.getAnnotationAttachments() != null) {
-            List<BLangAnnotationAttachment> annotationAttachments = functionNode.getAnnotationAttachments();
-            for (BLangAnnotationAttachment attachment:annotationAttachments) {
-                if (attachment.getAnnotationName().getValue().equals("deprecated")) {
-                    isDeprecated = true;
-                }
-            }
-        }
-
         return new Function(functionName, description(functionNode),
                         functionNode.getFlags().contains(Flag.REMOTE),
                         functionNode.getFlags().contains(Flag.NATIVE),
-                        isDeprecated, parameters, returnParams);
+                        isDeprecated(functionNode.getAnnotationAttachments()),
+                        parameters, returnParams);
     }
 
-    private static DefaultableVarible getVariable(BLangFunction functionNode, BLangSimpleVariable param, Module mod) {
+    private static DefaultableVariable getVariable(BLangFunction functionNode, BLangSimpleVariable param, Module mod) {
         String desc = paramAnnotation(functionNode, param);
         String defaultValue = EMPTY_STRING;
         if (null != param.getInitialExpression()) {
             defaultValue = param.getInitialExpression().toString();
         }
-        return new DefaultableVarible(param.getName().value, desc, Type.fromTypeNode(param.typeNode, mod.id),
+        return new DefaultableVariable(param.getName().value, desc, false, Type.fromTypeNode(param.typeNode, mod.id),
                 defaultValue);
     }
 
@@ -289,15 +272,17 @@ public class Generator {
             recordName = "Anonymous Record " + recordName.substring(recordName.lastIndexOf('$') + 1);
         }
         BLangMarkdownDocumentation documentationNode = typeDefinition.getMarkdownDocumentationAttachment();
-        List<DefaultableVarible> fields = getFields(recordType, recordType.fields, documentationNode, module);
+        List<DefaultableVariable> fields = getFields(recordType, recordType.fields, documentationNode, module);
         String documentationText = documentationNode == null ? null : documentationNode.getDocumentation();
 
-        module.records.add(new Record(recordName, documentationText, fields));
+        module.records
+                .add(new Record(recordName, documentationText, isDeprecated(typeDefinition.getAnnotationAttachments()),
+                        fields));
     }
 
-    private static List<DefaultableVarible> getFields(BLangNode node, List<BLangSimpleVariable> allFields,
+    private static List<DefaultableVariable> getFields(BLangNode node, List<BLangSimpleVariable> allFields,
                                          BLangMarkdownDocumentation documentation, Module module) {
-        List<DefaultableVarible> fields = new ArrayList<>();
+        List<DefaultableVariable> fields = new ArrayList<>();
         for (BLangSimpleVariable param : allFields) {
             if (param.getFlags().contains(Flag.PUBLIC)) {
                 String name = param.getName().value;
@@ -308,8 +293,9 @@ public class Generator {
                 if (null != param.getInitialExpression()) {
                     defaultValue = param.getInitialExpression().toString();
                 }
-                DefaultableVarible field = new DefaultableVarible(name, desc,
-                        Type.fromTypeNode(param.typeNode, module.id), defaultValue);
+                DefaultableVariable field = new DefaultableVariable(name, desc,
+                        isDeprecated(param.getAnnotationAttachments()), Type.fromTypeNode(param.typeNode, module.id),
+                        defaultValue);
                 fields.add(field);
             }
         }
@@ -335,8 +321,9 @@ public class Generator {
         List<Function> functions = new ArrayList<>();
         String name = parent.getName().getValue();
         String description = description(parent);
+        boolean isDeprecated = isDeprecated(parent.getAnnotationAttachments());
 
-        List<DefaultableVarible> fields = getFields(parent, objectType.fields,
+        List<DefaultableVariable> fields = getFields(parent, objectType.fields,
                     parent.getMarkdownDocumentationAttachment(), module);
 
         if (objectType.initFunction != null) {
@@ -360,11 +347,12 @@ public class Generator {
         }
 
         if (isEndpoint(objectType)) {
-            module.clients.add(new Client(name, description, fields, functions));
+            module.clients.add(new Client(name, description, isDeprecated, fields, functions));
         } else if (isListener(objectType)) {
-            module.listeners.add(new Listener(name, description, fields, functions));
+            module.listeners.add(new Listener(name, description, isDeprecated, fields, functions));
         } else {
-            module.objects.add(new Object(name, description, fields, functions));
+            module.objects.add(new Object(name, description, isDeprecated(parent.getAnnotationAttachments()), fields,
+                    functions));
         }
     }
 
@@ -473,5 +461,23 @@ public class Generator {
     private static boolean isDocumentAttached(BLangNode node) {
         return node instanceof DocumentableNode
                 && ((DocumentableNode) node).getMarkdownDocumentationAttachment() != null;
+    }
+
+    /**
+     * Check @deprecated annotation is available in the annotation attachments.
+     *
+     * @param annotationAttachments annotation attachments
+     * @return @deprecated annotation contains
+     */
+    private static boolean isDeprecated(List<BLangAnnotationAttachment> annotationAttachments) {
+        boolean isDeprecated = false;
+        if (annotationAttachments != null) {
+            for (BLangAnnotationAttachment attachment : annotationAttachments) {
+                if (attachment.getAnnotationName().getValue().equals("deprecated")) {
+                    isDeprecated = true;
+                }
+            }
+        }
+        return isDeprecated;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -38,6 +38,7 @@ import org.ballerinalang.model.tree.DocumentableNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.SimpleVariableNode;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangMarkdownDocumentation;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -233,10 +234,22 @@ public class Generator {
 
         }
 
+        // functionNode.getAnnotationAttachments().get(0).annotationName.value.equals("deprecated")
+        // deprecated annotation
+        boolean isDeprecated = false;
+        if (functionNode.getAnnotationAttachments() != null) {
+            List<BLangAnnotationAttachment> annotationAttachments = functionNode.getAnnotationAttachments();
+            for (BLangAnnotationAttachment attachment:annotationAttachments) {
+                if (attachment.getAnnotationName().getValue().equals("deprecated")) {
+                    isDeprecated = true;
+                }
+            }
+        }
+
         return new Function(functionName, description(functionNode),
                         functionNode.getFlags().contains(Flag.REMOTE),
                         functionNode.getFlags().contains(Flag.NATIVE),
-                        parameters, returnParams);
+                        isDeprecated, parameters, returnParams);
     }
 
     private static DefaultableVarible getVariable(BLangFunction functionNode, BLangSimpleVariable param, Module mod) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -191,7 +191,19 @@ public class Generator {
         java.lang.Object value = constant.symbol.value;
         String desc = description(constant);
         BLangType typeNode = constant.typeNode != null ? constant.typeNode : constant.associatedTypeDefinition.typeNode;
-        return new Constant(constantName, desc, Type.fromTypeNode(typeNode, module.id), value.toString());
+
+        // deprecated annotation
+        boolean isDeprecated = false;
+        if (constant.getAnnotationAttachments() != null) {
+            List<BLangAnnotationAttachment> annotationAttachments = constant.getAnnotationAttachments();
+            for (BLangAnnotationAttachment attachment:annotationAttachments) {
+                if (attachment.getAnnotationName().getValue().equals("deprecated")) {
+                    isDeprecated = true;
+                }
+            }
+        }
+
+        return new Constant(constantName, desc, isDeprecated, Type.fromTypeNode(typeNode, module.id), value.toString());
     }
 
     /**
@@ -234,7 +246,6 @@ public class Generator {
 
         }
 
-        // functionNode.getAnnotationAttachments().get(0).annotationName.value.equals("deprecated")
         // deprecated annotation
         boolean isDeprecated = false;
         if (functionNode.getAnnotationAttachments() != null) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
@@ -28,7 +28,7 @@ import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.github.jknack.handlebars.io.FileTemplateLoader;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.docgen.docs.BallerinaDocConstants;
-import org.ballerinalang.docgen.generator.model.DefaultableVarible;
+import org.ballerinalang.docgen.generator.model.DefaultableVariable;
 import org.ballerinalang.docgen.generator.model.PageContext;
 import org.ballerinalang.docgen.generator.model.Type;
 import org.ballerinalang.docgen.generator.model.Variable;
@@ -64,7 +64,7 @@ public class Writer {
             Handlebars handlebars = new Handlebars().with(new ClassPathTemplateLoader(templatesClassPath), new
                     FileTemplateLoader(templatesFolderPath));
             handlebars.registerHelpers(StringHelpers.class);
-            handlebars.registerHelper("paramSummary", (Helper<List<DefaultableVarible>>)
+            handlebars.registerHelper("paramSummary", (Helper<List<DefaultableVariable>>)
                     (varList, options) -> varList.stream()
                             .map(variable -> getTypeLabel(variable.type, options.context) + " " + variable.name)
                             .collect(Collectors.joining(", "))

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -149,37 +149,7 @@ public class BallerinaDocGenerator {
         Map<String, List<Path>> resources = new HashMap<>();
 
         // Generate project model
-        Project project = new Project();
-        project.isSingleFile = moduleDocList.size() == 1 &&
-                moduleDocList.get(0).bLangPackage.packageID.name.value.equals(".");
-        if (project.isSingleFile) {
-            project.sourceFileName = moduleDocList.get(0).bLangPackage.packageID.sourceFileName.value;
-        }
-        project.name = "";
-        project.description = "";
-        project.modules = moduleDocList.stream().map(moduleDoc -> {
-
-            // Generate module models
-            Module module = new Module();
-            module.id = moduleDoc.bLangPackage.packageID.name.toString();
-            module.orgName = moduleDoc.bLangPackage.packageID.orgName.toString();
-            String moduleVersion = moduleDoc.bLangPackage.packageID.version.toString();
-            // get version from system property if not found in bLangPackage
-            module.version = moduleVersion.equals("")
-                    ? System.getProperty(BallerinaDocConstants.VERSION)
-                    : moduleVersion;
-            module.summary = moduleDoc.summary;
-            module.description = moduleDoc.description;
-
-            // populate module constructs
-            sortModuleConstructs(moduleDoc.bLangPackage);
-            Generator.generateModuleConstructs(module, moduleDoc.bLangPackage);
-
-            // collect module's doc resources
-            resources.put(module.id, moduleDoc.resources);
-
-            return module;
-        }).collect(Collectors.toList());
+        Project project = getDocsGenModel(moduleDocList, resources);
 
         // Generate index.html for the project
         String projectTemplateName = System.getProperty(BallerinaDocConstants.PROJECT_TEMPLATE_NAME_KEY, "index");
@@ -209,7 +179,15 @@ public class BallerinaDocGenerator {
 
         String rootPathModuleLevel = project.isSingleFile ? "./" : "../";
         String rootPathConstructLevel = project.isSingleFile ? "../" : "../../";
+
         // Generate module pages
+        if (project.modules == null) {
+            String errMessage =
+                    "docerina: API documentation generation failed. Couldn't create the [output directory] " + output;
+            out.println(errMessage);
+            log.error(errMessage);
+            return;
+        }
         for (Module module : project.modules) {
             try {
                 if (BallerinaDocUtils.isDebugEnabled()) {
@@ -336,7 +314,7 @@ public class BallerinaDocGenerator {
         } catch (IOException e) {
             out.println(String.format("docerina: failed to copy the docerina-theme resource. Cause: %s", e.getMessage
                     ()));
-            log.error("Failed to coxpy the docerina-theme resource.", e);
+            log.error("Failed to copy the docerina-theme resource.", e);
         }
         if (BallerinaDocUtils.isDebugEnabled()) {
             out.println("docerina: successfully copied HTML theme into " + output);
@@ -382,6 +360,50 @@ public class BallerinaDocGenerator {
                     .getMessage()));
             log.error(String.format("API documentation zip packaging failed for %s", output), e);
         }
+    }
+
+    /**
+     * Generate docs generator model.
+     *
+     * @param moduleDocList modules list which docs ti be generated
+     * @param resources     module level doc resources
+     * @return docs generator model of the project
+     */
+    public static Project getDocsGenModel(List<ModuleDoc> moduleDocList, Map<String, List<Path>> resources) {
+        Project project = new Project();
+        project.isSingleFile =
+                moduleDocList.size() == 1 && moduleDocList.get(0).bLangPackage.packageID.name.value.equals(".");
+        if (project.isSingleFile) {
+            project.sourceFileName = moduleDocList.get(0).bLangPackage.packageID.sourceFileName.value;
+        }
+        project.name = "";
+        project.description = "";
+
+        List<Module> moduleDocs = new ArrayList<>();
+        for (ModuleDoc moduleDoc : moduleDocList) {
+            // Generate module models
+            Module module = new Module();
+            module.id = moduleDoc.bLangPackage.packageID.name.toString();
+            module.orgName = moduleDoc.bLangPackage.packageID.orgName.toString();
+            String moduleVersion = moduleDoc.bLangPackage.packageID.version.toString();
+            // get version from system property if not found in bLangPackage
+            module.version = moduleVersion.equals("") ?
+                    System.getProperty(BallerinaDocConstants.VERSION) :
+                    moduleVersion;
+            module.summary = moduleDoc.summary;
+            module.description = moduleDoc.description;
+
+            // populate module constructs
+            sortModuleConstructs(moduleDoc.bLangPackage);
+            Generator.generateModuleConstructs(module, moduleDoc.bLangPackage);
+
+            // collect module's doc resources
+            resources.put(module.id, moduleDoc.resources);
+
+            moduleDocs.add(module);
+        }
+        project.modules = moduleDocs;
+        return project;
     }
 
     public static Map<String, ModuleDoc> generateModuleDocsFromBLangPackages(String sourceRoot,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
@@ -22,8 +22,8 @@ public class Annotation extends Construct {
     public Type type;
     public String attachmentPoints;
 
-    public Annotation(String name, String description, Type type, String attachmentPoints) {
-        super(name, description);
+    public Annotation(String name, String description, boolean isDeprecated, Type type, String attachmentPoints) {
+        super(name, description, isDeprecated);
         this.type = type;
         this.attachmentPoints = attachmentPoints;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -26,7 +26,8 @@ public class Client extends Object {
 
     public List<Function> remoteMethods = new ArrayList<>();
 
-    public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields, List<Function> methods) {
+    public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
+            List<Function> methods) {
         super(name, description, isDeprecated, fields, methods);
         this.remoteMethods = getRemoteMethods(methods);
         this.otherMethods = getOtherMethods(methods);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -26,8 +26,8 @@ public class Client extends Object {
 
     public List<Function> remoteMethods = new ArrayList<>();
 
-    public Client(String name, String description, List<DefaultableVarible> fields, List<Function> methods) {
-        super(name, description, fields, methods);
+    public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields, List<Function> methods) {
+        super(name, description, isDeprecated, fields, methods);
         this.remoteMethods = getRemoteMethods(methods);
         this.otherMethods = getOtherMethods(methods);
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
@@ -21,10 +21,12 @@ package org.ballerinalang.docgen.generator.model;
 public class Constant extends Construct {
     public Type type;
     public String value;
+    public boolean isDeprecated;
 
-    public Constant(String name, String description, Type type, String value) {
+    public Constant(String name, String description, boolean isDeprecated, Type type, String value) {
         super(name, description);
         this.type = type;
         this.value = value;
+        this.isDeprecated = isDeprecated;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
@@ -21,12 +21,10 @@ package org.ballerinalang.docgen.generator.model;
 public class Constant extends Construct {
     public Type type;
     public String value;
-    public boolean isDeprecated;
 
     public Constant(String name, String description, boolean isDeprecated, Type type, String value) {
-        super(name, description);
+        super(name, description, isDeprecated);
         this.type = type;
         this.value = value;
-        this.isDeprecated = isDeprecated;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
@@ -21,9 +21,11 @@ package org.ballerinalang.docgen.generator.model;
 public class Construct {
     public String name;
     public String description;
+    public boolean isDeprecated;
 
-    public Construct(String name, String description) {
+    public Construct(String name, String description, boolean isDeprecated) {
         this.name = name;
         this.description = description;
+        this.isDeprecated = isDeprecated;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/DefaultableVariable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/DefaultableVariable.java
@@ -18,11 +18,11 @@ package org.ballerinalang.docgen.generator.model;
 /**
  * Represents a defaultable variable.
  */
-public class DefaultableVarible extends Variable {
+public class DefaultableVariable extends Variable {
     public String defaultValue;
 
-    public DefaultableVarible(String name, String description, Type type, String defaultValue) {
-        super(name, description, type);
+    public DefaultableVariable(String name, String description, boolean isDeprecated, Type type, String defaultValue) {
+        super(name, description, isDeprecated, type);
         this.defaultValue = defaultValue;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
@@ -21,8 +21,8 @@ package org.ballerinalang.docgen.generator.model;
 public class Error extends Construct {
     public Type detailType;
 
-    public Error(String name, String description, Type detailType) {
-        super(name, description);
+    public Error(String name, String description, boolean isDeprecated, Type detailType) {
+        super(name, description, isDeprecated);
         this.detailType = detailType;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FiniteType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FiniteType.java
@@ -25,8 +25,8 @@ public class FiniteType extends Type {
 
     public List<String> valueSpace = new ArrayList<>();
 
-    public FiniteType(String name, String description, List<String> valueSpace) {
-        super(name, description);
+    public FiniteType(String name, String description, boolean isDeprecated,  List<String> valueSpace) {
+        super(name, description, isDeprecated);
         this.valueSpace = valueSpace;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -24,16 +24,14 @@ import java.util.List;
 public class Function extends Construct {
     public boolean isRemote;
     public boolean isExtern;
-    public boolean isDeprecated;
-    public List<DefaultableVarible> parameters = new ArrayList<>();
+    public List<DefaultableVariable> parameters = new ArrayList<>();
     public List<Variable> returnParameters = new ArrayList<>();
 
     public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
-                    List<DefaultableVarible> parameters, List<Variable> returnParameters) {
-        super(name, description);
+                    List<DefaultableVariable> parameters, List<Variable> returnParameters) {
+        super(name, description, isDeprecated);
         this.isRemote = isRemote;
         this.isExtern = isExtern;
-        this.isDeprecated = isDeprecated;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -24,14 +24,16 @@ import java.util.List;
 public class Function extends Construct {
     public boolean isRemote;
     public boolean isExtern;
+    public boolean isDeprecated;
     public List<DefaultableVarible> parameters = new ArrayList<>();
     public List<Variable> returnParameters = new ArrayList<>();
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern,
+    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
                     List<DefaultableVarible> parameters, List<Variable> returnParameters) {
         super(name, description);
         this.isRemote = isRemote;
         this.isExtern = isExtern;
+        this.isDeprecated = isDeprecated;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
@@ -26,8 +26,9 @@ public class Listener extends Object {
 
     public List<Function> lifeCycleMethods = new ArrayList<>();
 
-    public Listener(String name, String description, List<DefaultableVarible> fields, List<Function> methods) {
-        super(name, description, fields, methods);
+    public Listener(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
+            List<Function> methods) {
+        super(name, description, isDeprecated, fields, methods);
         this.lifeCycleMethods = getLCMethods(methods);
         this.otherMethods = getOtherMethods(methods);
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Object.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Object.java
@@ -30,7 +30,8 @@ public class Object extends Construct {
     public Function initMethod;
     public List<Function> otherMethods = new ArrayList<>();
 
-    public Object(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields, List<Function> methods) {
+    public Object(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
+            List<Function> methods) {
         super(name, description, isDeprecated);
         this.fields = fields;
         this.methods = methods;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Object.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Object.java
@@ -25,13 +25,13 @@ import java.util.stream.Collectors;
  */
 public class Object extends Construct {
 
-    public List<DefaultableVarible> fields = new ArrayList<>();
+    public List<DefaultableVariable> fields = new ArrayList<>();
     public List<Function> methods = new ArrayList<>();
     public Function initMethod;
     public List<Function> otherMethods = new ArrayList<>();
 
-    public Object(String name, String description, List<DefaultableVarible> fields, List<Function> methods) {
-        super(name, description);
+    public Object(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields, List<Function> methods) {
+        super(name, description, isDeprecated);
         this.fields = fields;
         this.methods = methods;
         Optional<Function> initMethod = getInitMethod(methods);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Record.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Record.java
@@ -23,10 +23,10 @@ import java.util.List;
  */
 public class Record extends Construct {
 
-    public List<DefaultableVarible> fields  = new ArrayList<>();
+    public List<DefaultableVariable> fields  = new ArrayList<>();
 
-    public Record(String name, String description, List<DefaultableVarible> fields) {
-        super(name, description);
+    public Record(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields) {
+        super(name, description, isDeprecated);
         this.fields = fields;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -56,6 +56,7 @@ public class Type {
     public boolean isNullable;
     public boolean isTuple;
     public boolean isLambda;
+    public boolean isDeprecated;
     public boolean generateUserDefinedTypeLink = true;
     public List<Type> memberTypes = new ArrayList<>();
     public List<Type> paramTypes = new ArrayList<>();
@@ -112,9 +113,10 @@ public class Type {
         setCategory(type.type);
     }
 
-    public Type(String name, String description) {
+    public Type(String name, String description, boolean isDeprecated) {
         this.name = name;
         this.description = description;
+        this.isDeprecated = isDeprecated;
     }
 
     public static Type fromTypeNode(BLangType type, String currentModule) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/UnionType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/UnionType.java
@@ -21,8 +21,8 @@ import java.util.List;
  * Represents a union type.
  */
 public class UnionType extends Type {
-    public UnionType(String name, String description, List<Type> memberTypes) {
-        super(name, description);
+    public UnionType(String name, String description, boolean isDeprecated, List<Type> memberTypes) {
+        super(name, description, isDeprecated);
         this.memberTypes = memberTypes;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
@@ -21,8 +21,8 @@ package org.ballerinalang.docgen.generator.model;
 public class Variable extends Construct {
     public Type type;
 
-    public Variable(String name, String description, Type type) {
-        super(name, description);
+    public Variable(String name, String description, boolean isDeprecated, Type type) {
+        super(name, description, isDeprecated);
         this.type = type;
     }
 }

--- a/misc/docerina/src/main/resources/template/html/constants.hbs
+++ b/misc/docerina/src/main/resources/template/html/constants.hbs
@@ -38,7 +38,11 @@
                     {{#each constants}}
                         <div class="params-listing">
                             <ul>
-                                <li id="{{ name }}"> <b>{{ name }}</b><span class="type">  {{{ typeName type }}}</span> {{ value }}</li>
+                                {{#if isDeprecated}}
+                                    <li id="{{ name }}">@deprecated <b>{{ name }}</b><span class="type"> {{{ typeName type }}}</span> {{ value }}</li>
+                                {{else}}
+                                    <li id="{{ name }}"> <b>{{ name }}</b><span class="type">  {{{ typeName type }}}</span> {{ value }}</li>
+                                {{/if}}
                                 <li>
                                     {{{ description }}}
                                 </li>

--- a/misc/docerina/src/main/resources/template/html/errors.hbs
+++ b/misc/docerina/src/main/resources/template/html/errors.hbs
@@ -61,7 +61,11 @@
                     {{#each errors}}
                         <div class="params-listing">
                             <ul>
-                                <li> <b>{{ name }} </b><span class="type">{{#if detailType }}{{{ typeName detailType }}}{{/if}}</span> {{ attachmentPoints }}</li>
+                                {{#if isDeprecated}}
+                                    <li>@deprecated <b>{{ name }} </b><span class="type">{{#if detailType }}{{{ typeName detailType }}}{{/if}}</span> {{ attachmentPoints }}</li>
+                                {{else}}
+                                    <li><b>{{ name }} </b><span class="type">{{#if detailType }}{{{ typeName detailType }}}{{/if}}</span> {{ attachmentPoints }}</li>
+                                {{/if}}
                                 <li>
                                     {{{ description }}}
                                 </li>

--- a/misc/docerina/src/main/resources/template/html/functions.hbs
+++ b/misc/docerina/src/main/resources/template/html/functions.hbs
@@ -62,8 +62,13 @@
                     {{#each functions}}
                         <tbody>
                             <tr>
-                                <td width="30%" ><a class="functions" href="#{{name}}">{{name}}</a></td>
-                                <td width="70%">{{{ description }}}</td>
+                                {{#if isDeprecated }}
+                                    <td width="40%">@deprecated <a class="functions" href="#{{name}}">{{name}}</a></td>
+                                    <td width="60%">{{{ description }}}</td>
+                                {{else}}
+                                    <td width="40%"><a class="functions" href="#{{name}}">{{name}}</a></td>
+                                    <td width="60%">{{{ description }}}</td>
+                                {{/if}}
                             </tr>
                         </tbody>
                     {{/each}}

--- a/misc/docerina/src/main/resources/template/html/functions.hbs
+++ b/misc/docerina/src/main/resources/template/html/functions.hbs
@@ -62,7 +62,7 @@
                     {{#each functions}}
                         <tbody>
                             <tr>
-                                {{#if isDeprecated }}
+                                {{#if isDeprecated}}
                                     <td width="40%">@deprecated <a class="functions" href="#{{name}}">{{name}}</a></td>
                                     <td width="60%">{{{ description }}}</td>
                                 {{else}}

--- a/misc/docerina/src/main/resources/template/html/method.hbs
+++ b/misc/docerina/src/main/resources/template/html/method.hbs
@@ -3,7 +3,11 @@
              <a class="url-link" href="#{{name}}">
                 <img class="url-link-img" src="{{ rootPath }}html-template-resources/images/link.svg">
             </a>
-            <h2> {{name}} </h2>
+            {{#if isDeprecated}}
+                @deprecated <h2> {{name}} </h2>
+            {{else}}
+                <h2> {{name}} </h2>
+            {{/if}}
         {{#if returnParameters }}
         <span class="method-types">
             <p>({{{ paramSummary parameters }}})</p>

--- a/misc/docerina/src/main/resources/template/html/methodSignature.hbs
+++ b/misc/docerina/src/main/resources/template/html/methodSignature.hbs
@@ -2,7 +2,10 @@
 <a href="#{{name}}">
     <div class="param-sum">
         <div class="param-name">
-        {{name}} 
+            {{#if isDeprecated}}
+                @deprecated
+            {{/if}}
+            {{name}}
         </div>
         <div class="param-details"> {{{ description }}} </div>
     </div>

--- a/misc/docerina/src/main/resources/template/html/module.hbs
+++ b/misc/docerina/src/main/resources/template/html/module.hbs
@@ -51,9 +51,15 @@
                 <table>
                     {{#each module.records}}
                         <tr>
-                            <td class="module-title truncate records" id="{{name}}" title="{{name}}">
-                                <a class="records"
-                                   href="records/{{name}}.html">{{name}}</a></td>
+                            {{#if isDeprecated}}
+                                <td class="module-title truncate records" id="{{name}}" title="{{name}}">
+                                    @deprecated <a class="records" href="records/{{name}}.html">{{name}}</a>
+                                </td>
+                            {{else}}
+                                <td class="module-title truncate records" id="{{name}}" title="{{name}}">
+                                    <a class="records" href="records/{{name}}.html">{{name}}</a>
+                                </td>
+                            {{/if}}
                             <td class="module-desc">{{{ description }}}</td>
                         </tr>
                     {{/each}}
@@ -72,12 +78,15 @@
                 <table>
                     {{#each module.objects}}
                         <tr>
-                            <td class="module-title truncate objects" id="{{name}}" title="{{name}}">
-                                <a class="objects"
-                                   href="objects/{{name}}.html">
-                                    {{name}}
-                                </a>
-                            </td>
+                            {{#if isDeprecated}}
+                                <td class="module-title truncate objects" id="{{name}}" title="{{name}}">
+                                    @deprecated <a class="objects" href="objects/{{name}}.html">{{name}}</a>
+                                </td>
+                            {{else}}
+                                <td class="module-title truncate objects" id="{{name}}" title="{{name}}">
+                                    <a class="objects" href="objects/{{name}}.html">{{name}}</a>
+                                </td>
+                            {{/if}}
                             <td class="module-desc">{{{ description }}}</td>
                         </tr>
                     {{/each}}
@@ -211,9 +220,15 @@
                 <table>
                     {{#each module.unionTypes}}
                         <tr>
-                            <td class="module-title truncate types" id="{{name}}" title="{{name}}">
-                                <a class="types" href="types.html#{{name}}">{{name}}</a>
-                            </td>
+                            {{#if isDeprecated}}
+                                <td class="module-title truncate types" id="{{name}}" title="{{name}}">
+                                    @deprecated <a class="types" href="types.html#{{name}}">{{name}}</a>
+                                </td>
+                            {{else}}
+                                <td class="module-title truncate types" id="{{name}}" title="{{name}}">
+                                    <a class="types" href="types.html#{{name}}">{{name}}</a>
+                                </td>
+                            {{/if}}
                             <td class="module-desc">{{{ description }}}</td>
                         </tr>
                     {{/each}}
@@ -232,9 +247,15 @@
                 <table>
                     {{#each module.errors}}
                         <tr>
-                            <td class="module-title truncate errors" id="{{name}}" title="{{name}}">
-                                <a class="errors" href="errors.html#{{name}}">{{name}}</a>
-                            </td>
+                            {{#if isDeprecated}}
+                                <td class="module-title truncate errors" id="{{name}}" title="{{name}}">
+                                    @deprecated <a class="errors" href="errors.html#{{name}}">{{name}}</a>
+                                </td>
+                            {{else}}
+                                <td class="module-title truncate errors" id="{{name}}" title="{{name}}">
+                                    <a class="errors" href="errors.html#{{name}}">{{name}}</a>
+                                </td>
+                            {{/if}}
                             <td class="module-desc">{{{ description }}}</td>
                         </tr>
                     {{/each}}

--- a/misc/docerina/src/main/resources/template/html/module.hbs
+++ b/misc/docerina/src/main/resources/template/html/module.hbs
@@ -139,8 +139,13 @@
                 <table>
                     {{#each module.functions}}
                         <tr>
-                            <td class="module-title truncate functions" id="{{name}}" title="{{name}}"><a
-                                    class="functions" href="functions.html#{{name}}">{{name}}</a></td>
+                            {{#if isDeprecated}}
+                                <td class="module-title truncate functions" id="{{name}}" title="{{name}}">
+                                    @deprecated <a class="functions" href="functions.html#{{name}}">{{name}}</a></td>
+                            {{else}}
+                                <td class="module-title truncate functions" id="{{name}}" title="{{name}}"><a
+                                        class="functions" href="functions.html#{{name}}">{{name}}</a></td>
+                            {{/if}}
                             <td class="module-desc">{{{ description }}}</td>
                         </tr>
                     {{/each}}
@@ -160,8 +165,13 @@
                 <table>
                     {{#each module.constants}}
                         <tr>
-                            <td class="module-title truncate constant" id="{{name}}" title="{{name}}"><a
-                                    class="constant" href="constants.html#{{name}}">{{name}}</a></td>
+                            {{#if isDeprecated}}
+                                <td class="module-title truncate constant" id="{{name}}" title="{{name}}">
+                                    @deprecated <a class="constant" href="constants.html#{{name}}">{{name}}</a></td>
+                            {{else}}
+                                <td class="module-title truncate constant" id="{{name}}" title="{{name}}"><a
+                                        class="constant" href="constants.html#{{name}}">{{name}}</a></td>
+                            {{/if}}
                             <td class="module-desc">{{{ description }}}</td>
                         </tr>
                     {{/each}}

--- a/misc/docerina/src/main/resources/template/html/object.hbs
+++ b/misc/docerina/src/main/resources/template/html/object.hbs
@@ -57,7 +57,13 @@
                 {{else}}
                     <a href="{{ rootPath }}{{module.id}}/index.html">{{module.id}}</a>
                 {{/if}} :
-                <span class="objects">{{ object.name }}</span>
+                <span class="objects">
+                    {{#if object.isDeprecated}}
+                        @deprecated {{ object.name }}
+                    {{else}}
+                        {{ object.name }}
+                    {{/if}}
+                </span>
             </h1>
             <p>{{{ object.description }}}</p>
 

--- a/misc/docerina/src/main/resources/template/html/record.hbs
+++ b/misc/docerina/src/main/resources/template/html/record.hbs
@@ -56,7 +56,13 @@
                 {{else}}
                     <a href="{{ rootPath }}{{module.id}}/index.html">{{module.id}}</a>
                 {{/if}}
-                 : <span class="records">{{ record.name }}</span>
+                 : <span class="records">
+                {{#if record.isDeprecated}}
+                    @deprecated {{ record.name }}
+                {{else}}
+                    {{ record.name }}
+                {{/if}}
+                </span>
             </h1>
             <p>{{{ record.description }}}</p>
             <div class="constants">

--- a/misc/docerina/src/main/resources/template/html/types.hbs
+++ b/misc/docerina/src/main/resources/template/html/types.hbs
@@ -62,8 +62,13 @@
                     {{#each types}}
                         <div class="params-listing">
                             <ul>
-                                <li id="{{ name }}"><b>{{ name }}</b><span class="type">  {{{ unionTypeSummary
-                                        memberTypes }}}</span></li>
+                                {{#if isDeprecated}}
+                                    <li id="{{ name }}">@deprecated <b>{{ name }}</b><span class="type">
+                                        {{{ unionTypeSummary memberTypes }}}</span></li>
+                                {{else}}
+                                    <li id="{{ name }}"><b>{{ name }}</b><span class="type">  {{{ unionTypeSummary
+                                            memberTypes }}}</span></li>
+                                {{/if}}
                                 <li>
                                     {{{ description }}}
                                 </li>
@@ -73,7 +78,13 @@
                     {{#each module.finiteTypes }}
                         <div class="params-listing">
                             <ul>
-                                <li id="{{ name }}"><b>{{ name }}</b><span class="type">  {{{ pipeJoin valueSpace }}}</span></li>
+                                {{#if isDeprecated}}
+                                    <li id="{{ name }}">@deprecated <b>{{ name }}</b><span class="type">
+                                        {{{ pipeJoin valueSpace }}}</span></li>
+                                {{else}}
+                                    <li id="{{ name }}"><b>{{ name }}</b><span class="type">
+                                        {{{ pipeJoin valueSpace }}}</span></li>
+                                {{/if}}
                                 <li>
                                     {{{ description }}}
                                 </li>

--- a/tests/jballerina-unit-test/build.gradle
+++ b/tests/jballerina-unit-test/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation project(':ballerina-runtime')
     implementation project(':ballerina-jsonutils')
     implementation project(':ballerina-xmlutils')
+    implementation project(':docerina')
 
     implementation 'com.h2database:h2'
     implementation 'org.testng:testng'

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/docerina/DeprecatedAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/docerina/DeprecatedAnnotationTest.java
@@ -1,0 +1,264 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.docerina;
+
+import org.ballerinalang.docgen.docs.BallerinaDocGenerator;
+import org.ballerinalang.docgen.generator.model.Constant;
+import org.ballerinalang.docgen.generator.model.Construct;
+import org.ballerinalang.docgen.generator.model.Error;
+import org.ballerinalang.docgen.generator.model.FiniteType;
+import org.ballerinalang.docgen.generator.model.Function;
+import org.ballerinalang.docgen.generator.model.Module;
+import org.ballerinalang.docgen.generator.model.Object;
+import org.ballerinalang.docgen.generator.model.Project;
+import org.ballerinalang.docgen.generator.model.Record;
+import org.ballerinalang.docgen.generator.model.UnionType;
+import org.ballerinalang.docgen.model.ModuleDoc;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test cases to check @deprecated annotation is showing in the docs.
+ */
+public class DeprecatedAnnotationTest {
+
+    private Module testModule;
+
+    @BeforeClass
+    public void setup() throws IOException {
+        String sourceRoot = "test-src/docerina/deprecated/moduleLevelTypeDeclProject";
+        CompileResult result = BCompileUtil.compile(sourceRoot, "testmodule");
+
+        List<BLangPackage> modules = new LinkedList<>();
+        modules.add((BLangPackage) result.getAST());
+        Map<String, ModuleDoc> docsMap = BallerinaDocGenerator.generateModuleDocsFromBLangPackages(
+                Paths.get("src/test/resources", sourceRoot).toAbsolutePath().toString(), modules);
+        List<ModuleDoc> moduleDocList = new ArrayList<>(docsMap.values());
+        moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
+        Map<String, List<Path>> resources = new HashMap<>();
+
+        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList, resources);
+        testModule = project.modules.get(0);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level union type definitions")
+    public void testDeprecatedUnionTypeDef() {
+        List<UnionType> unionTypes = testModule.unionTypes;
+        UnionType depUnionType = null;
+        UnionType nonDepUnionType = null;
+
+        for (UnionType type : unionTypes) {
+            String typeName = type.name;
+            if ("CountryCode".equals(typeName)) {
+                depUnionType = type;
+            } else if ("NewCountryCode".equals(typeName)) {
+                nonDepUnionType = type;
+            }
+        }
+
+        Assert.assertNotNull(depUnionType);
+        Assert.assertTrue(depUnionType.isDeprecated);
+
+        Assert.assertNotNull(nonDepUnionType);
+        Assert.assertFalse(nonDepUnionType.isDeprecated);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level finite type definitions")
+    public void testDeprecatedFiniteTypeDef() {
+        List<FiniteType> finiteTypes = testModule.finiteTypes;
+        FiniteType depFiniteType = null;
+        FiniteType nonDepFiniteType = null;
+
+        for (FiniteType finiteType : finiteTypes) {
+            String fTypeName = finiteType.name;
+            if ("State".equals(fTypeName)) {
+                depFiniteType = finiteType;
+            } else if ("NewState".equals(fTypeName)) {
+                nonDepFiniteType = finiteType;
+            }
+        }
+
+        Assert.assertNotNull(depFiniteType);
+        Assert.assertTrue(depFiniteType.isDeprecated);
+
+        Assert.assertNotNull(nonDepFiniteType);
+        Assert.assertFalse(nonDepFiniteType.isDeprecated);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level object type definitions")
+    public void testDeprecatedObjectTypeDef() {
+        List<Object> objTypes = testModule.objects;
+        Object deprecatedObj = null;
+        Object nonDeprecatedObj = null;
+
+        for (Object object : objTypes) {
+            String objName = object.name;
+            if ("Person".equals(objName)) {
+                deprecatedObj = object;
+            } else if ("Student".equals(objName)) {
+                nonDeprecatedObj = object;
+            }
+        }
+
+        testDeprecated(deprecatedObj);
+        testNonDeprecated(nonDeprecatedObj);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level record type definitions")
+    public void testDeprecatedRecordTypeDef() {
+        List<Record> records = testModule.records;
+        Record deprecatedRecord = null;
+        Record nonDeprecatedRecord = null;
+
+        for (Record record : records) {
+            String recordName = record.name;
+            if ("Address".equals(recordName)) {
+                deprecatedRecord = record;
+            } else if ("Bank".equals(recordName)) {
+                nonDeprecatedRecord = record;
+            }
+        }
+
+        testDeprecated(deprecatedRecord);
+        testNonDeprecated(nonDeprecatedRecord);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level error type definitions")
+    public void testDeprecatedErrorTypeDef() {
+        List<Error> errTypes = testModule.errors;
+        Error deprecatedErr = null;
+        Error nonDeprecatedErr = null;
+
+        for (Error error : errTypes) {
+            String errName = error.name;
+            if ("InvalidAccountTypeError".equals(errName)) {
+                deprecatedErr = error;
+            } else if ("InvalidBankTypeError".equals(errName)) {
+                nonDeprecatedErr = error;
+            }
+        }
+
+        testDeprecated(deprecatedErr);
+        testNonDeprecated(nonDeprecatedErr);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level constant declarations")
+    public void testDeprecatedConstantDecl() {
+        List<Constant> constants = testModule.constants;
+        Constant deprecatedLKA = null;
+        Constant nonDeprecatedLK = null;
+        Constant nonDeprecatedUSA = null;
+
+        for (Constant constant : constants) {
+            String constName = constant.name;
+            if ("LKA".equals(constName)) {
+                deprecatedLKA = constant;
+            } else if ("LK".equals(constName)) {
+                nonDeprecatedLK = constant;
+            } else if ("USA".equals(constName)) {
+                nonDeprecatedUSA = constant;
+            }
+        }
+
+        testDeprecated(deprecatedLKA);
+        testNonDeprecated(nonDeprecatedLK);
+        testNonDeprecated(nonDeprecatedUSA);
+    }
+
+    @Test(description = "Test @deprecated annotation for module-level function definition")
+    public void testDeprecatedFunctionDef() {
+        List<Function> functions = testModule.functions;
+        Function deprecatedFunc = null;
+        Function nonDeprecatedFunc = null;
+
+        for (Function function : functions) {
+            String funcName = function.name;
+            if ("createPerson".equals(funcName)) {
+                deprecatedFunc = function;
+            } else if ("sayHello".equals(funcName)) {
+                nonDeprecatedFunc = function;
+            }
+        }
+
+        testDeprecated(deprecatedFunc);
+        testNonDeprecated(nonDeprecatedFunc);
+    }
+
+    @Test(description = "Test @deprecated annotation for object member method")
+    public void testDeprecatedObjectMemberMethod() {
+        List<Object> objects = testModule.objects;
+        Object personObj = null;
+        Object studentObj = null;
+
+        for (Object obj : objects) {
+            String objName = obj.name;
+            if ("Person".equals(objName)) {
+                personObj = obj;
+            } else if ("Student".equals(objName)) {
+                studentObj = obj;
+            }
+        }
+
+        // test deprecated object member methods
+        Assert.assertNotNull(personObj);
+        for (Function method : personObj.methods) {
+            String methodName = method.name;
+            if ("getFullName".equals(methodName)) {
+                testDeprecated(method);
+            } else if ("getCity".equals(methodName)) {
+                testNonDeprecated(method);
+            }
+        }
+
+        // test non-deprecated object member methods
+        Assert.assertNotNull(studentObj);
+        for (Function method : personObj.methods) {
+            String methodName = method.name;
+            if ("getName".equals(methodName)) {
+                testDeprecated(method);
+            } else if ("getAge".equals(methodName)) {
+                testNonDeprecated(method);
+            }
+        }
+    }
+
+    private void testDeprecated(Construct element) {
+        Assert.assertNotNull(element);
+        Assert.assertTrue(element.isDeprecated);
+    }
+
+    private void testNonDeprecated(Construct element) {
+        Assert.assertNotNull(element);
+        Assert.assertFalse(element.isDeprecated);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/docerina/deprecated/moduleLevelTypeDeclProject/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/docerina/deprecated/moduleLevelTypeDeclProject/Ballerina.toml
@@ -1,0 +1,3 @@
+[project]
+org-name="test_org"
+version="1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/docerina/deprecated/moduleLevelTypeDeclProject/src/testmodule/test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/docerina/deprecated/moduleLevelTypeDeclProject/src/testmodule/test.bal
@@ -1,0 +1,147 @@
+import ballerina/io;
+
+//========== MODULE-LEVEL CONST DECL ========================
+
+# Country code for Sri Lanka.
+# # Deprecated
+# This constant is deprecated. Use the constant `LK` instead.
+@deprecated
+public const string LKA = "LKA";
+
+# New country code for Sri Lanka.
+public const string LK = "LK";
+# Country code for USA.
+public const string USA = "USA";
+
+//========== MODULE-LEVEL TYPE DECL =========================
+//========== 1.union types ==================================
+@deprecated
+public type CountryCode LK|LKA|USA;
+
+public type NewCountryCode LK|USA;
+
+//========= 2.finite types ==================================
+@deprecated
+public type State "on"|"off";
+
+public type NewState "on"|"off";
+
+
+//========= 3.objects =======================================
+// also used for object member methods test
+
+@deprecated
+public type Person object {
+    public string firstName = "John";
+    public string lastName = "Doe";
+
+    Address addr = {
+        street: "Palm Grove",
+        city: "Colombo 3",
+
+        countryCode: LKA
+    };
+
+    @deprecated
+    public function getFullName() returns string {
+        return self.firstName + " " + self.lastName;
+    }
+
+    public function getCity() returns string {
+        return self.addr.city;
+    }
+};
+
+public type Student object {
+    public string name = "Saman";
+    public int age = 15;
+
+    @deprecated
+    public function getName() returns string {
+        return self.name;
+    }
+
+    public function getAge() returns int {
+        return self.age;
+    }
+};
+
+//========= 4.records =======================================
+
+# Address record
+#
+# + street - street Parameter Description
+# + city - city Parameter Description
+# + countryCode - countryCode Parameter Description
+# # Deprecated
+@deprecated
+public type Address record {|
+    string street;
+    string city;
+    CountryCode countryCode;
+|};
+
+# Bank record
+#
+# + street - street Parameter Description
+# + city - city Parameter Description
+# + countryCode - countryCode Parameter Description
+public type Bank record {|
+    string street;
+    string city;
+    CountryCode countryCode;
+|};
+
+//========= 5.errors ========================================
+
+const INVALID_ACC_TYPE = "InvalidAccountType";
+type InvalidAccountTypeErrorData record {
+    string message?;
+    error cause?;
+    string accountType;
+};
+
+# Invalid account error
+# # Deprecated
+@deprecated
+public type InvalidAccountTypeError error<INVALID_ACC_TYPE, InvalidAccountTypeErrorData>;
+
+# Invalid bank error
+public type InvalidBankTypeError error<INVALID_ACC_TYPE, InvalidAccountTypeErrorData>;
+
+//========= MODULE-LEVEL FUNCTION DEF =======================
+
+# Creates and returns a `Person` object given the parameters.
+#
+# + fname - First name of the person
+# + lname - Last name of the person
+# + street - Street the person is living at
+# + city - The city the person is living in
+# + countryCode - The country code for the country the person is living in
+# + return - A new `Person` object
+#
+# # Deprecated
+# This function is deprecated since the `Person` type is deprecated.
+@deprecated
+public function createPerson(string fname, string lname, string street,
+                             string city, CountryCode countryCode) returns Person {
+    Person p = new;
+    p.firstName = fname;
+    p.lastName = lname;
+    p.addr = {street, city, countryCode};
+    return p;
+}
+
+# say hello
+#
+# + name - name person want to say hello
+public function sayHello(string name) {
+    io:println("Hello " + name);
+}
+
+// main method
+
+public function main() {
+    Person p = createPerson("Jane", "Doe", "Castro Street", "Mountain View", USA);
+    io:println(p.getFullName());
+}

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -129,6 +129,7 @@
             <package name="org.ballerinalang.test.javainterop.*"/>
             <package name="org.ballerinalang.test.execution.*" />
             <package name="org.ballerinalang.test.query.*" />
+            <package name="org.ballerinalang.test.docerina.*"/>
         </packages>
 
         <classes>


### PR DESCRIPTION
## Purpose
> $Title

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/21725

## Approach
> According to the Deprecation ballerina spec [1] attachment points to which the @deprecated annotation can be attached as follows.

The module-level symbols with public visibility:

- `module-type-defn` - Added to docerina
- `module-const-decl` - Added to docerina
- `annotation-decl` - Not supported in ballerina yet
- `function-defn` - Added to docerina

Function and method parameters:

- `required-param with public visibility` - Not supported in ballerina yet
- `defaultable-param with public visibility` - Not supported in ballerina yet

Object members with public visibility:

- `object-method` - Added to docerina
- `object-field-descriptor` - Not supported in ballerina yet

Deprecation is not supported for some of the constructs listed above according to this issue [2].

> Introduced a new field `isDeprecated` for all docerina model constructs which applicable to deprecation.

[1] https://github.com/ballerina-platform/ballerina-spec/blob/master/langext/deprecation/spec.md#attachment-points
[2] https://github.com/ballerina-platform/ballerina-lang/issues/21621

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
