### PR TITLE
Add Object method mocking functionality

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -302,7 +302,7 @@ public class BIRGen extends BLangNodeVisitor {
                     String functionKey = null;
 
                     // Generate the function key
-                    if (callTerminator.isVirtual && callTerminator.args.size() == 1) {
+                    if (callTerminator.isVirtual) {
                         // Function key for object methods
                         String objectPkg = callTerminator.args.get(0).variableDcl.type.toString();
                         functionKey = objectPkg + MOCK_ANNOTATION_DELIMITER + callTerminator.name.toString();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -203,6 +203,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     // Required variables for Mock function implementation
     private static final String MOCK_ANNOTATION_DELIMITER = "#";
+    private static final String MOCK_OBJECT_DELIMITER = ":";
 
     public static BIRGen getInstance(CompilerContext context) {
         BIRGen birGen = context.get(BIR_GEN);
@@ -297,16 +298,32 @@ public class BIRGen extends BLangNodeVisitor {
             for (BIRBasicBlock functionBasicBlock : functionBasicBlocks) {
                 BIRTerminator bbTerminator = functionBasicBlock.terminator;
                 if (bbTerminator.kind.equals(InstructionKind.CALL)) {
-                    //We get the callee and the name and generate 'calleepackage#name'
                     BIRTerminator.Call callTerminator = (BIRTerminator.Call) bbTerminator;
-                    String functionKey = callTerminator.calleePkg.toString() + MOCK_ANNOTATION_DELIMITER
-                            + callTerminator.name.toString();
-                    if (mockFunctionMap.get(functionKey) != null) {
-                        // Just "get" the reference. If this doesnt work then it doesnt exist
-                        String mockfunctionName = mockFunctionMap.get(functionKey);
-                        callTerminator.name = new Name(mockfunctionName);
-                        callTerminator.calleePkg = function.pos.src.pkgID;
+                    String functionKey = null;
+
+                    // Generate the function key
+                    if (callTerminator.isVirtual && callTerminator.args.size() == 1) {
+                        // Function key for object methods
+                        String objectPkg = callTerminator.args.get(0).variableDcl.type.toString();
+                        functionKey = objectPkg + MOCK_ANNOTATION_DELIMITER + callTerminator.name.toString();
+                    } else {
+                        // Function key for normal functions
+                        functionKey = callTerminator.calleePkg.toString() + MOCK_ANNOTATION_DELIMITER
+                                + callTerminator.name.toString();
                     }
+
+                    // Get the mock function from the Mock function map and replace where necessary
+                    if (mockFunctionMap.get(functionKey) != null) {
+                        String mockFunctionName = mockFunctionMap.get(functionKey);
+                        callTerminator.name = new Name(mockFunctionName);
+                        callTerminator.calleePkg = function.pos.src.pkgID;
+
+                        if (callTerminator.isVirtual) {
+                            callTerminator.isVirtual = false;
+                            callTerminator.args.remove(0);
+                        }
+                    }
+
                 }
             }
         }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -40,7 +40,7 @@ public class MockTest extends BaseTestCase {
 
     @Test
     public void testAssertTrue() throws BallerinaTestException {
-        String msg = "4 passing";
+        String msg = "5 passing";
         LogLeecher clientLeecher = new LogLeecher(msg);
         balClient.runMain("test", new String[]{"--all"}, null,
                 new String[]{}, new LogLeecher[]{clientLeecher}, projectPath);

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/mock-tests/src/Mock/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/mock-tests/src/Mock/main.bal
@@ -2,6 +2,22 @@ public function main() {
     int ans = intAdd(5, 3);
 }
 
+//
+// Object Definition
+//
+type Person object {
+    public string firstName;
+    public string lastName;
+
+    function __init(string firstName, string lastName) {
+        self.firstName = firstName;
+        self.lastName = lastName;
+    }
+
+    function getFullName() returns string {
+        return self.firstName + " " + self.lastName;
+    }
+};
 
 //
 // FUNCTIONS

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/mock-tests/src/Mock/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/mock-tests/src/Mock/tests/main_test.bal
@@ -41,6 +41,15 @@ function test_MockNativeFunction() {
     test:assertEquals(answer, 125.0, "Mocking did not take place");
 }
 
+// Test Function mocking for Object methods
+Person p1 = new ("Jane", "Doe");
+
+@test:Config {
+}
+function test_MockObjectFunction() {
+    test:assertEquals(p1.getFullName(), "John Doe", "Mocking did not take place");
+}
+
 
 //
 // FUNCTION MOCKS
@@ -70,4 +79,12 @@ function mocksqrt(float a) returns (float) {
     return a*a*a;
 }
 
+@test:Mock {
+    moduleName : "",
+    objectName : "Person",
+    functionName : "getFullName"
+}
+function mock_getFullName() returns string {
+    return "John Doe";
+}
 


### PR DESCRIPTION
## Purpose
Object method mocking functionality is implemented in this PR

Fixes #22095 

## Approach
Iterate through type definitions to verify if the function exists in the Object and it the return types are compatible

During BIR generation, the `callTerminator` of the object method we are mocking is modified. 
`isVirtual` is set to false and the Object reference is removed from the arguments

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
