### PR TITLE
[1.2.x] Add support for record -> JSON assignment

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONUtils.java
@@ -237,7 +237,7 @@ public class JSONUtils {
 
         BType type = ((RefValue) json).getType();
         int typeTag = type.getTag();
-        return typeTag == TypeTags.JSON_TAG || typeTag == TypeTags.MAP_TAG || typeTag == TypeTags.RECORD_TYPE_TAG;
+        return typeTag == TypeTags.MAP_TAG || typeTag == TypeTags.RECORD_TYPE_TAG;
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/JSONUtils.java
@@ -236,7 +236,8 @@ public class JSONUtils {
         }
 
         BType type = ((RefValue) json).getType();
-        return type.getTag() == TypeTags.JSON_TAG || type.getTag() == TypeTags.MAP_TAG;
+        int typeTag = type.getTag();
+        return typeTag == TypeTags.JSON_TAG || typeTag == TypeTags.MAP_TAG || typeTag == TypeTags.RECORD_TYPE_TAG;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -518,7 +518,7 @@ public class Types {
 
         if (targetTag == TypeTags.MAP && sourceTag == TypeTags.RECORD) {
             BRecordType recordType = (BRecordType) source;
-            return isAssignableRecordType(recordType, (BMapType) target);
+            return isAssignableRecordType(recordType, target);
         }
 
         if (target.getKind() == TypeKind.SERVICE && source.getKind() == TypeKind.SERVICE) {
@@ -564,6 +564,10 @@ public class Types {
 
             if (sourceTag == TypeTags.MAP) {
                 return isAssignable(((BMapType) source).constraint, target, unresolvedTypes);
+            }
+
+            if (sourceTag == TypeTags.RECORD) {
+                return isAssignableRecordType((BRecordType) source, target);
             }
         }
 
@@ -618,17 +622,34 @@ public class Types {
                 isArrayTypesAssignable(source, target, unresolvedTypes);
     }
 
-    private boolean isAssignableRecordType(BRecordType recordType, BMapType targetMapType) {
+    private boolean isAssignableRecordType(BRecordType recordType, BType type) {
+        BType targetType;
+        switch (type.tag) {
+            case TypeTags.MAP:
+                targetType = ((BMapType) type).constraint;
+                break;
+            case TypeTags.JSON:
+                targetType = type;
+                break;
+            default:
+                throw new IllegalArgumentException("Incompatible target type: " + type.toString());
+        }
+
         if (recordType.sealed) {
-            return recordFieldsAssignableToMap(recordType, targetMapType);
+            return recordFieldsAssignableToType(recordType, targetType);
         } else {
-            return isAssignable(recordType.restFieldType, targetMapType.constraint)
-                    && recordFieldsAssignableToMap(recordType, targetMapType);
+            return recordFieldsAssignableToType(recordType, targetType) &&
+                    isAssignable(recordType.restFieldType, targetType);
         }
     }
 
-    private boolean recordFieldsAssignableToMap(BRecordType recordType, BMapType targetMapType) {
-        return recordType.fields.stream().allMatch(field -> isAssignable(field.type, targetMapType.constraint));
+    private boolean recordFieldsAssignableToType(BRecordType recordType, BType targetType) {
+        for (BField field : recordType.fields) {
+            if (!isAssignable(field.type, targetType)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean isErrorTypeAssignable(BErrorType source, BErrorType target, Set<TypePair> unresolvedTypes) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -634,13 +634,7 @@ public class Types {
             default:
                 throw new IllegalArgumentException("Incompatible target type: " + type.toString());
         }
-
-        if (recordType.sealed) {
-            return recordFieldsAssignableToType(recordType, targetType);
-        } else {
-            return recordFieldsAssignableToType(recordType, targetType) &&
-                    isAssignable(recordType.restFieldType, targetType);
-        }
+        return recordFieldsAssignableToType(recordType, targetType);
     }
 
     private boolean recordFieldsAssignableToType(BRecordType recordType, BType targetType) {
@@ -649,6 +643,11 @@ public class Types {
                 return false;
             }
         }
+
+        if (!recordType.sealed) {
+            return isAssignable(recordType.restFieldType, targetType);
+        }
+
         return true;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
@@ -1,0 +1,81 @@
+/*
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.types.json;
+
+import org.ballerinalang.test.util.BAssertUtil;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.util.BAssertUtil.validateError;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for assignability of records to JSON.
+ *
+ * @since 1.2.1
+ */
+public class RecordToJSONTest {
+
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/types/jsontype/record_to_json.bal");
+    }
+
+    @Test
+    public void testNegatives() {
+        CompileResult result = BCompileUtil.compile("test-src/types/jsontype/record_to_json_negative.bal");
+        int indx = 0;
+        validateError(result, indx++,
+                      "incompatible types: expected 'json', found 'record {| string name; anydata...; |}'", 22, 15);
+        validateError(result, indx++, "incompatible types: expected 'json', found 'record {| map m; |}'", 28, 15);
+        validateError(result, indx++,
+                      "incompatible types: expected 'json', found 'record {| string name; record {| record {| int x; " +
+                              "any y; |} nestedL2; |} nestedL1; |}'",
+                      40, 15);
+        validateError(result, indx++,
+                      "incompatible types: expected 'json', found 'record {| string name; record {| record {| int x; " +
+                              "(int|string|typedesc)...; |} nestedL2; |} nestedL1; |}'",
+                      52, 15);
+        assertEquals(result.getErrorCount(), indx);
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp =
+                  ".*KeyNotFound message=invalid field access: field 'newField' not found in " +
+                          "record type 'Foo'.*")
+    public void testClosedRecordToJson() {
+        BRunUtil.invoke(compileResult, "testClosedRecordToJson");
+    }
+
+    @Test
+    public void testOpenRecordToJson() {
+        BRunUtil.invoke(compileResult, "testOpenRecordToJson");
+    }
+
+    @Test
+    public void testNestedRecordModification() {
+        BRunUtil.invoke(compileResult, "testNestedRecordModification");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
@@ -17,12 +17,10 @@
  */
 package org.ballerinalang.test.types.json;
 
-import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/record_to_json.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/record_to_json.bal
@@ -1,0 +1,139 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo record {|
+    int i = 10;
+    string s = "foo";
+    float f = 12.34;
+    decimal d = 23.456;
+    boolean b = true;
+    byte byt = 127;
+    json j = {"name": "Pubudu"};
+|};
+
+function testClosedRecordToJson() {
+    Foo f = {};
+    json j = f;
+    assert(<map<json>>{"i": 10, "s": "foo", "f": 12.34, "d": 23.456d, b: true, "byt": 127, "j": {"name": "Pubudu"}}, j);
+
+    map<json> mJ = <map<json>>j;
+    mJ["newField"] = 20;
+}
+
+function testOpenRecordToJson() {
+    record {|
+        string fname = "John";
+        string lname = "Doe";
+        string...;
+    |} person = {"country": "Sri Lanka"};
+
+    json j1 = person;
+    assert(<json>{"fname": "John", "lname": "Doe", "country": "Sri Lanka"}, j1);
+
+    map<json> mJ1 = <map<json>>j1;
+    mJ1["city"] = "Colombo 3";
+    assert(<json>{"fname": "John", "lname": "Doe", "country": "Sri Lanka", "city": "Colombo 3"}, mJ1);
+}
+
+type Address record {|
+   string street;
+   string city;
+   string country;
+|};
+
+type Person record {|
+    string name;
+    record {|
+        Address adr;
+    |} residentialDetails;
+|};
+
+function testNestedRecordToJson() {
+    Person p = {
+        name: "John",
+        residentialDetails: {
+            adr: {
+                street: "Palm Grove",
+                city: "Colombo 3",
+                country: "Sri Lanka"
+            }
+        }
+    };
+
+    json jPerson = p;
+
+    json expectedP = {
+        "name": "John",
+        "residentialDetails": {
+            "adr": {
+                "street": "Palm Grove",
+                "city": "Colombo 3",
+                "country": "Sri Lanka"
+            }
+        }
+    };
+
+    assert(expectedP, jPerson);
+}
+
+function testNestedRecordModification() {
+    record {|
+        string name;
+        record {|
+            record {|
+                int x;
+                float...;
+            |} nestedL2;
+        |} nestedL1;
+    |} rec = {
+        name: "John",
+        nestedL1: {
+            nestedL2: {
+                x: 100
+            }
+        }
+    };
+
+    json jR = rec;
+
+    json nestedL2 = checkpanic jR.nestedL1.nestedL2;
+    map<json> l2M = <map<json>>nestedL2;
+    l2M["restF1"] = 12.34;
+
+    json expected = {
+        "name": "John",
+        "nestedL1": {
+            "nestedL2": {
+                "x": 100,
+                "restF1": 12.34
+            }
+        }
+    };
+
+    assert(expected, jR);
+}
+
+// Util functions
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string detail = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/record_to_json_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/record_to_json_negative.bal
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testNegatives() {
+    record {
+        string name;
+    } person = {name: "John"};
+
+    json j1 = person; // open with anydata record to json
+
+    record {|
+        map<any> m;
+    |} r1 = {m: {}};
+
+    json j2 = r1;
+
+    record {|
+        string name = "";
+        record {|
+            record {|
+                int x = 10;
+                any y = ();
+            |} nestedL2 = {};
+        |} nestedL1 = {};
+    |} r2 = {};
+
+    json j3 = r2;
+
+    record {|
+        string name = "";
+        record {|
+            record {|
+                int x = 10;
+                (int|string|typedesc<any>)...;
+            |} nestedL2 = {};
+        |} nestedL1 = {};
+    |} r3 = {};
+
+    json j4 = r3;
+}
+


### PR DESCRIPTION
## Purpose
> This PR adds support for assigning compatible records to `json`. 
> Fixes #18697
> Fixes #22306

## Samples
```ballerina
public function main() {
    Person p = {};
    json j = p; // Used to be a compile error
}

type Person record {|
    string name = "";
    int age = 0;
|};
```
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
