### PR TITLE
Narrow type bound to union type parameters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -414,8 +414,6 @@ public class TypeParamAnalyzer {
         for (BType type : actualType.getMemberTypes()) {
             if (type.tag == TypeTags.ARRAY) {
                 tupleTypes.add(((BArrayType) type).eType);
-            } else {
-                tupleTypes.add(type);
             }
         }
         BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
@@ -428,8 +426,6 @@ public class TypeParamAnalyzer {
         for (BType type : actualType.getMemberTypes()) {
             if (type.tag == TypeTags.MAP) {
                 tupleTypes.add(((BMapType) type).constraint);
-            } else {
-                tupleTypes.add(type);
             }
         }
         BUnionType tupleElementType = BUnionType.create(null, tupleTypes);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -278,6 +278,7 @@ public class TypeParamAnalyzer {
             updateTypeParamAndBoundType(pos, env, expType, actualType);
 
             // If type param discovered before, now type check with actual type. It has to be matched.
+
             if (checkContravariance) {
                 types.checkType(pos, getMatchingBoundType(expType, env, new HashSet<>()), actualType,
                                 DiagnosticCode.INCOMPATIBLE_TYPES);
@@ -311,10 +312,6 @@ public class TypeParamAnalyzer {
                 if (actualType.tag == TypeTags.RECORD) {
                     findTypeParamInMapForRecord(pos, (BMapType) expType, (BRecordType) actualType, env, resolvedTypes,
                                                 result);
-                }
-                if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnion(pos, ((BMapType) expType).constraint, (BUnionType) actualType, env, resolvedTypes,
-                                               result);
                 }
                 return;
             case TypeTags.STREAM:
@@ -422,6 +419,35 @@ public class TypeParamAnalyzer {
         BUnionType tupleElementType = BUnionType.create(null, members);
         findTypeParam(pos, expType, tupleElementType, env, resolvedTypes, result);
     }
+
+    private void findTypeParamInUnionForArray(DiagnosticPos pos, BArrayType expType, BUnionType actualType,
+    SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
+        for (BType type : actualType.getMemberTypes()) {
+            if (type.tag == TypeTags.ARRAY) {
+                tupleTypes.add(((BArrayType) type).eType);
+            } else {
+                tupleTypes.add(type);
+            }
+        }
+        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
+        findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
+    }
+
+    private void findTypeParamInUnionForMap(DiagnosticPos pos, BMapType expType, BUnionType actualType,
+                                            SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
+        for (BType type : actualType.getMemberTypes()) {
+            if (type.tag == TypeTags.MAP) {
+                tupleTypes.add(((BMapType) type).constraint);
+            } else {
+                tupleTypes.add(type);
+            }
+        }
+        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
+        findTypeParam(pos, expType.constraint, tupleElementType, env, resolvedTypes, result);
+    }
+
 
     private void findTypeParamInRecord(DiagnosticPos pos, BRecordType expType, BRecordType actualType, SymbolEnv env,
                                        HashSet<BType> resolvedTypes, FindTypeParamResult result) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -314,8 +314,8 @@ public class TypeParamAnalyzer {
                                                 result);
                 }
                 if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnion(pos, ((BMapType) expType).constraint, (BUnionType) actualType, env, resolvedTypes,
-                                         result);
+                    findTypeParamInUnion(pos, ((BMapType) expType).constraint, (BUnionType) actualType, env,
+                                         resolvedTypes, result);
                 }
                 return;
             case TypeTags.STREAM:
@@ -323,6 +323,7 @@ public class TypeParamAnalyzer {
                     findTypeParamInStream(pos, ((BStreamType) expType), ((BStreamType) actualType), env, resolvedTypes,
                                           result);
                 }
+                // TODO : Handle unions
                 return;
             case TypeTags.TUPLE:
                 if (actualType.tag == TypeTags.TUPLE) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -330,6 +330,9 @@ public class TypeParamAnalyzer {
                     findTypeParamInTuple(pos, (BTupleType) expType, (BTupleType) actualType, env, resolvedTypes,
                                          result);
                 }
+                if (actualType.tag == TypeTags.UNION) {
+                    findTypeParamInUnion(pos, expType, (BUnionType) actualType, env, resolvedTypes, result);
+                }
                 return;
             case TypeTags.RECORD:
                 if (actualType.tag == TypeTags.RECORD) {
@@ -337,8 +340,7 @@ public class TypeParamAnalyzer {
                                           result);
                 }
                 if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnion(pos, expType, (BUnionType) actualType, env,
-                                         resolvedTypes, result);
+                    findTypeParamInUnion(pos, expType, (BUnionType) actualType, env, resolvedTypes, result);
                 }
                 return;
             case TypeTags.INVOKABLE:
@@ -428,6 +430,9 @@ public class TypeParamAnalyzer {
                 for (BField field : ((BRecordType) type).getFields()) {
                     members.add(field.type);
                 }
+            }
+            if (type.tag == TypeTags.TUPLE) {
+                members.addAll(((BTupleType) type).getTupleTypes());
             }
         }
         BUnionType tupleElementType = BUnionType.create(null, members);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -323,7 +323,7 @@ public class TypeParamAnalyzer {
                     findTypeParamInStream(pos, ((BStreamType) expType), ((BStreamType) actualType), env, resolvedTypes,
                                           result);
                 }
-                // TODO : Handle unions
+                // TODO : Handle unions after - github.com/ballerina-platform/ballerina-lang/issues/22570
                 return;
             case TypeTags.TUPLE:
                 if (actualType.tag == TypeTags.TUPLE) {
@@ -335,6 +335,10 @@ public class TypeParamAnalyzer {
                 if (actualType.tag == TypeTags.RECORD) {
                     findTypeParamInRecord(pos, (BRecordType) expType, (BRecordType) actualType, env, resolvedTypes,
                                           result);
+                }
+                if (actualType.tag == TypeTags.UNION) {
+                    findTypeParamInUnion(pos, expType, (BUnionType) actualType, env,
+                                         resolvedTypes, result);
                 }
                 return;
             case TypeTags.INVOKABLE:
@@ -419,6 +423,11 @@ public class TypeParamAnalyzer {
             }
             if (type.tag == TypeTags.MAP) {
                 members.add(((BMapType) type).constraint);
+            }
+            if (type.tag == TypeTags.RECORD) {
+                for (BField field : ((BRecordType) type).getFields()) {
+                    members.add(field.type);
+                }
             }
         }
         BUnionType tupleElementType = BUnionType.create(null, members);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -313,6 +313,10 @@ public class TypeParamAnalyzer {
                     findTypeParamInMapForRecord(pos, (BMapType) expType, (BRecordType) actualType, env, resolvedTypes,
                                                 result);
                 }
+                if (actualType.tag == TypeTags.UNION) {
+                    findTypeParamInUnionForMap(pos, (BMapType) expType, (BUnionType) actualType, env, resolvedTypes,
+                                               result);
+                }
                 return;
             case TypeTags.STREAM:
                 if (actualType.tag == TypeTags.STREAM) {
@@ -418,30 +422,6 @@ public class TypeParamAnalyzer {
         }
         BUnionType tupleElementType = BUnionType.create(null, members);
         findTypeParam(pos, expType, tupleElementType, env, resolvedTypes, result);
-    }
-
-    private void findTypeParamInUnionForArray(DiagnosticPos pos, BArrayType expType, BUnionType actualType,
-    SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
-        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
-        for (BType type : actualType.getMemberTypes()) {
-            if (type.tag == TypeTags.ARRAY) {
-                tupleTypes.add(((BArrayType) type).eType);
-            }
-        }
-        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
-        findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
-    }
-
-    private void findTypeParamInUnionForMap(DiagnosticPos pos, BMapType expType, BUnionType actualType,
-                                            SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
-        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
-        for (BType type : actualType.getMemberTypes()) {
-            if (type.tag == TypeTags.MAP) {
-                tupleTypes.add(((BMapType) type).constraint);
-            }
-        }
-        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
-        findTypeParam(pos, expType.constraint, tupleElementType, env, resolvedTypes, result);
     }
 
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -426,8 +426,6 @@ public class TypeParamAnalyzer {
         for (BType type : actualType.getMemberTypes()) {
             if (type.tag == TypeTags.ARRAY) {
                 tupleTypes.add(((BArrayType) type).eType);
-            } else {
-                tupleTypes.add(type);
             }
         }
         BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
@@ -440,8 +438,6 @@ public class TypeParamAnalyzer {
         for (BType type : actualType.getMemberTypes()) {
             if (type.tag == TypeTags.MAP) {
                 tupleTypes.add(((BMapType) type).constraint);
-            } else {
-                tupleTypes.add(type);
             }
         }
         BUnionType tupleElementType = BUnionType.create(null, tupleTypes);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -299,7 +299,7 @@ public class TypeParamAnalyzer {
                                                  result);
                 }
                 if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnionForArray(pos, (BArrayType) expType, (BUnionType) actualType, env, resolvedTypes,
+                    findTypeParamInUnion(pos, ((BArrayType) expType).eType, (BUnionType) actualType, env, resolvedTypes,
                                                  result);
                 }
                 return;
@@ -313,7 +313,7 @@ public class TypeParamAnalyzer {
                                                 result);
                 }
                 if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnionForMap(pos, (BMapType) expType, (BUnionType) actualType, env, resolvedTypes,
+                    findTypeParamInUnion(pos, ((BMapType) expType).constraint, (BUnionType) actualType, env, resolvedTypes,
                                                result);
                 }
                 return;
@@ -408,28 +408,19 @@ public class TypeParamAnalyzer {
         findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
     }
 
-    private void findTypeParamInUnionForArray(DiagnosticPos pos, BArrayType expType, BUnionType actualType,
+    private void findTypeParamInUnion(DiagnosticPos pos, BType expType, BUnionType actualType,
                                               SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
-        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
+        LinkedHashSet<BType> members = new LinkedHashSet<>();
         for (BType type : actualType.getMemberTypes()) {
             if (type.tag == TypeTags.ARRAY) {
-                tupleTypes.add(((BArrayType) type).eType);
+                members.add(((BArrayType) type).eType);
             }
-        }
-        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
-        findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
-    }
-
-    private void findTypeParamInUnionForMap(DiagnosticPos pos, BMapType expType, BUnionType actualType,
-                                            SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
-        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
-        for (BType type : actualType.getMemberTypes()) {
             if (type.tag == TypeTags.MAP) {
-                tupleTypes.add(((BMapType) type).constraint);
+                members.add(((BMapType) type).constraint);
             }
         }
-        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
-        findTypeParam(pos, expType.constraint, tupleElementType, env, resolvedTypes, result);
+        BUnionType tupleElementType = BUnionType.create(null, members);
+        findTypeParam(pos, expType, tupleElementType, env, resolvedTypes, result);
     }
 
     private void findTypeParamInRecord(DiagnosticPos pos, BRecordType expType, BRecordType actualType, SymbolEnv env,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -314,8 +314,8 @@ public class TypeParamAnalyzer {
                                                 result);
                 }
                 if (actualType.tag == TypeTags.UNION) {
-                    findTypeParamInUnionForMap(pos, (BMapType) expType, (BUnionType) actualType, env, resolvedTypes,
-                                               result);
+                    findTypeParamInUnion(pos, ((BMapType) expType).constraint, (BUnionType) actualType, env, resolvedTypes,
+                                         result);
                 }
                 return;
             case TypeTags.STREAM:

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -112,11 +112,12 @@ public class TypeParamTest {
     @Test(description = "Tests for type narrowing for union return parameters")
     public void testTypeNarrowingForUnionReturnParameters() {
         CompileResult result = BCompileUtil.compile("test-src/type-param/type_param_narrowing_for_union_return.bal");
-        BRunUtil.invoke(result, "testSimpleUnionReturnParameterNarrowing");
-        BRunUtil.invoke(result, "testUnionOfMapsReturnParameterNarrowing");
-        BRunUtil.invoke(result, "testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing");
-        BRunUtil.invoke(result, "testIntFloatSimpleAndMapUnionReturnParameterNarrowing");
-        BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnionReturnParameterNarrowing");
-        BRunUtil.invoke(result, "testUnionOfRecordTypeParamNarrowing");
+        BRunUtil.invoke(result, "testSimpleUnion");
+        BRunUtil.invoke(result, "testUnionOfMaps");
+        BRunUtil.invoke(result, "testStringIntFloatSimpleAndArrayUnion");
+        BRunUtil.invoke(result, "testIntFloatSimpleAndMapUnion");
+        BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnion");
+        BRunUtil.invoke(result, "testUnionOfRecordTypes");
+        BRunUtil.invoke(result, "testUnionOfSimpleTupleTypes");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -117,5 +117,6 @@ public class TypeParamTest {
         BRunUtil.invoke(result, "testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testIntFloatSimpleAndMapUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnionReturnParameterNarrowing");
+        BRunUtil.invoke(result, "testStreamTypeParamNarrowing");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -117,6 +117,6 @@ public class TypeParamTest {
         BRunUtil.invoke(result, "testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testIntFloatSimpleAndMapUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnionReturnParameterNarrowing");
-        BRunUtil.invoke(result, "testStreamTypeParamNarrowing");
+        BRunUtil.invoke(result, "testUnionOfRecordTypeParamNarrowing");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -70,6 +70,8 @@ public class TypeParamTest {
         BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'boolean'", 130,
                                   14);
         BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'float'", 131, 24);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected '[int,(int|float)][]', found '[int," +
+                "(int|float|string)][]'", 137, 34);
         Assert.assertEquals(result.getErrorCount(), err);
     }
 
@@ -112,6 +114,9 @@ public class TypeParamTest {
         CompileResult result = BCompileUtil.compile("test-src/type-param/type_param_narrowing_for_union_return.bal");
         BRunUtil.invoke(result, "testSimpleUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testUnionOfMapsReturnParameterNarrowing");
+        BRunUtil.invoke(result, "testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing");
+        BRunUtil.invoke(result, "testIntFloatSimpleAndMapUnionReturnParameterNarrowing");
+        BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnionReturnParameterNarrowing");
         Assert.assertEquals(result.getErrorCount(), 0);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -117,6 +117,5 @@ public class TypeParamTest {
         BRunUtil.invoke(result, "testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testIntFloatSimpleAndMapUnionReturnParameterNarrowing");
         BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnionReturnParameterNarrowing");
-        Assert.assertEquals(result.getErrorCount(), 0);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -67,13 +67,9 @@ public class TypeParamTest {
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'int', found 'float'", 119, 21);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 122, 31);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 125, 26);
-
-        // Disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/22137
-        // BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'int'", 130,
-        // 14);
-        // BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'float'", 131,
-        //                           24);
-
+        BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'boolean'", 130,
+                                  14);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'float'", 131, 24);
         Assert.assertEquals(result.getErrorCount(), err);
     }
 
@@ -111,4 +107,11 @@ public class TypeParamTest {
         Assert.assertEquals(ret2[0].stringValue(), "100");
     }
 
+    @Test(description = "Tests for type narrowing for union return parameters")
+    public void testTypeNarrowingForUnionReturnParameters() {
+        CompileResult result = BCompileUtil.compile("test-src/type-param/type_param_narrowing_for_union_return.bal");
+        BRunUtil.invoke(result, "testSimpleUnionReturnParameterNarrowing");
+        BRunUtil.invoke(result, "testUnionOfMapsReturnParameterNarrowing");
+        Assert.assertEquals(result.getErrorCount(), 0);
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 function testSimpleUnionReturnParameterNarrowing() {
     int[]|float[] arr = <int[]>[1, 2];
     [int, (int|float)][] y = arr.enumerate();
@@ -45,4 +61,13 @@ function assertTrue(any|error actual) {
     }
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected 'true', found '" + actual.toString () + "'");
+}
+
+function assertEqual(anydata|error expected, anydata|error actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -17,7 +17,10 @@
 function testSimpleUnionReturnParameterNarrowing() {
     int[]|float[] arr = <int[]>[1, 2];
     [int, (int|float)][] y = arr.enumerate();
-    assertTrue(true);
+    assertTrue(y[0][0] is int);
+    assertTrue(y[0][1] is int);
+    assertEqual(1, y[0][1][0]);
+    assertEqual(2, y[0][1][1]);
 }
 
 function testUnionOfMapsReturnParameterNarrowing() {

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -1,0 +1,21 @@
+function testSimpleUnionReturnParameterNarrowing() {
+    int[]|float[] arr = <int[]>[1, 2];
+    [int, (int|float)][] y = arr.enumerate();
+    assertTrue(true);
+}
+
+function testUnionOfMapsReturnParameterNarrowing() {
+    map<int>|map<float> m = <map<int>>{"1": 1};
+    int|float x = m.get("1");
+    assertTrue(true);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertTrue(any|error actual) {
+    if actual is boolean && actual {
+        return;
+    }
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected 'true', found '" + actual.toString () + "'");
+}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -33,7 +33,7 @@ function assertEqual(anydata|error expected, anydata|error actual) {
                 message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }
 
-function testSimpleUnionReturnParameterNarrowing() {
+function testSimpleUnion() {
     int[]|float[] arr = <int[]>[1, 2];
     [int, (int|float)][] y = arr.enumerate();
     assertTrue(y[0][1] is int);
@@ -41,13 +41,13 @@ function testSimpleUnionReturnParameterNarrowing() {
     assertEqual(2, y[1][1]);
 }
 
-function testUnionOfMapsReturnParameterNarrowing() {
+function testUnionOfMaps() {
     map<int>|map<float> m = <map<int>>{"1": 1};
     int|float x = m.get("1");
     assertEqual(1, x);
 }
 
-function testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing() {
+function testStringIntFloatSimpleAndArrayUnion() {
     string | int[] | int | float[] | float arr = <int[]>[1, 2];
     if (arr is int[] | float[]) {
         [int, (int|float)][] y = arr.enumerate();
@@ -59,7 +59,7 @@ function testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing() {
     }
 }
 
-function testIntFloatSimpleAndMapUnionReturnParameterNarrowing() {
+function testIntFloatSimpleAndMapUnion() {
     map<int> | int | map<float> | float  m = <map<int>>{"1": 1};
     if (m is map<int> | map<float>) {
         int|float x = m.get("1");
@@ -70,7 +70,7 @@ function testIntFloatSimpleAndMapUnionReturnParameterNarrowing() {
     }
 }
 
-function testIntFloatSimpleArrayMapUnionReturnParameterNarrowing() {
+function testIntFloatSimpleArrayMapUnion() {
     map<int> | int[] | map<float> | float[]  m = <map<int>>{"1": 1};
     if (m is map<float> | map<int>) {
         int|float x = m.get("1");
@@ -94,9 +94,18 @@ type IntIdRecord record {
     int id;
 };
 
-function testUnionOfRecordTypeParamNarrowing() {
+
+function testUnionOfRecordTypes() {
     StringIdRecord|IntIdRecord recordId = <StringIdRecord>{id: "34"};
     string|int stringOrIntVar = recordId.get("id");
     assertEqual("34", stringOrIntVar);
-    assertTrue(fbs is string);
+    assertTrue(stringOrIntVar is string);
+}
+
+function testUnionOfSimpleTupleTypes() {
+    [int]|[string] intOrStringTuple = <[int]>[4];
+    var x = intOrStringTuple.iterator();
+    record {|int|string value;|}? valueRecord = x.next();
+    assertEqual(4, valueRecord["value"]);
+    assertTrue(valueRecord["value"] is int);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -10,6 +10,33 @@ function testUnionOfMapsReturnParameterNarrowing() {
     assertTrue(true);
 }
 
+function testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing() {
+    string | int[] | int | float[] | float arr = <int[]>[1, 2];
+    if (arr is int[] | float[]) {
+        [int, (int|float)][] y = arr.enumerate();
+    }
+    assertTrue(true);
+}
+
+function testIntFloatSimpleAndMapUnionReturnParameterNarrowing() {
+    map<int> | int | map<float> | float  m = <map<int>>{"1": 1};
+    if (m is map<int> | map<float>) {
+        int | float x = m.get("1");
+    }
+    assertTrue(true);
+}
+
+function testIntFloatSimpleArrayMapUnionReturnParameterNarrowing() {
+    map<int> | int[] | map<float> | float[]  m = <map<int>>{"1": 1};
+    if (m is map<float> | map<int>) {
+        int | float x = m.get("1");
+    }
+    if (m is int[] | float[]) {
+        [int, (int|float)][] y = m.enumerate();
+    }
+    assertTrue(true);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -17,43 +17,49 @@
 function testSimpleUnionReturnParameterNarrowing() {
     int[]|float[] arr = <int[]>[1, 2];
     [int, (int|float)][] y = arr.enumerate();
-    assertTrue(y[0][0] is int);
     assertTrue(y[0][1] is int);
-    assertEqual(1, y[0][1][0]);
-    assertEqual(2, y[0][1][1]);
+    assertEqual(1, y[0][1]);
+    assertEqual(2, y[1][1]);
 }
 
 function testUnionOfMapsReturnParameterNarrowing() {
     map<int>|map<float> m = <map<int>>{"1": 1};
     int|float x = m.get("1");
-    assertTrue(true);
+    assertEqual(1, x);
 }
 
 function testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing() {
     string | int[] | int | float[] | float arr = <int[]>[1, 2];
     if (arr is int[] | float[]) {
         [int, (int|float)][] y = arr.enumerate();
+        assertTrue(y[0][1] is int);
+        assertEqual(1, y[0][1]);
+        assertEqual(2, y[1][1]);
+    } else {
+        assertTrue(false);
     }
-    assertTrue(true);
 }
 
 function testIntFloatSimpleAndMapUnionReturnParameterNarrowing() {
     map<int> | int | map<float> | float  m = <map<int>>{"1": 1};
     if (m is map<int> | map<float>) {
-        int | float x = m.get("1");
+        int|float x = m.get("1");
+        assertTrue(x is int);
+        assertEqual(1, x);
+    } else {
+        assertTrue(false);
     }
-    assertTrue(true);
 }
 
 function testIntFloatSimpleArrayMapUnionReturnParameterNarrowing() {
     map<int> | int[] | map<float> | float[]  m = <map<int>>{"1": 1};
     if (m is map<float> | map<int>) {
-        int | float x = m.get("1");
+        int|float x = m.get("1");
+        assertTrue(x is int);
+        assertEqual(1, x);
+    } else {
+        assertTrue(false);
     }
-    if (m is int[] | float[]) {
-        [int, (int|float)][] y = m.enumerate();
-    }
-    assertTrue(true);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -14,6 +14,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertTrue(any|error actual) {
+    if actual is boolean && actual {
+        return;
+    }
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected 'true', found '" + actual.toString () + "'");
+}
+
+function assertEqual(anydata|error expected, anydata|error actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}
+
 function testSimpleUnionReturnParameterNarrowing() {
     int[]|float[] arr = <int[]>[1, 2];
     [int, (int|float)][] y = arr.enumerate();
@@ -62,21 +81,19 @@ function testIntFloatSimpleArrayMapUnionReturnParameterNarrowing() {
     }
 }
 
-const ASSERTION_ERROR_REASON = "AssertionError";
+type Foo record {
+    string id;
+};
 
-function assertTrue(any|error actual) {
-    if actual is boolean && actual {
-        return;
-    }
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
-}
+type Bar record {
+    int id;
+};
 
-function assertEqual(anydata|error expected, anydata|error actual) {
-    if expected == actual {
-        return;
-    }
-
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
-}
+//function testStreamTypeParamNarrowing() {
+//    Foo[] fooList = [{id: "1234"}, {id: "5678"}];
+//    stream<Foo> fooStream = fooList.toStream();
+//    stream<Foo>|stream<Bar> fooBarStream = fooStream;
+//
+//    var res = fooBarStream.next();
+//    Foo|Bar retValue = <Foo|Bar>res;
+//}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -81,19 +81,22 @@ function testIntFloatSimpleArrayMapUnionReturnParameterNarrowing() {
     }
 }
 
-type Foo record {
+type StringIdRecord record {
     string id;
 };
 
-type Bar record {
+type IdAndAge record {
+    string id;
+    int age;
+};
+
+type IntIdRecord record {
     int id;
 };
 
-//function testStreamTypeParamNarrowing() {
-//    Foo[] fooList = [{id: "1234"}, {id: "5678"}];
-//    stream<Foo> fooStream = fooList.toStream();
-//    stream<Foo>|stream<Bar> fooBarStream = fooStream;
-//
-//    var res = fooBarStream.next();
-//    Foo|Bar retValue = <Foo|Bar>res;
-//}
+function testUnionOfRecordTypeParamNarrowing() {
+    StringIdRecord|IntIdRecord recordId = <StringIdRecord>{id: "34"};
+    string|int stringOrIntVar = recordId.get("id");
+    assertEqual("34", stringOrIntVar);
+    assertTrue(fbs is string);
+}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
@@ -126,7 +126,14 @@ function testInvalidArgForBoundRequiredParam() {
 }
 
 function testInvalidArgOnUnionTypedValue() {
-    int[]|string[] arr = [1, 2];
+    int[] | string[] arr = [1, 2];
     arr.push(true);
     array:unshift(arr, 13.2);
+}
+
+function testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing() {
+    string[] | int[] | int | float[] | float arr = <int[]>[1, 2];
+    if (arr is int[] | float[] | string[]) {
+        [int, (int|float)][] y = arr.enumerate();
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_test_negative.bal
@@ -126,14 +126,14 @@ function testInvalidArgForBoundRequiredParam() {
 }
 
 function testInvalidArgOnUnionTypedValue() {
-    int[] | string[] arr = [1, 2];
+    int[]|string[] arr = [1, 2];
     arr.push(true);
     array:unshift(arr, 13.2);
 }
 
 function testStringIntFloatSimpleAndArrayUnionReturnParameterNarrowing() {
-    string[] | int[] | int | float[] | float arr = <int[]>[1, 2];
-    if (arr is int[] | float[] | string[]) {
+    string[]|int[]|int|float[]|float arr = <int[]>[1, 2];
+    if (arr is int[]|float[]|string[]) {
         [int, (int|float)][] y = arr.enumerate();
     }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #16828
Fixes #22137

## Approach
Add logic to TypeParamAnalyser. Union and union with arrays will be flattened and merged as a union again.

## Samples
> Provide high-level details about the samples related to this feature.
#### Case 1
```Ballerina
int[]|float[] arr = <int[]>[1, 2];
[int, int][] y = arr.enumerate();
```
##### Previous output
```Logtalk
error: .::t3.bal:5:30: incompatible types: expected '[int,int][]', found '[int,(any|error)][]'
```
##### output after PR
```Logtalk
error: .::t3_bad.bal:5:22: incompatible types: expected '[int,int][]', found '[int,(int|float)][]'
```
Correct code must be `[int, (int | float)][] y = arr.enumerate();`

#### Case 2
```Ballerina
map<int>|map<Person> m = <map<int>>{"1": 1};
int|Person x = m.get("1");
```
##### Previous output
```Logtalk
error: .::t1.bal:7:20: incompatible types: expected '(int|Person)', found '(any|error)'
```
##### output after PR
compiles correctly

#### Case 3
```Ballerina
int[]|string[] arr = [1, 2];
arr.push(true);
```
##### Previous output
```Logtalk
ballerina: Oh no, something really went wrong.
```
##### output after PR
```Logtalks
error: .::tt2.bal:4:14: incompatible types: expected '(int|string)', found 'boolean'
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
