### PR TITLE
Issue an error on stack and queue method calls on fixed-length lists

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -496,6 +496,9 @@ public enum DiagnosticCode {
     DEPRECATION_DOCUMENTATION_SHOULD_BE_AVAILABLE("deprecation.documentation.should.available"),
     DEPRECATED_PARAMETERS_DOCUMENTATION_NOT_ALLOWED("deprecated.parameters.documentation.not.allowed"),
     INVALID_ATTRIBUTE_REFERENCE("invalid.attribute.reference"),
+
+    ILLEGAL_FUNCTION_ARRAY_SIZE("illegal.function.array.size"),
+    ILLEGAL_FUNCTION_TUPLE_SIZE("illegal.function.tuple.size"),
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -498,6 +498,7 @@ public enum DiagnosticCode {
     INVALID_ATTRIBUTE_REFERENCE("invalid.attribute.reference"),
 
     ILLEGAL_FUNCTION_CHANGE_LIST_SIZE("illegal.function.change.list.size"),
+    ILLEGAL_FUNCTION_CHANGE_TUPLE_SHAPE("illegal.function.change.tuple.shape"),
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -497,8 +497,7 @@ public enum DiagnosticCode {
     DEPRECATED_PARAMETERS_DOCUMENTATION_NOT_ALLOWED("deprecated.parameters.documentation.not.allowed"),
     INVALID_ATTRIBUTE_REFERENCE("invalid.attribute.reference"),
 
-    ILLEGAL_FUNCTION_ARRAY_SIZE("illegal.function.array.size"),
-    ILLEGAL_FUNCTION_TUPLE_SIZE("illegal.function.tuple.size"),
+    ILLEGAL_FUNCTION_CHANGE_LIST_SIZE("illegal.function.change.list.size"),
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -227,7 +227,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         return pkgNode;
     }
 
-
     // Visitor methods
 
     public void visit(BLangPackage pkgNode) {
@@ -620,7 +619,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             }
             return;
         }
-
         // Here we create a new symbol environment to catch self references by keep the current
         // variable symbol in the symbol environment
         // e.g. int a = x + a;
@@ -2856,7 +2854,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             if (annotationName.equals(Names.ANNOTATION_TYPE_PARAM.value)) {
                 dlog.error(attachment.pos, DiagnosticCode.TYPE_PARAM_OUTSIDE_LANG_MODULE);
             } else if (annotationName.equals(Names.ANNOTATION_BUILTIN_SUBTYPE.value)) {
-                dlog.error(attachment.pos, DiagnosticCode.TYPE_PARAM_OUTSIDE_LANG_MODULE);
+                dlog.error(attachment.pos, DiagnosticCode.BUILTIN_SUBTYPE_OUTSIDE_LANG_MODULE);
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -227,6 +227,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         return pkgNode;
     }
 
+
     // Visitor methods
 
     public void visit(BLangPackage pkgNode) {
@@ -619,6 +620,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             }
             return;
         }
+
         // Here we create a new symbol environment to catch self references by keep the current
         // variable symbol in the symbol environment
         // e.g. int a = x + a;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -178,8 +178,9 @@ import static org.wso2.ballerinalang.compiler.util.Constants.WORKER_LAMBDA_VAR_P
  */
 public class TypeChecker extends BLangNodeVisitor {
 
-    private static final CompilerContext.Key<TypeChecker> TYPE_CHECKER_KEY =
-            new CompilerContext.Key<>();
+    private static final CompilerContext.Key<TypeChecker> TYPE_CHECKER_KEY = new CompilerContext.Key<>();
+    private static Set<String> modifierFunctions = new HashSet<>();
+
     private static final String TABLE_TNAME = "table";
     private static final String FUNCTION_PUSH_NAME = "push";
     private static final String FUNCTION_POP_NAME = "pop";
@@ -200,10 +201,8 @@ public class TypeChecker extends BLangNodeVisitor {
     private BLangAnonymousModelHelper anonymousModelHelper;
     private SemanticAnalyzer semanticAnalyzer;
     private boolean nonErrorLoggingCheck = false;
-    private Set<String> modifierFunctions = new HashSet<>();
-
-
     private int letCount = 0;
+
     /**
      * Expected types or inherited types.
      */
@@ -211,6 +210,13 @@ public class TypeChecker extends BLangNodeVisitor {
     private BType resultType;
 
     private DiagnosticCode diagCode;
+
+    static {
+        modifierFunctions.add(FUNCTION_PUSH_NAME);
+        modifierFunctions.add(FUNCTION_POP_NAME);
+        modifierFunctions.add(FUNCTION_SHIFT_NAME);
+        modifierFunctions.add(FUNCTION_UNSHIFT_NAME);
+    }
 
     public static TypeChecker getInstance(CompilerContext context) {
         TypeChecker typeChecker = context.get(TYPE_CHECKER_KEY);
@@ -235,14 +241,6 @@ public class TypeChecker extends BLangNodeVisitor {
         this.typeParamAnalyzer = TypeParamAnalyzer.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
-        initModifierFunctions();
-    }
-
-    private void initModifierFunctions() {
-        this.modifierFunctions.add(FUNCTION_PUSH_NAME);
-        this.modifierFunctions.add(FUNCTION_POP_NAME);
-        this.modifierFunctions.add(FUNCTION_SHIFT_NAME);
-        this.modifierFunctions.add(FUNCTION_UNSHIFT_NAME);
     }
 
     public BType checkExpr(BLangExpression expr, SymbolEnv env) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -236,6 +236,8 @@ public class TypeChecker extends BLangNodeVisitor {
     private void init() {
         this.modifierFunctions.add("push");
         this.modifierFunctions.add("pop");
+        this.modifierFunctions.add("shift");
+        this.modifierFunctions.add("unshift");
     }
 
     public BType checkExpr(BLangExpression expr, SymbolEnv env) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -167,7 +167,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;
@@ -182,10 +181,10 @@ public class TypeChecker extends BLangNodeVisitor {
     private static Set<String> modifierFunctions = new HashSet<>();
 
     private static final String TABLE_TNAME = "table";
-    private static final String FUNCTION_PUSH_NAME = "push";
-    private static final String FUNCTION_POP_NAME = "pop";
-    private static final String FUNCTION_SHIFT_NAME = "shift";
-    private static final String FUNCTION_UNSHIFT_NAME = "unshift";
+    private static final String FUNCTION_NAME_PUSH = "push";
+    private static final String FUNCTION_NAME_POP = "pop";
+    private static final String FUNCTION_NAME_SHIFT = "shift";
+    private static final String FUNCTION_NAME_UNSHIFT = "unshift";
 
     private Names names;
     private SymbolTable symTable;
@@ -212,10 +211,10 @@ public class TypeChecker extends BLangNodeVisitor {
     private DiagnosticCode diagCode;
 
     static {
-        modifierFunctions.add(FUNCTION_PUSH_NAME);
-        modifierFunctions.add(FUNCTION_POP_NAME);
-        modifierFunctions.add(FUNCTION_SHIFT_NAME);
-        modifierFunctions.add(FUNCTION_UNSHIFT_NAME);
+        modifierFunctions.add(FUNCTION_NAME_PUSH);
+        modifierFunctions.add(FUNCTION_NAME_POP);
+        modifierFunctions.add(FUNCTION_NAME_SHIFT);
+        modifierFunctions.add(FUNCTION_NAME_UNSHIFT);
     }
 
     public static TypeChecker getInstance(CompilerContext context) {
@@ -1870,7 +1869,7 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         if ((varRefType.tag == TypeTags.TUPLE) && hasDifferentTypeThanRest((BTupleType) varRefType) &&
-                (invocationName.compareTo(FUNCTION_SHIFT_NAME) == 0)) {
+                (invocationName.compareTo(FUNCTION_NAME_SHIFT) == 0)) {
             dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_TUPLE_SHAPE, invocationName, varRefType);
             resultType = symTable.semanticError;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1870,12 +1870,18 @@ public class TypeChecker extends BLangNodeVisitor {
             return;
         }
 
-        if ((varRefType.tag == TypeTags.TUPLE) && hasDifferentTypeThanRest((BTupleType) varRefType) &&
-                (invocationName.compareTo(FUNCTION_NAME_SHIFT) == 0)) {
+        if (isShiftOnIncompatibleTuples(varRefType, invocationName)) {
             dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_TUPLE_SHAPE, invocationName,
                        varRefType);
             resultType = symTable.semanticError;
             return;
+        }
+    }
+
+    private boolean isShiftOnIncompatibleTuples(BType varRefType, String invocationName) {
+        if ((varRefType.tag == TypeTags.TUPLE) && (invocationName.compareTo(FUNCTION_NAME_SHIFT) == 0) &&
+                hasDifferentTypeThanRest((BTupleType) varRefType)) {
+            return true;
         }
 
         if ((varRefType.tag == TypeTags.UNION) && (invocationName.compareTo(FUNCTION_NAME_SHIFT) == 0)) {
@@ -1890,12 +1896,9 @@ public class TypeChecker extends BLangNodeVisitor {
                     break;
                 }
             }
-            if (allTuplesHasFixedShape) {
-                dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_TUPLE_SHAPE, invocationName,
-                           varRefType);
-                resultType = symTable.semanticError;
-            }
+            return allTuplesHasFixedShape;
         }
+        return false;
     }
 
     private boolean hasDifferentTypeThanRest(BTupleType tupleType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1867,6 +1867,7 @@ public class TypeChecker extends BLangNodeVisitor {
         if (isFixedLengthList(varRefType)) {
             dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_LIST_SIZE, invocationName, varRefType);
             resultType = symTable.semanticError;
+            return;
         }
 
         if ((varRefType.tag == TypeTags.TUPLE) && hasDifferentTypeThanRest((BTupleType) varRefType) &&
@@ -1874,6 +1875,7 @@ public class TypeChecker extends BLangNodeVisitor {
             dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_TUPLE_SHAPE, invocationName,
                        varRefType);
             resultType = symTable.semanticError;
+            return;
         }
 
         if ((varRefType.tag == TypeTags.UNION) && (invocationName.compareTo(FUNCTION_NAME_SHIFT) == 0)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1886,17 +1886,18 @@ public class TypeChecker extends BLangNodeVisitor {
 
         if ((varRefType.tag == TypeTags.UNION) && (invocationName.compareTo(FUNCTION_NAME_SHIFT) == 0)) {
             BUnionType unionVarRef = (BUnionType) varRefType;
-            boolean allTuplesHasFixedShape = true;
+            boolean allMemberAreFixedShapeTuples = true;
             for (BType member : unionVarRef.getMemberTypes()) {
                 if (member.tag != TypeTags.TUPLE) {
+                    allMemberAreFixedShapeTuples = false;
                     break;
                 }
-                if (!hasDifferentTypeThanRest((BTupleType) varRefType)) {
-                    allTuplesHasFixedShape = false;
+                if (!hasDifferentTypeThanRest((BTupleType) member)) {
+                    allMemberAreFixedShapeTuples = false;
                     break;
                 }
             }
-            return allTuplesHasFixedShape;
+            return allMemberAreFixedShapeTuples;
         }
         return false;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1840,7 +1840,7 @@ public class TypeChecker extends BLangNodeVisitor {
     private boolean isFixedLengthList(BType type) {
         switch(type.tag) {
             case TypeTags.ARRAY:
-                return (((BArrayType) type).state == BArrayState.CLOSED_SEALED);
+                return (((BArrayType) type).state != BArrayState.UNSEALED);
             case TypeTags.TUPLE:
                 return (((BTupleType) type).restType == null);
             case TypeTags.UNION:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -230,10 +230,10 @@ public class TypeChecker extends BLangNodeVisitor {
         this.typeParamAnalyzer = TypeParamAnalyzer.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
-        init();
+        initModifierFunctions();
     }
 
-    private void init() {
+    private void initModifierFunctions() {
         this.modifierFunctions.add("push");
         this.modifierFunctions.add("pop");
         this.modifierFunctions.add("shift");
@@ -1837,7 +1837,7 @@ public class TypeChecker extends BLangNodeVisitor {
             BArrayType arrayType = (BArrayType) varRefType;
             if (arrayType.state == BArrayState.CLOSED_SEALED && this.modifierFunctions.contains(
                     iExpr.name.getValue())) {
-                dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_ARRAY_SIZE, iExpr.name.value, arrayType);
+                dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_LIST_SIZE, iExpr.name.value, arrayType);
                 resultType = symTable.semanticError;
                 return;
             }
@@ -1846,7 +1846,7 @@ public class TypeChecker extends BLangNodeVisitor {
         if (varRefType.tag == TypeTags.TUPLE) {
             BTupleType tupleType = (BTupleType) varRefType;
             if ((tupleType.restType == null) && this.modifierFunctions.contains(iExpr.name.getValue())) {
-                dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_TUPLE_SIZE, iExpr.name.value, tupleType);
+                dlog.error(iExpr.name.pos, DiagnosticCode.ILLEGAL_FUNCTION_CHANGE_LIST_SIZE, iExpr.name.value, tupleType);
                 resultType = symTable.semanticError;
                 return;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -124,7 +124,6 @@ public class Types {
         if (types == null) {
             types = new Types(context);
         }
-
         return types;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -124,6 +124,7 @@ public class Types {
         if (types == null) {
             types = new Types(context);
         }
+
         return types;
     }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1254,4 +1254,4 @@ error.illegal.function.change.list.size=\
   cannot call ''{0}'' on fixed length list(s) of type ''{1}''
 
 error.illegal.function.change.tuple.shape=\
-  cannot call ''{0}'' on tuple(s) of type ''{1}''; cannot violate inherent type
+  cannot call ''{0}'' on tuple(s) of type ''{1}'': cannot violate inherent type

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1252,3 +1252,6 @@ error.illegal.function.tuple.size=\
 
 error.illegal.function.change.list.size=\
   cannot call ''{0}'' on fixed length list(s) of type ''{1}''
+
+error.illegal.function.change.tuple.shape=\
+  cannot call ''{0}'' on tuple of type ''{1}'': change inherent shape

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1244,14 +1244,11 @@ error.invalid.deprecation.documentation=\
 error.deprecation.documentation.should.available=\
   constructs annotated as ''@deprecated'' must have ''Deprecated'' documentation
 
-error.deprecated.parameters.documentation.not.allowed=\
-  ''Deprecated parameters'' documentation is not allowed here
-
 error.invalid.attribute.reference=\
   invalid attribute reference
 
-error.illegal.function.array.size=\
-  cannot call ''{0}'' on fixed length array ''{1}''
-
 error.illegal.function.tuple.size=\
   cannot call ''{0}'' on fixed length tuple ''{1}''
+
+error.illegal.function.change.list.size=\
+  cannot call ''{0}'' on fixed length list(s) of type ''{1}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1254,4 +1254,4 @@ error.illegal.function.change.list.size=\
   cannot call ''{0}'' on fixed length list(s) of type ''{1}''
 
 error.illegal.function.change.tuple.shape=\
-  cannot call ''{0}'' on tuple of type ''{1}'': change inherent shape
+  cannot call ''{0}'' on tuple(s) of type ''{1}''; cannot violate inherent type

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1244,11 +1244,11 @@ error.invalid.deprecation.documentation=\
 error.deprecation.documentation.should.available=\
   constructs annotated as ''@deprecated'' must have ''Deprecated'' documentation
 
+error.deprecated.parameters.documentation.not.allowed=\
+  ''Deprecated parameters'' documentation is not allowed here
+
 error.invalid.attribute.reference=\
   invalid attribute reference
-
-error.illegal.function.tuple.size=\
-  cannot call ''{0}'' on fixed length tuple ''{1}''
 
 error.illegal.function.change.list.size=\
   cannot call ''{0}'' on fixed length list(s) of type ''{1}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1249,3 +1249,9 @@ error.deprecated.parameters.documentation.not.allowed=\
 
 error.invalid.attribute.reference=\
   invalid attribute reference
+
+error.illegal.function.array.size=\
+  cannot call ''{0}'' on fixed length array ''{1}''
+
+error.illegal.function.tuple.size=\
+  cannot call ''{0}'' on fixed length tuple ''{1}''

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Pop.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Pop.java
@@ -40,7 +40,7 @@ import static org.ballerinalang.jvm.values.utils.ArrayUtils.checkIsArrayOnlyOper
 )
 public class Pop {
 
-    public static final String FUNCTION_SIGNATURE = "pop()";
+    private static final String FUNCTION_SIGNATURE = "pop()";
 
     public static Object pop(Strand strand, ArrayValue arr) {
         checkIsArrayOnlyOperation(arr.getType(), FUNCTION_SIGNATURE);

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Pop.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Pop.java
@@ -40,8 +40,10 @@ import static org.ballerinalang.jvm.values.utils.ArrayUtils.checkIsArrayOnlyOper
 )
 public class Pop {
 
+    public static final String FUNCTION_SIGNATURE = "pop()";
+
     public static Object pop(Strand strand, ArrayValue arr) {
-        checkIsArrayOnlyOperation(arr.getType(), "pop()");
+        checkIsArrayOnlyOperation(arr.getType(), FUNCTION_SIGNATURE);
         return arr.shift(arr.size() - 1);
     }
 }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Push.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Push.java
@@ -42,7 +42,7 @@ import static org.ballerinalang.jvm.values.utils.ArrayUtils.createOpNotSupported
 )
 public class Push {
 
-    public static final String FUNCTION_SIGNATURE = "push()";
+    private static final String FUNCTION_SIGNATURE = "push()";
 
     public static void push(Strand strand, ArrayValue arr, ArrayValue vals) {
         BType arrType = arr.getType();
@@ -55,7 +55,7 @@ public class Push {
                 }
                 break;
             default:
-                throw createOpNotSupportedError(arrType, "push()");
+                throw createOpNotSupportedError(arrType, FUNCTION_SIGNATURE);
         }
     }
 

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Push.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Push.java
@@ -42,6 +42,8 @@ import static org.ballerinalang.jvm.values.utils.ArrayUtils.createOpNotSupported
 )
 public class Push {
 
+    public static final String FUNCTION_SIGNATURE = "push()";
+
     public static void push(Strand strand, ArrayValue arr, ArrayValue vals) {
         BType arrType = arr.getType();
         int nVals = vals.size();

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -400,44 +400,61 @@ public class LangLibArrayTest {
     @Test
     public void callingLengthModificationFunctionsOnFixedLengthLists() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/arraylib_test_negative.bal");
-        BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length list(s) of type 'int[1]'",
+        int errorIndex = 0;
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'push' on fixed length list(s) of type " +
+                                          "'int[1]'",
                                   19, 22);
-        BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length list(s) of type '[int,int]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'push' on fixed length list(s) of type " +
+                                          "'[int,int]'",
                                   24, 22);
-        BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length list(s) of type 'int[1]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'pop' on fixed length list(s) of type " +
+                                          "'int[1]'",
                                   29, 35);
-        BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length list(s) of type '[int,int]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'pop' on fixed length list(s) of type " +
+                                          "'[int,int]'",
                                   34, 35);
-        BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length list(s) of type 'int[1]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'shift' on fixed length list(s) of type " +
+                                          "'int[1]'",
                                   45, 30);
-        BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length list(s) of type 'int[1]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'unshift' on fixed length list(s) of " +
+                                          "type 'int[1]'",
                                   50, 22);
-        BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length list(s) of type '[int,int]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'shift' on fixed length list(s) of type " +
+                                          "'[int,int]'",
                                   55, 35);
-        BAssertUtil.validateError(negativeResult, 7,
+        BAssertUtil.validateError(negativeResult, errorIndex++,
                                   "cannot call 'unshift' on fixed length list(s) of type '[int,int]'",
                                   60, 22);
-        BAssertUtil.validateError(negativeResult, 8, "cannot call 'push' on fixed length list(s) of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'push' on fixed length list(s) of type " +
+                                          "'int[2]'",
                                   66, 22);
-        BAssertUtil.validateError(negativeResult, 9, "cannot call 'pop' on fixed length list(s) of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'pop' on fixed length list(s) of type " +
+                                          "'int[2]'",
                                   67, 30);
-        BAssertUtil.validateError(negativeResult, 10, "cannot call 'shift' on fixed length list(s) of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'shift' on fixed length list(s) of type " +
+                                          "'int[2]'",
                                   68, 26);
-        BAssertUtil.validateError(negativeResult, 11, "cannot call 'unshift' on fixed length list(s) of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, errorIndex++, "cannot call 'unshift' on fixed length list(s) of " +
+                                          "type 'int[2]'",
                                   69, 22);
-        BAssertUtil.validateError(negativeResult, 12,
+        BAssertUtil.validateError(negativeResult, errorIndex++,
                                   "cannot call 'push' on fixed length list(s) of type '(int[1]|float[1])'",
                                   74, 22);
-        BAssertUtil.validateError(negativeResult, 13,
+        BAssertUtil.validateError(negativeResult, errorIndex++,
                                   "cannot call 'push' on fixed length list(s) of type '([int,int][1]|[float," +
                                           "float][1])'",
                                   79, 22);
-        BAssertUtil.validateError(negativeResult, 14,
-                                  "cannot call 'shift' on tuple of type '[int,string...]': change inherent shape",
+        BAssertUtil.validateError(negativeResult, errorIndex++,
+                                  "cannot call 'shift' on tuple(s) of type '[int,string...]'; cannot violate inherent" +
+                                          " type",
                                   84, 24);
-        BAssertUtil.validateError(negativeResult, 15,
-                                  "cannot call 'shift' on tuple of type '[int,string,int...]': change inherent shape",
+        BAssertUtil.validateError(negativeResult, errorIndex++,
+                                  "cannot call 'shift' on tuple(s) of type '[int,string,int...]'; cannot violate " +
+                                          "inherent type",
                                   89, 24);
-        Assert.assertEquals(negativeResult.getErrorCount(), 16);
+        BAssertUtil.validateError(negativeResult, errorIndex++,
+                                  "cannot call 'push' on fixed length list(s) of type '([int,int]|[float,float])'",
+                                  100, 22);
+        Assert.assertEquals(negativeResult.getErrorCount(), errorIndex);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -455,6 +455,14 @@ public class LangLibArrayTest {
         BAssertUtil.validateError(negativeResult, errorIndex++,
                                   "cannot call 'push' on fixed length list(s) of type '([int,int]|[float,float])'",
                                   100, 22);
+        BAssertUtil.validateError(negativeResult, errorIndex++,
+                                  "cannot call 'shift' on fixed length list(s) of type '[string,int]'",
+                                  118, 24);
         Assert.assertEquals(negativeResult.getErrorCount(), errorIndex);
+    }
+
+    @Test
+    public void testShiftOperation() {
+        BRunUtil.invoke(compileResult, "testShiftOperation");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -409,12 +409,13 @@ public class LangLibArrayTest {
         BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length list(s) of type '[int,int]'",
                                   18, 35);
         BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length list(s) of type 'int[1]'",
-                                  29,30);
+                                  29, 30);
         BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length list(s) of type 'int[1]'",
                                   34, 22);
         BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length list(s) of type '[int,int]'",
                                   39, 35);
-        BAssertUtil.validateError(negativeResult, 7, "cannot call 'unshift' on fixed length list(s) of type '[int,int]'",
+        BAssertUtil.validateError(negativeResult, 7,
+                                  "cannot call 'unshift' on fixed length list(s) of type '[int,int]'",
                                   44, 22);
         BAssertUtil.validateError(negativeResult, 8, "cannot call 'push' on fixed length list(s) of type 'int[2]'",
                                   50, 22);
@@ -424,9 +425,12 @@ public class LangLibArrayTest {
                                   52, 26);
         BAssertUtil.validateError(negativeResult, 11, "cannot call 'unshift' on fixed length list(s) of type 'int[2]'",
                                   53, 22);
-        BAssertUtil.validateError(negativeResult, 12,"cannot call 'push' on fixed length list(s) of type '(int[1]|float[1])'",
+        BAssertUtil.validateError(negativeResult, 12,
+                                  "cannot call 'push' on fixed length list(s) of type '(int[1]|float[1])'",
                                   58, 22);
-        BAssertUtil.validateError(negativeResult, 13,"cannot call 'push' on fixed length list(s) of type '([int,int][1]|[float,float][1])'",
+        BAssertUtil.validateError(negativeResult, 13,
+                                  "cannot call 'push' on fixed length list(s) of type '([int,int][1]|[float," +
+                                          "float][1])'",
                                   63, 22);
         Assert.assertEquals(negativeResult.getErrorCount(), 14);
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -400,28 +400,34 @@ public class LangLibArrayTest {
     @Test
     public void callingLengthModificationFunctionsOnFixedLengthLists() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/arraylib_test_negative.bal");
-        BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length list of type 'int[1]'", 3, 22);
-        BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length list of type '[int,int]'", 8,
-                                  22);
-        BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length list of type 'int[1]'", 13, 35);
-        BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length list of type '[int,int]'", 18,
-                                  35);
-        BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length list of type 'int[1]'", 29,
-                                  30);
-        BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length list of type 'int[1]'", 34,
-                                  22);
-        BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length list of type '[int,int]'", 39,
-                                  35);
-        BAssertUtil.validateError(negativeResult, 7, "cannot call 'unshift' on fixed length list of type '[int,int]'",
+        BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length list(s) of type 'int[1]'",
+                                  3, 22);
+        BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length list(s) of type '[int,int]'",
+                                  8, 22);
+        BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length list(s) of type 'int[1]'",
+                                  13, 35);
+        BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length list(s) of type '[int,int]'",
+                                  18, 35);
+        BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length list(s) of type 'int[1]'",
+                                  29,30);
+        BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length list(s) of type 'int[1]'",
+                                  34, 22);
+        BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length list(s) of type '[int,int]'",
+                                  39, 35);
+        BAssertUtil.validateError(negativeResult, 7, "cannot call 'unshift' on fixed length list(s) of type '[int,int]'",
                                   44, 22);
-        BAssertUtil.validateError(negativeResult, 8, "cannot call 'push' on fixed length list of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, 8, "cannot call 'push' on fixed length list(s) of type 'int[2]'",
                                   50, 22);
-        BAssertUtil.validateError(negativeResult, 9, "cannot call 'pop' on fixed length list of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, 9, "cannot call 'pop' on fixed length list(s) of type 'int[2]'",
                                   51, 30);
-        BAssertUtil.validateError(negativeResult, 10, "cannot call 'shift' on fixed length list of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, 10, "cannot call 'shift' on fixed length list(s) of type 'int[2]'",
                                   52, 26);
-        BAssertUtil.validateError(negativeResult, 11, "cannot call 'unshift' on fixed length list of type 'int[2]'",
+        BAssertUtil.validateError(negativeResult, 11, "cannot call 'unshift' on fixed length list(s) of type 'int[2]'",
                                   53, 22);
-        Assert.assertEquals(negativeResult.getErrorCount(), 12);
+        BAssertUtil.validateError(negativeResult, 12,"cannot call 'push' on fixed length list(s) of type '(int[1]|float[1])'",
+                                  58, 22);
+        BAssertUtil.validateError(negativeResult, 13,"cannot call 'push' on fixed length list(s) of type '([int,int][1]|[float,float][1])'",
+                                  63, 22);
+        Assert.assertEquals(negativeResult.getErrorCount(), 14);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -432,6 +432,12 @@ public class LangLibArrayTest {
                                   "cannot call 'push' on fixed length list(s) of type '([int,int][1]|[float," +
                                           "float][1])'",
                                   79, 22);
-        Assert.assertEquals(negativeResult.getErrorCount(), 14);
+        BAssertUtil.validateError(negativeResult, 14,
+                                  "cannot call 'shift' on tuple of type '[int,string...]': change inherent shape",
+                                  84, 24);
+        BAssertUtil.validateError(negativeResult, 15,
+                                  "cannot call 'shift' on tuple of type '[int,string,int...]': change inherent shape",
+                                  89, 24);
+        Assert.assertEquals(negativeResult.getErrorCount(), 16);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -445,11 +445,11 @@ public class LangLibArrayTest {
                                           "float][1])'",
                                   79, 22);
         BAssertUtil.validateError(negativeResult, errorIndex++,
-                                  "cannot call 'shift' on tuple(s) of type '[int,string...]'; cannot violate inherent" +
+                                  "cannot call 'shift' on tuple(s) of type '[int,string...]': cannot violate inherent" +
                                           " type",
                                   84, 24);
         BAssertUtil.validateError(negativeResult, errorIndex++,
-                                  "cannot call 'shift' on tuple(s) of type '[int,string,int...]'; cannot violate " +
+                                  "cannot call 'shift' on tuple(s) of type '[int,string,int...]': cannot violate " +
                                           "inherent type",
                                   89, 24);
         BAssertUtil.validateError(negativeResult, errorIndex++,

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -401,37 +401,37 @@ public class LangLibArrayTest {
     public void callingLengthModificationFunctionsOnFixedLengthLists() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/arraylib_test_negative.bal");
         BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length list(s) of type 'int[1]'",
-                                  3, 22);
+                                  19, 22);
         BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length list(s) of type '[int,int]'",
-                                  8, 22);
+                                  24, 22);
         BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length list(s) of type 'int[1]'",
-                                  13, 35);
+                                  29, 35);
         BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length list(s) of type '[int,int]'",
-                                  18, 35);
+                                  34, 35);
         BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length list(s) of type 'int[1]'",
-                                  29, 30);
+                                  45, 30);
         BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length list(s) of type 'int[1]'",
-                                  34, 22);
+                                  50, 22);
         BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length list(s) of type '[int,int]'",
-                                  39, 35);
+                                  55, 35);
         BAssertUtil.validateError(negativeResult, 7,
                                   "cannot call 'unshift' on fixed length list(s) of type '[int,int]'",
-                                  44, 22);
+                                  60, 22);
         BAssertUtil.validateError(negativeResult, 8, "cannot call 'push' on fixed length list(s) of type 'int[2]'",
-                                  50, 22);
+                                  66, 22);
         BAssertUtil.validateError(negativeResult, 9, "cannot call 'pop' on fixed length list(s) of type 'int[2]'",
-                                  51, 30);
+                                  67, 30);
         BAssertUtil.validateError(negativeResult, 10, "cannot call 'shift' on fixed length list(s) of type 'int[2]'",
-                                  52, 26);
+                                  68, 26);
         BAssertUtil.validateError(negativeResult, 11, "cannot call 'unshift' on fixed length list(s) of type 'int[2]'",
-                                  53, 22);
+                                  69, 22);
         BAssertUtil.validateError(negativeResult, 12,
                                   "cannot call 'push' on fixed length list(s) of type '(int[1]|float[1])'",
-                                  58, 22);
+                                  74, 22);
         BAssertUtil.validateError(negativeResult, 13,
                                   "cannot call 'push' on fixed length list(s) of type '([int,int][1]|[float," +
                                           "float][1])'",
-                                  63, 22);
+                                  79, 22);
         Assert.assertEquals(negativeResult.getErrorCount(), 14);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BValueArray;
+import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
@@ -388,11 +389,21 @@ public class LangLibArrayTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: \\{ballerina/lang.array\\}InherentTypeViolation " +
-                            "message=cannot change the length of a tuple with '2' mandatory member\\(s\\) to '1'.*")
+          expectedExceptionsMessageRegExp =
+                  "error: \\{ballerina/lang.array\\}InherentTypeViolation " +
+                          "message=cannot change the length of a tuple with '2' mandatory member\\(s\\) to '1'.*")
     public void testTupleSetLengthIllegal() {
         BRunUtil.invoke(compileResult, "testTupleSetLengthIllegal");
         Assert.fail();
+    }
+
+    @Test
+    public void callingLengthModificationFunctionsOnFixedLengthLists() {
+        CompileResult negativeResult = BCompileUtil.compile("test-src/arraylib_test_negative.bal");
+        BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length array 'int[1]'", 3, 22);
+        BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length tuple '[int,int]'", 8, 22);
+        BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length array 'int[1]'", 13, 35);
+        BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length tuple '[int,int]'", 18, 35);
+        Assert.assertEquals(negativeResult.getErrorCount(), 4);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -400,14 +400,28 @@ public class LangLibArrayTest {
     @Test
     public void callingLengthModificationFunctionsOnFixedLengthLists() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/arraylib_test_negative.bal");
-        BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length array 'int[1]'", 3, 22);
-        BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length tuple '[int,int]'", 8, 22);
-        BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length array 'int[1]'", 13, 35);
-        BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length tuple '[int,int]'", 18, 35);
-        BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length array 'int[1]'", 29, 30);
-        BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length array 'int[1]'", 34, 22);
-        BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length tuple '[int,int]'", 39, 35);
-        BAssertUtil.validateError(negativeResult, 7, "cannot call 'unshift' on fixed length tuple '[int,int]'", 44, 22);
-        Assert.assertEquals(negativeResult.getErrorCount(), 8);
+        BAssertUtil.validateError(negativeResult, 0, "cannot call 'push' on fixed length list of type 'int[1]'", 3, 22);
+        BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length list of type '[int,int]'", 8,
+                                  22);
+        BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length list of type 'int[1]'", 13, 35);
+        BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length list of type '[int,int]'", 18,
+                                  35);
+        BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length list of type 'int[1]'", 29,
+                                  30);
+        BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length list of type 'int[1]'", 34,
+                                  22);
+        BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length list of type '[int,int]'", 39,
+                                  35);
+        BAssertUtil.validateError(negativeResult, 7, "cannot call 'unshift' on fixed length list of type '[int,int]'",
+                                  44, 22);
+        BAssertUtil.validateError(negativeResult, 8, "cannot call 'push' on fixed length list of type 'int[2]'",
+                                  50, 22);
+        BAssertUtil.validateError(negativeResult, 9, "cannot call 'pop' on fixed length list of type 'int[2]'",
+                                  51, 30);
+        BAssertUtil.validateError(negativeResult, 10, "cannot call 'shift' on fixed length list of type 'int[2]'",
+                                  52, 26);
+        BAssertUtil.validateError(negativeResult, 11, "cannot call 'unshift' on fixed length list of type 'int[2]'",
+                                  53, 22);
+        Assert.assertEquals(negativeResult.getErrorCount(), 12);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -404,6 +404,10 @@ public class LangLibArrayTest {
         BAssertUtil.validateError(negativeResult, 1, "cannot call 'push' on fixed length tuple '[int,int]'", 8, 22);
         BAssertUtil.validateError(negativeResult, 2, "cannot call 'pop' on fixed length array 'int[1]'", 13, 35);
         BAssertUtil.validateError(negativeResult, 3, "cannot call 'pop' on fixed length tuple '[int,int]'", 18, 35);
-        Assert.assertEquals(negativeResult.getErrorCount(), 4);
+        BAssertUtil.validateError(negativeResult, 4, "cannot call 'shift' on fixed length array 'int[1]'", 29, 30);
+        BAssertUtil.validateError(negativeResult, 5, "cannot call 'unshift' on fixed length array 'int[1]'", 34, 22);
+        BAssertUtil.validateError(negativeResult, 6, "cannot call 'shift' on fixed length tuple '[int,int]'", 39, 35);
+        BAssertUtil.validateError(negativeResult, 7, "cannot call 'unshift' on fixed length tuple '[int,int]'", 44, 22);
+        Assert.assertEquals(negativeResult.getErrorCount(), 8);
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -513,6 +513,25 @@ function testInvalidPushOnUnionOfSameBasicType() {
     assertValueEquality("incompatible types: expected 'int', found 'string'", err.detail()?.message);
 }
 
+function testShiftOperation() {
+    testShiftOnTupleWithoutValuesForRestParameter();
+}
+
+function testShiftOnTupleWithoutValuesForRestParameter() {
+    [int, int...] intTupleWithRest = [0];
+
+    var fn = function () {
+        var x = intTupleWithRest.shift();
+    };
+
+    error? res = trap fn();
+    assertTrue(res is error);
+
+    error err = <error> res;
+    assertValueEquality("{ballerina/lang.array}OperationNotSupported", err.reason());
+    assertValueEquality("shift() not supported on type 'null'", err.detail()?.message);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -70,17 +70,33 @@ function testPushPopShiftUnshitOnInferredFixedLengthArray() {
 }
 
 function testPushOnFixedLengthArrayUnions() {
-    int[1]|float[1] fixedLengthArray = <int[1]> [1];
+    int[1] | float[1] fixedLengthArray = <int[1]> [1];
     fixedLengthArray.push(4);
 }
 
 function testPushOnFixedLengthTupleUnion() {
-    [int, int][1]|[float, float][1] fixedLengthArray = <[float, float][1]> [[1.0, 2.3]];
+    [int, int][1] | [float, float][1] fixedLengthArray = <[float, float][1]> [[1.0, 2.3]];
     fixedLengthArray.push(<[float, float]>[1, 2]);
+}
+
+function testShiftOnTupleWithStringRestParamFixedInherantShapeWithInt() {
+    [int, string...] a = [1, "hello","world"];
+    int | string x = a.shift();
+}
+
+function testShiftOnTupleWithIntRestParamFixedInherantShapeWithIntString() {
+    [int, string, int...] a = [1, "hello", 5];
+    int | string x = a.shift();
 }
 
 // run time panic no compile time error
 function testPushOnFixedLengthAndDynamicTupleUnion() {
-    [int, int][1]|[float, float][] fixedLengthArray = <[float, float][1]> [[1, 2]];
+    [int, int][1] | [float, float][] fixedLengthArray = <[float, float][1]> [[1, 2]];
     fixedLengthArray.push(<[float, float]>[1, 2]);
+}
+
+// run time panic no compile time error
+function testShiftOnTupleWithIntRestParamFixedInherantShapeWithInt() {
+    [int, int...] a = [1];
+    int x = a.shift();
 }

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -59,7 +59,7 @@ function testPushOnFixedLengthArrayUnions() {
 }
 
 function testPushOnFixedLengthTupleUnion() {
-    [int, int][1] | [float, float][1] fixedLengthArray = <[float, float][1]> [[1.0, 2.3]];
+    [int, int][1]|[float, float][1] fixedLengthArray = <[float, float][1]> [[1.0, 2.3]];
     fixedLengthArray.push(<[float, float]>[1, 2]);
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 function testPushOnFixedLengthArray() {
     int[1] fixedLengthArray = [1];
     fixedLengthArray.push(4);

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -18,6 +18,28 @@ function testPopOnFixedLengthTuple() {
     int popped = fixedLengthTuple.pop();
 }
 
-public function main() {
-    testPushOnFixedLengthArray();
+function testShift() returns [int[], int] {
+    int[] s = [1, 2, 3, 4, 5];
+    var e = s.shift();
+    return [s, e];
+}
+
+function testShiftOnFixedLengthArray() {
+    int[1] fixedLengthArray = [1];
+    int x = fixedLengthArray.shift();
+}
+
+function testUnShiftOnFixedLengthArray() {
+    int[1] fixedLengthArray = [1];
+    fixedLengthArray.unshift(5);
+}
+
+function testShiftOnFixedLengthTuple() {
+    [int, int] fixedLengthTuple = [1, 2];
+    int popped = fixedLengthTuple.shift();
+}
+
+function testUnShiftOnFixedLengthTuple() {
+    [int, int] fixedLengthTuple = [1, 2];
+    fixedLengthTuple.unshift();
 }

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -105,3 +105,16 @@ function testShiftOnTupleWithIntRestParamFixedInherantShapeWithInt() {
     [int, int...] a = [1];
     int x = a.shift();
 }
+
+// run time panic no compile time error
+function testShiftOnUnionOfDifferentTuples() {
+    [string, string...]|[string, int] tuples = ["hi", 4];
+    var x = tuples.shift();
+}
+
+function testShiftOnUnionOfDifferentTuplesTypeNarrowed() {
+    [string, string...]|[string, int] tuples = ["hi", 4];
+    if (tuples is [string, int]) {
+        var x = tuples.shift();
+    }
+}

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -43,3 +43,12 @@ function testUnShiftOnFixedLengthTuple() {
     [int, int] fixedLengthTuple = [1, 2];
     fixedLengthTuple.unshift();
 }
+
+// inferred fixed length arrays
+function testPushPopShiftUnshitOnInferredFixedLengthArray() {
+    int[*] fixedLengthArray = [1, 2];
+    fixedLengthArray.push(4);
+    int x = fixedLengthArray.pop();
+    x = fixedLengthArray.shift();
+    fixedLengthArray.unshift();
+}

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -65,6 +65,6 @@ function testPushOnFixedLengthTupleUnion() {
 
 // run time panic no compile time error
 function testPushOnFixedLengthAndDynamicTupleUnion() {
-    [int, int][1] | [float, float][] fixedLengthArray = <[float, float][1]> [[1, 2]];
+    [int, int][1]|[float, float][] fixedLengthArray = <[float, float][1]> [[1, 2]];
     fixedLengthArray.push(<[float, float]>[1, 2]);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -95,6 +95,11 @@ function testPushOnFixedLengthAndDynamicTupleUnion() {
     fixedLengthArray.push(<[float, float]>[1, 2]);
 }
 
+function testPushOnFixedLengthTupleUnions() {
+    [int, int] | [float, float] fixedLengthArray = <[float, float]> [1, 2];
+    fixedLengthArray.push(<float>1);
+}
+
 // run time panic no compile time error
 function testShiftOnTupleWithIntRestParamFixedInherantShapeWithInt() {
     [int, int...] a = [1];

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -52,3 +52,19 @@ function testPushPopShiftUnshitOnInferredFixedLengthArray() {
     x = fixedLengthArray.shift();
     fixedLengthArray.unshift();
 }
+
+function testPushOnFixedLengthArrayUnions() {
+    int[1]|float[1] fixedLengthArray = <int[1]> [1];
+    fixedLengthArray.push(4);
+}
+
+function testPushOnFixedLengthTupleUnion() {
+    [int, int][1] | [float, float][1] fixedLengthArray = <[float, float][1]> [[1.0, 2.3]];
+    fixedLengthArray.push(<[float, float]>[1, 2]);
+}
+
+// run time panic no compile time error
+function testPushOnFixedLengthAndDynamicTupleUnion() {
+    [int, int][1] | [float, float][] fixedLengthArray = <[float, float][1]> [[1, 2]];
+    fixedLengthArray.push(<[float, float]>[1, 2]);
+}

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test_negative.bal
@@ -1,0 +1,23 @@
+function testPushOnFixedLengthArray() {
+    int[1] fixedLengthArray = [1];
+    fixedLengthArray.push(4);
+}
+
+function testPushOnFixedLengthTuple() {
+    [int, int] fixedLengthTuple = [1, 2];
+    fixedLengthTuple.push(4);
+}
+
+function testPopOnFixedLengthArray() {
+    int[1] fixedLengthArray = [1];
+    int popped = fixedLengthArray.pop();
+}
+
+function testPopOnFixedLengthTuple() {
+    [int, int] fixedLengthTuple = [1, 2];
+    int popped = fixedLengthTuple.pop();
+}
+
+public function main() {
+    testPushOnFixedLengthArray();
+}


### PR DESCRIPTION
## Purpose
Push/Pop functions do not natively support annotation or a way to declare that they will change the length of the list. This is not allowed in fixed-length arrays.

Fixes #18662

## Approach
`push`,`pop`, `shift` and `unshift` names are hardcoded and checked against invocations on fixed-length arrays and tuples without rest parameters to identify the invalid calls on compile time.

For unions of array types. When all the arrays are sealed types error will be given at compile time. Ignored otherwise.

## Samples
#### Code
```Ballerina
int[1] fixedLengthArray = [1];
fixedLengthArray.push(4);
```
#### Output
```
error: .::filename.bal:<line>:<column>: cannot call 'push' on fixed length list(s) of type 'int[1]'
```
## Remarks

- Some other functions like `setLength` and `removeAll` also eligible for an compile-time check but spec does not specifically request a compile-time check. 
- Spec issue # 345 may provide a way to implement this elegantly in the future.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
