### PR TITLE
Add support to access resource files inside resources directory

### DIFF
--- a/stdlib/file/src/main/java/org/ballerinalang/stdlib/file/utils/FileConstants.java
+++ b/stdlib/file/src/main/java/org/ballerinalang/stdlib/file/utils/FileConstants.java
@@ -50,6 +50,7 @@ public class FileConstants {
     public static final String PERMISSION_ERROR = "{ballerina/file}PermissionError";
     public static final String FILE_SYSTEM_ERROR = "{ballerina/file}FileSystemError";
     public static final String FILE_NOT_FOUND_ERROR = "{ballerina/file}FileNotFoundError";
+    public static final String UNZIPPING_FILE_ERROR = "{ballerina/file}UnzippingFileError";
     static final String ERROR_DETAILS = "Detail";
     static final String ERROR_MESSAGE = "message";
 

--- a/stdlib/file/src/main/java/org/ballerinalang/stdlib/file/utils/FileUtils.java
+++ b/stdlib/file/src/main/java/org/ballerinalang/stdlib/file/utils/FileUtils.java
@@ -30,6 +30,7 @@ import java.nio.file.attribute.FileTime;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.zip.ZipEntry;
 
 import static org.ballerinalang.stdlib.file.utils.FileConstants.FILE_INFO_TYPE;
 import static org.ballerinalang.stdlib.file.utils.FileConstants.FILE_PACKAGE_ID;
@@ -92,6 +93,15 @@ public class FileUtils {
                 inputFile.length(), lastModifiedInstance, inputFile.isDirectory(), inputFile.getAbsolutePath());
     }
 
+    public static ObjectValue getFileInfo(ZipEntry entry) {
+        MapValue<String, Object> lastModifiedInstance;
+        FileTime lastModified = entry.getLastModifiedTime();
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse(lastModified.toString());
+        lastModifiedInstance = createTimeRecord(getTimeZoneRecord(), getTimeRecord(),
+                lastModified.toMillis(), zonedDateTime.getZone().toString());
+        return BallerinaValues.createObjectValue(FILE_PACKAGE_ID, FILE_INFO_TYPE, entry.getName(),
+                entry.getSize(), lastModifiedInstance, entry.isDirectory(), entry.getName());
+    }
 
     /**
      * Returns the system property which corresponds to the given key.

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ByteChannelUtils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ByteChannelUtils.java
@@ -146,10 +146,16 @@ public class ByteChannelUtils extends AbstractNativeChannel {
 
     public static Object openReadableResourceFile(String pathUrl) {
         String[] className = Thread.currentThread().getStackTrace()[5].getClassName().split("\\.");
-        String resourcePath = RESOURCES + File.separator + className[0] + File.separator + className[1] + File.separator
-                + pathUrl;
+        String resourcePath = RESOURCES + File.separator + className[0] + File.separator + className[1]
+                + File.separator + pathUrl;
         InputStream resourceAsStream = ByteChannelUtils.class.getClassLoader().getResourceAsStream(resourcePath);
-        ReadableByteChannel readableByteChannel = Channels.newChannel(resourceAsStream);
+
+        ReadableByteChannel readableByteChannel;
+        if (resourceAsStream != null) {
+            readableByteChannel = Channels.newChannel(resourceAsStream);
+        } else {
+            return IOUtils.createError("No such file : " + resourcePath);
+        }
         Channel channel = new BlobIOChannel(new BlobChannel(readableByteChannel));
         return createChannel(channel);
     }


### PR DESCRIPTION
## Purpose
This PR will support to access the resource files which are inside the resources directory in Ballerina.

Consider resource directories as a separate file system and use the functions available in standard lib to access the files or directories. B7a file system will be a read only file system.

Resource files can be accessed by adding `b7a:` prefix to the existing file system.

Detailed analysis of this approach is in [1].
[1] https://docs.google.com/document/d/1jB9-qnE31zIsSI4wuu95eisrP0dXulLI_YV1h22LhMc/edit?usp=sharing

Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/18881

Find the ballerina sample below:
[main.bal.zip](https://github.com/ballerina-platform/ballerina-lang/files/4401719/main.bal.zip)




