### PR TITLE
Fix trivia test in windows

### DIFF
--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
@@ -100,8 +100,7 @@ public class ParserTestUtils {
      */
     public static String getSourceText(Path sourceFilePath) {
         try {
-            return new String(Files.readAllBytes(RESOURCE_DIRECTORY.resolve(sourceFilePath)),
-                    StandardCharsets.UTF_8);
+            return new String(Files.readAllBytes(RESOURCE_DIRECTORY.resolve(sourceFilePath)), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -167,7 +166,12 @@ public class ParserTestUtils {
         // Validate the token text, if this is not a syntax token.
         // e.g: identifiers, basic-literals, etc.
         if (!isSyntaxToken(node.kind)) {
-            String expectedText = json.get(VALUE_FIELD).getAsString();
+            String expectedText;
+            if (node.kind == SyntaxKind.END_OF_LINE_TRIVIA) {
+                expectedText = System.lineSeparator();
+            } else {
+                expectedText = json.get(VALUE_FIELD).getAsString();
+            }
             String actualText = getTokenText(node);
             Assert.assertEquals(actualText, expectedText);
         }


### PR DESCRIPTION
## Purpose
Test case is failing due to the different line separators in windows and unix. assert json was generated in a unix env, so end-of-line trivia cannot be asserted using a pre-generated input. 

## Approach
Replaced the predefined newline with `System.newline()` for the end-of-line trivia.

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
