### PR TITLE
[IntelliJ Plugin] Improve error handling when executing ballerina commands internally 

### DIFF
--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/debugger/BallerinaDAPClientConnector.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/debugger/BallerinaDAPClientConnector.java
@@ -23,6 +23,7 @@ import io.ballerina.plugins.idea.debugger.client.DAPClient;
 import io.ballerina.plugins.idea.debugger.client.DAPRequestManager;
 import io.ballerina.plugins.idea.debugger.client.connection.BallerinaSocketStreamConnectionProvider;
 import io.ballerina.plugins.idea.debugger.client.connection.BallerinaStreamConnectionProvider;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.preloading.OSUtils;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkUtils;
 import io.ballerina.plugins.idea.settings.autodetect.BallerinaAutoDetectionSettings;
@@ -36,7 +37,6 @@ import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
@@ -145,7 +145,7 @@ public class BallerinaDAPClientConnector {
                 return res;
             });
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             myConnectionState = ConnectionState.NOT_CONNECTED;
             LOG.warn("Error occurred when trying to initialize connection with the debug server.", e);
         }
@@ -217,11 +217,16 @@ public class BallerinaDAPClientConnector {
             // Checks for the user-configured auto detection settings.
             if (Strings.isNullOrEmpty(balSdkPath) &&
                     BallerinaAutoDetectionSettings.getInstance(project).isAutoDetectionEnabled()) {
-                balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+                try {
+                    balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+                } catch (BallerinaCmdException e) {
+                    LOG.warn(String.format("failed to auto-detect ballerina home for the project %s, to start " +
+                            "debug server.", project.getName()));
+                    return null;
+                }
             }
-
             if (Strings.isNullOrEmpty(balSdkPath)) {
-                LOG.warn(String.format("Couldn't find ballerina SDK for the project %s to start debug server.",
+                LOG.warn(String.format("couldn't find ballerina SDK for the project %s to start debug server.",
                         project.getName()));
                 return null;
             }

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/inspections/VersionMismatchNotificationProvider.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/inspections/VersionMismatchNotificationProvider.java
@@ -28,6 +28,7 @@ import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import icons.BallerinaIcons;
 import io.ballerina.plugins.idea.BallerinaFileType;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkService;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkUtils;
 import org.jetbrains.annotations.NotNull;
@@ -71,11 +72,16 @@ public class VersionMismatchNotificationProvider extends EditorNotifications.Pro
             // Compares the major and minor version numbers between the ballerina sdk and the plugin.
             if (!getMajorVersion(sdkVersion).equals(getMajorVersion(pluginVersion))
                     || !getMinorVersion(sdkVersion).equals(getMinorVersion(pluginVersion))) {
-                return createPanel(module, sdkVersion, pluginVersion, true);
+                return createPanel(module, sdkVersion, pluginVersion, false);
             }
         } else if (Strings.isNullOrEmpty(sdkVersion)) {
             // Compares auto-detected ballerina version with the plugin version.
-            String autoDetectedBalHome = BallerinaSdkUtils.autoDetectSdk(myProject);
+            String autoDetectedBalHome = "";
+            try {
+                autoDetectedBalHome = BallerinaSdkUtils.autoDetectSdk(myProject);
+            } catch (BallerinaCmdException e) {
+                // no operation.
+            }
             sdkVersion = BallerinaSdkUtils.retrieveBallerinaVersion(autoDetectedBalHome);
             if (!Strings.isNullOrEmpty(sdkVersion) && !Strings.isNullOrEmpty(pluginVersion)) {
                 // Compares the major and minor version numbers between the auto detected ballerina version and

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/inspections/WrongSdkConfigurationNotificationProvider.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/inspections/WrongSdkConfigurationNotificationProvider.java
@@ -38,6 +38,7 @@ import com.intellij.util.messages.MessageBusConnection;
 import icons.BallerinaIcons;
 import io.ballerina.plugins.idea.BallerinaFileType;
 import io.ballerina.plugins.idea.BallerinaLanguage;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.project.BallerinaLibrariesService;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkService;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkUtils;
@@ -94,7 +95,12 @@ public class WrongSdkConfigurationNotificationProvider extends EditorNotificatio
 
         Module module = ModuleUtilCore.findModuleForPsiElement(psiFile);
         if (module == null) {
-            String sdkHomePath = BallerinaSdkUtils.autoDetectSdk(myProject);
+            String sdkHomePath;
+            try {
+                sdkHomePath = BallerinaSdkUtils.autoDetectSdk(myProject);
+            } catch (BallerinaCmdException e) {
+                return createMissingSdkPanel(myProject, null);
+            }
             if (Strings.isNullOrEmpty(sdkHomePath)) {
                 return createMissingSdkPanel(myProject, null);
             }
@@ -103,7 +109,11 @@ public class WrongSdkConfigurationNotificationProvider extends EditorNotificatio
 
         String sdkHomePath = BallerinaSdkUtils.getBallerinaSdkFor(myProject, module).getSdkPath();
         if (Strings.isNullOrEmpty(sdkHomePath)) {
-            sdkHomePath = BallerinaSdkUtils.autoDetectSdk(myProject);
+            try {
+                sdkHomePath = BallerinaSdkUtils.autoDetectSdk(myProject);
+            } catch (BallerinaCmdException e) {
+                return createMissingSdkPanel(myProject, module);
+            }
         }
         if (Strings.isNullOrEmpty(sdkHomePath)) {
             return createMissingSdkPanel(myProject, module);

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/preloading/BallerinaCmdException.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/preloading/BallerinaCmdException.java
@@ -1,0 +1,14 @@
+package io.ballerina.plugins.idea.preloading;
+
+/**
+ * Exception thrown when a failure is occurred due to any ballerina command execution failure.
+ */
+public class BallerinaCmdException extends Exception {
+    public BallerinaCmdException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public BallerinaCmdException(String message) {
+        super(message);
+    }
+}

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/runconfig/BallerinaRunConfigurationBase.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/runconfig/BallerinaRunConfigurationBase.java
@@ -41,6 +41,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.PathUtil;
 import com.intellij.util.containers.ContainerUtil;
 import io.ballerina.plugins.idea.BallerinaConstants;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkService;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkUtils;
 import io.ballerina.plugins.idea.settings.autodetect.BallerinaAutoDetectionSettings;
@@ -119,7 +120,13 @@ public abstract class BallerinaRunConfigurationBase<RunningState extends Balleri
         if (module != null) {
             if (BallerinaSdkService.getInstance(module.getProject()).getSdkHomePath(module) == null) {
                 if (BallerinaAutoDetectionSettings.getInstance(getProject()).isAutoDetectionEnabled()) {
-                    String autoDetectedPath = BallerinaSdkUtils.autoDetectSdk(getProject());
+                    String autoDetectedPath;
+                    try {
+                        autoDetectedPath = BallerinaSdkUtils.autoDetectSdk(getProject());
+                    } catch (BallerinaCmdException e) {
+                        throw new RuntimeConfigurationError(String.format("Ballerina SDK is not specified and auto " +
+                                "detection is failed for module '%s'", module.getName()));
+                    }
                     if (autoDetectedPath.isEmpty()) {
                         throw new RuntimeConfigurationError(String.format("Ballerina SDK is not specified and auto " +
                                 "detection is failed for module '%s'", module.getName()));

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/runconfig/application/BallerinaApplicationRunningState.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/runconfig/application/BallerinaApplicationRunningState.java
@@ -28,6 +28,7 @@ import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.psi.impl.BallerinaPsiImplUtil;
 import io.ballerina.plugins.idea.runconfig.BallerinaRunningState;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkService;
@@ -147,7 +148,12 @@ public class BallerinaApplicationRunningState extends BallerinaRunningState<Ball
             // If any sdk is not found and user has chosen to auto detect ballerina home.
             if (Strings.isNullOrEmpty(balSdkPath) && BallerinaAutoDetectionSettings.getInstance(project).
                     isAutoDetectionEnabled()) {
-                balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+                try {
+                    balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+                } catch (BallerinaCmdException e) {
+                    throw new ExecutionException(String.format("cannot find ballerina SDK/auto-detected ballerina " +
+                            "home to run the file '%s'", file.getVirtualFile().getPath()));
+                }
             }
             ballerinaExecutor.withBallerinaPath(balSdkPath);
 
@@ -174,7 +180,12 @@ public class BallerinaApplicationRunningState extends BallerinaRunningState<Ball
             // If any sdk is not found and user has chosen to auto detect ballerina home.
             if (Strings.isNullOrEmpty(balSdkPath) && BallerinaAutoDetectionSettings.getInstance(project)
                     .isAutoDetectionEnabled()) {
-                balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+                try {
+                    balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+                } catch (BallerinaCmdException e) {
+                    throw new ExecutionException(String.format("cannot find ballerina SDK/auto-detected ballerina " +
+                            "home to run the file '%s'", file.getVirtualFile().getPath()));
+                }
             }
             ballerinaExecutor.withBallerinaPath(balSdkPath);
 

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/sdk/BallerinaSdkUtils.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/sdk/BallerinaSdkUtils.java
@@ -47,6 +47,7 @@ import com.intellij.util.Function;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.containers.ContainerUtil;
 import io.ballerina.plugins.idea.BallerinaConstants;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.preloading.OSUtils;
 import io.ballerina.plugins.idea.project.BallerinaApplicationLibrariesService;
 import io.ballerina.plugins.idea.project.BallerinaLibrariesService;
@@ -262,14 +263,14 @@ public class BallerinaSdkUtils {
     /**
      * @return an empty string if it fails to auto-detect the ballerina home automatically.
      */
-    public static String autoDetectSdk(Project project) {
+    public static String autoDetectSdk(Project project) throws BallerinaCmdException {
 
         // Checks for the user-configured auto detection settings.
         if (!BallerinaAutoDetectionSettings.getInstance(project).isAutoDetectionEnabled()) {
             return "";
         }
 
-        String ballerinaPath = getByCommand(String.format("%s %s", BALLERINA_CMD, BALLERINA_HOME_CMD));
+        String ballerinaPath = execBalHomeCmd(String.format("%s %s", BALLERINA_CMD, BALLERINA_HOME_CMD));
         if (ballerinaPath.isEmpty()) {
             // Todo - Verify
             // Tries for default installer based locations since "ballerina" commands might not work
@@ -277,34 +278,40 @@ public class BallerinaSdkUtils {
             // runtime.
             String routerScriptPath = getByDefaultPath();
             if (OSUtils.isWindows()) {
-                ballerinaPath = getByCommand(String.format("\"%s\" %s", routerScriptPath, BALLERINA_HOME_CMD));
+                ballerinaPath = execBalHomeCmd(String.format("\"%s\" %s", routerScriptPath, BALLERINA_HOME_CMD));
             } else {
-                ballerinaPath = getByCommand(String.format("%s %s", routerScriptPath, BALLERINA_HOME_CMD));
+                ballerinaPath = execBalHomeCmd(String.format("%s %s", routerScriptPath, BALLERINA_HOME_CMD));
             }
         }
 
         return ballerinaPath;
     }
 
-    public static String getByCommand(String cmd) {
+    /**
+     * Executes ballerina home command and returns the result.
+     *
+     * @param cmd command to be executed.
+     * @return ballerina distribution location.
+     */
+    public static String execBalHomeCmd(String cmd) throws BallerinaCmdException {
         java.util.Scanner s;
+        // This may returns a symlink which links to the real path.
         try {
-            // This may returns a symlink which links to the real path.
             s = new java.util.Scanner(Runtime.getRuntime().exec(cmd).getInputStream()).useDelimiter("\\A");
+
             String path = s.hasNext() ? s.next().trim().replace(System.lineSeparator(), "").trim() : "";
-            LOG.info(cmd + "command returned: " + path);
+            LOG.info(String.format("%s command returned: %s", cmd, path));
 
             // Todo - verify
             // Since errors might be coming from the input stream when retrieving ballerina distribution path, we need
             // an additional check.
             if (!new File(path).exists()) {
-                LOG.warn(String.format("Invalid result received by \"%s\" command. Received Output: %s", cmd, path));
-                return "";
+                throw new BallerinaCmdException(String.format("unexpected output received by \"%s\" command. " +
+                        "received output: %s", cmd, path));
             }
             return path;
-        } catch (Exception e) {
-            LOG.warn("Unexpected error occurred when executing ballerina command: " + cmd, e);
-            return "";
+        } catch (IOException e) {
+            throw new BallerinaCmdException("Unexpected error occurred when executing ballerina command: " + cmd, e);
         }
     }
 

--- a/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/webview/diagram/preview/BallerinaDiagramUtils.java
+++ b/tool-plugins/intellij/src/main/java/io/ballerina/plugins/idea/webview/diagram/preview/BallerinaDiagramUtils.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.ballerina.plugins.idea.preloading.BallerinaCmdException;
 import io.ballerina.plugins.idea.sdk.BallerinaSdkUtils;
 import io.ballerina.plugins.idea.settings.autodetect.BallerinaAutoDetectionSettings;
 import org.jetbrains.annotations.NonNls;
@@ -88,7 +89,12 @@ public class BallerinaDiagramUtils {
         // Checks for the user-configured auto detection settings.
         if (Strings.isNullOrEmpty(balSdkPath)
                 && BallerinaAutoDetectionSettings.getInstance(project).isAutoDetectionEnabled()) {
-            balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+            try {
+                balSdkPath = BallerinaSdkUtils.autoDetectSdk(project);
+            } catch (BallerinaCmdException e) {
+                LOG.warn(String.format("failed to auto detect ballerina home for the project: %s", project.getName()));
+                return "";
+            }
         }
 
         if (Strings.isNullOrEmpty(balSdkPath)) {


### PR DESCRIPTION
## Purpose
This PR improves error handling when `ballerina home`/`ballerina start-language-server` command execution fails, which are used to auto detect ballerina distribution and initiate language server connection.
Now the user can see the error in IDEA event log console if any ballerina command execution is failed internally when trying to auto detect ballerina home. (i.e. due to incompatible java version)

Fixes #22081.

## Remarks
Related PR - #21894

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
