### PR TITLE
Fix for index out of range for specific mock functions

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -354,7 +354,7 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
             value = parent.packageID.toString();
 
         // If value does NOT contain 'ballerina/' then it could be fully qualified
-        } else if (!value.substring(0, 9).contains(Names.BALLERINA_ORG.value + Names.ORG_NAME_SEPARATOR.value)) {
+        } else if (!value.contains(Names.BALLERINA_ORG.value + Names.ORG_NAME_SEPARATOR.value)) {
 
             // If value is NOT fully qualified, then it is probably a SINGLE module name that needs formatting
             if (!value.contains(Names.ORG_NAME_SEPARATOR.value) && !value.contains(Names.VERSION_SEPARATOR.value)) {


### PR DESCRIPTION
## Purpose
The check for substring is no longer viable in the following case as it causes an out of range exception in some cases. 

Fixes #22243


## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
