### PR TITLE
[1.2.x] Add markdown doc for annotation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -561,6 +561,8 @@ public class BIRPackageSymbolEnter {
                 this.env.pkgSymbol.pkgID, null, this.env.pkgSymbol);
         annotationSymbol.type = new BAnnotationType(annotationSymbol);
 
+        defineMarkDownDocAttachment(annotationSymbol, readDocBytes(dataInStream));
+
         this.env.pkgSymbol.scope.define(annotationSymbol.name, annotationSymbol);
         if (annotationType != symTable.noType) { //TODO fix properly
             annotationSymbol.attachedType = annotationType.tsymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -742,7 +742,7 @@ public class BIRGen extends BLangNodeVisitor {
 
         BIRAnnotation birAnn = new BIRAnnotation(astAnnotation.pos, annSymbol.name, annSymbol.flags, annSymbol.points,
                 annSymbol.attachedType == null ? symTable.trueType : annSymbol.attachedType.type);
-
+        birAnn.setMarkdownDocAttachment(annSymbol.markdownDocumentation);
         this.env.enclPkg.annotations.add(birAnn);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -509,7 +509,7 @@ public abstract class BIRNode {
      *
      * @since 0.995.0
      */
-    public static class BIRAnnotation extends BIRNode {
+    public static class BIRAnnotation extends BIRDocumentableNode {
         /**
          * Name of the annotation definition.
          */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -333,6 +333,7 @@ public class BIRBinaryWriter {
         }
 
         writeType(buf, birAnnotation.annotationType);
+        typeWriter.writeMarkdownDocAttachment(buf, birAnnotation.markdownDocAttachment);
     }
 
     private void writeConstants(ByteBuf buf, List<BIRNode.BIRConstant> birConstList) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
-import org.wso2.ballerinalang.compiler.tree.BLangMarkdownDocumentation;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.Name;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
@@ -108,6 +108,7 @@ public class DocumentationTest {
     @Test(description = "Test doc attachments in annotations")
     public void testAnnotationDoc() {
         PackageNode packageNode = result.getAST();
+        Assert.assertEquals(result.getErrorCount(), 0);
         BPackageSymbol symbol = ((BLangPackage) packageNode).symbol;
 
         BPackageSymbol testOrgPackage = (BPackageSymbol) symbol.scope.lookup(new Name("test")).symbol;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.balo.documentation;
 
+import org.ballerinalang.model.elements.MarkdownDocAttachment;
 import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.test.balo.BaloCreator;
 import org.ballerinalang.test.util.BCompileUtil;
@@ -29,6 +30,7 @@ import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.tree.BLangMarkdownDocumentation;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.Name;
 
@@ -102,6 +104,20 @@ public class DocumentationTest {
         Assert.assertNotNull(isMaleFuncSymbol.markdownDocumentation.returnValueDescription);
         Assert.assertEquals(isMaleFuncSymbol.markdownDocumentation.returnValueDescription
                 .replaceAll(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "True if male");
+    }
+
+    @Test(description = "Test doc attachments in annotations")
+    public void testAnnotationDoc() {
+        PackageNode packageNode = result.getAST();
+        BPackageSymbol symbol = ((BLangPackage) packageNode).symbol;
+
+        BPackageSymbol testOrgPackage = (BPackageSymbol) symbol.scope.lookup(new Name("test")).symbol;
+        BSymbol annotationSymbol = testOrgPackage.scope.lookup(new Name("Test")).symbol;
+
+        MarkdownDocAttachment markdownDocumentation = annotationSymbol.markdownDocumentation;
+
+        Assert.assertNotNull(annotationSymbol.markdownDocumentation);
+        Assert.assertEquals(markdownDocumentation.description, "Documentation for Test annotation");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/documentation/test_documentation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/documentation/test_documentation.bal
@@ -4,3 +4,7 @@ import testDocOrg/test;
 function testDocDummy() returns (boolean) {
     return test:open("testt");
 }
+
+@test:Test
+function testAnnotation() {
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/documentation/test_documentation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/documentation/test_documentation.bal
@@ -5,6 +5,6 @@ function testDocDummy() returns (boolean) {
     return test:open("testt");
 }
 
-@test:Test
+@test:Test{}
 function testAnnotation() {
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_documentation/src/test/test_documentation_symbol.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_documentation/src/test/test_documentation_symbol.bal
@@ -25,3 +25,16 @@ public type Person object {
         return true;
     }
 };
+
+# Documentation for Test annotation
+# + a - 'field a' documentation
+# + b - 'field b' documentation
+# + c - 'field c' documentation
+type Tst record {
+    string a = "";
+    string b = "";
+    string c = "";
+};
+
+# Documentation for Test annotation
+annotation Tst Test on function;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_documentation/src/test/test_documentation_symbol.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_documentation/src/test/test_documentation_symbol.bal
@@ -37,4 +37,4 @@ type Tst record {
 };
 
 # Documentation for Test annotation
-annotation Tst Test on function;
+public annotation Tst Test on function;


### PR DESCRIPTION
## Purpose
Add markdown documentation attachment for annotation

Fixes #22262 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
