### PR TITLE
Fix the issue in proto compiler when proto filepath contains white space(1.2.x)

### DIFF
--- a/misc/protobuf-ballerina/src/main/java/org/ballerinalang/protobuf/cmd/GrpcCmd.java
+++ b/misc/protobuf-ballerina/src/main/java/org/ballerinalang/protobuf/cmd/GrpcCmd.java
@@ -39,7 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.ballerinalang.net.grpc.proto.ServiceProtoConstants.TMP_DIRECTORY_PATH;
@@ -66,10 +66,14 @@ import static org.ballerinalang.protobuf.utils.BalFileGenerationUtils.grantPermi
         description = "generate Ballerina gRPC client stub for gRPC service for a given gRPC protoc " +
                 "definition.")
 public class GrpcCmd implements BLauncherCmd {
+
     private static final Logger LOG = LoggerFactory.getLogger(GrpcCmd.class);
-    
+
     private static final PrintStream outStream = System.out;
-    
+    private static final String PROTO_EXTENSION = "proto";
+    private static final String WHITESPACE_CHARACTOR = " ";
+    private static final String WHITESPACE_REPLACEMENT = "\\ ";
+
     private CommandLine parentCmdParser;
 
     @CommandLine.Option(names = {"-h", "--help"}, hidden = true)
@@ -87,7 +91,7 @@ public class GrpcCmd implements BLauncherCmd {
             description = "Generated Ballerina source files location"
     )
     private String balOutPath;
-    
+
     private String protocExePath;
 
     @CommandLine.Option(names = {"--protocVersion"}, hidden = true)
@@ -103,7 +107,9 @@ public class GrpcCmd implements BLauncherCmd {
         }
 
         // check input protobuf file path
-        if (protoPath == null || !protoPath.toLowerCase(Locale.ENGLISH).endsWith(PROTO_SUFFIX)) {
+        Optional<String> pathExtension = getFileExtension(protoPath);
+        if (!pathExtension.isPresent() ||
+                !PROTO_EXTENSION.equalsIgnoreCase(pathExtension.get())) {
             String errorMessage = "Invalid proto file path. Please input valid proto file location.";
             outStream.println(errorMessage);
             return;
@@ -149,8 +155,8 @@ public class GrpcCmd implements BLauncherCmd {
                 return;
             }
             try {
-                root = DescriptorsGenerator.generateRootDescriptor(this.protocExePath, new File(protoPath)
-                        .getAbsolutePath(), descFile.getAbsolutePath());
+                root = DescriptorsGenerator.generateRootDescriptor(this.protocExePath,
+                        escapeSpaceCharacter(protoPath), descFile.getAbsolutePath());
             } catch (CodeGeneratorException e) {
                 String errorMessage = "Error occurred when generating proto descriptor. " + e.getMessage();
                 LOG.error("Error occurred when generating proto descriptor.", e);
@@ -165,8 +171,8 @@ public class GrpcCmd implements BLauncherCmd {
             }
             LOG.debug("Successfully generated root descriptor.");
             try {
-                dependant = DescriptorsGenerator.generateDependentDescriptor(this.protocExePath, new File(protoPath)
-                                .getAbsolutePath(), descFile.getAbsolutePath());
+                dependant = DescriptorsGenerator.generateDependentDescriptor(this.protocExePath,
+                        escapeSpaceCharacter(protoPath), descFile.getAbsolutePath());
             } catch (CodeGeneratorException e) {
                 String errorMessage = "Error occurred when generating dependent proto descriptor. " + e.getMessage();
                 LOG.error(errorMessage, e);
@@ -225,6 +231,16 @@ public class GrpcCmd implements BLauncherCmd {
         if (!dirName.exists() && !dirName.mkdir()) {
             throw new IllegalStateException("Couldn't create dir: " + dirName);
         }
+    }
+
+    private Optional<String> getFileExtension(String filename) {
+        return Optional.ofNullable(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1));
+    }
+
+    private String escapeSpaceCharacter(String protoPath) {
+        return Paths.get(protoPath.replace(WHITESPACE_CHARACTOR, WHITESPACE_REPLACEMENT)).toAbsolutePath().toString();
     }
 
     /**

--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/BallerinaFileBuilder.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/builder/BallerinaFileBuilder.java
@@ -260,7 +260,7 @@ public class BallerinaFileBuilder {
             if (outputDir != null) {
                 Files.createDirectories(Paths.get(outputDir));
             }
-            File file = new File(outputDir + FILE_SEPARATOR + fileName);
+            File file = new File(outputDir, fileName);
             if (!file.isFile()) {
                 Files.createFile(Paths.get(file.getAbsolutePath()));
             }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -64,7 +64,25 @@ public class StubGeneratorTestCase {
 
     @Test
     public void testUnaryHelloWorld() throws IllegalAccessException, ClassNotFoundException, InstantiationException {
-        CompileResult compileResult = getStubCompileResult("helloWorld.proto", "helloWorld_pb.bal");
+        CompileResult compileResult = getStubCompileResult("helloWorld.proto", outputDirPath, "helloWorld_pb.bal");
+        assertEquals(compileResult.getDiagnostics().length, 0);
+        assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,
+                "Expected type definitions not found in compile results.");
+        assertEquals(((BLangPackage) compileResult.getAST()).functions.size(), 13,
+                "Expected functions not found in compile results.");
+        validatePublicAttachedFunctions(compileResult);
+        assertEquals(((BLangPackage) compileResult.getAST()).globalVars.size(), 1,
+                "Expected global variables not found in compile results.");
+        assertEquals(((BLangPackage) compileResult.getAST()).constants.size(), 1,
+                "Expected constants not found in compile results.");
+        assertEquals(((BLangPackage) compileResult.getAST()).imports.size(), 1,
+                "Expected imports not found in compile results.");
+    }
+
+    @Test(description = "Test proto definition compilation when proto file inside a directory with white space")
+    public void testDirectoryWithSpace() throws IllegalAccessException, ClassNotFoundException, InstantiationException {
+        CompileResult compileResult = getStubCompileResult(Paths.get("a b","helloWorld.proto").toString(),
+                outputDirPath.resolve("a b"), "helloWorld_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,
                 "Expected type definitions not found in compile results.");
@@ -83,7 +101,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithDependency() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithDependency.proto",
-                "helloWorldWithDependency_pb.bal");
+                 outputDirPath, "helloWorldWithDependency_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 10);
         assertEquals(compileResult.getDiagnostics()[0].toString(),
                      "ERROR: .::helloWorldWithDependency_pb.bal:15:34:: unknown type 'HelloRequest'");
@@ -96,7 +114,8 @@ public class StubGeneratorTestCase {
     @Test(description = "Test service stub generation for service definition with enum messages")
     public void testUnaryHelloWorldWithEnum() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
-        CompileResult compileResult = getStubCompileResult("helloWorldWithEnum.proto", "helloWorldWithEnum_pb.bal");
+        CompileResult compileResult = getStubCompileResult("helloWorldWithEnum.proto", outputDirPath,
+                "helloWorldWithEnum_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 11,
                 "Expected type definitions not found in compile results.");
@@ -112,7 +131,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithNestedEnum() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithNestedEnum.proto",
-                "helloWorldWithNestedEnum_pb.bal");
+                outputDirPath, "helloWorldWithNestedEnum_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 11,
                 "Expected type definitions not found in compile results.");
@@ -128,7 +147,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithNestedMessage() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithNestedMessage.proto",
-                "helloWorldWithNestedMessage_pb.bal");
+                outputDirPath, "helloWorldWithNestedMessage_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 9,
                 "Expected type definitions not found in compile results.");
@@ -138,7 +157,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithMaps() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithMap.proto",
-                "helloWorldWithMap_pb.bal");
+                outputDirPath, "helloWorldWithMap_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,
                 "Expected type definitions not found in compile results.");
@@ -148,7 +167,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithReservedNames() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithReservedNames.proto",
-                "helloWorldWithReservedNames_pb.bal");
+                outputDirPath, "helloWorldWithReservedNames_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,
                 "Expected type definitions not found in compile results.");
@@ -160,7 +179,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithInvalidDependency() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithInvalidDependency.proto",
-                "helloWorldWithInvalidDependency_pb.bal");
+                outputDirPath, "helloWorldWithInvalidDependency_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 1);
     }
 
@@ -168,7 +187,7 @@ public class StubGeneratorTestCase {
     public void testUnaryHelloWorldWithPackage() throws IllegalAccessException,
             ClassNotFoundException, InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldWithPackage.proto",
-                "helloWorldWithPackage_pb.bal");
+                outputDirPath, "helloWorldWithPackage_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,
                 "Expected type definitions not found in compile results.");
@@ -217,7 +236,7 @@ public class StubGeneratorTestCase {
     public void testClientStreamingHelloWorld() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldClientStreaming.proto",
-                "helloWorldClientStreaming_pb.bal");
+                outputDirPath, "helloWorldClientStreaming_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 4,
                 "Expected type definitions not found in compile results.");
@@ -235,7 +254,7 @@ public class StubGeneratorTestCase {
     public void testServerStreamingHelloWorld() throws IllegalAccessException,
             ClassNotFoundException, InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldServerStreaming.proto",
-                "helloWorldServerStreaming_pb.bal");
+                outputDirPath, "helloWorldServerStreaming_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 4,
                 "Expected type definitions not found in compile results.");
@@ -252,7 +271,7 @@ public class StubGeneratorTestCase {
     @Test
     public void testStandardDataTypes() throws IllegalAccessException, ClassNotFoundException, InstantiationException {
         CompileResult compileResult = getStubCompileResult("helloWorldString.proto",
-                "helloWorldString_pb.bal");
+                outputDirPath, "helloWorldString_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 3,
                 "Expected type definitions not found in compile results.");
@@ -329,7 +348,7 @@ public class StubGeneratorTestCase {
     public void testOneofFieldRecordGeneration() throws IllegalAccessException, ClassNotFoundException,
             InstantiationException {
         CompileResult compileResult = getStubCompileResult("oneof_field_service.proto",
-                "oneof_field_service_pb.bal");
+                outputDirPath, "oneof_field_service_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 8,
                 "Expected type definitions not found in compile results.");
@@ -411,15 +430,15 @@ public class StubGeneratorTestCase {
         fail("constant for " + constantName + " doesn't exist in compiled results");
     }
 
-    private CompileResult getStubCompileResult(String protoFilename, String outputFilename)
+    private CompileResult getStubCompileResult(String protoFilename, Path outputDir, String outputFilename)
             throws ClassNotFoundException, InstantiationException, IllegalAccessException {
         Class<?> grpcCmd = Class.forName("org.ballerinalang.protobuf.cmd.GrpcCmd");
         GrpcCmd grpcCmd1 = (GrpcCmd) grpcCmd.newInstance();
         Path protoFilePath = resourceDir.resolve(protoFilename);
-        grpcCmd1.setBalOutPath(outputDirPath.toAbsolutePath().toString());
+        grpcCmd1.setBalOutPath(outputDir.toAbsolutePath().toString());
         grpcCmd1.setProtoPath(protoFilePath.toAbsolutePath().toString());
         grpcCmd1.execute();
-        Path outputFilePath = outputDirPath.resolve(outputFilename);
+        Path outputFilePath = outputDir.resolve(outputFilename);
         return BCompileUtil.compile(outputFilePath.toString());
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/grpc/tool/StubGeneratorTestCase.java
@@ -50,7 +50,6 @@ import static org.testng.Assert.fail;
  */
 public class StubGeneratorTestCase {
 
-    private static final String PACKAGE_NAME = ".";
     private static String protoExeName = "protoc-" + OSDetector.getDetectedClassifier() + ".exe";
     private Path resourceDir;
     private Path outputDirPath;
@@ -81,7 +80,7 @@ public class StubGeneratorTestCase {
 
     @Test(description = "Test proto definition compilation when proto file inside a directory with white space")
     public void testDirectoryWithSpace() throws IllegalAccessException, ClassNotFoundException, InstantiationException {
-        CompileResult compileResult = getStubCompileResult(Paths.get("a b","helloWorld.proto").toString(),
+        CompileResult compileResult = getStubCompileResult(Paths.get("a b", "helloWorld.proto").toString(),
                 outputDirPath.resolve("a b"), "helloWorld_pb.bal");
         assertEquals(compileResult.getDiagnostics().length, 0);
         assertEquals(((BLangPackage) compileResult.getAST()).typeDefinitions.size(), 7,

--- a/tests/jballerina-integration-test/src/test/resources/grpc/src/tool/a b/helloWorld.proto
+++ b/tests/jballerina-integration-test/src/test/resources/grpc/src/tool/a b/helloWorld.proto
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+syntax = "proto3";
+service helloWorld {
+		rpc hello(HelloRequest) returns (HelloResponse);
+		rpc bye(ByeRequest) returns (ByeResponse);
+}
+message HelloRequest {
+	string name = 1;
+}
+message HelloResponse {
+	string message = 1;
+}
+message ByeRequest {
+	string greet = 1;
+}
+message ByeResponse {
+	string say = 1;
+}
+


### PR DESCRIPTION
## Purpose
This is to fix the issue in gRPC compiler where it does not work when the .proto file is in a directory with white space

Fixes #20994

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
