### PR TITLE
Enable parallel run of strands where global locks arent shared inside locks in 1.2.x branch

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BLockStore.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BLockStore.java
@@ -50,12 +50,13 @@ public class BLockStore {
     }
 
     public void panicIfInLock(String lockName, Strand strand) {
-        BLock lock = getLockFromMap(lockName);
-        if (lock.isLockFree()) {
-            return;
-        }
-        if (lock.lockedBySameContext(strand)) {
-            throw BallerinaErrors.createError(BallerinaErrorReasons.ASYNC_CALL_INSIDE_LOCK);
+        for (BLock lock : globalLockMap.values()) {
+            if (lock.isLockFree()) {
+                continue;
+            }
+            if (lock.lockedBySameContext(strand)) {
+                throw BallerinaErrors.createError(BallerinaErrorReasons.ASYNC_CALL_INSIDE_LOCK);
+            }
         }
     }
 }

--- a/compiler/ballerina-lang/spotbugs-exclude.xml
+++ b/compiler/ballerina-lang/spotbugs-exclude.xml
@@ -153,4 +153,8 @@
         <Class name="org.wso2.ballerinalang.compiler.bir.model.BIRNode$BIRFunction"/>
         <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.ballerinalang.compiler.semantics.analyzer.cyclefind.GlobalVariableRefAnalyzer"/>
+        <Bug pattern="BC_UNCONFIRMED_CAST, BC_UNCONFIRMED_CAST_OF_RETURN_VALUE"/>
+    </Match>
 </FindBugsFilter>

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -202,6 +202,9 @@ public class BIRGen extends BLangNodeVisitor {
     // This is a global variable cache
     public Map<BSymbol, BIRGlobalVariableDcl> globalVarMap = new HashMap<>();
 
+    // This is to cache the lockstmt to BIR Lock
+    private Map<BLangLockStmt, BIRTerminator.Lock> lockStmtMap = new HashMap<>();
+
     // Required variables for Mock function implementation
     private static final String MOCK_ANNOTATION_DELIMITER = "#";
     private static final String MOCK_OBJECT_DELIMITER = ":";
@@ -1201,11 +1204,14 @@ public class BIRGen extends BLangNodeVisitor {
         }
         if (this.env.enclBB.terminator == null) {
             this.env.unlockVars.forEach(s -> {
-                long i = s.numLocks;
+                int i = s.size();
                 while (i > 0) {
                     BIRBasicBlock unlockBB = new BIRBasicBlock(this.env.nextBBId(names));
                     this.env.enclBasicBlocks.add(unlockBB);
-                    this.env.enclBB.terminator = new BIRTerminator.Unlock(null,  unlockBB);
+                    BIRTerminator.Unlock unlock = new BIRTerminator.Unlock(null,  unlockBB);
+                    this.env.enclBB.terminator = unlock;
+                    BIRTerminator.Lock lock = s.getLock(i - 1);
+                    unlock.relatedLock = lock;
                     this.env.enclBB = unlockBB;
                     i--;
                 }
@@ -1954,11 +1960,14 @@ public class BIRGen extends BLangNodeVisitor {
             this.env.enclBB = goToBB;
         }
 
-        long numLocks = toUnlock.numLocks;
+        int numLocks = toUnlock.size();
         while (numLocks > 0) {
             BIRBasicBlock unlockBB = new BIRBasicBlock(this.env.nextBBId(names));
             this.env.enclBasicBlocks.add(unlockBB);
-            this.env.enclBB.terminator = new BIRTerminator.Unlock(null, unlockBB);
+            BIRTerminator.Unlock unlock = new BIRTerminator.Unlock(null, unlockBB);
+            this.env.enclBB.terminator = unlock;
+            BIRTerminator.Lock lock = toUnlock.getLock(numLocks - 1);
+            unlock.relatedLock = lock;
             this.env.enclBB = unlockBB;
             numLocks--;
         }
@@ -1974,11 +1983,14 @@ public class BIRGen extends BLangNodeVisitor {
             this.env.enclBB.terminator = new BIRTerminator.GOTO(continueStmt.pos, goToBB);
             this.env.enclBB = goToBB;
         }
-        long numLocks = toUnlock.numLocks;
+        int numLocks = toUnlock.size();
         while (numLocks > 0) {
             BIRBasicBlock unlockBB = new BIRBasicBlock(this.env.nextBBId(names));
             this.env.enclBasicBlocks.add(unlockBB);
-            this.env.enclBB.terminator = new BIRTerminator.Unlock(null,  unlockBB);
+            BIRTerminator.Unlock unlock = new BIRTerminator.Unlock(null,  unlockBB);
+            this.env.enclBB.terminator = unlock;
+            BIRTerminator.Lock lock = toUnlock.getLock(numLocks - 1);
+            unlock.relatedLock = lock;
             this.env.enclBB = unlockBB;
             numLocks--;
         }
@@ -2001,11 +2013,13 @@ public class BIRGen extends BLangNodeVisitor {
         BIRBasicBlock lockedBB = new BIRBasicBlock(this.env.nextBBId(names));
         addToTrapStack(lockedBB);
         this.env.enclBasicBlocks.add(lockedBB);
-        this.env.enclBB.terminator = new BIRTerminator.Lock(null, lockedBB);
+        BIRTerminator.Lock lock = new BIRTerminator.Lock(null, lockedBB);
+        this.env.enclBB.terminator = lock;
+        lockStmtMap.put(lockStmt, lock); // Populate the cache.
+        this.env.unlockVars.peek().addLock(lock);
         populateBirLockWithGlobalVars(lockStmt);
         this.env.enclBB = lockedBB;
 
-        this.env.unlockVars.peek().numLocks++;
     }
 
     private void populateBirLockWithGlobalVars(BLangLockStmt lockStmt) {
@@ -2029,9 +2043,11 @@ public class BIRGen extends BLangNodeVisitor {
         addToTrapStack(unLockedBB);
         this.env.enclBasicBlocks.add(unLockedBB);
         this.env.enclBB.terminator = new BIRTerminator.Unlock(null, unLockedBB);
+        BIRTerminator.Lock relatedLock = lockStmtMap.get(unLockStmt.relatedLock);
+        ((BIRTerminator.Unlock) this.env.enclBB.terminator).relatedLock = relatedLock;
         this.env.enclBB = unLockedBB;
 
-        lockDetailsHolder.numLocks--;
+        lockDetailsHolder.removeLastLock();
     }
 
     private void emit(BIRNonTerminator instruction) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -142,6 +142,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangContinue;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock.BLangLockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock.BLangUnLockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
@@ -2001,9 +2002,20 @@ public class BIRGen extends BLangNodeVisitor {
         addToTrapStack(lockedBB);
         this.env.enclBasicBlocks.add(lockedBB);
         this.env.enclBB.terminator = new BIRTerminator.Lock(null, lockedBB);
+        populateBirLockWithGlobalVars(lockStmt);
         this.env.enclBB = lockedBB;
 
         this.env.unlockVars.peek().numLocks++;
+    }
+
+    private void populateBirLockWithGlobalVars(BLangLockStmt lockStmt) {
+        for (BVarSymbol globalVar : lockStmt.lockVariables) {
+            BIRGlobalVariableDcl birGlobalVar = globalVarMap.get(globalVar);
+            if (birGlobalVar == null) {
+                throw new RuntimeException("invalid global variable defined inside lock statment");
+            }
+            ((BIRTerminator.Lock) this.env.enclBB.terminator).lockVariables.add(birGlobalVar);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -2012,6 +2012,7 @@ public class BIRGen extends BLangNodeVisitor {
         for (BVarSymbol globalVar : lockStmt.lockVariables) {
             BIRGlobalVariableDcl birGlobalVar = globalVarMap.get(globalVar);
             if (birGlobalVar == null) {
+                // TODO: 3/26/20 Validate the error message 
                 throw new RuntimeException("invalid global variable defined inside lock statment");
             }
             ((BIRTerminator.Lock) this.env.enclBB.terminator).lockVariables.add(birGlobalVar);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -142,7 +142,6 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangContinue;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock.BLangLockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock.BLangUnLockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -2025,8 +2025,9 @@ public class BIRGen extends BLangNodeVisitor {
         for (BVarSymbol globalVar : lockStmt.lockVariables) {
             BIRGlobalVariableDcl birGlobalVar = globalVarMap.get(globalVar);
             if (birGlobalVar == null) {
-                // TODO: 3/26/20 Validate the error message 
-                throw new RuntimeException("invalid global variable defined inside lock statment");
+                // TODO: Check how to handle global variables of imported modules.
+                //throw new RuntimeException("invalid global variable defined inside lock statment");
+                continue;
             }
             ((BIRTerminator.Lock) this.env.enclBB.terminator).lockVariables.add(birGlobalVar);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -204,5 +204,5 @@ public class JvmConstants {
     public static final String METHOD_TOO_LARGE = "MethodTooLarge";
     public static final String CLASS_TOO_LARGE = "ClassTooLarge";
 
-    public static final String GLOBAL_LOCK_NAME = "global";
+    public static final String GLOBAL_LOCK_NAME = "lock";
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -351,8 +351,9 @@ public class JvmTerminatorGen {
             Label gotoLabel = this.labelGen.getLabel(funcName + lockIns.lockedBB.id.value);
             String lockStore = "L" + LOCK_STORE + ";";
             String initClassName = lookupGlobalVarClassName(this.currentPackageName, "LOCK_STORE");
+            String lockName = GLOBAL_LOCK_NAME + lockIns.lockId;
             this.mv.visitFieldInsn(GETSTATIC, initClassName, "LOCK_STORE", lockStore);
-            this.mv.visitLdcInsn(GLOBAL_LOCK_NAME);
+            this.mv.visitLdcInsn(lockName);
             this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_STORE, "getLockFromMap",
                     String.format("(L%s;)L%s;", STRING_VALUE, LOCK_VALUE), false);
             this.mv.visitVarInsn(ALOAD, localVarOffset);
@@ -373,9 +374,10 @@ public class JvmTerminatorGen {
 
             // unlocked in the same order https://yarchive.net/comp/linux/lock_ordering.html
             String lockStore = "L" + LOCK_STORE + ";";
+            String lockName = GLOBAL_LOCK_NAME + unlockIns.relatedLock.lockId;
             String initClassName = lookupGlobalVarClassName(this.currentPackageName, "LOCK_STORE");
             this.mv.visitFieldInsn(GETSTATIC, initClassName, "LOCK_STORE", lockStore);
-            this.mv.visitLdcInsn(GLOBAL_LOCK_NAME);
+            this.mv.visitLdcInsn(lockName);
             this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_STORE, "getLockFromMap", String.format("(L%s;)L%s;",
                     STRING_VALUE, LOCK_VALUE), false);
             this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_VALUE, "unlock", "()V", false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 
 /**
  * Root class of Ballerina intermediate representation-BIR.
@@ -723,11 +724,27 @@ public abstract class BIRNode {
      */
     public static class BIRLockDetailsHolder {
 
-        //This is the number of recursive locks in the current scope.
-        public long numLocks = 0;
+        //This is the list of recursive locks in the current scope.
+        private List<BIRTerminator.Lock> locks = new ArrayList<>();
 
         public boolean isEmpty() {
-            return numLocks == 0;
+            return locks.isEmpty();
+        }
+
+        public void removeLastLock() {
+            locks.remove(size() - 1);
+        }
+
+        public BIRTerminator.Lock getLock(int index) {
+            return locks.get(index);
+        }
+
+        public void addLock(BIRTerminator.Lock lock) {
+            locks.add(lock);
+        }
+
+        public int size() {
+            return locks.size();
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -31,7 +31,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 /**
  * Root class of Ballerina intermediate representation-BIR.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
@@ -234,6 +234,8 @@ public abstract class BIRTerminator extends BIRAbstractInstruction implements BI
 
         public Set<BIRGlobalVariableDcl> lockVariables = new HashSet<>();
 
+        public Integer lockId = -1;
+
         public Lock(DiagnosticPos pos, BIRBasicBlock lockedBB) {
             super(pos, InstructionKind.LOCK);
             this.lockedBB = lockedBB;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
@@ -282,6 +282,8 @@ public abstract class BIRTerminator extends BIRAbstractInstruction implements BI
     public static class Unlock extends BIRTerminator {
         public final BIRBasicBlock unlockBB;
 
+        public BIRTerminator.Lock relatedLock;
+
         public Unlock(DiagnosticPos pos, BIRBasicBlock unlockBB) {
             super(pos, InstructionKind.UNLOCK);
             this.unlockBB = unlockBB;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRTerminator.java
@@ -21,7 +21,9 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Terminators connects basic blocks together.
@@ -229,6 +231,8 @@ public abstract class BIRTerminator extends BIRAbstractInstruction implements BI
      */
     public static class Lock extends BIRTerminator {
         public final BIRBasicBlock lockedBB;
+
+        public Set<BIRGlobalVariableDcl> lockVariables = new HashSet<>();
 
         public Lock(DiagnosticPos pos, BIRBasicBlock lockedBB) {
             super(pos, InstructionKind.LOCK);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -70,6 +70,7 @@ public class BIRLockOptimizer extends BIRVisitor {
         Integer currentSetIdLocal = lockToSetMap.get(currentLock);
         List<BIRTerminator.Lock> currentSet = setToLockMap.get(currentSetIdLocal);
 
+        // Use the setId of the current one for the other shared locks
         setId = currentSetIdLocal;
         populateLockSet(currentSet, currentLock, lockListIndex);
         setId = previousSetId;
@@ -110,14 +111,18 @@ public class BIRLockOptimizer extends BIRVisitor {
 
             currentSet.addAll(previousSet);
 
+            // Remove the unwanted set since the content has been added to the new set.
+            setToLockMap.remove(comparedLocksSetId);
+
             for (BIRTerminator.Lock lock : previousSet) {
                 lockToSetMap.put(lock, setId);
             }
+        } else {
+            currentSet.add(comparedLock);
         }
 
         // Update the compared lock to the related set.
         lockToSetMap.put(comparedLock, setId);
-        currentSet.add(comparedLock);
     }
 
     private boolean isSharedLock(BIRTerminator.Lock currentLock,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -57,8 +57,9 @@ public class BIRLockOptimizer extends BIRVisitor {
 
     private void propagateLocks() {
         for (Map.Entry<Integer, List<BIRTerminator.Lock>> entry : setToLockMap.entrySet()) {
+            Integer lockId = entry.getKey();
             for (BIRTerminator.Lock lock : entry.getValue()) {
-                lock.lockId = entry.getKey();
+                lock.lockId = lockId;
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -113,15 +113,15 @@ public class BIRLockOptimizer extends BIRVisitor {
     }
 
     private boolean isNotInSameSet(BIRTerminator.Lock currentLock, BIRTerminator.Lock comparedLock) {
-        Integer currentLockId = lockToSetMap.get(currentLock);
-        Integer comparedLockId = lockToSetMap.get(comparedLock);
+        Integer currentLockSetId = lockToSetMap.get(currentLock);
+        Integer comparedLockSetId = lockToSetMap.get(comparedLock);
 
-        if (currentLockId == null ||
-                comparedLockId == null) {
+        if (currentLockSetId == null ||
+                comparedLockSetId == null) {
             return true;
         }
 
-        return currentLockId.compareTo(comparedLockId) != 0;
+        return currentLockSetId.compareTo(comparedLockSetId) != 0;
     }
 
     private void populateLockSet(List<BIRTerminator.Lock> currentSet, BIRTerminator.Lock comparedLock) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -107,10 +107,18 @@ public class BIRLockOptimizer extends BIRVisitor {
             BIRTerminator.Lock comparedLock = lockList.get(i);
             Set<BIRNode.BIRGlobalVariableDcl> globalVarSetOfComparedLock = comparedLock.lockVariables;
 
-            if (isSharedLock(currentLock, globalVarSetOfComparedLock)) {
+            if (isSharedLock(currentLock, globalVarSetOfComparedLock)
+                && isNotInSameSet(currentLock, comparedLock)) {
                 populateLockSet(currentSet, comparedLock);
             }
         }
+    }
+
+    private boolean isNotInSameSet(BIRTerminator.Lock currentLock, BIRTerminator.Lock comparedLock) {
+        Integer currentLockId = lockToSetMap.get(currentLock);
+        Integer comparedLockId = lockToSetMap.get(comparedLock);
+
+        return currentLockId != comparedLockId;
     }
 
     private void populateLockSet(List<BIRTerminator.Lock> currentSet, BIRTerminator.Lock comparedLock) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -52,6 +52,15 @@ public class BIRLockOptimizer extends BIRVisitor {
 
     private void optimizeLocks() {
         analyzeLocks();
+        propagateLocks();
+    }
+
+    private void propagateLocks() {
+        for (Map.Entry<Integer, List<BIRTerminator.Lock>> entry : setToLockMap.entrySet()) {
+            for (BIRTerminator.Lock lock : entry.getValue()) {
+                lock.lockId = entry.getKey();
+            }
+        }
     }
 
     private void analyzeLocks() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -1,22 +1,20 @@
 /*
- *  *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *  *
- *  *  WSO2 Inc. licenses this file to you under the Apache License,
- *  *  Version 2.0 (the "License"); you may not use this file except
- *  *  in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing,
- *  *  software distributed under the License is distributed on an
- *  *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  *  KIND, either express or implied.  See the License for the
- *  *  specific language governing permissions and limitations
- *  *  under the License.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
-
 package org.wso2.ballerinalang.compiler.bir.optimizer;
 
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Optimize Locks
+ * Optimize Locks.
  *
  * @since 1.2.1
  */
@@ -118,7 +118,12 @@ public class BIRLockOptimizer extends BIRVisitor {
         Integer currentLockId = lockToSetMap.get(currentLock);
         Integer comparedLockId = lockToSetMap.get(comparedLock);
 
-        return currentLockId != comparedLockId;
+        if (currentLockId == null ||
+                comparedLockId == null) {
+            return true;
+        }
+
+        return currentLockId.compareTo(comparedLockId) != 0;
     }
 
     private void populateLockSet(List<BIRTerminator.Lock> currentSet, BIRTerminator.Lock comparedLock) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -1,0 +1,230 @@
+/*
+ *  *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  *
+ *  *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  *  Version 2.0 (the "License"); you may not use this file except
+ *  *  in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing,
+ *  *  software distributed under the License is distributed on an
+ *  *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  *  KIND, either express or implied.  See the License for the
+ *  *  specific language governing permissions and limitations
+ *  *  under the License.
+ *
+ */
+
+package org.wso2.ballerinalang.compiler.bir.optimizer;
+
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
+import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
+import org.wso2.ballerinalang.compiler.bir.model.BIRVisitor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Optimize Locks
+ *
+ * @since 1.2.1
+ */
+public class BIRLockOptimizer extends BIRVisitor {
+
+    private List<BIRTerminator.Lock> lockList = new ArrayList<>();
+    private Map<BIRTerminator.Lock, Integer> lockToSetMap = new HashMap<>();
+    private Map<Integer, List<BIRTerminator.Lock>> setToLockMap = new HashMap<>();
+    private int setId = -1;
+
+    public void optimizeNode(BIRNode node) {
+        // Collect lock nodes
+        node.accept(this);
+
+        // Identify disjoint locks
+        optimizeLocks();
+    }
+
+    private void optimizeLocks() {
+        analyzeLocks();
+    }
+
+    private void analyzeLocks() {
+        for (int lockListIndex = 0; lockListIndex < lockList.size(); lockListIndex++) {
+            if (!lockToSetMap.containsKey(lockList.get(lockListIndex))) {
+                analyzeUnvisitedLock(lockListIndex);
+            } else {
+                analyzeVisitedLock(lockListIndex);
+            }
+        }
+    }
+
+    private void analyzeVisitedLock(int lockListIndex) {
+        BIRTerminator.Lock currentLock = lockList.get(lockListIndex);
+        int previousSetId = setId;
+        Integer currentSetIdLocal = lockToSetMap.get(currentLock);
+        List<BIRTerminator.Lock> currentSet = setToLockMap.get(currentSetIdLocal);
+
+        setId = currentSetIdLocal;
+        populateLockSet(currentSet, currentLock, lockListIndex);
+        setId = previousSetId;
+    }
+
+    private void analyzeUnvisitedLock(int lockListIndex) {
+        BIRTerminator.Lock currentLock = lockList.get(lockListIndex);
+        List<BIRTerminator.Lock> currentSet = new LinkedList<>();
+
+        // Add to the maps for the current unvisited lock.
+        lockToSetMap.put(currentLock, ++setId);
+
+        // Compare with the rest of the locks.
+        currentSet.add(currentLock);
+
+        populateLockSet(currentSet, currentLock, lockListIndex);
+
+        setToLockMap.put(setId, currentSet);
+    }
+
+    private void populateLockSet(List<BIRTerminator.Lock> currentSet, BIRTerminator.Lock currentLock,
+            int lockListIndex) {
+        for (int i = (lockListIndex + 1); i < lockList.size(); i++) {
+            BIRTerminator.Lock comparedLock = lockList.get(i);
+            Set<BIRNode.BIRGlobalVariableDcl> globalVarSetOfComparedLock = comparedLock.lockVariables;
+
+            if (isSharedLock(currentLock, globalVarSetOfComparedLock)) {
+                populateLockSet(currentSet, comparedLock);
+            }
+        }
+    }
+
+    private void populateLockSet(List<BIRTerminator.Lock> currentSet, BIRTerminator.Lock comparedLock) {
+        // Merge if there is already a set for the compared lock.
+        if (lockToSetMap.containsKey(comparedLock)) {
+            Integer comparedLocksSetId = lockToSetMap.get(comparedLock);
+            List<BIRTerminator.Lock> previousSet = setToLockMap.get(comparedLocksSetId);
+
+            currentSet.addAll(previousSet);
+
+            for (BIRTerminator.Lock lock : previousSet) {
+                lockToSetMap.put(lock, setId);
+            }
+        }
+
+        // Update the compared lock to the related set.
+        lockToSetMap.put(comparedLock, setId);
+        currentSet.add(comparedLock);
+    }
+
+    private boolean isSharedLock(BIRTerminator.Lock currentLock,
+            Set<BIRNode.BIRGlobalVariableDcl> globalVarSetOfComparedLock) {
+        for (BIRNode.BIRGlobalVariableDcl globalVarOfCurLock : currentLock.lockVariables) {
+            if (globalVarSetOfComparedLock.contains(globalVarOfCurLock)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(BIRNode.BIRPackage birPackage) {
+        birPackage.typeDefs.forEach(tDef -> tDef.accept(this));
+        birPackage.functions.forEach(func -> func.accept(this));
+    }
+
+    @Override
+    public void visit(BIRNode.BIRTypeDefinition birTypeDefinition) {
+        birTypeDefinition.attachedFuncs.forEach(func -> func.accept(this));
+    }
+
+    @Override
+    public void visit(BIRNode.BIRFunction birFunction) {
+        birFunction.basicBlocks.forEach(bb -> bb.accept(this));
+    }
+
+    @Override
+    public void visit(BIRTerminator.GOTO birGoto) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Call birCall) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.AsyncCall birCall) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Return birReturn) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Branch birBranch) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.FPCall fpCall) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Lock lock) {
+        lockList.add(lock);
+    }
+
+    @Override
+    public void visit(BIRTerminator.FieldLock lock) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Unlock unlock) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Panic birPanic) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Wait birWait) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.WaitAll waitAll) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.Flush birFlush) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.WorkerReceive workerReceive) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRTerminator.WorkerSend workerSend) {
+        // Do nothing
+    }
+
+    @Override
+    public void visit(BIRNode.BIRBasicBlock birBasicBlock) {
+        BIRTerminator terminator = birBasicBlock.terminator;
+
+        terminator.accept(this);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
@@ -73,6 +73,8 @@ public class BIROptimizer {
 
         // LHS temp var optimization
         this.lhsTempVarOptimizer.optimizeNode(pkg, null);
+
+        // Optimize lock statements
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIROptimizer.java
@@ -51,6 +51,7 @@ public class BIROptimizer {
     private static final CompilerContext.Key<BIROptimizer> BIR_OPTIMIZER = new CompilerContext.Key<>();
     private RHSTempVarOptimizer rhsTempVarOptimizer;
     private LHSTempVarOptimizer lhsTempVarOptimizer;
+    private BIRLockOptimizer lockOptimizer;
 
     public static BIROptimizer getInstance(CompilerContext context) {
         BIROptimizer birGen = context.get(BIR_OPTIMIZER);
@@ -65,6 +66,7 @@ public class BIROptimizer {
         context.put(BIR_OPTIMIZER, this);
         this.rhsTempVarOptimizer = new RHSTempVarOptimizer();
         this.lhsTempVarOptimizer = new LHSTempVarOptimizer();
+        this.lockOptimizer = new BIRLockOptimizer();
     }
 
     public void optimizePackage(BIRPackage pkg) {
@@ -75,6 +77,7 @@ public class BIROptimizer {
         this.lhsTempVarOptimizer.optimizeNode(pkg, null);
 
         // Optimize lock statements
+        this.lockOptimizer.optimizeNode(pkg);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3348,6 +3348,10 @@ public class Desugar extends BLangNodeVisitor {
             // Package variable | service variable.
             // We consider both of them as package level variables.
             genVarRefExpr = new BLangPackageVarRef((BVarSymbol) varRefExpr.symbol);
+
+            if (!enclLocks.isEmpty()) {
+                enclLocks.peek().addLockVariable((BVarSymbol) varRefExpr.symbol);
+            }
         }
 
         genVarRefExpr.type = varRefExpr.type;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3595,6 +3595,11 @@ public class Desugar extends BLangNodeVisitor {
             result = rewriteErrorConstructor(iExpr);
         }
 
+        if (!enclLocks.isEmpty()) {
+            BLangLockStmt lock = enclLocks.peek();
+            lock.lockVariables.addAll(((BInvokableSymbol)iExpr.symbol).dependentGlobalVars);
+        }
+
         // Reorder the arguments to match the original function signature.
         reorderArguments(iExpr);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3597,7 +3597,7 @@ public class Desugar extends BLangNodeVisitor {
 
         if (!enclLocks.isEmpty()) {
             BLangLockStmt lock = enclLocks.peek();
-            lock.lockVariables.addAll(((BInvokableSymbol)iExpr.symbol).dependentGlobalVars);
+            lock.lockVariables.addAll(((BInvokableSymbol) iExpr.symbol).dependentGlobalVars);
         }
 
         // Reorder the arguments to match the original function signature.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2951,6 +2951,7 @@ public class Desugar extends BLangNodeVisitor {
         blockStmt.addStatement(simpleVariableDef);
 
         BLangUnLockStmt unLockStmt = new BLangUnLockStmt(lockNode.pos);
+        unLockStmt.relatedLock = lockStmt; // Used to find the related lock to unlock.
         blockStmt.addStatement(unLockStmt);
         BLangSimpleVarRef varRef = ASTBuilderUtil.createVariableRef(lockNode.pos, nillableErrorVarSymbol);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -523,6 +523,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangLock lockNode) {
+        analyzeNode(lockNode.body, this.env);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -265,7 +265,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         });
         sortedListOfNodes.forEach(topLevelNode -> analyzeNode((BLangNode) topLevelNode, env));
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage));
-        globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
+        this.globalVariableRefAnalyzer.populateFunctionDependencies(this.globalNodeDependsOn);
+        this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
         checkUnusedImports(pkgNode.imports);
         pkgNode.completedPhases.add(CompilerPhase.DATAFLOW_ANALYZE);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -268,8 +268,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         });
         sortedListOfNodes.forEach(topLevelNode -> analyzeNode((BLangNode) topLevelNode, env));
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage));
-        this.globalVariableRefAnalyzer.populateFunctionDependencies(this.functionToDependency);
         this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
+        this.globalVariableRefAnalyzer.populateFunctionDependencies(this.functionToDependency);
         checkUnusedImports(pkgNode.imports);
         pkgNode.completedPhases.add(CompilerPhase.DATAFLOW_ANALYZE);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -182,6 +182,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -211,6 +212,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private BLangDiagnosticLogHelper dlog;
     private Map<BSymbol, InitStatus> uninitializedVars;
     private Map<BSymbol, Set<BSymbol>> globalNodeDependsOn;
+    private Map<BSymbol, Set<BSymbol>> functionToDependency;
     private boolean flowTerminated = false;
 
     private static final CompilerContext.Key<DataflowAnalyzer> DATAFLOW_ANALYZER_KEY = new CompilerContext.Key<>();
@@ -245,6 +247,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     public BLangPackage analyze(BLangPackage pkgNode) {
         this.uninitializedVars = new HashMap<>();
         this.globalNodeDependsOn = new LinkedHashMap<>();
+        this.functionToDependency = new HashMap<>();
         SymbolEnv pkgEnv = this.symTable.pkgEnvMap.get(pkgNode.symbol);
         analyzeNode(pkgNode, pkgEnv);
         return pkgNode;
@@ -265,7 +268,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         });
         sortedListOfNodes.forEach(topLevelNode -> analyzeNode((BLangNode) topLevelNode, env));
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage));
-        this.globalVariableRefAnalyzer.populateFunctionDependencies(this.globalNodeDependsOn);
+        this.globalVariableRefAnalyzer.populateFunctionDependencies(this.functionToDependency);
         this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
         checkUnusedImports(pkgNode.imports);
         pkgNode.completedPhases.add(CompilerPhase.DATAFLOW_ANALYZE);
@@ -766,6 +769,13 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             return false;
         }
 
+        return isVariableOrConstant(symbol);
+    }
+
+    private boolean isVariableOrConstant(BSymbol symbol) {
+        if (symbol == null) {
+            return false;
+        }
         return ((symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) ||
                 ((symbol.tag & SymTag.CONSTANT) == SymTag.CONSTANT);
     }
@@ -783,6 +793,21 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             return;
         }
         Set<BSymbol> providers = globalNodeDependsOn.computeIfAbsent(dependent, s -> new LinkedHashSet<>());
+        providers.add(provider);
+
+        // Store the dependencies of functions seperately for lock optimization in later stage.
+        addFunctionToGlobalVarDependency(dependent, provider);
+    }
+
+    private void addFunctionToGlobalVarDependency(BSymbol dependent, BSymbol provider) {
+        if (dependent.kind != SymbolKind.FUNCTION) {
+            return;
+        }
+        if (isVariableOrConstant(provider) && !isGlobalVarSymbol(provider)) {
+            return;
+        }
+
+        Set<BSymbol> providers = this.functionToDependency.computeIfAbsent(dependent, s -> new HashSet<>());
         providers.add(provider);
     }
 
@@ -1418,6 +1443,12 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         if (varRef.getKind() != NodeKind.SIMPLE_VARIABLE_REF &&
                 varRef.getKind() != NodeKind.XML_ATTRIBUTE_ACCESS_EXPR) {
             return;
+        }
+
+        // So global variable assignments happen in functions.
+        if (varRef.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
+            BSymbol owner = this.env.scope.owner;
+            addFunctionToGlobalVarDependency(owner, ((BLangSimpleVarRef) varRef).symbol);
         }
 
         this.uninitializedVars.remove(((BLangVariableReference) varRef).symbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLogHelper;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -66,6 +67,7 @@ public class GlobalVariableRefAnalyzer {
     private final Deque<NodeInfo> nodeInfoStack;
     private final List<List<NodeInfo>> cycles;
     private final List<NodeInfo> dependencyOrder;
+    private final List<BSymbol> functionToGlobalVariable;
     private int curNodeId;
 
     public static GlobalVariableRefAnalyzer getInstance(CompilerContext context) {
@@ -84,6 +86,7 @@ public class GlobalVariableRefAnalyzer {
         this.cycles = new ArrayList<>();
         this.nodeInfoStack = new ArrayDeque<>();
         this.dependencyOrder = new ArrayList<>();
+        this.functionToGlobalVariable = new ArrayList<>();
     }
 
     /**
@@ -91,7 +94,9 @@ public class GlobalVariableRefAnalyzer {
      * @param globalNodeDependsOn symbol dependency relationship.
      */
     public void populateFunctionDependencies(Map<BSymbol, Set<BSymbol>> globalNodeDependsOn) {
+        resetAnalyzer();
         this.globalNodeDependsOn = globalNodeDependsOn;
+        pruneDependencyRelations();
 
         Set<BSymbol> dependentSet = this.globalNodeDependsOn.keySet();
         for (BSymbol dependent : dependentSet) {
@@ -99,23 +104,81 @@ public class GlobalVariableRefAnalyzer {
                 continue;
             }
 
-            Set<BSymbol> providers = globalNodeDependsOn.getOrDefault(dependent,  new HashSet<>());
-            if (dependent instanceof BInvokableSymbol) { // Spotbugs BC issue fix.
-                populateGlobalVariablesInInvokableSymbol((BInvokableSymbol) dependent, providers);
-            }
+            analyzeDependenciesRecursively(dependent);
         }
     }
 
-    private void populateGlobalVariablesInInvokableSymbol(BInvokableSymbol dependent, Set<BSymbol> providers) {
-        for (BSymbol symbol : providers) {
-            if (symbol.kind == SymbolKind.FUNCTION) {
-                Set<BSymbol> dependentsDependentSet = this.globalNodeDependsOn.getOrDefault(symbol, new HashSet<>());
-                populateGlobalVariablesInInvokableSymbol(dependent, dependentsDependentSet);
-            }
-            if (isGlobalVarSymbol(symbol)) {
-                dependent.dependentGlobalVars.add((BVarSymbol) symbol);
+    private void analyzeDependenciesRecursively(BSymbol dependent) {
+        // Only analyze unvisited nodes.
+        // Do DFS into dependency providers to detect cycles.
+        if (!dependencyNodes.containsKey(dependent)) {
+            NodeInfo node = new NodeInfo(curNodeId++, dependent);
+            dependencyNodes.put(dependent, node);
+            analyzeDependenciesRecursively(node);
+        }
+    }
+
+    private Set<BVarSymbol> analyzeDependenciesRecursively(NodeInfo node) {
+        if (node.onStack) {
+            return getGlobalVarFromCurrentNode(node);
+        }
+        if (node.visited) {
+            return getDependentsFromSymbol(node.symbol);
+        }
+
+        node.visited = true;
+
+        if (isGlobalVarSymbol(node.symbol)) {
+            return new HashSet<>(Arrays.asList((BVarSymbol) node.symbol));
+        }
+
+        node.onStack = true;
+
+        Set<BSymbol> providers = this.globalNodeDependsOn.getOrDefault(node.symbol, new LinkedHashSet<>());
+        // No providers means either not a function or function does not have dependents.
+        if (providers.isEmpty()) {
+            return new HashSet<>();
+        }
+
+        // Means the current node is a function and has dependencies. Lets analyze its dependencies further.
+        for (BSymbol providerSym : providers) {
+            NodeInfo providerNode =
+                    this.dependencyNodes.computeIfAbsent(providerSym, s -> new NodeInfo(curNodeId++, providerSym));
+            ((BInvokableSymbol) node.symbol).dependentGlobalVars
+                    .addAll(analyzeDependenciesRecursively(providerNode));
+        }
+
+        node.onStack = false;
+        return ((BInvokableSymbol) node.symbol).dependentGlobalVars;
+    }
+
+    private Set<BVarSymbol> getGlobalVarFromCurrentNode(NodeInfo node) {
+        Set<BVarSymbol> globalVars = new HashSet<>();
+        Set<BSymbol> providers = this.globalNodeDependsOn.getOrDefault(node.symbol, new LinkedHashSet<>());
+
+        for (BSymbol provider : providers) {
+            if (isGlobalVarSymbol(provider)) {
+                globalVars.add((BVarSymbol) provider);
             }
         }
+
+        return globalVars;
+    }
+
+    private Set<BVarSymbol> getDependentsFromSymbol(BSymbol symbol) {
+        if (isFunction(symbol)) {
+            return ((BInvokableSymbol) symbol).dependentGlobalVars;
+        } else if (isGlobalVarSymbol(symbol)) {
+            Set<BVarSymbol> dependentSet = new HashSet<>();
+            dependentSet.add((BVarSymbol) symbol);
+            return dependentSet;
+        }
+
+        return new HashSet<>();
+    }
+
+    private boolean isFunction(BSymbol symbol) {
+        return (symbol.tag & SymTag.FUNCTION) == SymTag.FUNCTION;
     }
 
     private boolean isGlobalVarSymbol(BSymbol symbol) {
@@ -126,6 +189,9 @@ public class GlobalVariableRefAnalyzer {
             return false;
         }
         if (symbol.owner.tag != SymTag.PACKAGE) {
+            return false;
+        }
+        if ((symbol.tag & SymTag.FUNCTION) == SymTag.FUNCTION) {
             return false;
         }
 
@@ -209,6 +275,7 @@ public class GlobalVariableRefAnalyzer {
         this.cycles.clear();
         this.nodeInfoStack.clear();
         this.dependencyOrder.clear();
+        this.curNodeId = 0;
     }
 
     private void pruneDependencyRelations() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -67,7 +67,6 @@ public class GlobalVariableRefAnalyzer {
     private final Deque<NodeInfo> nodeInfoStack;
     private final List<List<NodeInfo>> cycles;
     private final List<NodeInfo> dependencyOrder;
-    private final List<BSymbol> functionToGlobalVariable;
     private int curNodeId;
 
     public static GlobalVariableRefAnalyzer getInstance(CompilerContext context) {
@@ -86,7 +85,6 @@ public class GlobalVariableRefAnalyzer {
         this.cycles = new ArrayList<>();
         this.nodeInfoStack = new ArrayDeque<>();
         this.dependencyOrder = new ArrayList<>();
-        this.functionToGlobalVariable = new ArrayList<>();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
@@ -49,7 +49,7 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
     public String source;
     public SchedulerPolicy schedulerPolicy = SchedulerPolicy.PARENT;
 
-    public Set<BSymbol> dependentGlobalVars;
+    public Set<BVarSymbol> dependentGlobalVars;
 
     public BInvokableSymbol(int tag,
                             int flags,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
@@ -25,8 +25,10 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @since 0.94
@@ -47,6 +49,8 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
     public String source;
     public SchedulerPolicy schedulerPolicy = SchedulerPolicy.PARENT;
 
+    public Set<BSymbol> dependentGlobalVars;
+
     public BInvokableSymbol(int tag,
                             int flags,
                             Name name,
@@ -56,6 +60,7 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
         super(flags, name, pkgID, type, owner);
         this.tag = tag;
         this.params = new ArrayList<>();
+        this.dependentGlobalVars = new HashSet<>();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
@@ -103,6 +103,8 @@ public class BLangLock extends BLangStatement implements LockNode {
      */
     public static class BLangUnLockStmt extends BLangLock {
 
+        public BLangLockStmt relatedLock;
+
         public BLangUnLockStmt(DiagnosticPos pos) {
             this.pos = pos;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
@@ -20,8 +20,13 @@ package org.wso2.ballerinalang.compiler.tree.statements;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.statements.BlockStatementNode;
 import org.ballerinalang.model.tree.statements.LockNode;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation for the lock tree node.
@@ -70,6 +75,8 @@ public class BLangLock extends BLangStatement implements LockNode {
      */
     public static class BLangLockStmt extends BLangLock {
 
+        public Set<BVarSymbol> lockVariables = new HashSet<>();
+
         public BLangLockStmt(DiagnosticPos pos) {
             this.pos = pos;
         }
@@ -81,7 +88,11 @@ public class BLangLock extends BLangStatement implements LockNode {
 
         @Override
         public String toString() {
-            return "lock []";
+            return "lock [" + lockVariables.stream().map(s -> s.name.value).collect(Collectors.joining(", "));
+        }
+
+        public boolean addLockVariable(BVarSymbol variable) {
+            return lockVariables.add(variable);
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -262,18 +262,26 @@ public class LocksInMainTest {
         BValue[] returns = BRunUtil.invoke(parallelCompileResult, "runParallelUsingLocks");
     }
 
-    @Test
+    @Test(description = "Test for parallel run when invocations have global variable dependencies")
     public void testParallelRunWithInvocationDependencies() {
         BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLockWithInvokableAccessingGlobal");
     }
 
-    @Test
+    @Test(description = "Test for parallel run when invocations have loops and global var dependencies")
     public void testParallelRunWithChainedInvocationDependencies() {
         BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLockWIthInvokableChainsAccessingGlobal");
     }
 
-    @Test
+    @Test(description = "Test for parallel run when invocation are recursive and have global var dependencies")
     public void testParallelRunWithRecursiveInvocationDependencies() {
         BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLockWIthInvokableRecursiveAccessGlobal");
+    }
+
+    @Test(description = "Test for parallel run when invocations are imported and contains global var dependencies")
+    public void testParallelRunWithImportInvocationDependencies() {
+        CompileResult importInvocationDependencies = BCompileUtil.compile("test-src/lock/locks-in-imports-test",
+                "mod1", true);
+
+        BRunUtil.invoke(importInvocationDependencies, "testLockWIthInvokableChainsAccessingGlobal");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -41,6 +42,14 @@ import static org.testng.Assert.assertTrue;
  * @since 0.961.0
  */
 public class LocksInMainTest {
+
+    private  CompileResult parallelCompileResult;
+
+    @BeforeClass
+    public void setup() {
+        parallelCompileResult = BCompileUtil.compile("test-src/lock/parallel-run-lock.bal");
+        Assert.assertEquals(parallelCompileResult.getErrorCount(), 0);
+    }
 
     @Test(description = "Tests lock within a lock")
     public void testLockWithinLock() {
@@ -250,15 +259,21 @@ public class LocksInMainTest {
 
     @Test(description = "Test for parallel run using locks")
     public void testParallelRunUsingLocks() {
-        CompileResult compileResult = BCompileUtil.compile("test-src/lock/parallel-run-lock.bal");
-
-        BValue[] returns = BRunUtil.invoke(compileResult, "runParallelUsingLocks");
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "runParallelUsingLocks");
     }
 
     @Test
     public void testParallelRunWithInvocationDependencies() {
-        CompileResult compileResult = BCompileUtil.compile("test-src/lock/parallel-run-lock.bal");
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLockWithInvokableAccessingGlobal");
+    }
 
-        BValue[] returns = BRunUtil.invoke(compileResult, "testLockWithInvokableAccessingGlobal");
+    @Test
+    public void testParallelRunWithChainedInvocationDependencies() {
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLockWIthInvokableChainsAccessingGlobal");
+    }
+
+    @Test
+    public void testParallelRunWithRecursiveInvocationDependencies() {
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLockWIthInvokableRecursiveAccessGlobal");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -247,4 +247,11 @@ public class LocksInMainTest {
         BAssertUtil.validateError(compileResult, 1, "undefined symbol 'val1'",
                 18, 9);
     }
+
+    @Test(description = "Test for parallel run using locks")
+    public void testParallelRunUsingLocks() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/lock/parallel-run-lock.bal");
+
+        BValue[] returns = BRunUtil.invoke(compileResult, "runParallelUsingLocks");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -30,7 +30,6 @@ import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
@@ -253,5 +254,12 @@ public class LocksInMainTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/parallel-run-lock.bal");
 
         BValue[] returns = BRunUtil.invoke(compileResult, "runParallelUsingLocks");
+    }
+
+    @Test
+    public void testParallelRunWithInvocationDependencies() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/lock/parallel-run-lock.bal");
+
+        BValue[] returns = BRunUtil.invoke(compileResult, "testLockWithInvokableAccessingGlobal");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
@@ -68,3 +68,13 @@ function runParallelUsingLocks() {
         panic error("Error in parallel run using locks");
     }
 }
+
+int x = 0;
+int y = 0;
+
+function add() {
+    x = x + 1;
+    y = y + 1;
+}
+
+function

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
@@ -99,3 +99,89 @@ function testLockWithInvokableAccessingGlobal() {
         panic error("Invalid Value");
     }
 }
+
+int recurs1 = 0;
+int recurs2 = 0;
+
+function chain(int chainBreak, boolean startFunc) {
+    if (chainBreak == 1 && !startFunc) {
+        return;
+    }
+
+    recurs1 += 10;
+    chain2(chainBreak, false);
+}
+
+function chain2(int chainBreak, boolean startFunc) {
+    if (chainBreak == 2 && !startFunc) {
+        return;
+    }
+
+    recurs2 += 10;
+    chain3(chainBreak, false);
+}
+
+function chain3(int chainBreak, boolean startFunc) {
+    if (chainBreak == 3 && !startFunc) {
+        return;
+    }
+
+    chain(chainBreak, false);
+}
+
+function testLockWIthInvokableChainsAccessingGlobal() {
+    @strand{thread : "any"}
+    worker w1 {
+        lock {
+            runtime:sleep(20);
+            chain(1, true);
+        }
+    }
+
+    @strand{thread : "any"}
+    worker w2 {
+        lock {
+            runtime:sleep(20);
+            chain2(2, true);
+        }
+    }
+
+    runtime:sleep(20);
+    if (recurs2 == 20  || recurs1 == 20) {
+        panic error("Invalid Value");
+    }
+}
+
+int recurs3 = 0;
+
+function recursive(int breakCondition) {
+    if (breakCondition == 0) {
+        return;
+    }
+
+    recurs3 += 10;
+    recursive(breakCondition - 1);
+}
+
+function testLockWIthInvokableRecursiveAccessGlobal() {
+    @strand{thread : "any"}
+    worker w1 {
+        lock {
+            runtime:sleep(20);
+            recursive(5);
+        }
+    }
+
+    @strand{thread : "any"}
+    worker w2 {
+        lock {
+            runtime:sleep(20);
+            recursive(3);
+        }
+    }
+
+    runtime:sleep(20);
+    if (recurs3 == 80) {
+        panic error("Invalid Value");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
@@ -70,11 +70,32 @@ function runParallelUsingLocks() {
 }
 
 int x = 0;
-int y = 0;
+string y = "";
 
 function add() {
-    x = x + 1;
-    y = y + 1;
+    x += 10;
+    y += "lockValueInFunction";
 }
 
-function
+function testLockWithInvokableAccessingGlobal() {
+    @strand{thread : "any"}
+    worker w1 {
+        lock {
+            runtime:sleep(20);
+            add();
+        }
+    }
+
+    @strand{thread : "any"}
+    worker w2 {
+        lock {
+            runtime:sleep(20);
+            add();
+        }
+    }
+
+    runtime:sleep(20);
+    if (y == "lockValueInFunctionlockValueInFunction" || x == 20) {
+        panic error("Invalid Value");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
@@ -1,0 +1,70 @@
+import ballerina/runtime;
+
+int a = 0;
+int b = 0;
+int c = 0;
+int d = 0;
+int e = 0;
+int f = 0;
+int g = 0;
+int h = 0;
+
+function runParallelUsingLocks() {
+    @strand{thread:"any"}
+    worker w1 {
+        lock {
+            runtime:sleep(20);
+            a = 1;
+        }
+    }
+
+    @strand{thread:"any"}
+    worker w2 {
+        lock {
+            runtime:sleep(20);
+            b = 1;
+        }
+    }
+
+    @strand{thread:"any"}
+    worker w3 {
+        lock {
+            runtime:sleep(20);
+            c = 1;
+            d = 1;
+        }
+    }
+
+    @strand{thread:"any"}
+    worker w4 {
+        lock {
+            runtime:sleep(20);
+            d = 1;
+            e = 1;
+        }
+    }
+
+    @strand{thread:"any"}
+    worker w5 {
+        lock {
+            runtime:sleep(20);
+            g = 1;
+            h = 1;
+        }
+    }
+
+    @strand{thread:"any"}
+    worker w6 {
+        lock {
+            runtime:sleep(20);
+            b = 1;
+            e = 1;
+        }
+    }
+
+    runtime:sleep(80);
+
+    if (!(a == 1 && b == 1 && c == 1 && d == 1 && e == 1 && f == 0 && g == 1 && h == 1)) {
+        panic error("Error in parallel run using locks");
+    }
+}


### PR DESCRIPTION
## Purpose
> In the previous release the concurrent design was supported but the parallelism was reduced when locks were used. This has been fixed in this PR.

## Approach
> Collect global variables accessed within lock statement.
> Analyse the lock statements and put them in to sets by the locks they use. 
> This will give us a set of disjoint sets.
> Create JVM locks for each set.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
