### PR TITLE
Throw unused import error along with semantic errors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -158,7 +158,6 @@ public class Compiler {
                 // skip the packages that were not loaded properly
                 packages.add(bLangPackage);
             }
-            dlog.resetErrorCount();
         }
 
         // 3) Invoke compiler phases. e.g. type_check, code_analyze, taint_analyze, desugar etc.
@@ -166,6 +165,7 @@ public class Compiler {
             if (pkgNode.symbol != null) {
                 this.compilerDriver.compilePackage(pkgNode);
             }
+            dlog.resetErrorCount();
         }
         return packages;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -158,6 +158,7 @@ public class Compiler {
                 // skip the packages that were not loaded properly
                 packages.add(bLangPackage);
             }
+            dlog.resetErrorCount();
         }
 
         // 3) Invoke compiler phases. e.g. type_check, code_analyze, taint_analyze, desugar etc.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -164,8 +164,8 @@ public class Compiler {
         for (BLangPackage pkgNode : packages) {
             if (pkgNode.symbol != null) {
                 this.compilerDriver.compilePackage(pkgNode);
+                dlog.resetErrorCount();
             }
-            dlog.resetErrorCount();
         }
         return packages;
     }


### PR DESCRIPTION
## Purpose
> To fix the error of unused import is not thrown when modules consist of other semantic errors.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/21878

## Approach
> Reset the error count before compiling each module

## Suggested labels
Area/BuildTools

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
