### PR TITLE
Add info log to print observability backend

### DIFF
--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClient.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClient.java
@@ -24,6 +24,8 @@ import org.ballerinalang.observe.trace.extension.choreo.gen.NegotiatorOuterClass
 import org.ballerinalang.observe.trace.extension.choreo.gen.NegotiatorOuterClass.PublishProgramRequest;
 import org.ballerinalang.observe.trace.extension.choreo.gen.TelemetryGrpc;
 import org.ballerinalang.observe.trace.extension.choreo.gen.TelemetryOuterClass;
+import org.ballerinalang.observe.trace.extension.choreo.logging.LogFactory;
+import org.ballerinalang.observe.trace.extension.choreo.logging.Logger;
 import org.ballerinalang.observe.trace.extension.choreo.model.ChoreoMetric;
 import org.ballerinalang.observe.trace.extension.choreo.model.ChoreoTraceSpan;
 
@@ -34,6 +36,8 @@ import java.util.concurrent.TimeUnit;
  * Manages the communication with Choreo cloud.
  */
 public class ChoreoClient implements AutoCloseable {
+    private static final Logger LOGGER = LogFactory.getLogger();
+
     private String id;      // ID received from the handshake
     private String instanceId;
     private ManagedChannel channel;
@@ -42,6 +46,8 @@ public class ChoreoClient implements AutoCloseable {
     private Thread uploadingThread;
 
     public ChoreoClient(String hostname, int port, boolean useSSL) {
+        LOGGER.info("initializing connection with observability backend " + hostname + ":" + port);
+
         ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(hostname, port);
         if (!useSSL) {
             channelBuilder.usePlaintext();


### PR DESCRIPTION
## Describe your problem(s)

We need a way to identify the connecting observability backend for debugging purposes.

## Describe your solution

After adding the log to the tracing extension, the initial program output would look like below.
```
ballerina: initializing connection with observability backend periscope.choreo.dev:443
ballerina: visit https://development.choreo.dev/observe/app/obs67c9f2d1-60a6-4aa3-b354-56ea97ce4a84 to access observability data
ballerina: started publishing metrics to Choreo
ballerina: started publishing traces to Choreo
```